### PR TITLE
Various translation fixes

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.de_de/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.de_de/strings.po
@@ -103,3 +103,7 @@ msgstr "Video"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Manuelles Video"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.el_gr/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.el_gr/strings.po
@@ -66,19 +66,19 @@ msgstr "Μέγιστο"
 
 msgctxt "#30151"
 msgid "480p"
-msgstr ""
+msgstr "480p"
 
 msgctxt "#30152"
 msgid "640p"
-msgstr ""
+msgstr "640p"
 
 msgctxt "#30153"
 msgid "720p"
-msgstr ""
+msgstr "720p"
 
 msgctxt "#30154"
 msgid "1080p"
-msgstr ""
+msgstr "1080p"
 
 msgctxt "#30155"
 msgid "Auto"
@@ -103,3 +103,7 @@ msgstr "Βίντεο"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Δείξε όλες τις ροές βίντεο"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -16,41 +16,48 @@ msgctxt "#30100"
 msgid "General"
 msgstr ""
 
+# The minimum bandwidth which should not be deceeded.
 msgctxt "#30101"
 msgid "Min. Bandwidth (Bit/s)"
-msgstr "The minimum bandwidth which should not be deceeded."
+msgstr ""
 
+# The maximum bandwidth which should not be exceeded. 0=unlimited
 msgctxt "#30102"
 msgid "Max. Bandwidth (Bit/s)"
-msgstr "The maximum bandwidth which should not be exeeded. 0=unlimited"
+msgstr ""
 
+# Absolute path to the folder containing the decrypters
 msgctxt "#30103"
 msgid "Decrypter path"
-msgstr "Absolute path to the folder containing the decrypters"
+msgstr ""
 
+# Maximum Resolution
 msgctxt "#30110"
 msgid "Max. Resolution general decoder"
-msgstr "Maximum Resolution"
+msgstr ""
 
 msgctxt "#30111"
 msgid "Stream Selection"
-msgstr "Stream Selection"
+msgstr ""
 
 msgctxt "#30112"
 msgid "Media"
-msgstr "Media"
+msgstr ""
 
+# Maximum allowed resolution if decoded through secure path
 msgctxt "#30113"
 msgid "Max. Resolution secure decoder"
-msgstr "Maximum allowed resolution if decoded through secure path"
+msgstr ""
 
+# Select streams without respecting HDCP status
 msgctxt "#30114"
 msgid "Override HDCP status"
-msgstr "Select streams without respecting HDCP status"
+msgstr ""
 
+# Do not respect display resolution when selecting streams
 msgctxt "#30115"
 msgid "Ignore Display Resolution"
-msgstr "Do not respect display resolution when selecting streams"
+msgstr ""
 
 msgctxt "#30120"
 msgid "Expert"
@@ -100,9 +107,10 @@ msgctxt "#30159"
 msgid "Video"
 msgstr ""
 
+# Show all video streams
 msgctxt "#30160"
 msgid "Manual video"
-msgstr "Show all video streams"
+msgstr ""
 
 msgctxt "#30161"
 msgid "Video + Subtitles"

--- a/inputstream.adaptive/resources/language/resource.language.es_es/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.es_es/strings.po
@@ -99,3 +99,11 @@ msgstr "Audio"
 msgctxt "#30159"
 msgid "Video"
 msgstr "Vídeo"
+
+msgctxt "#30160"
+msgid "Manual video"
+msgstr ""
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.fr_fr/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.fr_fr/strings.po
@@ -26,7 +26,6 @@ msgstr "La bande passante maximale qui ne devrait pas être dépassée. 0=illimi
 
 msgctxt "#30103"
 msgid "Decrypter path"
-msgstr "Absolute path to the folder containing the decrypters"
 msgstr "Chemin absolu du répertoire contenant le décodeur"
 
 msgctxt "#30110"
@@ -51,7 +50,6 @@ msgstr "Sélection du flux sans tenir compte du status HDCP"
 
 msgctxt "#30115"
 msgid "Ignore Display Resolution"
