### PR TITLE
Allow for intermittient failing of HLS playlist refresh download

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -137,7 +137,8 @@ namespace adaptive
     {
       Representation() :bandwidth_(0), samplingRate_(0), width_(0), height_(0), fpsRate_(0), fpsScale_(1), aspect_(0.0f),
         flags_(0), hdcpVersion_(0), indexRangeMin_(0), indexRangeMax_(0), channelCount_(0), nalLengthSize_(0), pssh_set_(0), expired_segments_(0),
-        containerType_(AdaptiveTree::CONTAINERTYPE_MP4), startNumber_(1), nextPts_(0), duration_(0), timescale_(0), current_segment_(nullptr) {};
+        containerType_(AdaptiveTree::CONTAINERTYPE_MP4), startNumber_(1), nextPts_(0), duration_(0), timescale_(0), current_segment_(nullptr),
+	      unparsed_hls_rep_(""){};
       ~Representation() {
         if (flags_ & Representation::URLSEGMENTS)
         {
@@ -188,6 +189,7 @@ namespace adaptive
       Segment initialization_;
       SPINCACHE<Segment> segments_;
       const Segment *current_segment_;
+      std::string unparsed_hls_rep_;
       const Segment *get_initialization()const { return (flags_ & INITIALIZATION) ? &initialization_ : 0; };
       const Segment *get_next_segment(const Segment *seg)const
       {

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -282,7 +282,23 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
     if (!effective_url_.empty() && download_url.find(base_url_) == 0)
       download_url.replace(0, base_url_.size(), effective_url_);
 
-    if (download(download_url.c_str(), manifest_headers_, &stream, false))
+	  bool download_successful = download(download_url.c_str(), manifest_headers_, &stream, false);
+	  
+    if (!download_successful)
+    {
+      if (rep->unparsed_hls_rep_.size() > 0)
+      {
+        Log(LOGLEVEL_ERROR, "Playlist refresh failed, attempting to use previous.");
+        stream.str(rep->unparsed_hls_rep_);
+        download_successful = true;
+      }
+    }
+    else
+    {
+      rep->unparsed_hls_rep_ = stream.str();
+    }
+
+    if (download_successful)
     {
 #if FILEDEBUG
       FILE *f = fopen("inputstream_adaptive_sub.m3u8", "w");


### PR DESCRIPTION
Hi @peak3d 

Myself and a lot of other uses of @matthuisman addon https://github.com/matthuisman/plugin.video.kayo.sports have been having intermittient issues on typically a Friday and Saturday evening where the service will return HTTP 404 for the playlist, typically for up to 10 seconds. The service is using Akamai CDN but it's hard to know exactly what's going on but it would appear to be some sort of bottleneck between Kayo and Akamai.

At the moment when a playlist 404 happens the stream stalls and doesn't recover (you are just looking at a still image), attempting to seek will cause playback to end.

This fix stores a string copy of the playlist in the representation to pass in during prepareRepresentation in case of AdaptiveTree::download failing.

I've tested using a mitmproxy script to return 404 for the playlist (first 15 seconds of each minute) and had success.  Segment downloads and playback continue while the playlist is 404.

Happy for all/any feedback. I know this is somewhat of a workaround for (in this case) a content provider's buggy service but my reasoning is that if we retry on segment 404 then shouldn't that also be applied to a playlist refresh?

Thanks

Glenn