### PR TITLE
Do not seek past live stream

### DIFF
--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -57,7 +57,7 @@ namespace adaptive
       uint32_t  bytesToRead);
     uint64_t tell(){ read(0, 0);  return absolute_position_; };
     bool seek(uint64_t const pos);
-    bool seek_time(double seek_seconds, double current_seconds, bool &needReset);
+    bool seek_time(double seek_seconds, double current_seconds, bool &needReset, double &startPts);
     AdaptiveTree::AdaptationSet const *getAdaptationSet() { return current_adp_; };
     AdaptiveTree::Representation const *getRepresentation(){ return current_rep_; };
     double get_download_speed() const { return tree_.get_download_speed(); };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2201,7 +2201,7 @@ bool CInputStreamAdaptive::DemuxSeekTime(double time, bool backwards, double &st
 
   kodi::Log(ADDON_LOG_INFO, "DemuxSeekTime (%0.4lf)", time);
 
-  return m_session->SeekTime(time * 0.001f, 0, !backwards);
+  return m_session->SeekTime(time * 0.001l, 0, !backwards);
 }
 
 //callback - will be called from kodi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1690,9 +1690,10 @@ SampleReader *Session::GetNextSample()
   return 0;
 }
 
-bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
+bool Session::SeekTime(double seekTime,  double &startPts, unsigned int streamId, bool preceeding)
 {
   bool ret(false);
+  double dvdNoPts(startPts);
 
   //we don't have pts < 0 here and work internally with uint64
   if (seekTime < 0)
@@ -1702,8 +1703,10 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
     if ((*b)->enabled && (streamId == 0 || (*b)->info_.m_pID == streamId))
     {
       bool bReset;
-      if ((*b)->stream_.seek_time(seekTime + GetPresentationTimeOffset(), last_pts_, bReset))
+      if ((*b)->stream_.seek_time(seekTime + GetPresentationTimeOffset(), last_pts_, bReset, startPts))
       {
+        if (startPts != dvdNoPts)
+          seekTime = (startPts - GetPresentationTimeOffset())/1000000l;
         if (bReset)
           (*b)->reader_->Reset(false);
         if (!(*b)->reader_->TimeSeek(seekTime, preceeding))
@@ -2201,7 +2204,7 @@ bool CInputStreamAdaptive::DemuxSeekTime(double time, bool backwards, double &st
 
   kodi::Log(ADDON_LOG_INFO, "DemuxSeekTime (%0.4lf)", time);
 
-  return m_session->SeekTime(time * 0.001l, 0, !backwards);
+  return m_session->SeekTime(time * 0.001l, startpts, 0, !backwards);
 }
 
 //callback - will be called from kodi

--- a/src/main.h
+++ b/src/main.h
@@ -125,7 +125,7 @@ public:
   double GetPTS()const { return last_pts_; };
   bool CheckChange(bool bSet = false){ bool ret = changed_; changed_ = bSet; return ret; };
   void SetVideoResolution(unsigned int w, unsigned int h) { width_ = w; height_ = h;};
-  bool SeekTime(double seekTime, unsigned int streamId = 0, bool preceeding=true);
+  bool SeekTime(double seekTime, double &startPts, unsigned int streamId = 0, bool preceeding=true);
   bool IsLive() const { return adaptiveTree_->has_timeshift_buffer_; };
   MANIFEST_TYPE GetManifestType() const { return manifest_type_; };
   const AP4_UI08 *GetDefaultKeyId(const uint8_t index) const;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1098,7 +1098,7 @@ end(void *data, const char *el)
                   continue;
                 std::vector<uint32_t>::const_iterator sdb(dash->current_adaptationset_->segment_durations_.data.begin()),
                   sde(dash->current_adaptationset_->segment_durations_.data.end());
-                uint64_t spts(0);
+                uint64_t spts((*b)->segments_[0]->startPTS_);
                 for (std::vector<DASHTree::Segment>::iterator sb((*b)->segments_.data.begin()), se((*b)->segments_.data.end()); sb != se && sdb != sde; ++sb, ++sdb)
                 {
                   sb->startPTS_ = spts;


### PR DESCRIPTION
With this patch, Kodi will continue playing the live stream from its current position (minus ~12 seconds) instead of freezing the stream in case of seeking too far.

In my opinion,
caps.m_supportsSeek = session && !session->IsLive();
could with this patch be changed to
caps.m_supportsSeek = session;

Due to a conflict, this PR includes:
https://github.com/peak3d/inputstream.adaptive/pull/29