-msgstr "Do not respect display resolution when selecting streams"
 msgstr "Ne pas tenir compte de la résolution d'écran lors de la sélection du flux"
 
 msgctxt "#30120"
@@ -105,3 +103,7 @@ msgstr "Vidéo"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Montrer tous les flux vidéo"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.hr_hr/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.hr_hr/strings.po
@@ -101,3 +101,7 @@ msgstr "Video"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Ručni video"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.hu_hu/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.hu_hu/strings.po
@@ -65,19 +65,19 @@ msgstr "Max"
 
 msgctxt "#30151"
 msgid "480p"
-msgstr ""
+msgstr "480p"
 
 msgctxt "#30152"
 msgid "640p"
-msgstr ""
+msgstr "640p"
 
 msgctxt "#30153"
 msgid "720p"
-msgstr ""
+msgstr "720p"
 
 msgctxt "#30154"
 msgid "1080p"
-msgstr ""
+msgstr "1080p"
 
 msgctxt "#30155"
 msgid "Auto"
@@ -106,4 +106,3 @@ msgstr "Minden videó stream mutatása"
 msgctxt "#30161"
 msgid "Video + Subtitles"
 msgstr "Videó + feliratok"
-

--- a/inputstream.adaptive/resources/language/resource.language.it_it/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.it_it/strings.po
@@ -66,19 +66,19 @@ msgstr "Massima"
 
 msgctxt "#30151"
 msgid "480p"
-msgstr ""
+msgstr "480p"
 
 msgctxt "#30152"
 msgid "640p"
-msgstr ""
+msgstr "640p"
 
 msgctxt "#30153"
 msgid "720p"
-msgstr ""
+msgstr "720p"
 
 msgctxt "#30154"
 msgid "1080p"
-msgstr ""
+msgstr "1080p"
 
 msgctxt "#30155"
 msgid "Auto"
@@ -103,3 +103,7 @@ msgstr "Solo video"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Manuale (solo per video)"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.ja_JP/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.ja_JP/strings.po
@@ -103,3 +103,7 @@ msgstr "ビデオ"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "ビデオ手動選択"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.ko_KR/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.ko_KR/strings.po
@@ -103,3 +103,7 @@ msgstr "비디오"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "비디오 수동선택"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.nl_nl/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.nl_nl/strings.po
@@ -103,3 +103,7 @@ msgstr "Video"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Video (handmatig)"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr "Video + ondertiteling"

--- a/inputstream.adaptive/resources/language/resource.language.pl_pl/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.pl_pl/strings.po
@@ -103,3 +103,7 @@ msgstr "Video"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Ręcznie video"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.ru_ru/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.ru_ru/strings.po
@@ -1,4 +1,4 @@
-﻿# Kodi Media Center language file
+# Kodi Media Center language file
 # Addon Name: Inputstream.adaptive
 # Addon id: inputstream.adaptive
 # Addon Provider: peak3d
@@ -66,19 +66,19 @@ msgstr "Макс"
 
 msgctxt "#30151"
 msgid "480p"
-msgstr ""
+msgstr "480p"
 
 msgctxt "#30152"
 msgid "640p"
-msgstr ""
+msgstr "640p"
 
 msgctxt "#30153"
 msgid "720p"
-msgstr ""
+msgstr "720p"
 
 msgctxt "#30154"
 msgid "1080p"
-msgstr ""
+msgstr "1080p"
 
 msgctxt "#30155"
 msgid "Auto"
@@ -103,3 +103,7 @@ msgstr "Видео"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Видео вручную"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.sv_se/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.sv_se/strings.po
@@ -94,3 +94,7 @@ msgstr "Video"
 msgctxt "#30160"
 msgid "Manual video"
 msgstr "Manuell video"
+
+msgctxt "#30161"
+msgid "Video + Subtitles"
+msgstr ""


### PR DESCRIPTION
This PR includes:
- Translations for strings that were expected to be identical
- Add missing strings to most languages
- Translate untranslated strings for Dutch
- Remove BOM from Russian translation
- Fix syntax errors in French translation
- Remove unused/incorrect English `msgstr` entries