### PR TITLE
Subtitles webvtt fixed encoding strings

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -172,6 +172,26 @@ std::string b64_encode(unsigned char const* in, unsigned int in_len, bool urlEnc
   return ret;
 }
 
+bool replace(std::string& s, const std::string& from, const std::string& to)
+{
+    size_t start_pos = s.find(from);
+    if (start_pos == std::string::npos)
+        return false;
+    s.replace(start_pos, from.length(), to);
+    return true;
+}
+
+void replaceAll(std::string& s, const std::string& from, const std::string& to)
+{
+    if (from.empty())
+        return;
+    size_t pos = 0;
+    while ((pos = s.find(from, pos)) != std::string::npos) {
+        s.replace(pos, from.length(), to);
+        pos += to.length();
+    }
+}
+
 std::vector<std::string> split(const std::string& s, char seperator)
 {
   std::vector<std::string> output;

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -30,6 +30,9 @@ bool b64_decode(const char *in, unsigned int in_len, uint8_t *out, unsigned int 
 std::string ToDecimal(const uint8_t *data, size_t data_size);
 std::string b64_encode(unsigned char const* in, unsigned int in_len, bool urlEncode);
 
+bool replace(std::string& s, const std::string& from, const std::string& to);
+void replaceAll(std::string& s, const std::string& from, const std::string& to);
+
 std::vector<std::string> split(const std::string& s, char seperator);
 
 std::string &trim(std::string &src);

--- a/src/parser/WebVTT.cpp
+++ b/src/parser/WebVTT.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "WebVTT.h"
+#include "../helpers.h"
 #include <cstring>
 
 bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t buffer_size, uint64_t timescale, uint64_t ptsOffset)
@@ -111,10 +112,8 @@ bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t b
           strText = std::string(cbuf, next - cbuf);
           if (!strText.empty() && strText.back() == '\r')
             strText.resize(strText.size() - 1);
-          if (strText.find("&rlm;", 0, 5) == 0)
-            strText.replace(0, 5, "\0xE2\0x80\0xAB");
-          else if (strText.find("&lrm;", 0, 5) == 0)
-            strText.replace(0, 5, "\0xE2\0x80\0xAA");
+          replace(strText, "&lrm;", "\xE2\x80\xAA");
+          replace(strText, "&rlm;", "\xE2\x80\xAB");
           if (!strText.empty())
             m_subTitles.back().text.push_back(strText);
           else


### PR DESCRIPTION
I had to change the identification of encoding strings, unfortunately here you have set the search from the beginning of the string, and this does not work in all cases

this is an example of a netflix arab subtitle string:
`<c.arabic>&lrm;‏‎.‎لست جباناً‎ ؟‎من يقول إنّي جبان‎‏</c.arabic>`
as you see in this case there are also tags
so you need to search not by position

~I've also added recognition of the missing escapes~
~often displayed in netflix subtitles in any language~

~I followed the example of another Webtt parser~
~that performs the replacement more or less as you implemented~
~https://github.com/caitp/webvtt~
For this wait approve of : https://github.com/xbmc/xbmc/pull/17085

it would be very much appreciated if you would also apply this fix also on Leia branch
because a lot of users complain about this inconvenience

refs:
https://forum.kodi.tv/showthread.php?tid=329767&pid=2910574#pid2910574
https://github.com/CastagnaIT/plugin.video.netflix/issues/120

Tested on Kodi 18.5 with windows build

let me know @peak3d and merry Christmas!