### PR TITLE
[HLS] EXT-X-DISCONTINUITY (multiple periods)

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -179,6 +179,7 @@ public:
     static const uint16_t ENABLED = 256;
     static const uint16_t WAITFORSEGMENT = 512;
     static const uint16_t INITIALIZATION_PREFIXED = 1024;
+    static const uint16_t DOWNLOADED = 2048;
 
     uint16_t flags_;
     uint16_t hdcpVersion_;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -86,211 +86,214 @@ HLSTree::~HLSTree()
 bool HLSTree::open(const std::string &url, const std::string &manifestUpdateParam)
 {
   PreparePaths(url, manifestUpdateParam);
-  std::stringstream stream;
-  if (download(manifest_url_.c_str(), manifest_headers_, &stream))
-  {
+  if (download(manifest_url_.c_str(), manifest_headers_, &manifest_stream))
+    return processManifest(manifest_stream, url);
+  return false;
+}
+
+bool HLSTree::processManifest(std::stringstream& stream, const std::string &url)
+{
 #if FILEDEBUG
     FILE *f = fopen("inputstream_adaptive_master.m3u8", "w");
     fwrite(m_stream.str().data(), 1, m_stream.str().size(), f);
     fclose(f);
 #endif
 
-    std::string line;
-    bool startCodeFound = false;
+  std::string line;
+  bool startCodeFound = false;
 
-    current_adaptationset_ = nullptr;
-    current_representation_ = nullptr;
+  current_adaptationset_ = nullptr;
+  current_representation_ = nullptr;
 
-    periods_.push_back(new Period());
-    current_period_ = periods_[0];
+  periods_.push_back(new Period());
+  current_period_ = periods_.back();
+  current_period_->timescale_ = 1000000;
 
-    std::map<std::string, std::string> map;
+  std::map<std::string, std::string> map;
 
-    while (std::getline(stream, line))
+  while (std::getline(stream, line))
+  {
+    if (!startCodeFound)
     {
-      if (!startCodeFound)
-      {
-        if (line.compare(0, 7, "#EXTM3U") == 0)
-          startCodeFound = true;
+      if (line.compare(0, 7, "#EXTM3U") == 0)
+        startCodeFound = true;
+      continue;
+    }
+
+    std::string::size_type sz(line.size());
+    while (sz && (line[sz - 1] == '\r' || line[sz - 1] == '\n' || line[sz - 1] == ' ')) --sz;
+    line.resize(sz);
+
+    if (line.compare(0, 13, "#EXT-X-MEDIA:") == 0)
+    {
+      //#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="bipbop_audio",LANGUAGE="eng",NAME="BipBop Audio 2",AUTOSELECT=NO,DEFAULT=NO,URI="alternate_audio_aac_sinewave/prog_index.m3u8"
+      parseLine(line, 13, map);
+
+      StreamType type;
+      if (map["TYPE"] == "AUDIO")
+        type = AUDIO;
+      //else if (map["TYPE"] == "SUBTITLES")
+      //  type = SUBTITLE;
+      else
         continue;
+
+      EXTGROUP &group = m_extGroups[map["GROUP-ID"]];
+
+      AdaptationSet *adp = new AdaptationSet();
+      Representation *rep = new Representation();
+      adp->representations_.push_back(rep);
+      group.m_sets.push_back(adp);
+
+      adp->type_ = type;
+      adp->language_ =  map["LANGUAGE"];
+      adp->timescale_ = 1000000;
+      adp->name_ = map["NAME"];
+      adp->default_ = map["DEFAULT"] == "YES";
+
+      rep->codecs_ = group.m_codec;
+      rep->timescale_ = 1000000;
+      rep->containerType_ = CONTAINERTYPE_NOTYPE;
+
+      std::map<std::string, std::string>::iterator res;
+      if ((res = map.find("URI")) != map.end())
+      {
+        if (res->second[0] == '/')
+          rep->source_url_ = base_domain_ + res->second;
+        else if (res->second.find("://", 0) == std::string::npos)
+          rep->source_url_ = base_url_ + res->second;
+        else
+          rep->source_url_ = res->second;
+
+        if (!manifest_parameter_.empty()
+            && rep->source_url_.compare(0, base_url_.size(), base_url_) == 0
+            && rep->source_url_.find('?') == std::string::npos)
+          rep->source_url_ += manifest_parameter_;
+      }
+      else
+      {
+        rep->flags_ = Representation::INCLUDEDSTREAM;
+        current_period_->included_types_ |= 1U << type;
       }
 
-      std::string::size_type sz(line.size());
-      while (sz && (line[sz - 1] == '\r' || line[sz - 1] == '\n' || line[sz - 1] == ' ')) --sz;
-      line.resize(sz);
+      if ((res = map.find("CHANNELS")) != map.end())
+        rep->channelCount_ = atoi(res->second.c_str());
+    }
+    else if (line.compare(0, 18, "#EXT-X-STREAM-INF:") == 0)
+    {
+      // TODO: If CODECS value is not present, get StreamReps from stream program section
+      //#EXT-X-STREAM-INF:BANDWIDTH=263851,CODECS="mp4a.40.2, avc1.4d400d",RESOLUTION=416x234,AUDIO="bipbop_audio",SUBTITLES="subs"
+      parseLine(line, 18, map);
 
-      if (line.compare(0, 13, "#EXT-X-MEDIA:") == 0)
+      current_representation_ = nullptr;
+
+      if (map.find("BANDWIDTH") == map.end())
+        continue;
+
+      if (!current_adaptationset_)
       {
-        //#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="bipbop_audio",LANGUAGE="eng",NAME="BipBop Audio 2",AUTOSELECT=NO,DEFAULT=NO,URI="alternate_audio_aac_sinewave/prog_index.m3u8"
-        parseLine(line, 13, map);
-
-        StreamType type;
-        if (map["TYPE"] == "AUDIO")
-          type = AUDIO;
-        //else if (map["TYPE"] == "SUBTITLES")
-        //  type = SUBTITLE;
-        else
-          continue;
-
-        EXTGROUP &group = m_extGroups[map["GROUP-ID"]];
-
-        AdaptationSet *adp = new AdaptationSet();
-        Representation *rep = new Representation();
-        adp->representations_.push_back(rep);
-        group.m_sets.push_back(adp);
-
-        adp->type_ = type;
-        adp->language_ =  map["LANGUAGE"];
-        adp->timescale_ = 1000000;
-        adp->name_ = map["NAME"];
-        adp->default_ = map["DEFAULT"] == "YES";
-
-        rep->codecs_ = group.m_codec;
-        rep->timescale_ = 1000000;
-        rep->containerType_ = CONTAINERTYPE_NOTYPE;
-
-        std::map<std::string, std::string>::iterator res;
-        if ((res = map.find("URI")) != map.end())
-        {
-          if (res->second[0] == '/')
-            rep->source_url_ = base_domain_ + res->second;
-          else if (res->second.find("://", 0) == std::string::npos)
-            rep->source_url_ = base_url_ + res->second;
-          else
-            rep->source_url_ = res->second;
-
-          if (!manifest_parameter_.empty()
-              && rep->source_url_.compare(0, base_url_.size(), base_url_) == 0
-              && rep->source_url_.find('?') == std::string::npos)
-            rep->source_url_ += manifest_parameter_;
-        }
-        else
-        {
-          rep->flags_ = Representation::INCLUDEDSTREAM;
-          current_period_->included_types_ |= 1U << type;
-        }
-
-        if ((res = map.find("CHANNELS")) != map.end())
-          rep->channelCount_ = atoi(res->second.c_str());
-      }
-      else if (line.compare(0, 18, "#EXT-X-STREAM-INF:") == 0)
-      {
-        // TODO: If CODECS value is not present, get StreamReps from stream program section
-        //#EXT-X-STREAM-INF:BANDWIDTH=263851,CODECS="mp4a.40.2, avc1.4d400d",RESOLUTION=416x234,AUDIO="bipbop_audio",SUBTITLES="subs"
-        parseLine(line, 18, map);
-
-        current_representation_ = nullptr;
-
-        if (map.find("BANDWIDTH") == map.end())
-          continue;
-
-        if (!current_adaptationset_)
-        {
-          current_adaptationset_ = new AdaptationSet();
-          current_adaptationset_->type_ = VIDEO;
-          current_adaptationset_->timescale_ = 1000000;
-          current_period_->adaptationSets_.push_back(current_adaptationset_);
-        }
-        current_representation_ = new Representation();
-        current_adaptationset_->representations_.push_back(current_representation_);
-        current_representation_->timescale_ = 1000000;
-        current_representation_->codecs_ = getVideoCodec(map["CODECS"]);
-        current_representation_->bandwidth_ = atoi(map["BANDWIDTH"].c_str());
-        current_representation_->containerType_ = CONTAINERTYPE_NOTYPE;
-
-        if (map.find("RESOLUTION") != map.end())
-          parseResolution(current_representation_->width_, current_representation_->height_, map["RESOLUTION"]);
-
-        if (map.find("AUDIO") != map.end())
-          m_extGroups[map["AUDIO"]].setCodec(getAudioCodec(map["CODECS"]));
-        else
-        {
-          // We assume audio is included
-          current_period_->included_types_ |= 1U << AUDIO;
-          m_audioCodec = getAudioCodec(map["CODECS"]);
-        }
-      }
-      else if (line.compare(0, 8, "#EXTINF:") == 0)
-      {
-        //Uh, this is not a multi - bitrate playlist
         current_adaptationset_ = new AdaptationSet();
         current_adaptationset_->type_ = VIDEO;
         current_adaptationset_->timescale_ = 1000000;
         current_period_->adaptationSets_.push_back(current_adaptationset_);
+      }
+      current_representation_ = new Representation();
+      current_adaptationset_->representations_.push_back(current_representation_);
+      current_representation_->timescale_ = 1000000;
+      current_representation_->codecs_ = getVideoCodec(map["CODECS"]);
+      current_representation_->bandwidth_ = atoi(map["BANDWIDTH"].c_str());
+      current_representation_->containerType_ = CONTAINERTYPE_NOTYPE;
 
-        current_representation_ = new Representation();
-        current_representation_->timescale_ = 1000000;
-        current_representation_->bandwidth_ = 0;
-        current_representation_->codecs_ = getVideoCodec("");
-        current_representation_->containerType_ = CONTAINERTYPE_NOTYPE;
-        if (!effective_url_.empty())
-          current_representation_->source_url_ = effective_url_ + "/" + effective_filename_;
-        else
-          current_representation_->source_url_ = url;
-        current_adaptationset_->representations_.push_back(current_representation_);
+      if (map.find("RESOLUTION") != map.end())
+        parseResolution(current_representation_->width_, current_representation_->height_, map["RESOLUTION"]);
 
+      if (map.find("AUDIO") != map.end())
+        m_extGroups[map["AUDIO"]].setCodec(getAudioCodec(map["CODECS"]));
+      else
+      {
         // We assume audio is included
         current_period_->included_types_ |= 1U << AUDIO;
-        m_audioCodec = getAudioCodec("");
-        break;
-      }
-      else if (!line.empty() && line.compare(0, 1, "#") != 0 && current_representation_)
-      {
-        if (line[0] == '/')
-          current_representation_->source_url_ = base_domain_ + line;
-        else if (line.find("://", 0) == std::string::npos)
-          current_representation_->source_url_ = base_url_ + line;
-        else
-          current_representation_->source_url_ = line;
-
-        if (!manifest_parameter_.empty()
-            && current_representation_->source_url_.compare(0, base_url_.size(), base_url_) == 0
-            && current_representation_->source_url_.find('?') == std::string::npos)
-          current_representation_->source_url_ += manifest_parameter_;
-
-        //Ignore duplicate reps
-        for (auto const *rep : current_adaptationset_->representations_)
-          if (rep != current_representation_ &&  rep->source_url_ == current_representation_->source_url_)
-          {
-            delete current_representation_;
-            current_representation_ = nullptr;
-            current_adaptationset_->representations_.pop_back();
-            break;
-          }
+        m_audioCodec = getAudioCodec(map["CODECS"]);
       }
     }
-
-    if (current_period_)
+    else if (line.compare(0, 8, "#EXTINF:") == 0)
     {
-      // We may need to create the Default / Dummy audio representation
-      if (!m_audioCodec.empty())
-      {
-        current_adaptationset_ = new AdaptationSet();
-        current_adaptationset_->type_ = AUDIO;
-        current_adaptationset_->timescale_ = 1000000;
-        current_period_->adaptationSets_.push_back(current_adaptationset_);
+      //Uh, this is not a multi - bitrate playlist
+      current_adaptationset_ = new AdaptationSet();
+      current_adaptationset_->type_ = VIDEO;
+      current_adaptationset_->timescale_ = 1000000;
+      current_period_->adaptationSets_.push_back(current_adaptationset_);
 
-        current_representation_ = new Representation();
-        current_representation_->timescale_ = 1000000;
-        current_representation_->codecs_ = m_audioCodec;
-        current_representation_->flags_ = Representation::INCLUDEDSTREAM;
-        current_adaptationset_->representations_.push_back(current_representation_);
-      }
+      current_representation_ = new Representation();
+      current_representation_->timescale_ = 1000000;
+      current_representation_->bandwidth_ = 0;
+      current_representation_->codecs_ = getVideoCodec("");
+      current_representation_->containerType_ = CONTAINERTYPE_NOTYPE;
+      if (!effective_url_.empty())
+        current_representation_->source_url_ = effective_url_ + "/" + effective_filename_;
+      else
+        current_representation_->source_url_ = url;
+      current_adaptationset_->representations_.push_back(current_representation_);
 
-      //Register external adaptationsets
-      for (const auto &group : m_extGroups)
-        for (auto *adp : group.second.m_sets)
-          current_period_->adaptationSets_.push_back(adp);
-      m_extGroups.clear();
-
-      SortTree();
+      // We assume audio is included
+      current_period_->included_types_ |= 1U << AUDIO;
+      m_audioCodec = getAudioCodec("");
+      break;
     }
-    // Set Live as default
-    has_timeshift_buffer_ = true;
-    update_parameter_ = "full";
-    return true;
+    else if (!line.empty() && line.compare(0, 1, "#") != 0 && current_representation_)
+    {
+      if (line[0] == '/')
+        current_representation_->source_url_ = base_domain_ + line;
+      else if (line.find("://", 0) == std::string::npos)
+        current_representation_->source_url_ = base_url_ + line;
+      else
+        current_representation_->source_url_ = line;
+
+      if (!manifest_parameter_.empty()
+          && current_representation_->source_url_.compare(0, base_url_.size(), base_url_) == 0
+          && current_representation_->source_url_.find('?') == std::string::npos)
+        current_representation_->source_url_ += manifest_parameter_;
+
+      //Ignore duplicate reps
+      for (auto const *rep : current_adaptationset_->representations_)
+        if (rep != current_representation_ &&  rep->source_url_ == current_representation_->source_url_)
+        {
+          delete current_representation_;
+          current_representation_ = nullptr;
+          current_adaptationset_->representations_.pop_back();
+          break;
+        }
+    }
   }
-  return false;
+
+  if (current_period_)
+  {
+    // We may need to create the Default / Dummy audio representation
+    if (!m_audioCodec.empty())
+    {
+      current_adaptationset_ = new AdaptationSet();
+      current_adaptationset_->type_ = AUDIO;
+      current_adaptationset_->timescale_ = 1000000;
+      current_period_->adaptationSets_.push_back(current_adaptationset_);
+
+      current_representation_ = new Representation();
+      current_representation_->timescale_ = 1000000;
+      current_representation_->codecs_ = m_audioCodec;
+      current_representation_->flags_ = Representation::INCLUDEDSTREAM;
+      current_adaptationset_->representations_.push_back(current_representation_);
+    }
+
+    //Register external adaptationsets
+    for (const auto &group : m_extGroups)
+      for (auto *adp : group.second.m_sets)
+        current_period_->adaptationSets_.push_back(adp);
+    m_extGroups.clear();
+
+    SortTree();
+  }
+  // Set Live as default
+  has_timeshift_buffer_ = true;
+  update_parameter_ = "full";
+  return true;
 }
 
 bool HLSTree::prepareRepresentation(Representation *rep, bool update)
@@ -303,6 +306,11 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
     uint32_t segmentId(rep->getCurrentSegmentNumber());
     std::stringstream stream;
     std::string download_url = rep->source_url_.c_str();
+    uint32_t per_pos = ~0ULL;
+    uint32_t adp_pos = ~0ULL;
+    uint32_t rep_pos = ~0ULL;
+    uint32_t discont_count = 0;
+    Period* starting_period = current_period_;
 
     if (!effective_url_.empty() && download_url.find(base_url_) == 0)
       download_url.replace(0, base_url_.size(), effective_url_);
@@ -428,6 +436,52 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
           if (newInterval < updateInterval_)
             updateInterval_ = newInterval;
         }
+        else if (line.compare(0, 21, "#EXT-X-DISCONTINUITY") == 0)
+        {
+          if (newSegments.size() == 0)
+            continue;
+          current_period_->duration_ = pts - newSegments[0]->startPTS_;
+          if (!byteRange)
+            rep->flags_ |= Representation::URLSEGMENTS;
+          if (rep->containerType_ == CONTAINERTYPE_MP4 && byteRange && newSegments.data[0].range_begin_ > 0)
+          {
+            rep->flags_ |= Representation::INITIALIZATION;
+            rep->initialization_.range_begin_ = 0;
+            rep->initialization_.range_end_ = newSegments.data[0].range_begin_ - 1;
+            rep->initialization_.pssh_set_ = 0;
+          }
+          FreeSegments(rep);
+          rep->segments_.swap(newSegments);
+          rep->startNumber_ = newStartNumber;
+
+          if (segmentInitialization)
+            std::swap(rep->initialization_, newInitialization);
+
+          if (periods_.size() == ++discont_count)
+          {
+            manifest_stream.clear();
+            manifest_stream.seekg(0);
+            processManifest(manifest_stream, manifest_url_);
+          }
+          else
+            current_period_ = periods_[discont_count];
+          if (!(~per_pos))
+            for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep; ++bp)
+              for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea; ++ba)
+                for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()), er((*ba)->representations_.end()); br != er; ++br)
+                  if (rep == *br)
+                  {
+                    per_pos = bp - periods_.begin();
+                    adp_pos = ba - (*bp)->adaptationSets_.begin();
+                    rep_pos = br - (*ba)->representations_.begin();
+                    break;
+                  }
+          rep = current_period_->adaptationSets_[adp_pos]->representations_[rep_pos];
+          segment.range_begin_ = ~0ULL;
+          segment.range_end_ = 0;
+          segment.startPTS_ = ~0ULL;
+          segment.pssh_set_ = 0;
+        }
         else if (line.compare(0, 11, "#EXT-X-KEY:") == 0)
         {
           if (!rep->pssh_set_)
@@ -489,8 +543,18 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
           }
         }
       }
