### PR TITLE
Fix seeking in timeshift

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2510,7 +2510,7 @@ bool CInputStreamAdaptive::DemuxSeekTime(double time, bool backwards, double &st
 
   kodi::Log(ADDON_LOG_INFO, "DemuxSeekTime (%0.4lf)", time);
 
-  return m_session->SeekTime(time * 0.001f, 0, !backwards);
+  return m_session->SeekTime(time * 0.001l, 0, !backwards);
 }
 
 //callback - will be called from kodi

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1103,7 +1103,7 @@ end(void *data, const char *el)
                   continue;
                 std::vector<uint32_t>::const_iterator sdb(dash->current_adaptationset_->segment_durations_.data.begin()),
                   sde(dash->current_adaptationset_->segment_durations_.data.end());
-                uint64_t spts(0);
+                uint64_t spts((*b)->segments_[0]->startPTS_);
                 for (std::vector<DASHTree::Segment>::iterator sb((*b)->segments_.data.begin()), se((*b)->segments_.data.end()); sb != se && sdb != sde; ++sb, ++sdb)
                 {
                   sb->startPTS_ = spts;


### PR DESCRIPTION
In case of re-aligning the segments, use the first PTS as starting
point.

Use double instead of float