### PR TITLE
[fix] set default TimeScale

### DIFF
--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -236,8 +236,10 @@ start(void *data, const char *el, const char **attr)
       }
       attr += 2;
     }
-    if (timeScale)
-      dash->overallSeconds_ = duration / timeScale;
+    if (!timeScale)
+      timeScale = 10000000; //Defalt Smmoothstream frequency (10Khz)
+
+    dash->overallSeconds_ = duration / timeScale;
     dash->currentNode_ |= SmoothTree::SSMNODE_SSM;
     dash->minPresentationOffset = ~0ULL;
     dash->base_time_ = ~0ULL;


### PR DESCRIPTION
I've got ism manifests where TimeScale parameter is omitted,
according to https://msdn.microsoft.com/en-us/library/ee673438 it is optional
and should default to 10000000 if omitted

this fixes an issue where it's impossible to seek with such manifests