-
-      overallSeconds_ = newSegments[0] ? (pts - newSegments[0]->startPTS_) / rep->timescale_ : 0;
+      if (discont_count)
+      {
+        periods_[discont_count]->duration_ = pts - newSegments[0]->startPTS_;
+        overallSeconds_ = 0;
+        for (auto p : periods_)
+          overallSeconds_ += p->duration_ / p->timescale_;
+        current_period_ = starting_period;
+        current_adaptationset_ = current_period_->adaptationSets_[adp_pos];
+        current_representation_ = current_adaptationset_->representations_[rep_pos];
+      }
+      else
+        overallSeconds_ = newSegments[0] ? (pts - newSegments[0]->startPTS_) / rep->timescale_ : 0;
 
       if (!byteRange)
         rep->flags_ |= Representation::URLSEGMENTS;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -481,6 +481,8 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
           segment.range_end_ = 0;
           segment.startPTS_ = ~0ULL;
           segment.pssh_set_ = 0;
+          newStartNumber = 0;
+          pts = 0;
         }
         else if (line.compare(0, 11, "#EXT-X-KEY:") == 0)
         {

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -549,9 +549,6 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
         overallSeconds_ = 0;
         for (auto p : periods_)
           overallSeconds_ += p->duration_ / p->timescale_;
-        current_period_ = starting_period;
-        current_adaptationset_ = current_period_->adaptationSets_[adp_pos];
-        current_representation_ = current_adaptationset_->representations_[rep_pos];
       }
       else
         overallSeconds_ = newSegments[0] ? (pts - newSegments[0]->startPTS_) / rep->timescale_ : 0;
