### PR TITLE
Add missing includes

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -16,6 +16,8 @@
 *
 */
 
+#include <cstring>
+
 #include "AdaptiveTree.h"
 
 namespace adaptive

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <cstring>
+#include <cfloat>
 #include <fstream>
 
 #include "SmoothTree.h"


### PR DESCRIPTION
Just tried to build inputstream.adaptive on Linux (Gentoo), and needed these changes to make it build:

- ~~Makes CMake happy as it couldn't find "DashTree.cpp" (case-sensitivity, file is named "DASHTree.cpp")~~
- ~~Makes gcc find DASHTree.h and SmoothTree.h (/ instead of \ in #include)~~
- Fixes "src/common/AdaptiveTree.cpp:25:40: error: ‘strchr’ was not declared in this scope"
- Fixes "src/parser/SmoothTree.cpp:187:35: error: ‘DBL_MAX’ was not declared in this scope"

Not sure if any addon already makes use of inputstream.adaptive (also not sure if you want/like/accept patches yet) but these little fixes at least makes the addon build on linux.