### PR TITLE
Ensure seeking to zero does not wrap around

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2754,10 +2754,10 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
   {
     seekTimeCorrected += timing_stream_->stream_.GetAbsolutePTSOffset();
     int64_t ptsDiff = timing_stream_->reader_->GetPTSDiff();
-    if (ptsDiff < 0 && seekTimeCorrected + ptsDiff < seekTimeCorrected)
-      seekTimeCorrected += ptsDiff;
-    else
+    if (ptsDiff < 0 && seekTimeCorrected + ptsDiff > seekTimeCorrected)
       seekTimeCorrected = 0;
+    else
+      seekTimeCorrected += ptsDiff;
 
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2753,7 +2753,12 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
   if (timing_stream_)
   {
     seekTimeCorrected += timing_stream_->stream_.GetAbsolutePTSOffset();
-    seekTimeCorrected += timing_stream_->reader_->GetPTSDiff();
+    int64_t ptsDiff = timing_stream_->reader_->GetPTSDiff();
+    if (ptsDiff < 0 && seekTimeCorrected + ptsDiff < seekTimeCorrected)
+      seekTimeCorrected += ptsDiff;
+    else
+      seekTimeCorrected = 0;
+
   }
 
   for (std::vector<STREAM*>::const_iterator b(streams_.begin()), e(streams_.end()); b != e; ++b)


### PR DESCRIPTION
Hi @peak3d 

reader_->GetPTSDiff can return a negative number and seek to or near zero will cause the adaptivestream to download every segment available in the tree (I think it must be looking for the right PTS?), playback pauses until this has finished and hangs on pressing the stop key.

I'm not sure this is an issue for fmp4 but definitely for ts streams.

Stream used for testing:
```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8
```

You can reproduce by starting the stream and pressing down (seeking backwards by pressing left doesn't allow you to easily seek to zero)

Thanks to @matthuisman for finding and investigating this issue