@@ -581,6 +578,13 @@ bool HLSTree::prepareRepresentation(Representation *rep, bool update)
 
       if (segmentInitialization)
         std::swap(rep->initialization_, newInitialization);
+
+      if (discont_count)
+      {
+        current_period_ = starting_period;
+        current_adaptationset_ = current_period_->adaptationSets_[adp_pos];
+        current_representation_ = current_adaptationset_->representations_[rep_pos];
+      }
     }
 
     if (update)

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -38,6 +38,7 @@ namespace adaptive
     virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) override;
     virtual void OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize) override;
     virtual void RefreshSegments(Representation *rep, StreamType type) override;
+    virtual bool processManifest(std::stringstream& stream, const std::string &url);
 
   protected:
     virtual void RefreshSegments() override;
@@ -65,6 +66,7 @@ namespace adaptive
     bool m_refreshPlayList = true;
     uint8_t m_segmentIntervalSec = 4;
     AESDecrypter *m_decrypter;
+    std::stringstream manifest_stream;
   };
 
 } // namespace


### PR DESCRIPTION
Hi @peak3d 

The #EXT-X-DISCONTINUITY tags are handled this way:
* Close off the current representation (freeSegments, swap newsegments etc.) and set period duration
* Add a new period (re-use master manifest to set up) if there isn't one already from preparation of other representations
* use the index of our current rep/adp to ensure we keep working on the same rep in the new period

Apologies for the large diff.

With HLS a 'period' differs from DASH since it is defined within a representation/adaptationset, therefore each period should contain an identical amount of adaptationsets with an identical amount of representations. So my solution is to copy the adaptationset/representations to each new period.

I thought the easiest and safest way to deep-copy the periods is to just re-parse the master manifest. To avoid downloading the manifest each time I split the functions, producing the pretty sizable diff. 

To help you read it, in processManifest the changes are at the top of the funtion (no changes after `std::map<std::string, std::string> map;`)

A small test strm file:
```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
https://stream.test.theplatform.com/nbc/cmaf/master-24fps.m3u8
```
Seeking works well with fmp4, however seeking in TS seems to seek to the PTS of the TS stream i.e if there's a 25 minute program with a 5 minute ad inserted at 10:00, seeking to 17:00 will land the player at 22:00 (17:00 of the show that we're watching but not what would be expected behavior I assume)

Thanks for your time

Glenn