### PR TITLE
WebVTT fix for multiple rlm lrm in the same string

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -174,22 +174,31 @@ std::string b64_encode(unsigned char const* in, unsigned int in_len, bool urlEnc
 
 bool replace(std::string& s, const std::string& from, const std::string& to)
 {
-    size_t start_pos = s.find(from);
-    if (start_pos == std::string::npos)
-        return false;
-    s.replace(start_pos, from.length(), to);
-    return true;
+  size_t start_pos = s.find(from);
+  if (start_pos == std::string::npos)
+    return false;
+  s.replace(start_pos, from.length(), to);
+  return true;
 }
 
-void replaceAll(std::string& s, const std::string& from, const std::string& to)
+void replaceAll(std::string& s, const std::string& from, const std::string& to, bool nextEmpty)
 {
-    if (from.empty())
-        return;
-    size_t pos = 0;
-    while ((pos = s.find(from, pos)) != std::string::npos) {
-        s.replace(pos, from.length(), to);
-        pos += to.length();
+  if (from.empty())
+    return;
+  size_t pos = 0;
+  bool isFirstReplaced = false;
+  while ((pos = s.find(from, pos)) != std::string::npos) {
+    if (isFirstReplaced)
+    {
+      s.replace(pos, from.length(), "");
+      isFirstReplaced = true;
     }
+    else
+    {
+      s.replace(pos, from.length(), to);
+      pos += to.length();
+    }
+  }
 }
 
 std::vector<std::string> split(const std::string& s, char seperator)

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -31,7 +31,7 @@ std::string ToDecimal(const uint8_t *data, size_t data_size);
 std::string b64_encode(unsigned char const* in, unsigned int in_len, bool urlEncode);
 
 bool replace(std::string& s, const std::string& from, const std::string& to);
-void replaceAll(std::string& s, const std::string& from, const std::string& to);
+void replaceAll(std::string& s, const std::string& from, const std::string& to, bool nextEmpty);
 
 std::vector<std::string> split(const std::string& s, char seperator);
 

--- a/src/parser/WebVTT.cpp
+++ b/src/parser/WebVTT.cpp
@@ -112,8 +112,8 @@ bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t b
           strText = std::string(cbuf, next - cbuf);
           if (!strText.empty() && strText.back() == '\r')
             strText.resize(strText.size() - 1);
-          replace(strText, "&lrm;", "\xE2\x80\xAA");
-          replace(strText, "&rlm;", "\xE2\x80\xAB");
+          replaceAll(strText, "&lrm;", "\xE2\x80\xAA", true);
+          replaceAll(strText, "&rlm;", "\xE2\x80\xAB", true);
           if (!strText.empty())
             m_subTitles.back().text.push_back(strText);
           else


### PR DESCRIPTION
When netflix assigns some style to the text it also includes the orientation string, unfortunately the previous fix does not remove the remaining encodings string

Example:
`<c.bg_transparent><i>&lrm;Mândrie și prejudecată,</i></c.bg_transparent><c.bg_transparent>&lrm; nu?</c.bg_transparent>`

Locke & Key Season 1 ep.4
![image](https://user-images.githubusercontent.com/3257156/74104983-1cc47b80-4b5a-11ea-8210-9e3a14a38621.png)

In this case it should be maintained only at the beginning and the others removed

After the fix:
![image](https://user-images.githubusercontent.com/3257156/74105076-00750e80-4b5b-11ea-8228-ee1292c286d8.png)
