### PR TITLE
[HLS] set pssh media type for widevine

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '(["/]PlatformDefs|"(system|system_gl))\.h"'
+    Priority:        5
+  - Regex:           '"platform/[^/]+/'
+    Priority:        2
+  - Regex:           '^<[a-z0-9_]+>$'
+    Priority:        3
+  - Regex:           '^<(assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>$'
+    Priority:        3
+  - Regex:           '^<'
+    Priority:        4
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60000
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -104,7 +104,7 @@ int AdaptiveStream::SecondsSinceUpdate() const
   return static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - tPoint).count());
 }
 
-int AdaptiveStream::SecondsSinceMediaRenewal() const
+uint32_t AdaptiveStream::SecondsSinceMediaRenewal() const
 {
   const std::chrono::time_point<std::chrono::system_clock> &tPoint(lastMediaRenewal_ > tree_.GetLastMediaRenewal() ? lastMediaRenewal_ : tree_.GetLastMediaRenewal());
   return static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - tPoint).count());

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -84,7 +84,7 @@ namespace adaptive
     const std::string& getMediaRenewalUrl() const { return tree_.media_renewal_url_; };
     const uint32_t& getMediaRenewalTime() const { return tree_.media_renewal_time_; };
     std::string buildDownloadUrl(const std::string &url);
-    int SecondsSinceMediaRenewal() const;
+    uint32_t SecondsSinceMediaRenewal() const;
     void UpdateSecondsSinceMediaRenewal();
   private:
     // Segment download section

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -198,6 +198,82 @@ namespace adaptive
       return current_period_->InsertPSSHSet(nullptr);
   }
 
+  void AdaptiveTree::Representation::CopyBasicData(Representation* src)
+  {
+    url_ = src->url_;
+    id = src->id;
+    codecs_ = src->codecs_;
+    codec_private_data_ = src->codec_private_data_;
+    source_url_ = src->source_url_;
+    bandwidth_ = src->bandwidth_;
+    samplingRate_ = src->samplingRate_;
+    width_ = src->width_;
+    height_ = src->height_;
+    fpsRate_ = src->fpsRate_;
+    aspect_ = src->aspect_;
+    flags_ = src->flags_;
+    hdcpVersion_ = src->hdcpVersion_;
+    channelCount_ = src->channelCount_;
+    nalLengthSize_ = src->nalLengthSize_;
+    containerType_ = src->containerType_;
+    timescale_ = src->timescale_;
+    timescale_ext_ = src->timescale_ext_;
+    timescale_int_ = src->timescale_int_;
+  }
+
+  void AdaptiveTree::AdaptationSet::CopyBasicData(AdaptiveTree::AdaptationSet* src)
+  {
+    representations_.resize(src->representations_.size());
+    auto itRep = src->representations_.begin();
+    for (Representation*& rep : representations_)
+    {
+      rep = new Representation();
+      rep->CopyBasicData(*itRep++);
+    }
+
+    type_ = src->type_;
+    timescale_ = src->timescale_;
+    duration_ = src->duration_;
+    startPTS_ = src->startPTS_;
+    startNumber_ = src->startNumber_;
+    impaired_ = src->impaired_;
+    original_ = src->original_;
+    default_ = src->default_;
+    forced_ = src->forced_;
+    language_ = src->language_;
+    mimeType_ = src->mimeType_;
+    base_url_ = src->base_url_;
+    id_ = src->id_;
+    group_ = src->group_;
+    codecs_ = src->codecs_;
+    audio_track_id_ = src->audio_track_id_;
+    name_ = src->name_;
+  }
+
+  // Create a HLS master playlist copy (no representations)
+  void AdaptiveTree::Period::CopyBasicData(AdaptiveTree::Period* period)
+  {
+    adaptationSets_.resize(period->adaptationSets_.size());
+    auto itAdp = period->adaptationSets_.begin();
+    for (AdaptationSet*& adp : adaptationSets_)
+    {
+      adp = new AdaptationSet();
+      adp->CopyBasicData(*itAdp++);
+    }
+
+    base_url_ = period->base_url_;
+    id_ = period->id_;
+    timescale_ = period->timescale_;
+    startNumber_ = period->startNumber_;
+
+    start_ = period->start_;
+    startPTS_ = period->startPTS_;
+    duration_ = period->duration_;
+    encryptionState_ = period->encryptionState_;
+    included_types_ = period->included_types_;
+    need_secure_decoder_ = period->need_secure_decoder_;
+  }
+
   uint16_t AdaptiveTree::Period::InsertPSSHSet(PSSH* pssh)
   {
     if (pssh)

--- a/src/main.h
+++ b/src/main.h
@@ -96,7 +96,8 @@ public:
     const char *ov_audio,
     bool play_timeshift_buffer);
   virtual ~Session();
-  bool initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
+  bool Initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
+  bool InitializeDRM();
   bool InitializePeriod();
   SampleReader *GetNextSample();
 

--- a/src/main.h
+++ b/src/main.h
@@ -94,7 +94,8 @@ public:
     uint16_t display_width,
     uint16_t display_height,
     const char *ov_audio,
-    bool play_timeshift_buffer);
+    bool play_timeshift_buffer,
+    bool force_secure_decoder);
   virtual ~Session();
   bool Initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
   bool InitializeDRM();
@@ -131,7 +132,7 @@ public:
   };
 
   void UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &caps);
