### PR TITLE
Fallback, assume TS container also on unknown extensions

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -379,8 +379,8 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
                 rep->containerType_ = CONTAINERTYPE_MP4;
               else
               {
-                rep->containerType_ = CONTAINERTYPE_INVALID;
-                continue;
+                //Fallback, assume .ts
+                rep->containerType_ = CONTAINERTYPE_TS;
               }
             }
             else


### PR DESCRIPTION
Currently HLS assumes TS container only for segments that have no file extension. Also assuming TS container for segments with unknown extension improves compability with more streams that have random extensions instead of .ts.  
Maybe this name check should be removed and container detected based on the file content.