### PR TITLE
Fix SegFault on SegmentURL handling

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -268,15 +268,13 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment *seg)
           download_url_ = current_rep_->url_ + download_url_;
       }
       else
-      {
         download_url_ = current_rep_->url_;
-        uint64_t fileOffset = seg != &current_rep_->initialization_ ? m_segmentFileOffset : 0;
-        if (~seg->range_end_)
-          sprintf(rangebuf, "bytes=%" PRIu64 "-%" PRIu64, seg->range_begin_ + fileOffset, seg->range_end_ + fileOffset);
-        else
-          sprintf(rangebuf, "bytes=%" PRIu64 "-", seg->range_begin_ + fileOffset);
-        rangeHeader = rangebuf;
-      }
+      uint64_t fileOffset = seg != &current_rep_->initialization_ ? m_segmentFileOffset : 0;
+      if (~seg->range_end_)
+        sprintf(rangebuf, "bytes=%" PRIu64 "-%" PRIu64, seg->range_begin_ + fileOffset, seg->range_end_ + fileOffset);
+      else
+        sprintf(rangebuf, "bytes=%" PRIu64 "-", seg->range_begin_ + fileOffset);
+      rangeHeader = rangebuf;
     }
     else if (seg != &current_rep_->initialization_) //templated segment
     {

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -269,12 +269,15 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment *seg)
       }
       else
         download_url_ = current_rep_->url_;
-      uint64_t fileOffset = seg != &current_rep_->initialization_ ? m_segmentFileOffset : 0;
-      if (~seg->range_end_)
-        sprintf(rangebuf, "bytes=%" PRIu64 "-%" PRIu64, seg->range_begin_ + fileOffset, seg->range_end_ + fileOffset);
-      else
-        sprintf(rangebuf, "bytes=%" PRIu64 "-", seg->range_begin_ + fileOffset);
-      rangeHeader = rangebuf;
+      if (~seg->range_begin_)
+      {
+        uint64_t fileOffset = seg != &current_rep_->initialization_ ? m_segmentFileOffset : 0;
+        if (~seg->range_end_)
+          sprintf(rangebuf, "bytes=%" PRIu64 "-%" PRIu64, seg->range_begin_ + fileOffset, seg->range_end_ + fileOffset);
+        else
+          sprintf(rangebuf, "bytes=%" PRIu64 "-", seg->range_begin_ + fileOffset);
+        rangeHeader = rangebuf;
+      }
     }
     else if (seg != &current_rep_->initialization_) //templated segment
     {

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -116,11 +116,8 @@ namespace adaptive
     {
       void SetRange(const char *range);
       uint64_t range_begin_; //Either byterange start or timestamp or ~0
-      union
-      {
-        uint64_t range_end_; //Either byterange end or sequence_id or char* if range_begin is ~0
-        const char *url;
-      };
+      uint64_t range_end_; //Either byterange end or sequence_id if range_begin is ~0
+      const char *url;
       uint64_t startPTS_;
       uint16_t pssh_set_;
     };


### PR DESCRIPTION
While trying to create a Kodi addon for Rakuten I got several times a segmentation fault for some videos. It turned out that the MPD of the crashing ones was different then for the working ones.
In the crashing ones they use in SegmentURL elements both "media" and "mediaRange" attribute at the same time. 
Therefore I adjusted Segment structure to keep both attributes at the same time. In addition to that the range header handling was added for that case too.

Additional side-effect is that it fixes this issue with the Youtube addon:
https://github.com/jdf76/plugin.video.youtube/issues/595

I don't know if those audio streams are using the same structure like Rakuten but at least no I have sound there as well.


