### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: kodi-inputstream-adaptive
 Priority: extra
 Maintainer: peak3d <info@peak3d.de>
-Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 17.0.0),
-               kodi-addon-dev, pkg-config, libexpat1-dev
+Build-Depends: debhelper (>= 9.0.0), cmake, kodi-addon-dev, pkg-config, libexpat1-dev
 Standards-Version: 3.9.7
 Section: libs
 Homepage: http://www.peak3d.de


### PR DESCRIPTION
The inputstream.adaptive binary addon does not use kodi-platform.
Remove existing references from debian/control.