### PR TITLE
fixed ttml subtitles problem, peak3d/inpustream.adaptive#247

### DIFF
--- a/src/parser/TTML.cpp
+++ b/src/parser/TTML.cpp
@@ -136,6 +136,8 @@ start(void *data, const char *el, const char **attr)
         *attr = nssep + 1;
       if (strcmp((const char*)*attr, "tickRate") == 0)
         ttml->m_tickRate = atoll((const char*)*(attr + 1));
+      else if (strcmp((const char*)*attr, "frameRate") == 0)
+        ttml->m_frameRate = atoll((const char*)*(attr + 1));
       attr += 2;
     }
   }
@@ -290,15 +292,22 @@ uint64_t TTML2SRT::GetTime(const char *tmchar)
   }
   else
   {
-    unsigned int th, tm, ts, tms;
-    char del, ctms[3];
-    if (sscanf(tmchar, "%u:%u:%u%c%3c", &th, &tm, &ts, &del, ctms) == 5)
+    unsigned int th, tm, ts, tf;
+    char del, ctf [4];
+    if (sscanf(tmchar, "%u:%u:%u%c%s", &th, &tm, &ts, &del, ctf) == 5)
     {
-      sscanf(ctms, "%3u", &tms);
-      if (strlen(ctms) == 2)
-        tms = tms*10;
+      sscanf(ctf, "%u", &tf);
+      if (strlen(ctf) == 2 && del == '.')
+        tf = tf * 10;
+      else if (strlen(ctf) == 2 && del == ':')
+      {
+        if (m_frameRate)
+          tf = (tf * 1000 / m_frameRate);
+        else
+          tf = (tf * 1000 / 30);
+      }
       ret = th * 3600 + tm * 60 + ts;
-      ret = ret * 1000 + tms;
+      ret = ret * 1000 + tf;
       ret = (ret * m_timescale) / 1000;
     }
   }

--- a/src/parser/TTML.h
+++ b/src/parser/TTML.h
@@ -26,7 +26,7 @@
 class TTML2SRT
 {
 public:
-  TTML2SRT() :m_node(0), m_pos(0), m_tickRate(0), m_timescale(0), m_ptsOffset(0) { m_styleStack.push_back(STYLE()); };
+  TTML2SRT() :m_node(0), m_pos(0), m_tickRate(0), m_frameRate(0), m_timescale(0), m_ptsOffset(0) { m_styleStack.push_back(STYLE()); };
 
   bool Parse(const void *buffer, size_t buffer_size, uint64_t timescale, uint64_t ptsOffset);
 
@@ -75,7 +75,7 @@ public:
   static const uint32_t NODE_SPAN = 1 << 13;
 
   uint32_t m_node, m_pos;
-  uint64_t m_tickRate;
+  uint64_t m_tickRate, m_frameRate;
 private:
   uint64_t GetTime(const char * tm);
 


### PR DESCRIPTION
fixed ttml subtitles problem on windows, fixes https://github.com/peak3d/inputstream.adaptive/issues/247:
- fixed sscanf problem on Windows with fraction after delimiter
- added support for frames in timeExpression