### PR TITLE
Fix seeking in timeshift

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1720,7 +1720,7 @@ extern "C" {
 
     xbmc->Log(ADDON::LOG_INFO, "DemuxSeekTime (%0.4lf)", time);
 
-    return session->SeekTime(time * 0.001f, 0, !backwards);
+    return session->SeekTime(time * 0.001l, 0, !backwards);
   }
 
   void DemuxSetSpeed(int speed)

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -992,7 +992,7 @@ end(void *data, const char *el)
                   continue;
                 std::vector<uint32_t>::const_iterator sdb(dash->current_adaptationset_->segment_durations_.data.begin()),
                   sde(dash->current_adaptationset_->segment_durations_.data.end());
-                uint64_t spts(0);
+                uint64_t spts((*b)->segments_[0]->startPTS_);
                 for (std::vector<DASHTree::Segment>::iterator sb((*b)->segments_.data.begin()), se((*b)->segments_.data.end()); sb != se && sdb != sde; ++sb, ++sdb)
                 {
                   sb->startPTS_ = spts;


### PR DESCRIPTION
In case of re-aligning the segments, use the first PTS as starting
point.

Use double instead of float