### PR TITLE
Setting default timescale to 1

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -389,7 +389,7 @@ start(void *data, const char *el, const char **attr)
           }
           else if (strcmp(el, "SegmentList") == 0)
           {
-            uint32_t dur(0), ts(0);
+            uint32_t dur(0), ts(1);
             for (; *attr;)
             {
               if (strcmp((const char*)*attr, "duration") == 0)


### PR DESCRIPTION
Seems that it is not mandatory to specify the timescale.
For example this stream does not use it:

http://www-itec.aau.at/~cmueller/libdashtest/showcases/big_buck_bunny_480.mpd

Facing some issues with this one

https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd
