### PR TITLE
Fix issue where 1080p means 720p

### DIFF
--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -20,8 +20,9 @@
             <options>
               <option label="30150">0</option> <!-- Max -->
               <option label="30151">1</option>  <!-- 480p -->
-              <option label="30153">2</option>  <!-- 720p -->
-              <option label="30154">3</option> <!-- 1080p -->
+              <option label="30152">2</option>  <!-- 640p -->
+              <option label="30153">3</option>  <!-- 720p -->
+              <option label="30154">4</option> <!-- 1080p -->
             </options>
           </constraints>
           <control type="spinner" format="string" />


### PR DESCRIPTION
It appears that the enumeration was not 100% the same in the settings causing 720p to be 640p, and 1080p to be 720p.

This fixes #237 and pietje666/plugin.video.vrt.nu#195