-  AP4_Movie *PrepareStream(STREAM *stream);
+  AP4_Movie *PrepareStream(STREAM *stream, bool& needRefetch);
 
   STREAM* GetStream(unsigned int sid)const { return sid - 1 < streams_.size() ? streams_[sid - 1] : 0; };
   void EnableStream(STREAM* stream, bool enable);
@@ -214,4 +215,5 @@ private:
   uint8_t drmConfig_;
   bool ignore_display_;
   bool play_timeshift_buffer_;
+  bool force_secure_decoder_;
 };

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -337,10 +337,9 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string &url)
           return false;
         case ENCRYPTIONTYPE_AES128:
         case ENCRYPTIONTYPE_WIDEVINE:
-          master_encryption_type_ = encryption_type;
-          master_pssh_ = current_pssh_;
-          master_defaultKID_ = current_defaultKID_;
-          master_iv_ = current_iv_;
+          // #EXT-X-SESSION-KEY is meant for preparing DRM without
+          // loading sub-playlist. As long our workfow is serial, we
+          // don't profite and therefore do not any action.
           break;
         default:;
       }
@@ -420,17 +419,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Representation* rep, bool
       uint64_t pts(0);
       newStartNumber = 0;
 
-      uint32_t currentEncryptionType = master_encryption_type_;
-      current_pssh_ = master_pssh_;
-      current_defaultKID_ = master_defaultKID_;
-      current_iv_ = master_iv_;
-      if (currentEncryptionType == ENCRYPTIONTYPE_WIDEVINE)
-      {
-        rep->pssh_set_ = insert_psshset(NOTYPE);
-        current_period_->encryptionState_ |= ENCRYTIONSTATE_SUPPORTED;
-        if (current_period_->psshSets_[rep->pssh_set_].use_count_ == 1)
-          retVal = PREPARE_RESULT_DRMCHANGED;
-      }
+      uint32_t currentEncryptionType = ENCRYPTIONTYPE_CLEAR;
 
       segment.range_begin_ = ~0ULL;
       segment.range_end_ = 0;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -586,7 +586,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Representation* rep, bool
 
           if (currentEncryptionType == ENCRYPTIONTYPE_WIDEVINE)
           {
-            rep->pssh_set_ = insert_psshset(NOTYPE);
+            rep->pssh_set_ = insert_psshset(current_adaptationset_->type_);
             current_period_->encryptionState_ |= ENCRYTIONSTATE_SUPPORTED;
           }
 
@@ -609,7 +609,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Representation* rep, bool
             case ENCRYPTIONTYPE_WIDEVINE:
               currentEncryptionType = ENCRYPTIONTYPE_WIDEVINE;
               current_period_->encryptionState_ |= ENCRYTIONSTATE_SUPPORTED;
-              rep->pssh_set_ = insert_psshset(NOTYPE);
+              rep->pssh_set_ = insert_psshset(current_adaptationset_->type_);
               if (current_period_->psshSets_[rep->pssh_set_].use_count_ == 1)
                 retVal = PREPARE_RESULT_DRMCHANGED;
               break;

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -76,10 +76,6 @@ namespace adaptive
     uint8_t m_segmentIntervalSec = 4;
     AESDecrypter *m_decrypter;
     std::stringstream manifest_stream;
-    uint32_t master_encryption_type_ = ENCRYPTIONTYPE_UNKNOWN;
-    std::string master_pssh_;
-    std::string master_defaultKID_;
-    std::string master_iv_;
   };
 
 } // namespace

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -32,15 +32,17 @@ namespace adaptive
   public:
     enum
     {
-      ENCRYPTIONTYPE_CLEAR = 0,
-      ENCRYPTIONTYPE_AES128 = 1,
-      ENCRYPTIONTYPE_WIDEVINE = 2
+      ENCRYPTIONTYPE_INVALID = 0,
+      ENCRYPTIONTYPE_CLEAR = 1,
+      ENCRYPTIONTYPE_AES128 = 2,
+      ENCRYPTIONTYPE_WIDEVINE = 3,
+      ENCRYPTIONTYPE_UNKNOWN = 4,
     };
     HLSTree(AESDecrypter *decrypter) : AdaptiveTree(), m_decrypter(decrypter) {};
     virtual ~HLSTree();
 
     virtual bool open(const std::string &url, const std::string &manifestUpdateParam) override;
-    virtual bool prepareRepresentation(Representation *rep, bool update = false) override;
+    virtual PREPARE_RESULT prepareRepresentation(Representation* rep, bool update = false) override;
     virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) override;
     virtual void OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize) override;
     virtual void RefreshSegments(Representation *rep, StreamType type) override;
@@ -50,6 +52,7 @@ namespace adaptive
     virtual void RefreshSegments() override;
 
   private:
+    int processEncryption(std::string baseUrl, std::map<std::string, std::string>& map);
     std::string m_audioCodec;
 
     struct EXTGROUP
@@ -73,6 +76,10 @@ namespace adaptive
     uint8_t m_segmentIntervalSec = 4;
     AESDecrypter *m_decrypter;
     std::stringstream manifest_stream;
+    uint32_t master_encryption_type_ = ENCRYPTIONTYPE_UNKNOWN;
+    std::string master_pssh_;
+    std::string master_defaultKID_;
+    std::string master_iv_;
   };
 
 } // namespace


### PR DESCRIPTION
Fixes crashing when playing hls streams with encrypted video AND audio with the same PSSH

Was not included in #395 as the workflow with EXT-X-SESSION-KEY was causing an extra psshset to be added -> crash when switching streams