### PR TITLE
Matrix Inputstream API change to v2.1.0 - Adaptive version 2.5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,45 @@
 # build artifacts
-./build/
+build/
+inputstream.*/addon.xml
+
+# Debian build files
 debian/changelog
 debian/files
-debian/kodi-inputstream-mpd-dbg.debhelper.log
-debian/kodi-inputstream-mpd-dbg.substvars
-debian/kodi-inputstream-mpd-dbg/
-debian/kodi-inputstream-mpd.debhelper.log
-debian/kodi-inputstream-mpd.postinst.debhelper
-debian/kodi-inputstream-mpd.postrm.debhelper
-debian/kodi-inputstream-mpd.substvars
-debian/kodi-inputstream-mpd/
+debian/*.log
+debian/*.substvars
+debian/.debhelper/
 debian/tmp/
+debian/kodi-pvr-*/
 obj-x86_64-linux-gnu/
-inputstream.adaptive/addon.xml
-inputstream.adaptive/resources/settings.xml
+
+# commonly used editors
+# vim
+*.swp
+
+# Eclipse
+*.project
+*.cproject
+.classpath
+*.sublime-*
+.settings/
+
+# KDevelop 4
+*.kdev4
+
+# gedit
+*~
+
+# CLion
+/.idea
 
 # clion
 .idea/
 
-# Eclipse/CDT
-.cproject
-.project
-.settings/
+# to prevent add after a "git format-patch VALUE" and "git add ." call
+/*.patch
+
+# Visual Studio Code
+.vscode
+
+# to prevent add if project code opened by Visual Studio over CMake file
+.vs/

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.5.4"
+  version="2.5.5"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -17,6 +17,10 @@
     <description lang="en">InputStream client for adaptive streams</description>
     <platform>@PLATFORM@</platform>
 	<news>
+v2.5.5 (2020-04-06)
+- Matrix API change - Remove CanPauseSteram() and CanSeekStream()
+- Update .gitignore
+
 v2.5.4 (2020-01-19)
 - [HLS] url based initialization segment
 - [DASH] Use effective URL for manifest update

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3011,8 +3011,6 @@ public:
   bool PosTime(int ms) override;
   int GetTotalTime() override;
   int GetTime() override;
-  bool CanPauseStream() override;
-  bool CanSeekStream() override;
   bool IsRealTimeStream() override;
 
 #if INPUTSTREAM_VERSION_LEVEL > 1
@@ -3561,16 +3559,6 @@ int CInputStreamAdaptive::GetTime()
 
   int timeMs = static_cast<int>(m_session->GetElapsedTimeMs());
   return timeMs;
-}
-
-bool CInputStreamAdaptive::CanPauseStream(void)
-{
-  return true;
-}
-
-bool CInputStreamAdaptive::CanSeekStream(void)
-{
-  return m_session && !m_session->IsLive();
 }
 
 bool CInputStreamAdaptive::IsRealTimeStream()


### PR DESCRIPTION
Minor API update to remove 2 unused function calls, modify PauseStream signature and increase num stream properties allowed in inputstream addons.

Kodi PR: https://github.com/xbmc/xbmc/pull/17620

Do not merge yet.