### PR TITLE
HLS Streams can now use cookies returned from the manifest get reques…

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -444,6 +444,7 @@ namespace adaptive
 
 protected:
   virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr, bool scanEffectiveURL = true);
+  virtual bool download_ext(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque, bool scanEffectiveURL, bool returnCookies, std::string &cookies);
   virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) = 0;
   bool PreparePaths(const std::string &url, const std::string &manifestUpdateParam);
   void SortTree();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,6 +264,12 @@ Kodi Streams implementation
 
 bool adaptive::AdaptiveTree::download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque, bool scanEffectiveURL)
 {
+  std::string dummy_str;
+  return adaptive::AdaptiveTree::download_ext(url, manifestHeaders, opaque, scanEffectiveURL, false, dummy_str);
+}
+
+bool adaptive::AdaptiveTree::download_ext(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque, bool scanEffectiveURL, bool returnCookies, std::string &cookies)
+{
   // open the file
   kodi::vfs::CFile file;
   if (!file.CURLCreate(url))
@@ -310,6 +316,27 @@ bool adaptive::AdaptiveTree::download(const char* url, const std::map<std::strin
 
   etag_ = file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, "etag");
   last_modified_ = file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, "last-modified");
+  
+  if (returnCookies)
+  {
+    const std::vector<std::string> c = file.GetPropertyValues(ADDON_FILE_PROPERTY_RESPONSE_HEADER, "Set-Cookie");
+    
+    cookies = "";
+    bool first = true;
+    for (const auto &entry : c)
+    {
+      std::string::size_type pos(entry.find(';'));
+      if (pos != std::string::npos)
+      {
+        if (first)
+          first = false;
+        else
+          cookies += "; ";
+
+        cookies += entry.substr(0, pos);
+      }
+    }
+  }
 
   //download_speed_ = file.GetFileDownloadSpeed();
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -80,7 +80,7 @@ bool HLSTree::open(const std::string &url, const std::string &manifestUpdatePara
 {
   PreparePaths(url, manifestUpdateParam);
   std::stringstream stream;
-  if (download(manifest_url_.c_str(), manifest_headers_, &stream))
+  if (download_ext(manifest_url_.c_str(), manifest_headers_, &stream, true, true, manifest_cookies))
   {
 #if FILEDEBUG
     FILE *f = fopen("inputstream_adaptive_master.m3u8", "w");
@@ -516,8 +516,10 @@ void HLSTree::OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16
             url += "&";
           url += keyParts[0];
         }
-        if (keyParts.size() > 1)
+        if (keyParts.size() > 1 && !keyParts[1].empty())
           parseheader(headers, keyParts[1].c_str());
+        if (keyParts.size() > 2 && keyParts[2].compare("manifest_cookies") == 0 && manifest_cookies.size() > 0)
+          headers["Cookie"] = manifest_cookies;
         if (download(url.c_str(), headers, &stream, false))
         {
           pssh.defaultKID_ = stream.str();

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -65,6 +65,7 @@ namespace adaptive
     bool m_refreshPlayList = true;
     uint8_t m_segmentIntervalSec = 4;
     AESDecrypter *m_decrypter;
+    std::string manifest_cookies;
   };
 
 } // namespace


### PR DESCRIPTION
…t to get the decrypt keys

Useful because some HLS streams has the following scenario:
get request to retrieve the manifest => returns cookies (cookies returned change at each get manifest call)
get requests to retrieve decrypt keys => must use the cookies returned by the previous call to get the manifest

To use this new feature, the user has to set the "inputstream.adaptive.license_key" property of the playItem to something like "||manifest_cookies"

The implementation of this new feature add optional parameters to the download function that give the ability to return the cookies.
The HLS parser is modified to set the cookies to retrieve the keys if the user has set the property "inputstream.adaptive.license_key" to something like "||manifest_cookies"
