### PR TITLE
[Android] only log (max)securitylevel if widevine used

### DIFF
--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -424,7 +424,8 @@ RETRY_OPEN:
   memcpy(session_id_char_, session_id_.data(), session_id_.size());
   session_id_char_[session_id_.size()] = 0;
 
-  Log(SSD_HOST::LL_DEBUG, "SessionId: %s, SecurityLevel: %d, MaxSecurityLevel: %d", session_id_char_, media_drm_.GetMediaDrm()->getSecurityLevel(session_id_), media_drm_.GetMediaDrm()->getMaxSecurityLevel());
+  if (media_drm_.GetKeySystemType() == WIDEVINE)
+    Log(SSD_HOST::LL_DEBUG, "SessionId: %s, SecurityLevel: %d, MaxSecurityLevel: %d", session_id_char_, media_drm_.GetMediaDrm()->getSecurityLevel(session_id_), media_drm_.GetMediaDrm()->getMaxSecurityLevel());
 }
 
 WV_CencSingleSampleDecrypter::~WV_CencSingleSampleDecrypter()


### PR DESCRIPTION
This PR fixes a Kodi crash when playing a stream on android when widevine is not used.

reason: (max)securitylevel is only supported by widevine.