### PR TITLE
add support for mpd location redirects

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -375,7 +375,7 @@ namespace adaptive
 
     double download_speed_, average_download_speed_;
 
-    std::string supportedKeySystem_;
+    std::string supportedKeySystem_, location_;
     struct PSSH
     {
       static const uint32_t MEDIA_VIDEO = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2126,9 +2126,14 @@ bool Session::initialize(const std::uint8_t config, uint32_t max_user_bandwidth)
     kodi::Log(ADDON_LOG_DEBUG, "Supported URN: %s", adaptiveTree_->supportedKeySystem_.c_str());
   }
 
-  // Open mpd file
-  if (!adaptiveTree_->open(mpdFileURL_.c_str(), mpdUpdateParam_.c_str()) || adaptiveTree_->empty())
+  // Open mpd file with mpd location redirect support
+  bool mpdSuccess;
+  while ((mpdSuccess = adaptiveTree_->open(mpdFileURL_.c_str(), mpdUpdateParam_.c_str())) && !adaptiveTree_->location_.empty())
   {
+    mpdFileURL_ = adaptiveTree_->location_;
+    adaptiveTree_->location_.clear();
+  }
+  if (!mpdSuccess || adaptiveTree_->empty()) {
     kodi::Log(ADDON_LOG_ERROR, "Could not open / parse mpdURL (%s)", mpdFileURL_.c_str());
     return false;
   }


### PR DESCRIPTION
Some streaming servers use MPD Location tag redirects for statistics or tracking purposes.
For instance:
```xml
<?xml version="1.0" encoding="utf-8"?>
<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns="urn:mpeg:dash:schema:mpd:2011"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
    profiles="urn:mpeg:dash:profile:isoff-live:2011"
    type="dynamic"
    availabilityStartTime="1970-01-01T00:00:00Z"
    publishTime="2019-08-08T07:57:22"
    minimumUpdatePeriod="PT10S"
    suggestedPresentationDelay="PT10S"
    minBufferTime="PT10S">
    <Location>https://dcs-live.apis.anvato.net/server/play/kZEoafO6xdBCB8JJd/manifest.mpd?anvsid=xxxxxxxxxx-xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</Location>
</MPD>
```
This pull request implements this kind of redirect by reading the Location tag and using this value as mpdFileURL_.