### PR TITLE
Support ContentProtection tags inside Representation

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -468,6 +468,40 @@ start(void *data, const char *el, const char **attr)
             }
             dash->currentNode_ |= DASHTree::MPDNODE_SEGMENTTEMPLATE;
           }
+		  else if (strcmp(el, "ContentProtection") == 0) //Inside Representation
+		  {
+			  dash->current_adaptationset_->encrypted = true;
+			  if (dash->adp_pssh_.second.empty())
+				  dash->adp_pssh_.second = "PROTECTED";
+
+			  dash->strXMLText_.clear();
+			  dash->encryptionState_ |= DASHTree::ENCRYTIONSTATE_ENCRYPTED;
+			  bool urnFound(false), mpdFound(false);
+			  const char *defaultKID(0);
+			  for (; *attr;)
+			  {
+				  if (strcmp((const char*)*attr, "schemeIdUri") == 0)
+				  {
+					  if (strcmp((const char*)*(attr + 1), "urn:mpeg:dash:mp4protection:2011") == 0)
+						  mpdFound = true;
+					  else
+					  {
+						  urnFound = stricmp(dash->adp_pssh_.first.c_str(), (const char*)*(attr + 1)) == 0;
+						  break;
+					  }
+				  }
+				  else if (strcmp((const char*)*attr, "cenc:default_KID") == 0)
+					  defaultKID = (const char*)*(attr + 1);
+				  attr += 2;
+			  }
+			  if (urnFound)
+			  {
+				  dash->currentNode_ |= DASHTree::MPDNODE_CONTENTPROTECTION;
+				  dash->encryptionState_ |= DASHTree::ENCRYTIONSTATE_SUPPORTED;
+			  }
+			  else if (mpdFound && defaultKID && strlen(defaultKID) == 36)
+				  dash->defaultKID_ = defaultKID;
+		  }
         }
         else if (dash->currentNode_ & DASHTree::MPDNODE_SEGMENTTEMPLATE)
         {
@@ -591,7 +625,7 @@ start(void *data, const char *el, const char **attr)
           }
           dash->currentNode_ |= DASHTree::MPDNODE_SEGMENTDURATIONS;
         }
-        else if (strcmp(el, "ContentProtection") == 0)
+        else if (strcmp(el, "ContentProtection") == 0) //Outside Representation
         {
           dash->current_adaptationset_->encrypted = true;
           if (dash->adp_pssh_.second.empty())


### PR DESCRIPTION
Snippet from example mpd:
```xml
<?xml version="1.0" encoding="utf-8"?>
<MPD
xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
xmlns="urn:mpeg:dash:schema:mpd:2011"
xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011
http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
id="3156" type="static" mediaPresentationDuration="PT142.84S"
minBufferTime="PT1S" profiles="urn:mpeg:dash:profile:isoff-main:2011">

<Period start="PT0.00S" id="1">
    <AdaptationSet mimeType="video/mp4"
segmentAlignment="true" subsegmentAlignment="true" startWithSAP="1"
subsegmentStartsWithSAP="1" bitstreamSwitching="true">

<Representation id="1" width="960" height="540" frameRate="25/1"
bandwidth="2371968" codecs="avc1.4D401F">
        <ContentProtection
schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"
cenc:default_KID="31ac5545-16eb-5293-ab13-c983f47cdd00"
xmlns:cenc="urn:mpeg:cenc:2013"/>
        <ContentProtection
schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">

<cenc:pssh
xmlns:cenc="urn:mpeg:cenc:2013">AAAAYnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAEISEDGsVUUW61KTqxPJg/R83QAaBm9veWFsYSIgZzNaR1ptWVRFNlQySEoyemFDSExHRHgyQnk1UzNBSlhI49yVmwY=</cenc:pssh>

</ContentProtection>
        <ContentProtection
schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR
2.0">
          <cenc:pssh
xmlns:cenc="urn:mpeg:cenc:2013">AAADBnBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAubmAgAAAQABANwCPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBSAFYAVwBzAE0AZQBzAFcAawAxAEsAcgBFADgAbQBEADkASAB6AGQAQQBBAD0APQA8AC8ASwBJAEQAPgA8AEwAQQBfAFUAUgBMAD4AaAB0AHQAcABzADoALwAvAHAAbABhAHkAZQByAC4AbwBvAHkAYQBsAGEALgBjAG8AbQAvAHMAYQBzAC8AZAByAG0AMgAvAEkAegBNAG0ATQB5AE8AcQBBAFgAdQBfAGUAUwBPAHkATAB1AFUAeAA1AGoARgBQAFkATQBWAFUALwBnADMAWgBHAFoAbQBZAFQARQA2AFQAMgBIAEoAMgB6AGEAQwBIAEwARwBEAHgAMgBCAHkANQBTADMAQQBKAFgALwBwAGwAYQB5AHIAZQBhAGQAeQBfAGMAZQBuAGMALwBvAG8AeQBhAGwAYQAvAHYAZQByAHMAaQBvAG4ALwAxADwALwBMAEEAXwBVAFIATAA+ADwALwBEAEEAVABBAD4APAAvAFcAUgBNAEgARQBBAEQARQBSAD4A</cenc:pssh>

</ContentProtection>
        <SegmentTemplate timescale="90000"
media="3156_video_1_0_$Number$.mp4?m=1490072601"
initialization="3156_video_1_0_init.mp4?m=1490072601" startNumber="2"
presentationTimeOffset="184615">
          <SegmentTimeline>

<S t="184615" d="180000" r="70"/>
            <S t="12964615"
d="75600"/>
          </SegmentTimeline>
        </SegmentTemplate>

</Representation>
```
MPD (2 minute movie trailer) can be found [here](http://bpmoviesmultidashvod857.ngcdn.telstra.com/g3ZGZmYTE6T2HJ2zaCHLGDx2By5S3AJX/1/dash/1.mpd) and license [here](http://player.ooyala.com/sas/drm2/IzMmMyOqAXu_eSOyLuUx5jFPYMVU/g3ZGZmYTE6T2HJ2zaCHLGDx2By5S3AJX/widevine_modular/ooyala?auth_token=UUQ4VWMwMWVIZSsvS1JQbDlTZTFnK21IenE2c0Z4V1pKVGpNbTN6QWszME80SUVsb0dpdzlXNERBelo4CnRWdDlCcS9SWWxCYnJLeWh5R3I0WGZEVG1LN0tjSWxVQlR1NlpBQlM2ZHdlMHVxUjFwTHMybVFROENBZgo5Qm9NOUUyaVNJNUJ1Z0pRRVhYcm9ONTk2bzVYVE1Dc1J3Nkh5azBzd2tUMkF3bSt3cHlsQkswejV0eWQKMUp3WE8vTk54Q0haVHVDOXZNUnRrdUdKbHVwM0xWWFMreGhkY0ZzbndCWUI0Um5PMEkybVJpMjZTQzg2CmxoV2srZVZZTUxqYzg4YjkK).
I'm not sure but they may be geo-locked to Australia.