### PR TITLE
Fix for manual stream changing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3428,7 +3428,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       if (m_IncludedStreams[i])
       {
         stream->reader_->AddStreamType(static_cast<INPUTSTREAM_INFO::STREAM_TYPE>(i), m_IncludedStreams[i]);
-        stream->reader_->GetInformation(m_session->GetStream(m_IncludedStreams[i])->info_);
+        stream->reader_->GetInformation(m_session->GetStream(m_IncludedStreams[i] - m_session->GetChapter() * 1000)->info_);
       }
   }
   m_session->EnableStream(stream, true);


### PR DESCRIPTION
Hi @peak3d

I noticed in my testing for #374 that manually choosing another stream during playback causes a crash (m_IncludedStreams[2] for eg. would be 1007) - this PR addresses that.