### PR TITLE
HLS Widevine

### DIFF
--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -30,6 +30,12 @@ namespace adaptive
   class HLSTree : public AdaptiveTree
   {
   public:
+    enum
+    {
+      ENCRYPTIONTYPE_CLEAR = 0,
+      ENCRYPTIONTYPE_AES128 = 1,
+      ENCRYPTIONTYPE_WIDEVINE = 2
+    };
     HLSTree(AESDecrypter *decrypter) : AdaptiveTree(), m_decrypter(decrypter) {};
     virtual ~HLSTree();
 


### PR DESCRIPTION
Hi @peak3d 

This will address #353 

A test strm: 
```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://cwip-shaka-proxy.appspot.com/no_auth||R{SSM}|
https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine-hls/hls.m3u8
```
As part of these changes EXT-X-MAP and EXT-X-KEY values now persist into the next period/discontinuity as this is a requirement in HLS spec. The test stream above requires this as the first two segments are in clear, then the encryption begins. There is a discontinuity tag however the initialization segment remains the same - there is no new map tag.

The EXT-X-SESSION-KEY in the master manifest will allow the SSD to be set up in `Session::initialize` (at this time we have not yet read a variant stream and any EXT-X-KEY values in it)
As the EXT-X-SESSION-KEY is only optional in HLS spec, master playlists without it will not play. I have working code to allow for this but thought it should be left for a separate PR. I haven't found any examples of HLS/Widevine that don't contain the session key tag so far.

Apart from the test stream above, the only other example of HLS/Widevine I could find is the Disney+ streams (there is a link to master/variant stream example for this in #353 ).

One issue that I have observed: *edit - disregard, @michaelarnauts pointed out this was an exisiting issue not to do with this PR*
~~In the above example strm when transitioning from period 1 to period 2 the video halts while audio continues to play for approx 8 seconds and then the audio halts while the video plays for approx 8 seconds, then playback continues normally. The OSD timeline in Kodi also shows some weird behaviour with the now marker and buffer jumping forwards briefly then backwards. This also happens in the Disney stream where all periods are encrypted, however the correction is quicker (maybe related to segment length). I'm unable to test if this is the case in DASH/Widevine, the only multiperiod mpd I've found has very poor bandwidth/buffering issues.~~

Thanks for your time.

@matthuisman would you like to test this when you get a chance?