### PR TITLE
fix return code of ParseFrameForSPS

### DIFF
--- a/lib/libbento4/Codecs/Ap4AvcParser.cpp
+++ b/lib/libbento4/Codecs/Ap4AvcParser.cpp
@@ -965,6 +965,7 @@ AP4_Result AP4_AvcFrameParser::ParseFrameForSPS(const AP4_Byte* data, AP4_Size d
       return ParseSPS(data, data_size, sps);
     data_size -= nalSize;
   }
+  return AP4_SUCCESS;
 }
 
 /*----------------------------------------------------------------------


### PR DESCRIPTION
inputstream.adaptive.5c9c7f2/lib/libbento4/Codecs/Ap4AvcParser.cpp:968:1: warning: control reaches end of non-void function [-Wreturn-type]

Signed-off-by: Olaf Hering <olaf@aepfle.de>