### PR TITLE
Fixed and improved subtitle properties

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -312,6 +312,8 @@ public:
       }
       else if (a->type_ == SUBTITLE)
       {
+        if (a->impaired_ != b->impaired_)
+          return !a->impaired_;
         if (a->forced_ != b->forced_)
           return a->forced_;
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2451,6 +2451,8 @@ bool Session::InitializePeriod()
         break;
       case adaptive::AdaptiveTree::SUBTITLE:
         stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_SUBTITLE;
+        if (adp->impaired_)
+          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_HEARING_IMPAIRED;
         if (adp->forced_)
           stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_FORCED;
         if (adp->default_)

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -596,8 +596,16 @@ start(void *data, const char *el, const char **attr)
               value = (const char*)*(attr + 1);
             attr += 2;
           }
-          if (schemeOk && value && strcmp(value, "subtitle") == 0)
-            dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
+          if (schemeOk && value)
+          {
+            if (strcmp(value, "subtitle") == 0)
+              dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
+            //Legacy compatibility
+            if (strcmp(value, "forced") == 0)
+              dash->current_adaptationset_->forced_ = true;
+            if (strcmp(value, "main") == 0)
+              dash->current_adaptationset_->default_ = true;
+          }
         }
         else if (strcmp(el, "Representation") == 0)
         {
@@ -718,24 +726,6 @@ start(void *data, const char *el, const char **attr)
         {
           dash->strXMLText_.clear();
           dash->currentNode_ |= MPDNODE_BASEURL;
-        }
-        else if (strcmp(el, "Role") == 0)
-        {
-          if (dash->current_adaptationset_->type_ == DASHTree::SUBTITLE)
-          {
-            for (; *attr;)
-            {
-              if (strcmp((const char*)*attr, "value") == 0)
-              {
-                if (strcmp((const char*)*(attr + 1), "forced") == 0)
-                  dash->current_adaptationset_->forced_ = true;
-                else
-                  dash->current_adaptationset_->default_ = true;
-                break;
-              }
-              attr += 2;
-            }
-          }
         }
         else if (strcmp(el, "mspr:pro") == 0)
         {

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -835,6 +835,8 @@ start(void *data, const char *el, const char **attr)
             dash->current_adaptationset_->audio_track_id_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "impaired") == 0)
             dash->current_adaptationset_->impaired_ = strcmp((const char*)*(attr + 1), "true") == 0;
+          else if (strcmp((const char*)*attr, "forced") == 0)
+            dash->current_adaptationset_->forced_ = strcmp((const char*)*(attr + 1), "true") == 0;
           else if (strcmp((const char*)*attr, "original") == 0)
             dash->current_adaptationset_->original_ = strcmp((const char*)*(attr + 1), "true") == 0;
           else if (strcmp((const char*)*attr, "default") == 0)


### PR DESCRIPTION
With the last changes made in branch, the properties of the subtitles have been broken, caused by a double identical condition, fixed this, i also introduced two new things:
- added "forced" property to adaptationset
this allow to set more than one property flag to a single subtitle stream (see screenshot, more properties splitted by comma)
- support to "impaired" property
allow to set a subtitle as for impaired people

![image](https://user-images.githubusercontent.com/3257156/69904138-66972580-13a3-11ea-8ecb-105bca980c53.png)

Tested on Windows with latest Kodi 18 and NF add-on