### PR TITLE
Fix for HLS playlists with valid encryption after non-valid encryption and cosmetics

### DIFF
--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -35,7 +35,7 @@ namespace SSD
     virtual bool CURLOpen(void* file) = 0;
     virtual size_t ReadFile(void* file, void* lpBuf, size_t uiBufSize) = 0;
     virtual void CloseFile(void* file) = 0;
-    virtual bool CreateDirectory(const char *dir) = 0;
+    virtual bool CreateDir(const char* dir) = 0;
     virtual bool GetBuffer(void* instance, SSD_PICTURE &picture) = 0;
     virtual void ReleaseBuffer(void* instance, void *buffer) = 0;
 

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -43,10 +43,15 @@ namespace adaptive
     AdaptiveStream(AdaptiveTree &tree, AdaptiveTree::StreamType type);
     virtual ~AdaptiveStream();
     void set_observer(AdaptiveStreamObserver *observer){ observer_ = observer; };
-    bool prepare_stream(const AdaptiveTree::AdaptationSet *adp,
-      const uint32_t width, const uint32_t height, uint32_t hdcpLimit, uint16_t hdcpVersion,
-      uint32_t min_bandwidth, uint32_t max_bandwidth, unsigned int repId,
-      const std::map<std::string, std::string> &media_headers);
+    bool prepare_stream(AdaptiveTree::AdaptationSet* adp,
+                        const uint32_t width,
+                        const uint32_t height,
+                        uint32_t hdcpLimit,
+                        uint16_t hdcpVersion,
+                        uint32_t min_bandwidth,
+                        uint32_t max_bandwidth,
+                        unsigned int repId,
+                        const std::map<std::string, std::string>& media_headers);
     bool start_stream(const uint32_t seg_offset, uint16_t width, uint16_t height, bool play_timeshift_buffer);
     bool restart_stream();
     bool select_stream(bool force = false, bool justInit = false, unsigned int repId = 0);
@@ -64,9 +69,11 @@ namespace adaptive
     uint32_t read(void* buffer, uint32_t  bytesToRead);
     uint64_t tell(){ read(0, 0);  return absolute_position_; };
     bool seek(uint64_t const pos);
+    bool getSize(unsigned long long& sz);
     bool seek_time(double seek_seconds, bool preceeding, bool &needReset);
-    AdaptiveTree::AdaptationSet const *getAdaptationSet() { return current_adp_; };
-    AdaptiveTree::Representation const *getRepresentation(){ return current_rep_; };
+    AdaptiveTree::Period* getPeriod() { return current_period_; };
+    AdaptiveTree::AdaptationSet* getAdaptationSet() { return current_adp_; };
+    AdaptiveTree::Representation* getRepresentation() { return current_rep_; };
     double get_download_speed() const { return tree_.get_download_speed(); };
     void set_download_speed(double speed) { tree_.set_download_speed(speed); };
     size_t getSegmentPos() { return current_rep_->getCurrentSegmentPos(); };
@@ -84,7 +91,7 @@ namespace adaptive
     const std::string& getMediaRenewalUrl() const { return tree_.media_renewal_url_; };
     const uint32_t& getMediaRenewalTime() const { return tree_.media_renewal_time_; };
     std::string buildDownloadUrl(const std::string &url);
-    int SecondsSinceMediaRenewal() const;
+    uint32_t SecondsSinceMediaRenewal() const;
     void UpdateSecondsSinceMediaRenewal();
   private:
     // Segment download section
@@ -125,8 +132,8 @@ namespace adaptive
     AdaptiveTree::StreamType type_;
     AdaptiveStreamObserver *observer_;
     // Active configuration
-    const AdaptiveTree::Period *current_period_;
-    const AdaptiveTree::AdaptationSet *current_adp_;
+    AdaptiveTree::Period* current_period_;
+    AdaptiveTree::AdaptationSet* current_adp_;
     AdaptiveTree::Representation *current_rep_;
     std::string download_url_;
     //We assume that a single segment can build complete frames

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -176,15 +176,22 @@ namespace adaptive
     memcpy(dst + dstOffset, src, dataSize);
   }
 
-  uint16_t AdaptiveTree::insert_psshset(StreamType type)
+  uint16_t AdaptiveTree::insert_psshset(StreamType type,
+                                        AdaptiveTree::Period* period,
+                                        AdaptiveTree::AdaptationSet* adp)
   {
+    if (!period)
+      period = current_period_;
+    if (!adp)
+      adp = current_adaptationset_;
+
     if (!current_pssh_.empty())
     {
       Period::PSSH pssh;
       pssh.pssh_ = current_pssh_;
       pssh.defaultKID_ = current_defaultKID_;
       pssh.iv = current_iv_;
-      pssh.adaptation_set_ = current_adaptationset_;
+      pssh.adaptation_set_ = adp;
       switch (type)
       {
       case VIDEO: pssh.media_ = Period::PSSH::MEDIA_VIDEO; break;
@@ -192,10 +199,86 @@ namespace adaptive
       case STREAM_TYPE_COUNT: pssh.media_ = Period::PSSH::MEDIA_VIDEO | Period::PSSH::MEDIA_AUDIO; break;
       default: pssh.media_ = 0; break;
       }
-      return current_period_->InsertPSSHSet(&pssh);
+      return period->InsertPSSHSet(&pssh);
     }
     else
-      return current_period_->InsertPSSHSet(nullptr);
+      return period->InsertPSSHSet(nullptr);
+  }
+
+  void AdaptiveTree::Representation::CopyBasicData(Representation* src)
+  {
+    url_ = src->url_;
+    id = src->id;
+    codecs_ = src->codecs_;
+    codec_private_data_ = src->codec_private_data_;
+    source_url_ = src->source_url_;
+    bandwidth_ = src->bandwidth_;
+    samplingRate_ = src->samplingRate_;
+    width_ = src->width_;
+    height_ = src->height_;
+    fpsRate_ = src->fpsRate_;
+    aspect_ = src->aspect_;
+    flags_ = src->flags_;
+    hdcpVersion_ = src->hdcpVersion_;
+    channelCount_ = src->channelCount_;
+    nalLengthSize_ = src->nalLengthSize_;
+    containerType_ = src->containerType_;
+    timescale_ = src->timescale_;
+    timescale_ext_ = src->timescale_ext_;
+    timescale_int_ = src->timescale_int_;
+  }
+
+  void AdaptiveTree::AdaptationSet::CopyBasicData(AdaptiveTree::AdaptationSet* src)
+  {
+    representations_.resize(src->representations_.size());
+    auto itRep = src->representations_.begin();
+    for (Representation*& rep : representations_)
+    {
+      rep = new Representation();
+      rep->CopyBasicData(*itRep++);
+    }
+
+    type_ = src->type_;
+    timescale_ = src->timescale_;
+    duration_ = src->duration_;
+    startPTS_ = src->startPTS_;
+    startNumber_ = src->startNumber_;
+    impaired_ = src->impaired_;
+    original_ = src->original_;
+    default_ = src->default_;
+    forced_ = src->forced_;
+    language_ = src->language_;
+    mimeType_ = src->mimeType_;
+    base_url_ = src->base_url_;
+    id_ = src->id_;
+    group_ = src->group_;
+    codecs_ = src->codecs_;
+    audio_track_id_ = src->audio_track_id_;
+    name_ = src->name_;
+  }
+
+  // Create a HLS master playlist copy (no representations)
+  void AdaptiveTree::Period::CopyBasicData(AdaptiveTree::Period* period)
+  {
+    adaptationSets_.resize(period->adaptationSets_.size());
+    auto itAdp = period->adaptationSets_.begin();
+    for (AdaptationSet*& adp : adaptationSets_)
+    {
+      adp = new AdaptationSet();
+      adp->CopyBasicData(*itAdp++);
+    }
+
+    base_url_ = period->base_url_;
+    id_ = period->id_;
+    timescale_ = period->timescale_;
+    startNumber_ = period->startNumber_;
+
+    start_ = period->start_;
+    startPTS_ = period->startPTS_;
+    duration_ = period->duration_;
+    encryptionState_ = period->encryptionState_;
+    included_types_ = period->included_types_;
+    need_secure_decoder_ = period->need_secure_decoder_;
   }
 
   uint16_t AdaptiveTree::Period::InsertPSSHSet(PSSH* pssh)
@@ -347,7 +430,7 @@ namespace adaptive
       {
         std::lock_guard<std::mutex> lck(treeMutex_);
         lastUpdated_ = std::chrono::system_clock::now();
-        RefreshSegments();
+        RefreshLiveSegments();
       }
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,33 +18,32 @@
 
 #include "main.h"
 
-#include <algorithm>
-#include <iostream>
-#include <stdio.h>
-#include <string.h>
-#include <sstream>
-#include <kodi/General.h>
-#include <kodi/Filesystem.h>
-#include <kodi/StreamCodec.h>
-#include <kodi/addon-instance/VideoCodec.h>
+#include "ADTSReader.h"
+#include "Ap4Utils.h"
 #include "DemuxCrypto.h"
-
+#include "TSReader.h"
+#include "WebmReader.h"
 #include "aes_decrypter.h"
 #include "helpers.h"
 #include "log.h"
 #include "oscompat.h"
 #include "parser/DASHTree.h"
-#include "parser/SmoothTree.h"
 #include "parser/HLSTree.h"
+#include "parser/SmoothTree.h"
 #include "parser/TTML.h"
 #include "parser/WebVTT.h"
-#include "TSReader.h"
-#include "ADTSReader.h"
-#include "WebmReader.h"
 
-#include "Ap4Utils.h"
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <stdio.h>
+#include <string.h>
 
 #include <dlfcn.h>
+#include <kodi/Filesystem.h>
+#include <kodi/General.h>
+#include <kodi/StreamCodec.h>
+#include <kodi/addon-instance/VideoCodec.h>
 
 #if defined(ANDROID)
 #include <kodi/platform/android/System.h>
@@ -52,9 +51,12 @@
 
 #define DVD_TIME_BASE 1000000
 
-#undef CreateDirectory
-
-#define SAFE_DELETE(p)       do { delete (p);     (p)=NULL; } while (0)
+#define SAFE_DELETE(p) \
+  do \
+  { \
+    delete (p); \
+    (p) = NULL; \
+  } while (0)
 
 //extern definition in helpers.h
 bool preReleaseFeatures = false;
@@ -66,14 +68,13 @@ void Log(const LogLevel loglevel, const char* format, ...)
   va_start(args, format);
   vsprintf(buffer, format, args);
   va_end(args);
-  ::kodi::addon::CAddonBase::m_interface->toKodi->addon_log_msg(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, loglevel, buffer);
+  ::kodi::addon::CAddonBase::m_interface->toKodi->addon_log_msg(
+      ::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, loglevel, buffer);
 }
 
 static const AP4_Track::Type TIDC[adaptive::AdaptiveTree::STREAM_TYPE_COUNT] = {
-  AP4_Track::TYPE_UNKNOWN,
-  AP4_Track::TYPE_VIDEO,
-  AP4_Track::TYPE_AUDIO,
-  AP4_Track::TYPE_SUBTITLES };
+    AP4_Track::TYPE_UNKNOWN, AP4_Track::TYPE_VIDEO, AP4_Track::TYPE_AUDIO,
+    AP4_Track::TYPE_SUBTITLES};
 
 /*******************************************************
 kodi host - interface for decrypter libraries
@@ -82,32 +83,20 @@ class KodiHost : public SSD::SSD_HOST
 {
 public:
 #if defined(ANDROID)
-  virtual void *GetJNIEnv() override
-  {
-    return m_androidSystem.GetJNIEnv();
-  };
+  virtual void* GetJNIEnv() override { return m_androidSystem.GetJNIEnv(); };
 
-  virtual int GetSDKVersion() override
-  {
-    return m_androidSystem.GetSDKVersion();
-  };
+  virtual int GetSDKVersion() override { return m_androidSystem.GetSDKVersion(); };
 
-  virtual const char *GetClassName() override
+  virtual const char* GetClassName() override
   {
     m_retvalHelper = m_androidSystem.GetClassName();
     return m_retvalHelper.c_str();
   };
 
 #endif
-  virtual const char *GetLibraryPath() const override
-  {
-    return m_strLibraryPath.c_str();
-  };
+  virtual const char* GetLibraryPath() const override { return m_strLibraryPath.c_str(); };
 
-  virtual const char *GetProfilePath() const override
-  {
-    return m_strProfilePath.c_str();
-  };
+  virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); };
 
   virtual void* CURLCreate(const char* strURL) override
   {
@@ -120,68 +109,74 @@ public:
     return file;
   };
 
-  virtual bool CURLAddOption(void* file, CURLOPTIONS opt, const char* name, const char * value)override
+  virtual bool CURLAddOption(void* file,
+                             CURLOPTIONS opt,
+                             const char* name,
+                             const char* value) override
   {
-    const CURLOptiontype xbmcmap[] = { ADDON_CURL_OPTION_PROTOCOL, ADDON_CURL_OPTION_HEADER };
+    const CURLOptiontype xbmcmap[] = {ADDON_CURL_OPTION_PROTOCOL, ADDON_CURL_OPTION_HEADER};
     return static_cast<kodi::vfs::CFile*>(file)->CURLAddOption(xbmcmap[opt], name, value);
   }
 
-  virtual const char* CURLGetProperty(void* file, CURLPROPERTY prop, const char *name) override
+  virtual const char* CURLGetProperty(void* file, CURLPROPERTY prop, const char* name) override
   {
-    const FilePropertyTypes xbmcmap[] = { ADDON_FILE_PROPERTY_RESPONSE_HEADER };
-    m_strPropertyValue = static_cast<kodi::vfs::CFile*>(file)->GetPropertyValue(xbmcmap[prop], name);
+    const FilePropertyTypes xbmcmap[] = {ADDON_FILE_PROPERTY_RESPONSE_HEADER};
+    m_strPropertyValue =
+        static_cast<kodi::vfs::CFile*>(file)->GetPropertyValue(xbmcmap[prop], name);
     return m_strPropertyValue.c_str();
   }
 
-  virtual bool CURLOpen(void* file)override
+  virtual bool CURLOpen(void* file) override
   {
     return static_cast<kodi::vfs::CFile*>(file)->CURLOpen(OpenFileFlags::READ_NO_CACHE);
   };
 
-  virtual size_t ReadFile(void* file, void* lpBuf, size_t uiBufSize)override
+  virtual size_t ReadFile(void* file, void* lpBuf, size_t uiBufSize) override
   {
     return static_cast<kodi::vfs::CFile*>(file)->Read(lpBuf, uiBufSize);
   };
 
-  virtual void CloseFile(void* file)override
+  virtual void CloseFile(void* file) override
   {
     return static_cast<kodi::vfs::CFile*>(file)->Close();
   };
 
-  virtual bool CreateDirectory(const char *dir)override
-  {
-    return kodi::vfs::CreateDirectory(dir);
-  };
+  virtual bool CreateDir(const char* dir) override { return kodi::vfs::CreateDirectory(dir); };
 
-  virtual void Log(LOGLEVEL level, const char *msg)override
+  virtual void Log(LOGLEVEL level, const char* msg) override
   {
-    const AddonLog xbmcmap[] = { ADDON_LOG_DEBUG, ADDON_LOG_INFO, ADDON_LOG_ERROR };
+    const AddonLog xbmcmap[] = {ADDON_LOG_DEBUG, ADDON_LOG_INFO, ADDON_LOG_ERROR};
     return kodi::Log(xbmcmap[level], msg);
   };
 
-  void SetLibraryPath(const char *libraryPath)
+  void SetLibraryPath(const char* libraryPath)
   {
     m_strLibraryPath = libraryPath;
 
-    const char *pathSep(libraryPath[0] && libraryPath[1] == ':' && isalpha(libraryPath[0]) ? "\\" : "/");
+    const char* pathSep(libraryPath[0] && libraryPath[1] == ':' && isalpha(libraryPath[0]) ? "\\"
+                                                                                           : "/");
 
     if (m_strLibraryPath.size() && m_strLibraryPath.back() != pathSep[0])
       m_strLibraryPath += pathSep;
   }
 
-  void SetProfilePath(const char *profilePath)
+  void SetProfilePath(const char* profilePath)
   {
     m_strProfilePath = profilePath;
 
-    const char *pathSep(profilePath[0] && profilePath[1] == ':' && isalpha(profilePath[0]) ? "\\" : "/");
+    const char* pathSep(profilePath[0] && profilePath[1] == ':' && isalpha(profilePath[0]) ? "\\"
+                                                                                           : "/");
 
     if (m_strProfilePath.size() && m_strProfilePath.back() != pathSep[0])
       m_strProfilePath += pathSep;
 
     //let us make cdm userdata out of the addonpath and share them between addons
-    m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 2));
-    m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1));
-    m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1) + 1);
+    m_strProfilePath.resize(
+        m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 2));
+    m_strProfilePath.resize(
+        m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1));
+    m_strProfilePath.resize(
+        m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1) + 1);
 
     kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
     m_strProfilePath += "cdm";
@@ -189,12 +184,14 @@ public:
     kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
   }
 
-  virtual bool GetBuffer(void* instance, SSD::SSD_PICTURE &picture) override
+  virtual bool GetBuffer(void* instance, SSD::SSD_PICTURE& picture) override
   {
-    return instance ? static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->GetFrameBuffer(*reinterpret_cast<VIDEOCODEC_PICTURE*>(&picture)) : false;
+    return instance ? static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->GetFrameBuffer(
+                          *reinterpret_cast<VIDEOCODEC_PICTURE*>(&picture))
+                    : false;
   }
 
-  virtual void ReleaseBuffer(void* instance, void *buffer) override
+  virtual void ReleaseBuffer(void* instance, void* buffer) override
   {
     if (instance)
       static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->ReleaseFrameBuffer(buffer);
@@ -207,7 +204,7 @@ private:
   kodi::platform::CInterfaceAndroidSystem m_androidSystem;
   std::string m_retvalHelper;
 #endif
-}*kodihost;
+} * kodihost;
 
 /*******************************************************
 Bento4 Streams
@@ -217,19 +214,17 @@ class AP4_DASHStream : public AP4_ByteStream
 {
 public:
   // Constructor
-  AP4_DASHStream(adaptive::AdaptiveStream *stream) :stream_(stream){};
+  AP4_DASHStream(adaptive::AdaptiveStream* stream) : stream_(stream){};
 
   // AP4_ByteStream methods
-  AP4_Result ReadPartial(void*    buffer,
-    AP4_Size  bytesToRead,
-    AP4_Size& bytesRead) override
+  AP4_Result ReadPartial(void* buffer, AP4_Size bytesToRead, AP4_Size& bytesRead) override
   {
     bytesRead = stream_->read(buffer, bytesToRead);
     return bytesRead > 0 ? AP4_SUCCESS : AP4_ERROR_READ_FAILED;
   };
   AP4_Result WritePartial(const void* buffer,
-    AP4_Size    bytesToWrite,
-    AP4_Size&   bytesWritten) override
+                          AP4_Size bytesToWrite,
+                          AP4_Size& bytesWritten) override
   {
     /* unimplemented */
     return AP4_ERROR_NOT_SUPPORTED;
@@ -245,25 +240,28 @@ public:
   };
   AP4_Result GetSize(AP4_LargeSize& size) override
   {
-    /* unimplemented */
-    return AP4_ERROR_NOT_SUPPORTED;
+    return stream_->getSize(size) ? AP4_SUCCESS : AP4_ERROR_EOS;
   };
   // AP4_Referenceable methods
-  void AddReference() override {};
-  void Release()override      {};
+  void AddReference() override{};
+  void Release() override{};
   bool waitingForSegment() const { return stream_->waitingForSegment(); }
   void FixateInitialization(bool on) { stream_->FixateInitialization(on); }
   void SetSegmentFileOffset(uint64_t offset) { stream_->SetSegmentFileOffset(offset); }
+
 protected:
   // members
-  adaptive::AdaptiveStream *stream_;
+  adaptive::AdaptiveStream* stream_;
 };
 
 /*******************************************************
 Kodi Streams implementation
 ********************************************************/
 
-bool adaptive::AdaptiveTree::download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque, bool scanEffectiveURL)
+bool adaptive::AdaptiveTree::download(const char* url,
+                                      const std::map<std::string, std::string>& manifestHeaders,
+                                      void* opaque,
+                                      bool scanEffectiveURL)
 {
   // open the file
   kodi::vfs::CFile file;
@@ -273,7 +271,7 @@ bool adaptive::AdaptiveTree::download(const char* url, const std::map<std::strin
   file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
   file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "gzip");
 
-  for (const auto &entry : manifestHeaders)
+  for (const auto& entry : manifestHeaders)
   {
     file.CURLAddOption(ADDON_CURL_OPTION_HEADER, entry.first.c_str(), entry.second.c_str());
   }
@@ -311,7 +309,8 @@ bool adaptive::AdaptiveTree::download(const char* url, const std::map<std::strin
   char buf[CHUNKSIZE];
   size_t nbRead;
 
-  while ((nbRead = file.Read(buf, CHUNKSIZE)) > 0 && ~nbRead && write_data(buf, nbRead, opaque));
+  while ((nbRead = file.Read(buf, CHUNKSIZE)) > 0 && ~nbRead && write_data(buf, nbRead, opaque))
+    ;
 
   etag_ = file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, "etag");
   last_modified_ = file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, "last-modified");
@@ -325,7 +324,8 @@ bool adaptive::AdaptiveTree::download(const char* url, const std::map<std::strin
   return nbRead == 0;
 }
 
-bool KodiAdaptiveStream::download(const char* url, const std::map<std::string, std::string> &mediaHeaders)
+bool KodiAdaptiveStream::download(const char* url,
+                                  const std::map<std::string, std::string>& mediaHeaders)
 {
   bool retry_403 = true;
   bool retry_MRT = true;
@@ -336,18 +336,19 @@ RETRY:
   // open the file
   if (!file.CURLCreate(url))
     return false;
-  file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable" , "0");
+  file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
   file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "gzip, deflate");
   if (mediaHeaders.find("connection") == mediaHeaders.end())
     file.CURLAddOption(ADDON_CURL_OPTION_HEADER, "connection", "keep-alive");
   file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
 
-  for (const auto &entry : mediaHeaders)
+  for (const auto& entry : mediaHeaders)
   {
     file.CURLAddOption(ADDON_CURL_OPTION_HEADER, entry.first.c_str(), entry.second.c_str());
   }
 
-  if (file.CURLOpen(OpenFileFlags::READ_CHUNKED | OpenFileFlags::READ_NO_CACHE | OpenFileFlags::READ_AUDIO_VIDEO))
+  if (file.CURLOpen(OpenFileFlags::READ_CHUNKED | OpenFileFlags::READ_NO_CACHE |
+                    OpenFileFlags::READ_AUDIO_VIDEO))
   {
     int returnCode = -1;
     std::string proto = file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL, "");
@@ -357,7 +358,10 @@ RETRY:
 
     size_t nbRead = ~0UL;
 
-    if (((returnCode == 403 && retry_403) || (getMediaRenewalTime() > 0  && SecondsSinceMediaRenewal() >= getMediaRenewalTime() && retry_MRT)) && !getMediaRenewalUrl().empty())
+    if (((returnCode == 403 && retry_403) ||
+         (getMediaRenewalTime() > 0 && SecondsSinceMediaRenewal() >= getMediaRenewalTime() &&
+          retry_MRT)) &&
+        !getMediaRenewalUrl().empty())
     {
       UpdateSecondsSinceMediaRenewal();
 
@@ -376,7 +380,8 @@ RETRY:
         goto RETRY;
       }
       else
-        kodi::Log(ADDON_LOG_ERROR, "Retrieving renewal URL failed (%s)", getMediaRenewalUrl().c_str());
+        kodi::Log(ADDON_LOG_ERROR, "Retrieving renewal URL failed (%s)",
+                  getMediaRenewalUrl().c_str());
     }
     else if (returnCode >= 400)
     {
@@ -385,9 +390,10 @@ RETRY:
     else
     {
       // read the file
-      char *buf = (char*)malloc(32 * 1024);
+      char* buf = (char*)malloc(32 * 1024);
       size_t nbReadOverall = 0;
-      while ((nbRead = file.Read(buf, 32 * 1024)) > 0 && ~nbRead && write_data(buf, nbRead)) nbReadOverall += nbRead;
+      while ((nbRead = file.Read(buf, 32 * 1024)) > 0 && ~nbRead && write_data(buf, nbRead))
+        nbReadOverall += nbRead;
       free(buf);
 
       if (!nbReadOverall)
@@ -404,9 +410,12 @@ RETRY:
       else
       {
         double ratio = (double)nbReadOverall / ref_packet;
-        set_download_speed((get_download_speed() * (1.0 - ratio)) + current_download_speed_*ratio);
+        set_download_speed((get_download_speed() * (1.0 - ratio)) +
+                           current_download_speed_ * ratio);
       }
-      kodi::Log(ADDON_LOG_DEBUG, "Download %s finished, avg speed: %0.2lfbyte/s, current speed: %0.2lfbyte/s", url, get_download_speed(), current_download_speed_);
+      kodi::Log(ADDON_LOG_DEBUG,
+                "Download %s finished, avg speed: %0.2lfbyte/s, current speed: %0.2lfbyte/s", url,
+                get_download_speed(), current_download_speed_);
     }
     file.Close();
     return nbRead == 0;
@@ -419,8 +428,10 @@ bool KodiAdaptiveStream::parseIndexRange()
   kodi::Log(ADDON_LOG_DEBUG, "Build segments from SIDX atom...");
   AP4_DASHStream byteStream(this);
 
-  adaptive::AdaptiveTree::Representation *rep(const_cast<adaptive::AdaptiveTree::Representation*>(getRepresentation()));
-  adaptive::AdaptiveTree::AdaptationSet *adp(const_cast<adaptive::AdaptiveTree::AdaptationSet*>(getAdaptationSet()));
+  adaptive::AdaptiveTree::Representation* rep(
+      const_cast<adaptive::AdaptiveTree::Representation*>(getRepresentation()));
+  adaptive::AdaptiveTree::AdaptationSet* adp(
+      const_cast<adaptive::AdaptiveTree::AdaptationSet*>(getAdaptationSet()));
 
   if (rep->containerType_ == adaptive::AdaptiveTree::CONTAINERTYPE_WEBM)
   {
@@ -440,7 +451,7 @@ bool KodiAdaptiveStream::parseIndexRange()
       rep->segments_.data.reserve(cuepoints.size());
       adp->segment_durations_.data.reserve(cuepoints.size());
 
-      for (const WebmReader::CUEPOINT &cue : cuepoints)
+      for (const WebmReader::CUEPOINT& cue : cuepoints)
       {
         seg.startPTS_ = cue.pts;
         seg.range_begin_ = cue.pos_start;
@@ -465,7 +476,7 @@ bool KodiAdaptiveStream::parseIndexRange()
         kodi::Log(ADDON_LOG_ERROR, "No MOOV in stream!");
         return false;
       }
-      if (1/*!(rep->flags_ & adaptive::AdaptiveTree::Representation::INITIALIZATION)*/)
+      if (1 /*!(rep->flags_ & adaptive::AdaptiveTree::Representation::INITIALIZATION)*/)
       {
         rep->flags_ |= adaptive::AdaptiveTree::Representation::INITIALIZATION;
         rep->initialization_.range_begin_ = 0;
@@ -481,7 +492,7 @@ bool KodiAdaptiveStream::parseIndexRange()
 
     do
     {
-      AP4_Atom *atom(NULL);
+      AP4_Atom* atom(NULL);
       if (AP4_FAILED(AP4_DefaultAtomFactory::Instance.CreateAtomFromStream(byteStream, atom)))
       {
         kodi::Log(ADDON_LOG_ERROR, "Unable to create SIDX from IndexRange bytes");
@@ -499,8 +510,8 @@ bool KodiAdaptiveStream::parseIndexRange()
         continue;
       }
 
-      AP4_SidxAtom *sidx(AP4_DYNAMIC_CAST(AP4_SidxAtom, atom));
-      const AP4_Array<AP4_SidxAtom::Reference> &refs(sidx->GetReferences());
+      AP4_SidxAtom* sidx(AP4_DYNAMIC_CAST(AP4_SidxAtom, atom));
+      const AP4_Array<AP4_SidxAtom::Reference>& refs(sidx->GetReferences());
       if (refs[0].m_ReferenceType == 1)
       {
         numSIDX = refs.ItemCount();
@@ -537,25 +548,21 @@ bool KodiAdaptiveStream::parseIndexRange()
 class CodecHandler
 {
 public:
-  CodecHandler(AP4_SampleDescription *sd)
-    : sample_description(sd)
-    , naluLengthSize(0)
-    , pictureId(0)
-    , pictureIdPrev(0xFF)
-  {};
-  virtual ~CodecHandler() {};
+  CodecHandler(AP4_SampleDescription* sd)
+    : sample_description(sd), naluLengthSize(0), pictureId(0), pictureIdPrev(0xFF){};
+  virtual ~CodecHandler(){};
 
   virtual void UpdatePPSId(AP4_DataBuffer const&){};
-  virtual bool GetInformation(INPUTSTREAM_INFO &info)
+  virtual bool GetInformation(INPUTSTREAM_INFO& info)
   {
     AP4_GenericAudioSampleDescription* asd(nullptr);
     if (sample_description)
     {
       if ((asd = dynamic_cast<AP4_GenericAudioSampleDescription*>(sample_description)))
       {
-        if ((!info.m_Channels && asd->GetChannelCount() != info.m_Channels)
-          || (!info.m_SampleRate && asd->GetSampleRate() != info.m_SampleRate)
-          || (!info.m_BitsPerSample && asd->GetSampleSize() != info.m_BitsPerSample))
+        if ((!info.m_Channels && asd->GetChannelCount() != info.m_Channels) ||
+            (!info.m_SampleRate && asd->GetSampleRate() != info.m_SampleRate) ||
+            (!info.m_BitsPerSample && asd->GetSampleSize() != info.m_BitsPerSample))
         {
           if (!info.m_Channels)
             info.m_Channels = asd->GetChannelCount();
@@ -569,12 +576,15 @@ public:
       else
       {
         //Netflix Framerate
-        AP4_Atom *atom;
-        AP4_UnknownUuidAtom *nxfr;
-        static const AP4_UI08 uuid[16] = { 0x4e,0x65,0x74,0x66,0x6c,0x69,0x78,0x46,0x72,0x61,0x6d,0x65,0x52,0x61,0x74,0x65 };
+        AP4_Atom* atom;
+        AP4_UnknownUuidAtom* nxfr;
+        static const AP4_UI08 uuid[16] = {0x4e, 0x65, 0x74, 0x66, 0x6c, 0x69, 0x78, 0x46,
+                                          0x72, 0x61, 0x6d, 0x65, 0x52, 0x61, 0x74, 0x65};
 
-        if ((atom = sample_description->GetDetails().GetChild(static_cast<const AP4_UI08*>(uuid), 0))
-          && (nxfr = dynamic_cast<AP4_UnknownUuidAtom*>(atom)) && nxfr->GetData().GetDataSize() == 10)
+        if ((atom = sample_description->GetDetails().GetChild(static_cast<const AP4_UI08*>(uuid),
+                                                              0)) &&
+            (nxfr = dynamic_cast<AP4_UnknownUuidAtom*>(atom)) &&
+            nxfr->GetData().GetDataSize() == 10)
         {
           AP4_UI16 fpsRate = nxfr->GetData().GetData()[7] | nxfr->GetData().GetData()[6] << 8;
           AP4_UI16 fpsScale = nxfr->GetData().GetData()[9] | nxfr->GetData().GetData()[8] << 8;
@@ -592,13 +602,16 @@ public:
   };
   virtual bool ExtraDataToAnnexB() { return false; };
   virtual STREAMCODEC_PROFILE GetProfile() { return STREAMCODEC_PROFILE::CodecProfileNotNeeded; };
-  virtual bool Transform(AP4_UI64 pts, AP4_UI32 duration, AP4_DataBuffer &buf, AP4_UI64 timescale) { return false; };
-  virtual bool ReadNextSample(AP4_Sample &sample, AP4_DataBuffer &buf) { return false; };
-  virtual void SetPTSOffset(AP4_UI64 offset) { };
+  virtual bool Transform(AP4_UI64 pts, AP4_UI32 duration, AP4_DataBuffer& buf, AP4_UI64 timescale)
+  {
+    return false;
+  };
+  virtual bool ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf) { return false; };
+  virtual void SetPTSOffset(AP4_UI64 offset){};
   virtual bool TimeSeek(AP4_UI64 seekPos) { return true; };
-  virtual void Reset() { };
+  virtual void Reset(){};
 
-  AP4_SampleDescription *sample_description;
+  AP4_SampleDescription* sample_description;
   AP4_DataBuffer extra_data;
   AP4_UI08 naluLengthSize;
   AP4_UI08 pictureId, pictureIdPrev;
@@ -609,18 +622,18 @@ public:
 class AVCCodecHandler : public CodecHandler
 {
 public:
-  AVCCodecHandler(AP4_SampleDescription *sd)
-    : CodecHandler(sd)
-    , countPictureSetIds(0)
-    , needSliceInfo(false)
+  AVCCodecHandler(AP4_SampleDescription* sd)
+    : CodecHandler(sd), countPictureSetIds(0), needSliceInfo(false)
   {
     unsigned int width(0), height(0);
-    if (AP4_VideoSampleDescription *video_sample_description = AP4_DYNAMIC_CAST(AP4_VideoSampleDescription, sample_description))
+    if (AP4_VideoSampleDescription* video_sample_description =
+            AP4_DYNAMIC_CAST(AP4_VideoSampleDescription, sample_description))
     {
       width = video_sample_description->GetWidth();
       height = video_sample_description->GetHeight();
     }
-    if (AP4_AvcSampleDescription *avc = AP4_DYNAMIC_CAST(AP4_AvcSampleDescription, sample_description))
+    if (AP4_AvcSampleDescription* avc =
+            AP4_DYNAMIC_CAST(AP4_AvcSampleDescription, sample_description))
     {
       extra_data.SetData(avc->GetRawBytes().GetData(), avc->GetRawBytes().GetDataSize());
       countPictureSetIds = avc->GetPictureParameters().ItemCount();
@@ -628,37 +641,38 @@ public:
       needSliceInfo = (countPictureSetIds > 1 || !width || !height);
       switch (avc->GetProfile())
       {
-      case AP4_AVC_PROFILE_BASELINE:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileBaseline;
-        break;
-      case AP4_AVC_PROFILE_MAIN:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileMain;
-        break;
-      case AP4_AVC_PROFILE_EXTENDED:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileExtended;
-        break;
-      case AP4_AVC_PROFILE_HIGH:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh;
-        break;
-      case AP4_AVC_PROFILE_HIGH_10:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh10;
-        break;
-      case AP4_AVC_PROFILE_HIGH_422:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh422;
-        break;
-      case AP4_AVC_PROFILE_HIGH_444:
-        codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh444Predictive;
-        break;
-      default:
-        codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
-        break;
+        case AP4_AVC_PROFILE_BASELINE:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileBaseline;
+          break;
+        case AP4_AVC_PROFILE_MAIN:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileMain;
+          break;
+        case AP4_AVC_PROFILE_EXTENDED:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileExtended;
+          break;
+        case AP4_AVC_PROFILE_HIGH:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh;
+          break;
+        case AP4_AVC_PROFILE_HIGH_10:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh10;
+          break;
+        case AP4_AVC_PROFILE_HIGH_422:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh422;
+          break;
+        case AP4_AVC_PROFILE_HIGH_444:
+          codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh444Predictive;
+          break;
+        default:
+          codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
+          break;
       }
     }
   }
 
   virtual bool ExtraDataToAnnexB() override
   {
-    if (AP4_AvcSampleDescription *avc = AP4_DYNAMIC_CAST(AP4_AvcSampleDescription, sample_description))
+    if (AP4_AvcSampleDescription* avc =
+            AP4_DYNAMIC_CAST(AP4_AvcSampleDescription, sample_description))
     {
       //calculate the size for annexb
       size_t sz(0);
@@ -670,17 +684,19 @@ public:
         sz += 4 + sps[i].GetDataSize();
 
       extra_data.SetDataSize(sz);
-      uint8_t *cursor(extra_data.UseData());
+      uint8_t* cursor(extra_data.UseData());
 
       for (unsigned int i(0); i < sps.ItemCount(); ++i)
       {
-        cursor[0] = cursor[1] = cursor[2] = 0; cursor[3] = 1;
+        cursor[0] = cursor[1] = cursor[2] = 0;
+        cursor[3] = 1;
         memcpy(cursor + 4, sps[i].GetData(), sps[i].GetDataSize());
         cursor += sps[i].GetDataSize() + 4;
       }
       for (unsigned int i(0); i < pps.ItemCount(); ++i)
       {
-        cursor[0] = cursor[1] = cursor[2] = 0; cursor[3] = 1;
+        cursor[0] = cursor[1] = cursor[2] = 0;
+        cursor[3] = 1;
         memcpy(cursor + 4, pps[i].GetData(), pps[i].GetDataSize());
         cursor += pps[i].GetDataSize() + 4;
       }
@@ -689,13 +705,13 @@ public:
     return false;
   }
 
-  virtual void UpdatePPSId(AP4_DataBuffer const &buffer) override
+  virtual void UpdatePPSId(AP4_DataBuffer const& buffer) override
   {
     if (!needSliceInfo)
       return;
 
     //Search the Slice header NALU
-    const AP4_UI08 *data(buffer.GetData());
+    const AP4_UI08* data(buffer.GetData());
     unsigned int data_size(buffer.GetDataSize());
     for (; data_size;)
     {
@@ -705,11 +721,26 @@ public:
 
       // get the next NAL unit
       AP4_UI32 nalu_size;
-      switch (naluLengthSize) {
-      case 1:nalu_size = *data++; data_size--; break;
-      case 2:nalu_size = AP4_BytesToInt16BE(data); data += 2; data_size -= 2; break;
-      case 4:nalu_size = AP4_BytesToInt32BE(data); data += 4; data_size -= 4; break;
-      default: data_size = 0; nalu_size = 1; break;
+      switch (naluLengthSize)
+      {
+        case 1:
+          nalu_size = *data++;
+          data_size--;
+          break;
+        case 2:
+          nalu_size = AP4_BytesToInt16BE(data);
+          data += 2;
+          data_size -= 2;
+          break;
+        case 4:
+          nalu_size = AP4_BytesToInt32BE(data);
+          data += 4;
+          data_size -= 4;
+          break;
+        default:
+          data_size = 0;
+          nalu_size = 1;
+          break;
       }
       if (nalu_size > data_size)
         break;
@@ -721,12 +752,13 @@ public:
       unsigned int nal_unit_type = *data & 0x1F;
 
       if (
-        //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_OF_NON_IDR_PICTURE ||
-        nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_OF_IDR_PICTURE //||
-        //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_DATA_PARTITION_A ||
-        //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_DATA_PARTITION_B ||
-        //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_DATA_PARTITION_C
-      ) {
+          //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_OF_NON_IDR_PICTURE ||
+          nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_OF_IDR_PICTURE //||
+          //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_DATA_PARTITION_A ||
+          //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_DATA_PARTITION_B ||
+          //nal_unit_type == AP4_AVC_NAL_UNIT_TYPE_CODED_SLICE_DATA_PARTITION_C
+      )
+      {
 
         AP4_DataBuffer unescaped(data, data_size);
         AP4_NalParser::Unescape(unescaped);
@@ -744,25 +776,30 @@ public:
     }
   }
 
-  virtual bool GetInformation(INPUTSTREAM_INFO &info) override
+  virtual bool GetInformation(INPUTSTREAM_INFO& info) override
   {
     if (pictureId == pictureIdPrev)
       return false;
     pictureIdPrev = pictureId;
 
-    if (AP4_AvcSampleDescription *avc = AP4_DYNAMIC_CAST(AP4_AvcSampleDescription, sample_description))
+    if (AP4_AvcSampleDescription* avc =
+            AP4_DYNAMIC_CAST(AP4_AvcSampleDescription, sample_description))
     {
       AP4_Array<AP4_DataBuffer>& ppsList(avc->GetPictureParameters());
       AP4_AvcPictureParameterSet pps;
       for (unsigned int i(0); i < ppsList.ItemCount(); ++i)
       {
-        if (AP4_SUCCEEDED(AP4_AvcFrameParser::ParsePPS(ppsList[i].GetData(), ppsList[i].GetDataSize(), pps)) && pps.pic_parameter_set_id == pictureId)
+        if (AP4_SUCCEEDED(AP4_AvcFrameParser::ParsePPS(ppsList[i].GetData(),
+                                                       ppsList[i].GetDataSize(), pps)) &&
+            pps.pic_parameter_set_id == pictureId)
         {
           AP4_Array<AP4_DataBuffer>& spsList = avc->GetSequenceParameters();
           AP4_AvcSequenceParameterSet sps;
           for (unsigned int i(0); i < spsList.ItemCount(); ++i)
           {
-            if (AP4_SUCCEEDED(AP4_AvcFrameParser::ParseSPS(spsList[i].GetData(), spsList[i].GetDataSize(), sps)) && sps.seq_parameter_set_id == pps.seq_parameter_set_id)
+            if (AP4_SUCCEEDED(AP4_AvcFrameParser::ParseSPS(spsList[i].GetData(),
+                                                           spsList[i].GetDataSize(), sps)) &&
+                sps.seq_parameter_set_id == pps.seq_parameter_set_id)
             {
               bool ret = sps.GetInfo(info.m_Width, info.m_Height);
               ret = sps.GetVUIInfo(info.m_FpsRate, info.m_FpsScale, info.m_Aspect) || ret;
@@ -776,10 +813,8 @@ public:
     return false;
   };
 
-  virtual STREAMCODEC_PROFILE GetProfile() override
-  {
-    return codecProfile;
-  };
+  virtual STREAMCODEC_PROFILE GetProfile() override { return codecProfile; };
+
 private:
   unsigned int countPictureSetIds;
   STREAMCODEC_PROFILE codecProfile;
@@ -791,10 +826,10 @@ private:
 class HEVCCodecHandler : public CodecHandler
 {
 public:
-  HEVCCodecHandler(AP4_SampleDescription *sd)
-    :CodecHandler(sd)
+  HEVCCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd)
   {
-    if (AP4_HevcSampleDescription *hevc = AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
+    if (AP4_HevcSampleDescription* hevc =
+            AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
     {
       extra_data.SetData(hevc->GetRawBytes().GetData(), hevc->GetRawBytes().GetDataSize());
       naluLengthSize = hevc->GetNaluLengthSize();
@@ -803,7 +838,8 @@ public:
 
   virtual bool ExtraDataToAnnexB() override
   {
-    if (AP4_HevcSampleDescription *hevc = AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
+    if (AP4_HevcSampleDescription* hevc =
+            AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
     {
       const AP4_Array<AP4_HvccAtom::Sequence>& sequences = hevc->GetSequences();
 
@@ -815,32 +851,39 @@ public:
 
       //calculate the size for annexb
       size_t sz(0);
-      for (const AP4_HvccAtom::Sequence *b(&sequences[0]), *e(&sequences[sequences.ItemCount()]); b != e; ++b)
-        for (const AP4_DataBuffer *bn(&b->m_Nalus[0]), *en(&b->m_Nalus[b->m_Nalus.ItemCount()]); bn != en; ++bn)
+      for (const AP4_HvccAtom::Sequence *b(&sequences[0]), *e(&sequences[sequences.ItemCount()]);
+           b != e; ++b)
+        for (const AP4_DataBuffer *bn(&b->m_Nalus[0]), *en(&b->m_Nalus[b->m_Nalus.ItemCount()]);
+             bn != en; ++bn)
           sz += (4 + bn->GetDataSize());
 
       extra_data.SetDataSize(sz);
-      uint8_t *cursor(extra_data.UseData());
+      uint8_t* cursor(extra_data.UseData());
 
-      for (const AP4_HvccAtom::Sequence *b(&sequences[0]), *e(&sequences[sequences.ItemCount()]); b != e; ++b)
-        for (const AP4_DataBuffer *bn(&b->m_Nalus[0]), *en(&b->m_Nalus[b->m_Nalus.ItemCount()]); bn != en; ++bn)
+      for (const AP4_HvccAtom::Sequence *b(&sequences[0]), *e(&sequences[sequences.ItemCount()]);
+           b != e; ++b)
+        for (const AP4_DataBuffer *bn(&b->m_Nalus[0]), *en(&b->m_Nalus[b->m_Nalus.ItemCount()]);
+             bn != en; ++bn)
         {
-          cursor[0] = cursor[1] = cursor[2] = 0; cursor[3] = 1;
+          cursor[0] = cursor[1] = cursor[2] = 0;
+          cursor[3] = 1;
           memcpy(cursor + 4, bn->GetData(), bn->GetDataSize());
           cursor += bn->GetDataSize() + 4;
         }
-      kodi::Log(ADDON_LOG_DEBUG, "Converted %lu bytes HEVC codec extradata", extra_data.GetDataSize());
+      kodi::Log(ADDON_LOG_DEBUG, "Converted %lu bytes HEVC codec extradata",
+                extra_data.GetDataSize());
       return true;
     }
     kodi::Log(ADDON_LOG_WARNING, "No HevcSampleDescription - annexb extradata not available");
     return false;
   }
 
-  virtual bool GetInformation(INPUTSTREAM_INFO &info) override
+  virtual bool GetInformation(INPUTSTREAM_INFO& info) override
   {
     if (!info.m_FpsRate)
     {
-      if (AP4_HevcSampleDescription *hevc = AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
+      if (AP4_HevcSampleDescription* hevc =
+              AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
       {
         bool ret = false;
         if (hevc->GetConstantFrameRate() && hevc->GetAverageFrameRate())
@@ -854,7 +897,6 @@ public:
     }
     return false;
   }
-
 };
 
 /***********************   MPEG   ************************/
@@ -862,13 +904,12 @@ public:
 class MPEGCodecHandler : public CodecHandler
 {
 public:
-  MPEGCodecHandler(AP4_SampleDescription *sd)
-    :CodecHandler(sd)
+  MPEGCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd)
   {
-    if (AP4_MpegSampleDescription *aac = AP4_DYNAMIC_CAST(AP4_MpegSampleDescription, sample_description))
+    if (AP4_MpegSampleDescription* aac =
+            AP4_DYNAMIC_CAST(AP4_MpegSampleDescription, sample_description))
       extra_data.SetData(aac->GetDecoderInfo().GetData(), aac->GetDecoderInfo().GetDataSize());
   }
-
 };
 
 /***********************   VP9   ************************/
@@ -876,17 +917,15 @@ public:
 class VP9CodecHandler : public CodecHandler
 {
 public:
-  VP9CodecHandler(AP4_SampleDescription *sd)
-    :CodecHandler(sd)
+  VP9CodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd)
   {
-    if (AP4_Atom *atom = sample_description->GetDetails().GetChild(AP4_ATOM_TYPE_VPCC, 0))
+    if (AP4_Atom* atom = sample_description->GetDetails().GetChild(AP4_ATOM_TYPE_VPCC, 0))
     {
-      AP4_VpcCAtom *vpcc(AP4_DYNAMIC_CAST(AP4_VpcCAtom, atom));
+      AP4_VpcCAtom* vpcc(AP4_DYNAMIC_CAST(AP4_VpcCAtom, atom));
       if (vpcc)
         extra_data.SetData(vpcc->GetData().GetData(), vpcc->GetData().GetDataSize());
     }
   }
-
 };
 
 /***********************   TTML   ************************/
@@ -894,17 +933,17 @@ public:
 class TTMLCodecHandler : public CodecHandler
 {
 public:
-  TTMLCodecHandler(AP4_SampleDescription *sd)
-    :CodecHandler(sd)
-    ,m_ptsOffset(0)
-  {};
+  TTMLCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd), m_ptsOffset(0){};
 
-  virtual bool Transform(AP4_UI64 pts, AP4_UI32 duration, AP4_DataBuffer &buf, AP4_UI64 timescale) override
+  virtual bool Transform(AP4_UI64 pts,
+                         AP4_UI32 duration,
+                         AP4_DataBuffer& buf,
+                         AP4_UI64 timescale) override
   {
     return m_ttml.Parse(buf.GetData(), buf.GetDataSize(), timescale, m_ptsOffset);
   }
 
-  virtual bool ReadNextSample(AP4_Sample &sample, AP4_DataBuffer &buf) override
+  virtual bool ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf) override
   {
     uint64_t pts;
     uint32_t dur;
@@ -922,20 +961,11 @@ public:
     return false;
   }
 
-  virtual void SetPTSOffset(AP4_UI64 offset) override
-  {
-    m_ptsOffset = offset;
-  };
+  virtual void SetPTSOffset(AP4_UI64 offset) override { m_ptsOffset = offset; };
 
-  virtual bool TimeSeek(AP4_UI64 seekPos) override
-  {
-    return m_ttml.TimeSeek(seekPos);
-  };
+  virtual bool TimeSeek(AP4_UI64 seekPos) override { return m_ttml.TimeSeek(seekPos); };
 
-  virtual void Reset() override
-  {
-    m_ttml.Reset();
-  }
+  virtual void Reset() override { m_ttml.Reset(); }
 
 
 private:
@@ -943,22 +973,22 @@ private:
   AP4_UI64 m_ptsOffset;
 };
 
-/***********************   TTML   ************************/
+/***********************   WebVTT   ************************/
 
 class WebVTTCodecHandler : public CodecHandler
 {
 public:
-  WebVTTCodecHandler(AP4_SampleDescription *sd)
-    :CodecHandler(sd)
-    , m_ptsOffset(0)
-  {};
+  WebVTTCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd), m_ptsOffset(0){};
 
-  virtual bool Transform(AP4_UI64 pts, AP4_UI32 duration, AP4_DataBuffer &buf, AP4_UI64 timescale) override
+  virtual bool Transform(AP4_UI64 pts,
+                         AP4_UI32 duration,
+                         AP4_DataBuffer& buf,
+                         AP4_UI64 timescale) override
   {
     return m_webVtt.Parse(pts, duration, buf.GetData(), buf.GetDataSize(), timescale, m_ptsOffset);
   }
 
-  virtual bool ReadNextSample(AP4_Sample &sample, AP4_DataBuffer &buf) override
+  virtual bool ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf) override
   {
     uint64_t pts;
     uint32_t dur;
@@ -976,20 +1006,11 @@ public:
     return false;
   }
 
-  virtual void SetPTSOffset(AP4_UI64 offset) override
-  {
-    m_ptsOffset = offset;
-  };
+  virtual void SetPTSOffset(AP4_UI64 offset) override { m_ptsOffset = offset; };
 
-  virtual bool TimeSeek(AP4_UI64 seekPos) override
-  {
-    return m_webVtt.TimeSeek(seekPos);
-  };
+  virtual bool TimeSeek(AP4_UI64 seekPos) override { return m_webVtt.TimeSeek(seekPos); };
 
-  virtual void Reset() override
-  {
-    m_webVtt.Reset();
-  }
+  virtual void Reset() override { m_webVtt.Reset(); }
 
 
 private:
@@ -1005,26 +1026,26 @@ class SampleReader
 {
 public:
   virtual ~SampleReader() = default;
-  virtual bool EOS()const = 0;
-  virtual uint64_t  DTS()const = 0;
-  virtual uint64_t  PTS()const = 0;
-  virtual uint64_t  DTSorPTS()const { return DTS() < PTS() ? DTS() : PTS(); };
-  virtual AP4_Result Start(bool &bStarted) = 0;
+  virtual bool EOS() const = 0;
+  virtual uint64_t DTS() const = 0;
+  virtual uint64_t PTS() const = 0;
+  virtual uint64_t DTSorPTS() const { return DTS() < PTS() ? DTS() : PTS(); };
+  virtual AP4_Result Start(bool& bStarted) = 0;
   virtual AP4_Result ReadSample() = 0;
   virtual void Reset(bool bEOS) = 0;
-  virtual bool GetInformation(INPUTSTREAM_INFO &info) = 0;
+  virtual bool GetInformation(INPUTSTREAM_INFO& info) = 0;
   virtual bool TimeSeek(uint64_t pts, bool preceeding) = 0;
   virtual void SetPTSOffset(uint64_t offset) = 0;
   virtual int64_t GetPTSDiff() const = 0;
-  virtual bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) = 0;
-  virtual uint32_t GetTimeScale()const = 0;
-  virtual AP4_UI32 GetStreamId()const = 0;
-  virtual AP4_Size GetSampleDataSize()const = 0;
-  virtual const AP4_Byte *GetSampleData()const = 0;
-  virtual uint64_t GetDuration()const = 0;
-  virtual bool IsEncrypted()const = 0;
-  virtual void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) {};
-  virtual void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) {};
+  virtual bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) = 0;
+  virtual uint32_t GetTimeScale() const = 0;
+  virtual AP4_UI32 GetStreamId() const = 0;
+  virtual AP4_Size GetSampleDataSize() const = 0;
+  virtual const AP4_Byte* GetSampleData() const = 0;
+  virtual uint64_t GetDuration() const = 0;
+  virtual bool IsEncrypted() const = 0;
+  virtual void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid){};
+  virtual void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid){};
   virtual bool RemoveStreamType(INPUTSTREAM_INFO::STREAM_TYPE type) { return true; };
 };
 
@@ -1032,31 +1053,31 @@ public:
 |   DummySampleReader
 ********************************************************/
 
-class DummyReader: public SampleReader
+class DummyReader : public SampleReader
 {
 public:
   virtual ~DummyReader() = default;
-  bool EOS()const override { return false; }
-  uint64_t  DTS()const override { return DVD_NOPTS_VALUE; }
-  uint64_t  PTS()const override { return DVD_NOPTS_VALUE; }
-  AP4_Result Start(bool &bStarted) override { return AP4_SUCCESS; }
+  bool EOS() const override { return false; }
+  uint64_t DTS() const override { return DVD_NOPTS_VALUE; }
+  uint64_t PTS() const override { return DVD_NOPTS_VALUE; }
+  AP4_Result Start(bool& bStarted) override { return AP4_SUCCESS; }
   AP4_Result ReadSample() override { return AP4_SUCCESS; }
   void Reset(bool bEOS) override {}
-  bool GetInformation(INPUTSTREAM_INFO &info) override { return false; }
+  bool GetInformation(INPUTSTREAM_INFO& info) override { return false; }
   bool TimeSeek(uint64_t pts, bool preceeding) override { return false; }
   void SetPTSOffset(uint64_t offset) override {}
   int64_t GetPTSDiff() const override { return 0; }
-  bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) override { return false; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
   uint32_t GetTimeScale() const override { return 1; }
   AP4_UI32 GetStreamId() const override { return 0; }
   AP4_Size GetSampleDataSize() const override { return 0; }
-  const AP4_Byte *GetSampleData() const override { return nullptr; }
+  const AP4_Byte* GetSampleData() const override { return nullptr; }
   uint64_t GetDuration() const override { return 0; }
   bool IsEncrypted() const override { return false; }
-  void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override {};
-  void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override {};
+  void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override{};
+  void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override{};
   bool RemoveStreamType(INPUTSTREAM_INFO::STREAM_TYPE type) override { return true; };
-}DummyReader;
+} DummyReader;
 
 /*******************************************************
 |   FragmentedSampleReader
@@ -1064,46 +1085,51 @@ public:
 class FragmentedSampleReader : public SampleReader, public AP4_LinearReader
 {
 public:
-
-  FragmentedSampleReader(AP4_ByteStream *input, AP4_Movie *movie, AP4_Track *track, AP4_UI32 streamId,
-    AP4_CencSingleSampleDecrypter *ssd, const SSD::SSD_DECRYPTER::SSD_CAPS &dcaps)
-    : AP4_LinearReader(*movie, input)
-    , m_track(track)
-    , m_streamId(streamId)
-    , m_sampleDescIndex(1)
-    , m_bSampleDescChanged(false)
-    , m_decrypterCaps(dcaps)
-    , m_failCount(0)
-    , m_eos(false)
-    , m_started(false)
-    , m_dts(0)
-    , m_pts(0)
-    , m_ptsDiff(0)
-    , m_ptsOffs(~0ULL)
-    , m_codecHandler(0)
-    , m_defaultKey(0)
-    , m_protectedDesc(0)
-    , m_singleSampleDecryptor(ssd)
-    , m_decrypter(0)
-    , m_nextDuration(0)
-    , m_nextTimestamp(0)
+  FragmentedSampleReader(AP4_ByteStream* input,
+                         AP4_Movie* movie,
+                         AP4_Track* track,
+                         AP4_UI32 streamId,
+                         AP4_CencSingleSampleDecrypter* ssd,
+                         const SSD::SSD_DECRYPTER::SSD_CAPS& dcaps)
+    : AP4_LinearReader(*movie, input),
+      m_track(track),
+      m_streamId(streamId),
+      m_sampleDescIndex(1),
+      m_bSampleDescChanged(false),
+      m_decrypterCaps(dcaps),
+      m_failCount(0),
+      m_eos(false),
+      m_started(false),
+      m_dts(0),
+      m_pts(0),
+      m_ptsDiff(0),
+      m_ptsOffs(~0ULL),
+      m_codecHandler(0),
+      m_defaultKey(0),
+      m_protectedDesc(0),
+      m_singleSampleDecryptor(ssd),
+      m_decrypter(0),
+      m_nextDuration(0),
+      m_nextTimestamp(0)
   {
     EnableTrack(m_track->GetId());
 
-    AP4_SampleDescription *desc(m_track->GetSampleDescription(0));
+    AP4_SampleDescription* desc(m_track->GetSampleDescription(0));
     if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
     {
       m_protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
 
-      AP4_ContainerAtom *schi;
-      if (m_protectedDesc->GetSchemeInfo() && (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
+      AP4_ContainerAtom* schi;
+      if (m_protectedDesc->GetSchemeInfo() &&
+          (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
       {
         AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
         if (tenc)
           m_defaultKey = tenc->GetDefaultKid();
         else
         {
-          AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
+          AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(
+              AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
           if (piff)
             m_defaultKey = piff->GetDefaultKid();
         }
@@ -1136,7 +1162,7 @@ public:
     delete m_codecHandler;
   }
 
-  AP4_Result Start(bool &bStarted) override
+  AP4_Result Start(bool& bStarted) override
   {
     bStarted = false;
     if (m_started)
@@ -1151,10 +1177,14 @@ public:
     AP4_Result result;
     if (!m_codecHandler || !m_codecHandler->ReadNextSample(m_sample, m_sampleData))
     {
-      bool useDecryptingDecoder = m_protectedDesc && (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0;
+      bool useDecryptingDecoder =
+          m_protectedDesc &&
+          (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0;
       bool decrypterPresent(m_decrypter != nullptr);
 
-      if (AP4_FAILED(result = ReadNextSample(m_track->GetId(), m_sample, (m_decrypter || useDecryptingDecoder) ? m_encrypted : m_sampleData)))
+      if (AP4_FAILED(result = ReadNextSample(m_track->GetId(), m_sample,
+                                             (m_decrypter || useDecryptingDecoder) ? m_encrypted
+                                                                                   : m_sampleData)))
       {
         if (result == AP4_ERROR_EOS)
         {
@@ -1181,7 +1211,8 @@ public:
         // If decrypter and addon are compiled with different DEBUG / RELEASE
         // options freeing HEAP memory will fail.
         m_sampleData.Reserve(m_encrypted.GetDataSize() + 4096);
-        if (AP4_FAILED(result = m_decrypter->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, NULL)))
+        if (AP4_FAILED(
+                result = m_decrypter->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, NULL)))
         {
           kodi::Log(ADDON_LOG_ERROR, "Decrypt Sample returns failure!");
           if (++m_failCount > 50)
@@ -1198,10 +1229,12 @@ public:
       else if (useDecryptingDecoder)
       {
         m_sampleData.Reserve(m_encrypted.GetDataSize() + 1024);
-        m_singleSampleDecryptor->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, nullptr, 0, nullptr, nullptr);
+        m_singleSampleDecryptor->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, nullptr, 0,
+                                                   nullptr, nullptr);
       }
 
-      if (m_codecHandler->Transform(m_sample.GetDts(), m_sample.GetDuration(), m_sampleData, m_track->GetMediaTimeScale()))
+      if (m_codecHandler->Transform(m_sample.GetDts(), m_sample.GetDuration(), m_sampleData,
+                                    m_track->GetMediaTimeScale()))
         m_codecHandler->ReadNextSample(m_sample, m_sampleData);
     }
 
@@ -1221,23 +1254,30 @@ public:
       m_codecHandler->Reset();
   }
 
-  bool EOS() const  override { return m_eos; };
-  uint64_t DTS()const override { return m_dts; };
-  uint64_t  PTS()const override { return m_pts; };
-  AP4_UI32 GetStreamId()const override { return m_streamId; };
-  AP4_Size GetSampleDataSize()const override { return m_sampleData.GetDataSize(); };
-  const AP4_Byte *GetSampleData()const override { return m_sampleData.GetData(); };
-  uint64_t GetDuration()const override { return (m_sample.GetDuration() * m_timeBaseExt) / m_timeBaseInt; };
-  bool IsEncrypted()const override { return (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0 && m_decrypter != nullptr; };
-  bool GetInformation(INPUTSTREAM_INFO &info) override
+  bool EOS() const override { return m_eos; };
+  uint64_t DTS() const override { return m_dts; };
+  uint64_t PTS() const override { return m_pts; };
+  AP4_UI32 GetStreamId() const override { return m_streamId; };
+  AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); };
+  const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); };
+  uint64_t GetDuration() const override
+  {
+    return (m_sample.GetDuration() * m_timeBaseExt) / m_timeBaseInt;
+  };
+  bool IsEncrypted() const override
+  {
+    return (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0 &&
+           m_decrypter != nullptr;
+  };
+  bool GetInformation(INPUTSTREAM_INFO& info) override
   {
     if (!m_codecHandler)
       return false;
 
     bool edchanged(false);
-    if (m_bSampleDescChanged && m_codecHandler->extra_data.GetDataSize()
-      && (info.m_ExtraSize != m_codecHandler->extra_data.GetDataSize()
-      || memcmp(info.m_ExtraData, m_codecHandler->extra_data.GetData(), info.m_ExtraSize)))
+    if (m_bSampleDescChanged && m_codecHandler->extra_data.GetDataSize() &&
+        (info.m_ExtraSize != m_codecHandler->extra_data.GetDataSize() ||
+         memcmp(info.m_ExtraData, m_codecHandler->extra_data.GetData(), info.m_ExtraSize)))
     {
       free((void*)(info.m_ExtraData));
       info.m_ExtraSize = m_codecHandler->extra_data.GetDataSize();
@@ -1254,7 +1294,7 @@ public:
     return edchanged;
   }
 
-  bool TimeSeek(uint64_t  pts, bool preceeding) override
+  bool TimeSeek(uint64_t pts, bool preceeding) override
   {
     AP4_Ordinal sampleIndex;
     AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));
@@ -1280,7 +1320,7 @@ public:
 
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
 
-  bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) override
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override
   {
     if (m_nextDuration)
     {
@@ -1289,40 +1329,44 @@ public:
     }
     else
     {
-      dur = dynamic_cast<AP4_FragmentSampleTable*>(FindTracker(m_track->GetId())->m_SampleTable)->GetDuration();
+      dur = dynamic_cast<AP4_FragmentSampleTable*>(FindTracker(m_track->GetId())->m_SampleTable)
+                ->GetDuration();
       ts = 0;
     }
     return true;
   };
-  uint32_t GetTimeScale()const override { return m_track->GetMediaTimeScale(); };
+  uint32_t GetTimeScale() const override { return m_track->GetMediaTimeScale(); };
 
 protected:
   AP4_Result ProcessMoof(AP4_ContainerAtom* moof,
-    AP4_Position       moof_offset,
-    AP4_Position       mdat_payload_offset,
-    AP4_UI64 mdat_payload_size) override
+                         AP4_Position moof_offset,
+                         AP4_Position mdat_payload_offset,
+                         AP4_UI64 mdat_payload_size) override
   {
     AP4_Result result;
 
-    if (AP4_SUCCEEDED((result = AP4_LinearReader::ProcessMoof(moof, moof_offset, mdat_payload_offset, mdat_payload_size))))
+    if (AP4_SUCCEEDED((result = AP4_LinearReader::ProcessMoof(
+                           moof, moof_offset, mdat_payload_offset, mdat_payload_size))))
     {
-      AP4_ContainerAtom *traf = AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
+      AP4_ContainerAtom* traf =
+          AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
 
       //For ISM Livestreams we have an UUID atom with one / more following fragment durations
       m_nextDuration = m_nextTimestamp = 0;
-      AP4_Atom *atom;
+      AP4_Atom* atom;
       unsigned int atom_pos(0);
-      const uint8_t uuid[16] = { 0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46, 0x95, 0x8e, 0x54, 0x26, 0xcb, 0x9e, 0x46, 0xa7, 0x9f };
-      while ((atom = traf->GetChild(AP4_ATOM_TYPE_UUID, atom_pos++))!= nullptr)
+      const uint8_t uuid[16] = {0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46, 0x95,
+                                0x8e, 0x54, 0x26, 0xcb, 0x9e, 0x46, 0xa7, 0x9f};
+      while ((atom = traf->GetChild(AP4_ATOM_TYPE_UUID, atom_pos++)) != nullptr)
       {
-        AP4_UuidAtom *uuid_atom(AP4_DYNAMIC_CAST(AP4_UuidAtom, atom));
+        AP4_UuidAtom* uuid_atom(AP4_DYNAMIC_CAST(AP4_UuidAtom, atom));
         if (memcmp(uuid_atom->GetUuid(), uuid, 16) == 0)
         {
           //verison(8) + flags(24) + numpairs(8) + pairs(ts(64)/dur(64))*numpairs
-          const AP4_DataBuffer &buf(AP4_DYNAMIC_CAST(AP4_UnknownUuidAtom, uuid_atom)->GetData());
+          const AP4_DataBuffer& buf(AP4_DYNAMIC_CAST(AP4_UnknownUuidAtom, uuid_atom)->GetData());
           if (buf.GetDataSize() >= 21)
           {
-            const uint8_t *data(buf.GetData());
+            const uint8_t* data(buf.GetData());
             m_nextTimestamp = AP4_BytesToUInt64BE(data + 5);
             m_nextDuration = AP4_BytesToUInt64BE(data + 13);
           }
@@ -1331,8 +1375,9 @@ protected:
       }
 
       //Check if the sample table description has changed
-      AP4_TfhdAtom *tfhd = AP4_DYNAMIC_CAST(AP4_TfhdAtom, traf->GetChild(AP4_ATOM_TYPE_TFHD, 0));
-      if ((tfhd && tfhd->GetSampleDescriptionIndex() != m_sampleDescIndex) || (!tfhd && (m_sampleDescIndex = 1)))
+      AP4_TfhdAtom* tfhd = AP4_DYNAMIC_CAST(AP4_TfhdAtom, traf->GetChild(AP4_ATOM_TYPE_TFHD, 0));
+      if ((tfhd && tfhd->GetSampleDescriptionIndex() != m_sampleDescIndex) ||
+          (!tfhd && (m_sampleDescIndex = 1)))
       {
         m_sampleDescIndex = tfhd->GetSampleDescriptionIndex();
         UpdateSampleDescription();
@@ -1353,34 +1398,40 @@ protected:
       if (m_protectedDesc)
       {
         //Setup the decryption
-        AP4_CencSampleInfoTable *sample_table;
+        AP4_CencSampleInfoTable* sample_table;
         AP4_UI32 algorithm_id = 0;
 
         delete m_decrypter;
         m_decrypter = 0;
 
-        AP4_ContainerAtom *traf = AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
+        AP4_ContainerAtom* traf =
+            AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
 
         if (!m_protectedDesc || !traf)
           return AP4_ERROR_INVALID_FORMAT;
 
-        if (AP4_FAILED(result = AP4_CencSampleInfoTable::Create(m_protectedDesc, traf, algorithm_id, *m_FragmentStream, moof_offset, sample_table)))
+        if (AP4_FAILED(result = AP4_CencSampleInfoTable::Create(m_protectedDesc, traf, algorithm_id,
+                                                                *m_FragmentStream, moof_offset,
+                                                                sample_table)))
           // we assume unencrypted fragment here
           goto SUCCESS;
 
-        if (AP4_FAILED(result = AP4_CencSampleDecrypter::Create(sample_table, algorithm_id, 0, 0, 0, m_singleSampleDecryptor, m_decrypter)))
+        if (AP4_FAILED(result =
+                           AP4_CencSampleDecrypter::Create(sample_table, algorithm_id, 0, 0, 0,
+                                                           m_singleSampleDecryptor, m_decrypter)))
           return result;
       }
     }
-SUCCESS:
+  SUCCESS:
     if (m_singleSampleDecryptor && m_codecHandler)
-      m_singleSampleDecryptor->SetFragmentInfo(m_poolId, m_defaultKey, m_codecHandler->naluLengthSize, m_codecHandler->extra_data, m_decrypterCaps.flags);
+      m_singleSampleDecryptor->SetFragmentInfo(m_poolId, m_defaultKey,
+                                               m_codecHandler->naluLengthSize,
+                                               m_codecHandler->extra_data, m_decrypterCaps.flags);
 
     return AP4_SUCCESS;
   }
 
 private:
-
   void UpdateSampleDescription()
   {
     if (m_codecHandler)
@@ -1388,7 +1439,7 @@ private:
     m_codecHandler = 0;
     m_bSampleDescChanged = true;
 
-    AP4_SampleDescription *desc(m_track->GetSampleDescription(m_sampleDescIndex - 1));
+    AP4_SampleDescription* desc(m_track->GetSampleDescription(m_sampleDescIndex - 1));
     if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
     {
       m_protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
@@ -1397,33 +1448,33 @@ private:
     kodi::Log(ADDON_LOG_DEBUG, "UpdateSampleDescription: codec %d", desc->GetFormat());
     switch (desc->GetFormat())
     {
-    case AP4_SAMPLE_FORMAT_AVC1:
-    case AP4_SAMPLE_FORMAT_AVC2:
-    case AP4_SAMPLE_FORMAT_AVC3:
-    case AP4_SAMPLE_FORMAT_AVC4:
-      m_codecHandler = new AVCCodecHandler(desc);
-      break;
-    case AP4_SAMPLE_FORMAT_HEV1:
-    case AP4_SAMPLE_FORMAT_HVC1:
-    case AP4_SAMPLE_FORMAT_DVHE:
-    case AP4_SAMPLE_FORMAT_DVH1:
-      m_codecHandler = new HEVCCodecHandler(desc);
-      break;
-    case AP4_SAMPLE_FORMAT_MP4A:
-      m_codecHandler = new MPEGCodecHandler(desc);
-      break;
-    case AP4_SAMPLE_FORMAT_STPP:
-      m_codecHandler = new TTMLCodecHandler(desc);
-      break;
-    case AP4_SAMPLE_FORMAT_WVTT:
-      m_codecHandler = new WebVTTCodecHandler(desc);
-      break;
-    case AP4_SAMPLE_FORMAT_VP09:
-      m_codecHandler = new VP9CodecHandler(desc);
-      break;
-    default:
-      m_codecHandler = new CodecHandler(desc);
-      break;
+      case AP4_SAMPLE_FORMAT_AVC1:
+      case AP4_SAMPLE_FORMAT_AVC2:
+      case AP4_SAMPLE_FORMAT_AVC3:
+      case AP4_SAMPLE_FORMAT_AVC4:
+        m_codecHandler = new AVCCodecHandler(desc);
+        break;
+      case AP4_SAMPLE_FORMAT_HEV1:
+      case AP4_SAMPLE_FORMAT_HVC1:
+      case AP4_SAMPLE_FORMAT_DVHE:
+      case AP4_SAMPLE_FORMAT_DVH1:
+        m_codecHandler = new HEVCCodecHandler(desc);
+        break;
+      case AP4_SAMPLE_FORMAT_MP4A:
+        m_codecHandler = new MPEGCodecHandler(desc);
+        break;
+      case AP4_SAMPLE_FORMAT_STPP:
+        m_codecHandler = new TTMLCodecHandler(desc);
+        break;
+      case AP4_SAMPLE_FORMAT_WVTT:
+        m_codecHandler = new WebVTTCodecHandler(desc);
+        break;
+      case AP4_SAMPLE_FORMAT_VP09:
+        m_codecHandler = new VP9CodecHandler(desc);
+        break;
+      default:
+        m_codecHandler = new CodecHandler(desc);
+        break;
     }
 
     if ((m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED) != 0)
@@ -1431,7 +1482,7 @@ private:
   }
 
 private:
-  AP4_Track *m_track;
+  AP4_Track* m_track;
   AP4_UI32 m_streamId;
   AP4_UI32 m_sampleDescIndex;
   bool m_bSampleDescChanged;
@@ -1445,15 +1496,15 @@ private:
 
   uint64_t m_timeBaseExt, m_timeBaseInt;
 
-  AP4_Sample     m_sample;
+  AP4_Sample m_sample;
   AP4_DataBuffer m_encrypted, m_sampleData;
 
-  CodecHandler *m_codecHandler;
-  const AP4_UI08 *m_defaultKey;
+  CodecHandler* m_codecHandler;
+  const AP4_UI08* m_defaultKey;
 
-  AP4_ProtectedSampleDescription *m_protectedDesc;
-  AP4_CencSingleSampleDecrypter *m_singleSampleDecryptor;
-  AP4_CencSampleDecrypter *m_decrypter;
+  AP4_ProtectedSampleDescription* m_protectedDesc;
+  AP4_CencSingleSampleDecrypter* m_singleSampleDecryptor;
+  AP4_CencSampleDecrypter* m_decrypter;
   uint64_t m_nextDuration, m_nextTimestamp;
 };
 
@@ -1464,10 +1515,10 @@ private:
 class SubtitleSampleReader : public SampleReader
 {
 public:
-  SubtitleSampleReader(const std::string &url, AP4_UI32 streamId, const std::string &codecInternalName)
-    : m_pts(0)
-    , m_streamId(streamId)
-    , m_eos(false)
+  SubtitleSampleReader(const std::string& url,
+                       AP4_UI32 streamId,
+                       const std::string& codecInternalName)
+    : m_pts(0), m_streamId(streamId), m_eos(false)
   {
     // open the file
     kodi::vfs::CFile file;
@@ -1495,10 +1546,43 @@ public:
     m_codecHandler->Transform(0, 0, result, 1000);
   };
 
-  bool EOS()const override { return m_eos; };
-  uint64_t DTS()const override { return m_pts; };
-  uint64_t PTS()const override { return m_pts; };
-  AP4_Result Start(bool &bStarted) override { m_eos = false; return AP4_SUCCESS; };
+  SubtitleSampleReader(AP4_ByteStream* input,
+                       AP4_UI32 streamId,
+                       const std::string& codecInternalName)
+    : m_pts(0), m_streamId(streamId), m_eos(false)
+  {
+    // read the file
+    AP4_DataBuffer result;
+    const AP4_Size chunkSize = 16384;
+    AP4_Byte buf[chunkSize];
+    AP4_LargeSize sz;
+    while (AP4_SUCCEEDED(input->GetSize(sz)))
+    {
+      while (sz)
+      {
+        AP4_Size readSize = sz > chunkSize ? chunkSize : static_cast<AP4_Size>(sz);
+        sz -= readSize;
+        if (AP4_SUCCEEDED(input->Read(buf, readSize)))
+          result.AppendData(buf, readSize);
+        else
+          break;
+      }
+    }
+    if (codecInternalName == "wvtt")
+      m_codecHandler = new WebVTTCodecHandler(nullptr);
+    else
+      m_codecHandler = new TTMLCodecHandler(nullptr);
+    m_codecHandler->Transform(0, 0, result, 1000);
+  }
+
+  bool EOS() const override { return m_eos; };
+  uint64_t DTS() const override { return m_pts; };
+  uint64_t PTS() const override { return m_pts; };
+  AP4_Result Start(bool& bStarted) override
+  {
+    m_eos = false;
+    return AP4_SUCCESS;
+  };
   AP4_Result ReadSample() override
   {
     if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))
@@ -1509,29 +1593,30 @@ public:
     m_eos = true;
     return AP4_ERROR_EOS;
   }
-  void Reset(bool bEOS) override {};
-  bool GetInformation(INPUTSTREAM_INFO &info) override { return false; };
-  bool TimeSeek(uint64_t  pts, bool preceeding) override
+  void Reset(bool bEOS) override{};
+  bool GetInformation(INPUTSTREAM_INFO& info) override { return false; };
+  bool TimeSeek(uint64_t pts, bool preceeding) override
   {
     if (m_codecHandler->TimeSeek(pts / 1000))
       return AP4_SUCCEEDED(ReadSample());
     return false;
   };
-  void SetPTSOffset(uint64_t offset) override {};
+  void SetPTSOffset(uint64_t offset) override{};
   int64_t GetPTSDiff() const override { return 0; }
-  bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) override { return false; };
-  uint32_t GetTimeScale()const override { return 1000; };
-  AP4_UI32 GetStreamId()const override { return m_streamId; };
-  AP4_Size GetSampleDataSize()const override { return m_sampleData.GetDataSize(); };
-  const AP4_Byte *GetSampleData()const override { return m_sampleData.GetData(); };
-  uint64_t GetDuration()const override { return m_sample.GetDuration() * 1000; };
-  bool IsEncrypted()const override { return false; };
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; };
+  uint32_t GetTimeScale() const override { return 1000; };
+  AP4_UI32 GetStreamId() const override { return m_streamId; };
+  AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); };
+  const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); };
+  uint64_t GetDuration() const override { return m_sample.GetDuration() * 1000; };
+  bool IsEncrypted() const override { return false; };
+
 private:
   uint64_t m_pts;
   AP4_UI32 m_streamId;
   bool m_eos;
 
-  CodecHandler *m_codecHandler;
+  CodecHandler* m_codecHandler;
 
   AP4_Sample m_sample;
   AP4_DataBuffer m_sampleData;
@@ -1543,10 +1628,13 @@ private:
 class TSSampleReader : public SampleReader, public TSReader
 {
 public:
-  TSSampleReader(AP4_ByteStream *input, INPUTSTREAM_INFO::STREAM_TYPE type, AP4_UI32 streamId, uint32_t requiredMask)
-    : TSReader(input, requiredMask)
-    , m_stream(dynamic_cast<AP4_DASHStream*>(input))
-    , m_typeMask(1 << type)
+  TSSampleReader(AP4_ByteStream* input,
+                 INPUTSTREAM_INFO::STREAM_TYPE type,
+                 AP4_UI32 streamId,
+                 uint32_t requiredMask)
+    : TSReader(input, requiredMask),
+      m_stream(dynamic_cast<AP4_DASHStream*>(input)),
+      m_typeMask(1 << type)
   {
     m_typeMap[type] = m_typeMap[INPUTSTREAM_INFO::TYPE_NONE] = streamId;
   };
@@ -1572,10 +1660,10 @@ public:
     return m_typeMask == 0;
   };
 
-  bool EOS()const override { return m_eos; }
-  uint64_t DTS()const override { return m_dts; }
-  uint64_t PTS()const override { return m_pts; }
-  AP4_Result Start(bool &bStarted) override
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_dts; }
+  uint64_t PTS() const override { return m_pts; }
+  AP4_Result Start(bool& bStarted) override
   {
     bStarted = false;
     if (m_started)
@@ -1616,10 +1704,7 @@ public:
     m_eos = bEOS;
   }
 
-  bool GetInformation(INPUTSTREAM_INFO &info) override
-  {
-    return TSReader::GetInformation(info);
-  }
+  bool GetInformation(INPUTSTREAM_INFO& info) override { return TSReader::GetInformation(info); }
 
   bool TimeSeek(uint64_t pts, bool preceeding) override
   {
@@ -1635,20 +1720,17 @@ public:
     return AP4_ERROR_EOS;
   }
 
-  void SetPTSOffset(uint64_t offset) override
-  {
-    m_ptsOffs = offset;
-  }
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
 
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
 
-  bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) override { return false; }
-  uint32_t GetTimeScale()const override { return 90000; }
-  AP4_UI32 GetStreamId()const override { return m_typeMap[GetStreamType()]; }
-  AP4_Size GetSampleDataSize()const override { return GetPacketSize(); }
-  const AP4_Byte *GetSampleData()const override { return GetPacketData(); }
-  uint64_t GetDuration()const override { return (TSReader::GetDuration() * 100) / 9; }
-  bool IsEncrypted()const override { return false; };
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 90000; }
+  AP4_UI32 GetStreamId() const override { return m_typeMap[GetStreamType()]; }
+  AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
+  const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
+  uint64_t GetDuration() const override { return (TSReader::GetDuration() * 100) / 9; }
+  bool IsEncrypted() const override { return false; };
 
 private:
   uint32_t m_typeMask; //Bit representation of INPUTSTREAM_INFO::STREAM_TYPES
@@ -1660,7 +1742,7 @@ private:
   uint64_t m_dts = 0;
   int64_t m_ptsDiff = 0;
   uint64_t m_ptsOffs = ~0ULL;
-  AP4_DASHStream *m_stream;
+  AP4_DASHStream* m_stream;
 };
 
 /*******************************************************
@@ -1669,17 +1751,13 @@ private:
 class ADTSSampleReader : public SampleReader, public ADTSReader
 {
 public:
-  ADTSSampleReader(AP4_ByteStream *input, AP4_UI32 streamId)
-    : ADTSReader(input)
-    , m_streamId(streamId)
-    , m_stream(dynamic_cast<AP4_DASHStream*>(input))
-  {
-  };
+  ADTSSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
+    : ADTSReader(input), m_streamId(streamId), m_stream(dynamic_cast<AP4_DASHStream*>(input)){};
 
-  bool EOS()const override { return m_eos; }
-  uint64_t DTS()const override { return m_pts; }
-  uint64_t PTS()const override { return m_pts; }
-  AP4_Result Start(bool &bStarted) override
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_pts; }
+  uint64_t PTS() const override { return m_pts; }
+  AP4_Result Start(bool& bStarted) override
   {
     bStarted = false;
     if (m_started)
@@ -1713,10 +1791,7 @@ public:
     m_eos = bEOS;
   }
 
-  bool GetInformation(INPUTSTREAM_INFO &info) override
-  {
-    return ADTSReader::GetInformation(info);
-  }
+  bool GetInformation(INPUTSTREAM_INFO& info) override { return ADTSReader::GetInformation(info); }
 
   bool TimeSeek(uint64_t pts, bool preceeding) override
   {
@@ -1729,20 +1804,17 @@ public:
     return AP4_ERROR_EOS;
   }
 
-  void SetPTSOffset(uint64_t offset) override
-  {
-    m_ptsOffs = offset;
-  }
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
 
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
 
-  bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) override { return false; }
-  uint32_t GetTimeScale()const override { return 90000; }
-  AP4_UI32 GetStreamId()const override { return m_streamId; }
-  AP4_Size GetSampleDataSize()const override { return GetPacketSize(); }
-  const AP4_Byte *GetSampleData()const override { return GetPacketData(); }
-  uint64_t GetDuration()const override { return (ADTSReader::GetDuration() * 100) / 9; }
-  bool IsEncrypted()const override { return false; };
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 90000; }
+  AP4_UI32 GetStreamId() const override { return m_streamId; }
+  AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
+  const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
+  uint64_t GetDuration() const override { return (ADTSReader::GetDuration() * 100) / 9; }
+  bool IsEncrypted() const override { return false; };
 
 private:
   bool m_eos = false;
@@ -1751,7 +1823,7 @@ private:
   uint64_t m_pts = 0;
   int64_t m_ptsDiff = 0;
   uint64_t m_ptsOffs = ~0ULL;
-  AP4_DASHStream *m_stream;
+  AP4_DASHStream* m_stream;
 };
 
 
@@ -1761,16 +1833,12 @@ private:
 class WebmSampleReader : public SampleReader, public WebmReader
 {
 public:
-  WebmSampleReader(AP4_ByteStream *input, AP4_UI32 streamId)
-    : WebmReader(input)
-    , m_streamId(streamId)
-    , m_stream(dynamic_cast<AP4_DASHStream*>(input))
-  {
-  };
+  WebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
+    : WebmReader(input), m_streamId(streamId), m_stream(dynamic_cast<AP4_DASHStream*>(input)){};
 
-  bool EOS()const override { return m_eos; }
-  uint64_t DTS()const override { return m_dts; }
-  uint64_t PTS()const override { return m_pts; }
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_dts; }
+  uint64_t PTS() const override { return m_pts; }
 
   bool Initialize()
   {
@@ -1782,7 +1850,7 @@ public:
     return ret;
   }
 
-  AP4_Result Start(bool &bStarted) override
+  AP4_Result Start(bool& bStarted) override
   {
     bStarted = false;
     if (m_started)
@@ -1816,15 +1884,16 @@ public:
     m_eos = bEOS;
   }
 
-  bool GetInformation(INPUTSTREAM_INFO &info) override
+  bool GetInformation(INPUTSTREAM_INFO& info) override
   {
     bool ret = WebmReader::GetInformation(info);
     // kodi supports VP9 without extrada since addon api version was introduced.
     // For older kodi versions (without api version) we have to fake extra-data
-    if (!info.m_ExtraSize && strcmp(info.m_codecName, "vp9") == 0 && kodi::addon::CAddonBase::m_strGlobalApiVersion.empty())
+    if (!info.m_ExtraSize && strcmp(info.m_codecName, "vp9") == 0 &&
+        kodi::addon::CAddonBase::m_strGlobalApiVersion.empty())
     {
       info.m_ExtraSize = 4;
-      uint8_t *annexb = static_cast<uint8_t*>(malloc(4));
+      uint8_t* annexb = static_cast<uint8_t*>(malloc(4));
       annexb[0] = annexb[1] = annexb[2] = 0;
       annexb[3] = 1;
       info.m_ExtraData = annexb;
@@ -1844,20 +1913,17 @@ public:
     return AP4_ERROR_EOS;
   }
 
-  void SetPTSOffset(uint64_t offset) override
-  {
-    m_ptsOffs = offset;
-  }
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
 
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
 
-  bool GetNextFragmentInfo(uint64_t &ts, uint64_t &dur) override { return false; }
-  uint32_t GetTimeScale()const override { return 1000; }
-  AP4_UI32 GetStreamId()const override { return m_streamId; }
-  AP4_Size GetSampleDataSize()const override { return GetPacketSize(); }
-  const AP4_Byte *GetSampleData()const override { return GetPacketData(); }
-  uint64_t GetDuration()const override { return WebmReader::GetDuration() *1000; }
-  bool IsEncrypted()const override { return false; };
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 1000; }
+  AP4_UI32 GetStreamId() const override { return m_streamId; }
+  AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
+  const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
+  uint64_t GetDuration() const override { return WebmReader::GetDuration() * 1000; }
+  bool IsEncrypted() const override { return false; };
 
 private:
   AP4_UI32 m_streamId = 0;
@@ -1868,7 +1934,7 @@ private:
   uint64_t m_dts = 0;
   int64_t m_ptsDiff = 0;
   uint64_t m_ptsOffs = ~0ULL;
-  AP4_DASHStream *m_stream;
+  AP4_DASHStream* m_stream;
 };
 
 /*******************************************************
@@ -1889,56 +1955,58 @@ void Session::STREAM::disable()
 }
 
 Session::Session(MANIFEST_TYPE manifestType,
-  const char *strURL,
-  const char *strUpdateParam,
-  const char *strLicType,
-  const char* strLicKey,
-  const char* strLicData,
-  const char* strCert,
-  const char* strMediaRenewalUrl,
-  const uint32_t intMediaRenewalTime,
-  const std::map<std::string, std::string> &manifestHeaders,
-  const std::map<std::string, std::string> &mediaHeaders,
-  const char* profile_path,
-  uint16_t display_width,
-  uint16_t display_height,
-  const char *ov_audio,
-  bool play_timeshift_buffer)
-  : manifest_type_(manifestType)
-  , mpdFileURL_(strURL)
-  , mpdUpdateParam_(strUpdateParam)
-  , license_key_(strLicKey)
-  , license_type_(strLicType)
-  , license_data_(strLicData)
-  , media_headers_(mediaHeaders)
-  , profile_path_(profile_path)
-  , ov_audio_(ov_audio)
-  , decrypterModule_(0)
-  , decrypter_(0)
-  , secure_video_session_(false)
-  , adaptiveTree_(0)
-  , width_(display_width)
-  , height_(display_height)
-  , timing_stream_(nullptr)
-  , changed_(false)
-  , manual_streams_(0)
-  , elapsed_time_(0)
-  , chapter_start_time_(0)
-  , chapter_seek_time_(0.0)
-  , play_timeshift_buffer_(play_timeshift_buffer)
+                 const char* strURL,
+                 const char* strUpdateParam,
+                 const char* strLicType,
+                 const char* strLicKey,
+                 const char* strLicData,
+                 const char* strCert,
+                 const char* strMediaRenewalUrl,
+                 const uint32_t intMediaRenewalTime,
+                 const std::map<std::string, std::string>& manifestHeaders,
+                 const std::map<std::string, std::string>& mediaHeaders,
+                 const char* profile_path,
+                 uint16_t display_width,
+                 uint16_t display_height,
+                 const char* ov_audio,
+                 bool play_timeshift_buffer,
+                 bool force_secure_decoder)
+  : manifest_type_(manifestType),
+    mpdFileURL_(strURL),
+    mpdUpdateParam_(strUpdateParam),
+    license_key_(strLicKey),
+    license_type_(strLicType),
+    license_data_(strLicData),
+    media_headers_(mediaHeaders),
+    profile_path_(profile_path),
+    ov_audio_(ov_audio),
+    decrypterModule_(0),
+    decrypter_(0),
+    secure_video_session_(false),
+    adaptiveTree_(0),
+    width_(display_width),
+    height_(display_height),
+    timing_stream_(nullptr),
+    changed_(false),
+    manual_streams_(0),
+    elapsed_time_(0),
+    chapter_start_time_(0),
+    chapter_seek_time_(0.0),
+    play_timeshift_buffer_(play_timeshift_buffer),
+    force_secure_decoder_(force_secure_decoder)
 {
   switch (manifest_type_)
   {
-  case MANIFEST_TYPE_MPD:
-    adaptiveTree_ = new adaptive::DASHTree;
-    break;
-  case MANIFEST_TYPE_ISM:
-    adaptiveTree_ = new adaptive::SmoothTree;
-    break;
-  case MANIFEST_TYPE_HLS:
-    adaptiveTree_ = new adaptive::HLSTree(new AESDecrypter(license_key_));
-    break;
-  default:;
+    case MANIFEST_TYPE_MPD:
+      adaptiveTree_ = new adaptive::DASHTree;
+      break;
+    case MANIFEST_TYPE_ISM:
+      adaptiveTree_ = new adaptive::SmoothTree;
+      break;
+    case MANIFEST_TYPE_HLS:
+      adaptiveTree_ = new adaptive::HLSTree(new AESDecrypter(license_key_));
+      break;
+    default:;
   };
 
   std::string fn(profile_path_ + "bandwidth.bin");
@@ -1974,18 +2042,18 @@ Session::Session(MANIFEST_TYPE manifestType,
   int buf = kodi::GetSettingInt("MEDIATYPE");
   switch (buf)
   {
-  case 1:
-    media_type_mask_ = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::AUDIO;
-    break;
-  case 2:
-    media_type_mask_ = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO;
-    break;
-  case 3:
-    media_type_mask_ = (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO)
-                     | (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::SUBTITLE);
-    break;
-  default:
-    media_type_mask_ = static_cast<uint8_t>(~0);
+    case 1:
+      media_type_mask_ = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::AUDIO;
+      break;
+    case 2:
+      media_type_mask_ = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO;
+      break;
+    case 3:
+      media_type_mask_ = (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO) |
+                         (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::SUBTITLE);
+      break;
+    default:
+      media_type_mask_ = static_cast<uint8_t>(~0);
   }
 
   ignore_display_ = kodi::GetSettingBoolean("IGNOREDISPLAY");
@@ -2023,9 +2091,10 @@ Session::~Session()
   adaptiveTree_ = nullptr;
 }
 
-void Session::GetSupportedDecrypterURN(std::string &key_system)
+void Session::GetSupportedDecrypterURN(std::string& key_system)
 {
-  typedef SSD::SSD_DECRYPTER *(*CreateDecryptorInstanceFunc)(SSD::SSD_HOST *host, uint32_t version);
+  typedef SSD::SSD_DECRYPTER* (*CreateDecryptorInstanceFunc)(SSD::SSD_HOST * host,
+                                                             uint32_t version);
 
   std::string specialpath = kodi::GetSettingString("DECRYPTERPATH");
   if (specialpath.empty())
@@ -2038,16 +2107,18 @@ void Session::GetSupportedDecrypterURN(std::string &key_system)
   std::vector<std::string> searchPaths(2);
 #ifdef ANDROID
   searchPaths[0] = getenv("KODI_ANDROID_LIBS")
-    ? getenv("KODI_ANDROID_LIBS")
-    : kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/");
+                       ? getenv("KODI_ANDROID_LIBS")
+                       : kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/");
 #else
-  searchPaths[0] = kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/");
+  searchPaths[0] =
+      kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/");
 #endif
   searchPaths[1] = kodi::GetAddonInfo("path");
 
   std::vector<kodi::vfs::CDirEntry> items;
 
-  for (std::vector<std::string>::const_iterator path(searchPaths.begin()); !decrypter_ && path != searchPaths.end(); ++path)
+  for (std::vector<std::string>::const_iterator path(searchPaths.begin());
+       !decrypter_ && path != searchPaths.end(); ++path)
   {
     kodi::Log(ADDON_LOG_DEBUG, "Searching for decrypters in: %s", path->c_str());
 
@@ -2056,17 +2127,18 @@ void Session::GetSupportedDecrypterURN(std::string &key_system)
 
     for (unsigned int i(0); i < items.size(); ++i)
     {
-      if (strncmp(items[i].Label().c_str(), "ssd_", 4) && strncmp(items[i].Label().c_str(), "libssd_", 7))
+      if (strncmp(items[i].Label().c_str(), "ssd_", 4) &&
+          strncmp(items[i].Label().c_str(), "libssd_", 7))
         continue;
 
-      void * mod(dlopen(items[i].Path().c_str(), RTLD_LAZY));
+      void* mod(dlopen(items[i].Path().c_str(), RTLD_LAZY));
       if (mod)
       {
         CreateDecryptorInstanceFunc startup;
         if ((startup = (CreateDecryptorInstanceFunc)dlsym(mod, "CreateDecryptorInstance")))
         {
-          SSD::SSD_DECRYPTER *decrypter = startup(kodihost, SSD::SSD_HOST::version);
-          const char *suppUrn(0);
+          SSD::SSD_DECRYPTER* decrypter = startup(kodihost, SSD::SSD_HOST::version);
+          const char* suppUrn(0);
 
           if (decrypter && (suppUrn = decrypter->SelectKeySytem(license_type_.c_str())))
           {
@@ -2090,7 +2162,8 @@ void Session::GetSupportedDecrypterURN(std::string &key_system)
 void Session::DisposeSampleDecrypter()
 {
   if (decrypter_)
-    for (std::vector<CDMSESSION>::iterator b(cdm_sessions_.begin()), e(cdm_sessions_.end()); b != e; ++b)
+    for (std::vector<CDMSESSION>::iterator b(cdm_sessions_.begin()), e(cdm_sessions_.end()); b != e;
+         ++b)
       if (!b->shared_single_sample_decryptor_)
         decrypter_->DestroySingleSampleDecrypter(b->single_sample_decryptor_);
 }
@@ -2102,8 +2175,9 @@ void Session::DisposeDecrypter()
 
   DisposeSampleDecrypter();
 
-  typedef void (*DeleteDecryptorInstanceFunc)(SSD::SSD_DECRYPTER *);
-  DeleteDecryptorInstanceFunc disposefn((DeleteDecryptorInstanceFunc)dlsym(decrypterModule_, "DeleteDecryptorInstance"));
+  typedef void (*DeleteDecryptorInstanceFunc)(SSD::SSD_DECRYPTER*);
+  DeleteDecryptorInstanceFunc disposefn(
+      (DeleteDecryptorInstanceFunc)dlsym(decrypterModule_, "DeleteDecryptorInstance"));
 
   if (disposefn)
     disposefn(decrypter_);
@@ -2117,7 +2191,7 @@ void Session::DisposeDecrypter()
 |   initialize
 +---------------------------------------------------------------------*/
 
-bool Session::initialize(const std::uint8_t config, uint32_t max_user_bandwidth)
+bool Session::Initialize(const std::uint8_t config, uint32_t max_user_bandwidth)
 {
   if (!adaptiveTree_)
     return false;
@@ -2130,16 +2204,18 @@ bool Session::initialize(const std::uint8_t config, uint32_t max_user_bandwidth)
   }
 
   // Open mpd file with mpd location redirect support  bool mpdSuccess;
-  std::string mpdUrl = adaptiveTree_->location_.empty() ? mpdFileURL_.c_str() : adaptiveTree_->location_;
-  if (!adaptiveTree_->open(mpdUrl.c_str(), mpdUpdateParam_.c_str()) || adaptiveTree_->empty()) {
+  std::string mpdUrl =
+      adaptiveTree_->location_.empty() ? mpdFileURL_.c_str() : adaptiveTree_->location_;
+  if (!adaptiveTree_->open(mpdUrl.c_str(), mpdUpdateParam_.c_str()) || adaptiveTree_->empty())
+  {
     kodi::Log(ADDON_LOG_ERROR, "Could not open / parse mpdURL (%s)", mpdFileURL_.c_str());
     return false;
   }
-  kodi::Log(ADDON_LOG_INFO, "Successfully parsed .mpd file. #Periods: %ld, #Streams in first period: %ld, Type: %s, Download speed: %0.4f Bytes/s",
-    adaptiveTree_->periods_.size(),
-    adaptiveTree_->current_period_->adaptationSets_.size(),
-    adaptiveTree_->has_timeshift_buffer_ ? "live" : "VOD",
-    adaptiveTree_->download_speed_);
+  kodi::Log(ADDON_LOG_INFO,
+            "Successfully parsed .mpd file. #Periods: %ld, #Streams in first period: %ld, Type: "
+            "%s, Download speed: %0.4f Bytes/s",
+            adaptiveTree_->periods_.size(), adaptiveTree_->current_period_->adaptationSets_.size(),
+            adaptiveTree_->has_timeshift_buffer_ ? "live" : "VOD", adaptiveTree_->download_speed_);
 
   drmConfig_ = config;
   maxUserBandwidth_ = max_user_bandwidth;
@@ -2147,44 +2223,8 @@ bool Session::initialize(const std::uint8_t config, uint32_t max_user_bandwidth)
   return InitializePeriod();
 }
 
-bool Session::InitializePeriod()
+bool Session::InitializeDRM()
 {
-  if (adaptiveTree_->next_period_)
-  {
-    adaptiveTree_->current_period_ = adaptiveTree_->next_period_;
-    adaptiveTree_->next_period_ = nullptr;
-  }
-
-  chapter_start_time_ = 0;
-  for (adaptive::AdaptiveTree::Period* p : adaptiveTree_->periods_)
-    if (p == adaptiveTree_->current_period_)
-      break;
-    else
-      chapter_start_time_ += (p->duration_ * DVD_TIME_BASE) / p->timescale_;
-
-  if (adaptiveTree_->current_period_->encryptionState_ == adaptive::AdaptiveTree::ENCRYTIONSTATE_ENCRYPTED)
-  {
-    kodi::Log(ADDON_LOG_ERROR, "Unable to handle decryption. Unsupported!");
-    return false;
-  }
-
-  uint32_t min_bandwidth(0), max_bandwidth(0);
-  {
-    int buf;
-    buf = kodi::GetSettingInt("MINBANDWIDTH"); min_bandwidth = buf;
-    buf = kodi::GetSettingInt("MAXBANDWIDTH"); max_bandwidth = buf;
-  }
-
-  if (max_bandwidth == 0 || (maxUserBandwidth_ && max_bandwidth > maxUserBandwidth_))
-    max_bandwidth = maxUserBandwidth_;
-
-  // create SESSION::STREAM objects. One for each AdaptationSet
-  unsigned int i(0);
-  const adaptive::AdaptiveTree::AdaptationSet *adp;
-
-  for (std::vector<STREAM*>::iterator b(streams_.begin()), e(streams_.end()); b != e; ++b)
-    SAFE_DELETE(*b);
-  streams_.clear();
   DisposeSampleDecrypter();
 
   cdm_sessions_.resize(adaptiveTree_->current_period_->psshSets_.size());
@@ -2222,7 +2262,8 @@ bool Session::InitializePeriod()
       strkey.erase(pos, 1);
     if (strkey.size() != 32)
     {
-      kodi::Log(ADDON_LOG_ERROR, "Key system mismatch (%s)!", adaptiveTree_->supportedKeySystem_.c_str());
+      kodi::Log(ADDON_LOG_ERROR, "Key system mismatch (%s)!",
+                adaptiveTree_->supportedKeySystem_.c_str());
       return false;
     }
 
@@ -2232,7 +2273,7 @@ bool Session::InitializePeriod()
     for (size_t ses(1); ses < cdm_sessions_.size(); ++ses)
     {
       AP4_DataBuffer init_data;
-      const char *optionalKeyParameter(nullptr);
+      const char* optionalKeyParameter(nullptr);
 
       if (adaptiveTree_->current_period_->psshSets_[ses].pssh_ == "FILE")
       {
@@ -2240,8 +2281,12 @@ bool Session::InitializePeriod()
 
         if (license_data_.empty())
         {
-          Session::STREAM stream(*adaptiveTree_, adaptiveTree_->current_period_->psshSets_[ses].adaptation_set_->type_);
-          stream.stream_.prepare_stream(adaptiveTree_->current_period_->psshSets_[ses].adaptation_set_, 0, 0, 0, 0, 0, 0, 0, media_headers_);
+          Session::STREAM stream(
+              *adaptiveTree_,
+              adaptiveTree_->current_period_->psshSets_[ses].adaptation_set_->type_);
+          stream.stream_.prepare_stream(
+              adaptiveTree_->current_period_->psshSets_[ses].adaptation_set_, 0, 0, 0, 0, 0, 0, 0,
+              media_headers_);
 
           stream.enabled = true;
           stream.stream_.start_stream(~0, width_, height_, play_timeshift_buffer_);
@@ -2266,21 +2311,29 @@ bool Session::InitializePeriod()
               if (adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.empty())
               {
                 if (pssh[i]->GetKid(0))
-                  adaptiveTree_->current_period_->psshSets_[ses].defaultKID_ = std::string((const char*)pssh[i]->GetKid(0), 16);
-                else if (AP4_Track *track = movie->GetTrack(TIDC[stream.stream_.get_type()]))
+                  adaptiveTree_->current_period_->psshSets_[ses].defaultKID_ =
+                      std::string((const char*)pssh[i]->GetKid(0), 16);
+                else if (AP4_Track* track = movie->GetTrack(TIDC[stream.stream_.get_type()]))
                 {
-                  AP4_ProtectedSampleDescription *m_protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(track->GetSampleDescription(0));
-                  AP4_ContainerAtom *schi;
-                  if (m_protectedDesc->GetSchemeInfo() && (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
+                  AP4_ProtectedSampleDescription* m_protectedDesc =
+                      static_cast<AP4_ProtectedSampleDescription*>(track->GetSampleDescription(0));
+                  AP4_ContainerAtom* schi;
+                  if (m_protectedDesc->GetSchemeInfo() &&
+                      (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
                   {
-                    AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
+                    AP4_TencAtom* tenc(
+                        AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
                     if (tenc)
-                      adaptiveTree_->current_period_->psshSets_[ses].defaultKID_ = std::string((const char*)tenc->GetDefaultKid(), 16);
+                      adaptiveTree_->current_period_->psshSets_[ses].defaultKID_ =
+                          std::string((const char*)tenc->GetDefaultKid(), 16);
                     else
                     {
-                      AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
+                      AP4_PiffTrackEncryptionAtom* piff(
+                          AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom,
+                                           schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
                       if (piff)
-                        adaptiveTree_->current_period_->psshSets_[ses].defaultKID_ = std::string((const char*)piff->GetDefaultKid(), 16);
+                        adaptiveTree_->current_period_->psshSets_[ses].defaultKID_ =
+                            std::string((const char*)piff->GetDefaultKid(), 16);
                     }
                   }
                 }
@@ -2290,7 +2343,8 @@ bool Session::InitializePeriod()
 
           if (!init_data.GetDataSize())
           {
-            kodi::Log(ADDON_LOG_ERROR, "Could not extract license from video stream (PSSH not found)");
+            kodi::Log(ADDON_LOG_ERROR,
+                      "Could not extract license from video stream (PSSH not found)");
             stream.disable();
             return false;
           }
@@ -2298,13 +2352,14 @@ bool Session::InitializePeriod()
         }
         else if (!adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.empty())
         {
-          init_data.SetData((AP4_Byte*)adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.data(), 16);
+          init_data.SetData(
+              (AP4_Byte*)adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.data(), 16);
 
           uint8_t ld[1024];
           unsigned int ld_size(1014);
           b64_decode(license_data_.c_str(), license_data_.size(), ld, ld_size);
 
-          uint8_t *uuid((uint8_t*)strstr((const char*)ld, "{KID}"));
+          uint8_t* uuid((uint8_t*)strstr((const char*)ld, "{KID}"));
           if (uuid)
           {
             memmove(uuid + 11, uuid, ld_size - (uuid - ld));
@@ -2325,12 +2380,14 @@ bool Session::InitializePeriod()
           {
             if (license_data_.empty())
               license_data_ = "e0tJRH0="; // {KID}
-            create_ism_license(adaptiveTree_->current_period_->psshSets_[ses].defaultKID_, license_data_, init_data);
+            create_ism_license(adaptiveTree_->current_period_->psshSets_[ses].defaultKID_,
+                               license_data_, init_data);
           }
           else
           {
-            init_data.SetData(reinterpret_cast<const uint8_t*>(adaptiveTree_->current_period_->psshSets_[ses].pssh_.data()),
-              adaptiveTree_->current_period_->psshSets_[ses].pssh_.size());
+            init_data.SetData(reinterpret_cast<const uint8_t*>(
+                                  adaptiveTree_->current_period_->psshSets_[ses].pssh_.data()),
+                              adaptiveTree_->current_period_->psshSets_[ses].pssh_.size());
             optionalKeyParameter = license_data_.empty() ? nullptr : license_data_.c_str();
           }
         }
@@ -2339,16 +2396,16 @@ bool Session::InitializePeriod()
           init_data.SetBufferSize(1024);
           unsigned int init_data_size(1024);
           b64_decode(adaptiveTree_->current_period_->psshSets_[ses].pssh_.data(),
-            adaptiveTree_->current_period_->psshSets_[ses].pssh_.size(),
-            init_data.UseData(), init_data_size);
+                     adaptiveTree_->current_period_->psshSets_[ses].pssh_.size(),
+                     init_data.UseData(), init_data_size);
           init_data.SetDataSize(init_data_size);
         }
       }
 
-      CDMSESSION &session(cdm_sessions_[ses]);
-      const char *defkid = adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.empty()
-        ? nullptr
-        : adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.data();
+      CDMSESSION& session(cdm_sessions_[ses]);
+      const char* defkid = adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.empty()
+                               ? nullptr
+                               : adaptiveTree_->current_period_->psshSets_[ses].defaultKID_.data();
       session.single_sample_decryptor_ = nullptr;
       session.shared_single_sample_decryptor_ = false;
 
@@ -2359,7 +2416,8 @@ bool Session::InitializePeriod()
         kodi::Log(ADDON_LOG_DEBUG, "Initializing stream with KID: %s", hexkid);
 
         for (unsigned int i(1); i < ses; ++i)
-          if (decrypter_->HasLicenseKey(cdm_sessions_[i].single_sample_decryptor_, (const uint8_t *)defkid))
+          if (decrypter_->HasLicenseKey(cdm_sessions_[i].single_sample_decryptor_,
+                                        (const uint8_t*)defkid))
           {
             session.single_sample_decryptor_ = cdm_sessions_[i].single_sample_decryptor_;
             session.shared_single_sample_decryptor_ = true;
@@ -2369,7 +2427,8 @@ bool Session::InitializePeriod()
       else if (!defkid)
       {
         for (unsigned int i(1); i < ses; ++i)
-          if (adaptiveTree_->current_period_->psshSets_[ses].pssh_ == adaptiveTree_->current_period_->psshSets_[i].pssh_)
+          if (adaptiveTree_->current_period_->psshSets_[ses].pssh_ ==
+              adaptiveTree_->current_period_->psshSets_[i].pssh_)
           {
             session.single_sample_decryptor_ = cdm_sessions_[i].single_sample_decryptor_;
             session.shared_single_sample_decryptor_ = true;
@@ -2379,15 +2438,15 @@ bool Session::InitializePeriod()
           kodi::Log(ADDON_LOG_WARNING, "Initializing stream with unknown KID!");
       }
 
-      if (decrypter_ && init_data.GetDataSize() >= 4 && (session.single_sample_decryptor_
-        || (session.single_sample_decryptor_ = decrypter_->CreateSingleSampleDecrypter(init_data, optionalKeyParameter, (const uint8_t *)defkid)) != 0))
+      if (decrypter_ && init_data.GetDataSize() >= 4 &&
+          (session.single_sample_decryptor_ ||
+           (session.single_sample_decryptor_ = decrypter_->CreateSingleSampleDecrypter(
+                init_data, optionalKeyParameter, (const uint8_t*)defkid)) != 0))
       {
 
-        decrypter_->GetCapabilities(
-          session.single_sample_decryptor_,
-          (const uint8_t *)defkid,
-          adaptiveTree_->current_period_->psshSets_[ses].media_,
-          session.decrypter_caps_);
+        decrypter_->GetCapabilities(session.single_sample_decryptor_, (const uint8_t*)defkid,
+                                    adaptiveTree_->current_period_->psshSets_[ses].media_,
+                                    session.decrypter_caps_);
 
         if (session.decrypter_caps_.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_INVALID)
           adaptiveTree_->current_period_->RemovePSSHSet(static_cast<std::uint16_t>(ses));
@@ -2396,7 +2455,7 @@ bool Session::InitializePeriod()
           session.cdm_session_str_ = session.single_sample_decryptor_->GetSessionId();
           secure_video_session_ = true;
           // Override this setting by information passed in manifest
-          if (!adaptiveTree_->current_period_->need_secure_decoder_)
+          if (!force_secure_decoder_ && !adaptiveTree_->current_period_->need_secure_decoder_)
             session.decrypter_caps_.flags &= ~SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER;
         }
       }
@@ -2409,6 +2468,58 @@ bool Session::InitializePeriod()
       }
     }
   }
+  return true;
+}
+
+bool Session::InitializePeriod()
+{
+  bool psshChanged = true;
+  if (adaptiveTree_->next_period_)
+  {
+    psshChanged =
+        !(adaptiveTree_->current_period_->psshSets_ == adaptiveTree_->next_period_->psshSets_);
+    adaptiveTree_->current_period_ = adaptiveTree_->next_period_;
+    adaptiveTree_->next_period_ = nullptr;
+  }
+
+  chapter_start_time_ = 0;
+  for (adaptive::AdaptiveTree::Period* p : adaptiveTree_->periods_)
+    if (p == adaptiveTree_->current_period_)
+      break;
+    else
+      chapter_start_time_ += (p->duration_ * DVD_TIME_BASE) / p->timescale_;
+
+  if (adaptiveTree_->current_period_->encryptionState_ ==
+      adaptive::AdaptiveTree::ENCRYTIONSTATE_ENCRYPTED)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Unable to handle decryption. Unsupported!");
+    return false;
+  }
+
+  uint32_t min_bandwidth(0), max_bandwidth(0);
+  {
+    int buf;
+    buf = kodi::GetSettingInt("MINBANDWIDTH");
+    min_bandwidth = buf;
+    buf = kodi::GetSettingInt("MAXBANDWIDTH");
+    max_bandwidth = buf;
+  }
+
+  if (max_bandwidth == 0 || (maxUserBandwidth_ && max_bandwidth > maxUserBandwidth_))
+    max_bandwidth = maxUserBandwidth_;
+
+  // create SESSION::STREAM objects. One for each AdaptationSet
+  unsigned int i(0);
+  adaptive::AdaptiveTree::AdaptationSet* adp;
+
+  for (std::vector<STREAM*>::iterator b(streams_.begin()), e(streams_.end()); b != e; ++b)
+    SAFE_DELETE(*b);
+  streams_.clear();
+
+  if (psshChanged && !InitializeDRM())
+    return false;
+  else if (adaptiveTree_->current_period_->encryptionState_)
+    kodi::Log(ADDON_LOG_DEBUG, "Reusing DRM psshSets for new period!");
 
   bool hdcpOverride = kodi::GetSettingBoolean("HDCPOVERRIDE");
 
@@ -2417,9 +2528,12 @@ bool Session::InitializePeriod()
     if (adp->representations_.empty())
       continue;
 
-    bool manual_streams = adp->type_ == adaptive::AdaptiveTree::StreamType::VIDEO ? manual_streams_ != 0 : manual_streams_ == 1;
+    bool manual_streams = adp->type_ == adaptive::AdaptiveTree::StreamType::VIDEO
+                              ? manual_streams_ != 0
+                              : manual_streams_ == 1;
 
-    const SSD::SSD_DECRYPTER::SSD_CAPS &caps(GetDecrypterCaps(adp->representations_[0]->get_psshset()));
+    const SSD::SSD_DECRYPTER::SSD_CAPS& caps(
+        GetDecrypterCaps(adp->representations_[0]->get_psshset()));
 
     uint32_t hdcpLimit(caps.hdcpLimit);
     uint16_t hdcpVersion(caps.hdcpVersion);
@@ -2431,48 +2545,54 @@ bool Session::InitializePeriod()
     }
 
     // Select good video stream
-    adaptive::AdaptiveStream defaultVideoStream(*adaptiveTree_, adaptive::AdaptiveTree::StreamType::VIDEO);
+    adaptive::AdaptiveStream defaultVideoStream(*adaptiveTree_,
+                                                adaptive::AdaptiveTree::StreamType::VIDEO);
     if (adp->type_ == adaptive::AdaptiveTree::StreamType::VIDEO && manual_streams_ == 2)
-      defaultVideoStream.prepare_stream(adp, GetVideoWidth(), GetVideoHeight(), hdcpLimit, hdcpVersion, min_bandwidth, max_bandwidth, 0, media_headers_);
+      defaultVideoStream.prepare_stream(adp, GetVideoWidth(), GetVideoHeight(), hdcpLimit,
+                                        hdcpVersion, min_bandwidth, max_bandwidth, 0,
+                                        media_headers_);
 
     size_t repId = manual_streams ? adp->representations_.size() : 0;
 
-    do {
+    do
+    {
       streams_.push_back(new STREAM(*adaptiveTree_, adp->type_));
-      STREAM &stream(*streams_.back());
+      STREAM& stream(*streams_.back());
 
-      stream.stream_.prepare_stream(adp, GetVideoWidth(), GetVideoHeight(), hdcpLimit, hdcpVersion, min_bandwidth, max_bandwidth, repId, media_headers_);
+      stream.stream_.prepare_stream(adp, GetVideoWidth(), GetVideoHeight(), hdcpLimit, hdcpVersion,
+                                    min_bandwidth, max_bandwidth, repId, media_headers_);
       stream.info_.m_flags = INPUTSTREAM_INFO::FLAG_NONE;
       size_t copySize = adp->name_.size() > 255 ? 255 : adp->name_.size();
       strncpy(stream.info_.m_name, adp->name_.c_str(), copySize), stream.info_.m_name[copySize] = 0;
 
       switch (adp->type_)
       {
-      case adaptive::AdaptiveTree::VIDEO:
-        stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_VIDEO;
-        if (manual_streams && stream.stream_.getRepresentation() == defaultVideoStream.getRepresentation())
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_DEFAULT;
-        break;
-      case adaptive::AdaptiveTree::AUDIO:
-        stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_AUDIO;
-        if (adp->impaired_)
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_VISUAL_IMPAIRED;
-        if (adp->default_)
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_DEFAULT;
-        if (adp->original_ || (!ov_audio_.empty() && adp->language_ == ov_audio_))
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_ORIGINAL;
-        break;
-      case adaptive::AdaptiveTree::SUBTITLE:
-        stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_SUBTITLE;
-        if (adp->impaired_)
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_HEARING_IMPAIRED;
-        if (adp->forced_)
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_FORCED;
-        if (adp->default_)
-          stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_DEFAULT;
-        break;
-      default:
-        break;
+        case adaptive::AdaptiveTree::VIDEO:
+          stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_VIDEO;
+          if (manual_streams &&
+              stream.stream_.getRepresentation() == defaultVideoStream.getRepresentation())
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_DEFAULT;
+          break;
+        case adaptive::AdaptiveTree::AUDIO:
+          stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_AUDIO;
+          if (adp->impaired_)
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_VISUAL_IMPAIRED;
+          if (adp->default_)
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_DEFAULT;
+          if (adp->original_ || (!ov_audio_.empty() && adp->language_ == ov_audio_))
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_ORIGINAL;
+          break;
+        case adaptive::AdaptiveTree::SUBTITLE:
+          stream.info_.m_streamType = INPUTSTREAM_INFO::TYPE_SUBTITLE;
+          if (adp->impaired_)
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_HEARING_IMPAIRED;
+          if (adp->forced_)
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_FORCED;
+          if (adp->default_)
+            stream.info_.m_flags |= INPUTSTREAM_INFO::FLAG_DEFAULT;
+          break;
+        default:
+          break;
       }
       stream.info_.m_pID = i | (repId << 16);
       strncpy(stream.info_.m_language, adp->language_.c_str(), sizeof(stream.info_.m_language) - 1);
@@ -2489,9 +2609,9 @@ bool Session::InitializePeriod()
   return true;
 }
 
-void Session::UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &caps)
+void Session::UpdateStream(STREAM& stream, const SSD::SSD_DECRYPTER::SSD_CAPS& caps)
 {
-  const adaptive::AdaptiveTree::Representation *rep(stream.stream_.getRepresentation());
+  const adaptive::AdaptiveTree::Representation* rep(stream.stream_.getRepresentation());
 
   stream.info_.m_Width = rep->width_;
   stream.info_.m_Height = rep->height_;
@@ -2504,10 +2624,10 @@ void Session::UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &c
   if (!stream.info_.m_ExtraSize && rep->codec_private_data_.size())
   {
     std::string annexb;
-    const std::string *res(&annexb);
+    const std::string* res(&annexb);
 
-    if ((caps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED)
-      && stream.info_.m_streamType == INPUTSTREAM_INFO::TYPE_VIDEO)
+    if ((caps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED) &&
+        stream.info_.m_streamType == INPUTSTREAM_INFO::TYPE_VIDEO)
     {
       kodi::Log(ADDON_LOG_DEBUG, "UpdateStream: Convert avc -> annexb");
       annexb = avc_to_annexb(rep->codec_private_data_);
@@ -2538,21 +2658,20 @@ void Session::UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &c
   stream.info_.m_colorSpace = INPUTSTREAM_INFO::COLORSPACE_UNKNOWN;
   stream.info_.m_colorRange = INPUTSTREAM_INFO::COLORRANGE_UNKNOWN;
 #endif
-  if (rep->codecs_.find("mp4a") == 0
-  || rep->codecs_.find("aac") == 0)
+  if (rep->codecs_.find("mp4a") == 0 || rep->codecs_.find("aac") == 0)
     strcpy(stream.info_.m_codecName, "aac");
   else if (rep->codecs_.find("dts") == 0)
     strcpy(stream.info_.m_codecName, "dca");
   else if (rep->codecs_.find("ec-3") == 0 || rep->codecs_.find("ac-3") == 0)
     strcpy(stream.info_.m_codecName, "eac3");
-  else if (rep->codecs_.find("avc") == 0
-  || rep->codecs_.find("h264") == 0)
+  else if (rep->codecs_.find("avc") == 0 || rep->codecs_.find("h264") == 0)
     strcpy(stream.info_.m_codecName, "h264");
   else if (rep->codecs_.find("hev") == 0)
     strcpy(stream.info_.m_codecName, "hevc");
   else if (rep->codecs_.find("hvc") == 0)
   {
-    stream.info_.m_codecFourCC = MKTAG(rep->codecs_[0], rep->codecs_[1], rep->codecs_[2], rep->codecs_[3]);
+    stream.info_.m_codecFourCC =
+        MKTAG(rep->codecs_[0], rep->codecs_[1], rep->codecs_[2], rep->codecs_[3]);
     strcpy(stream.info_.m_codecName, "hevc");
   }
   else if (rep->codecs_.find("vp9") == 0 || rep->codecs_.find("vp09") == 0)
@@ -2560,7 +2679,8 @@ void Session::UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &c
     strcpy(stream.info_.m_codecName, "vp9");
 #if INPUTSTREAM_VERSION_LEVEL > 0
     if ((pos = rep->codecs_.find(".")) != std::string::npos)
-      stream.info_.m_codecProfile = static_cast<STREAMCODEC_PROFILE>(VP9CodecProfile0 + atoi(rep->codecs_.c_str() + (pos + 1)));
+      stream.info_.m_codecProfile = static_cast<STREAMCODEC_PROFILE>(
+          VP9CodecProfile0 + atoi(rep->codecs_.c_str() + (pos + 1)));
 #endif
   }
   else if (rep->codecs_.find("dvhe") == 0)
@@ -2572,17 +2692,19 @@ void Session::UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &c
     strcpy(stream.info_.m_codecName, "opus");
   else if (rep->codecs_.find("vorbis") == 0)
     strcpy(stream.info_.m_codecName, "vorbis");
-  else if (rep->codecs_.find("stpp") == 0 || rep->codecs_.find("ttml") == 0 || rep->codecs_.find("wvtt") == 0)
+  else if (rep->codecs_.find("stpp") == 0 || rep->codecs_.find("ttml") == 0 ||
+           rep->codecs_.find("wvtt") == 0)
     strcpy(stream.info_.m_codecName, "srt");
   else
     stream.valid = false;
 
   // We support currently only mp4 / ts / adts
-  if (rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_NOTYPE
-  && rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_MP4
-  && rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TS
-  && rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_ADTS
-  && rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_WEBM)
+  if (rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_NOTYPE &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_MP4 &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TS &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_ADTS &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_WEBM &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TEXT)
     stream.valid = false;
 
   stream.info_.m_FpsRate = rep->fpsRate_;
@@ -2592,52 +2714,75 @@ void Session::UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &c
   stream.info_.m_BitRate = rep->bandwidth_;
 }
 
-AP4_Movie *Session::PrepareStream(STREAM *stream)
+AP4_Movie* Session::PrepareStream(STREAM* stream, bool& needRefetch)
 {
-  if (!adaptiveTree_->prepareRepresentation(const_cast<adaptive::AdaptiveTree::Representation *>(stream->stream_.getRepresentation())))
-    return nullptr;
+  needRefetch = false;
+  switch (adaptiveTree_->prepareRepresentation(stream->stream_.getPeriod(),
+                                               stream->stream_.getAdaptationSet(),
+                                               stream->stream_.getRepresentation()))
+  {
+    case adaptive::AdaptiveTree::PREPARE_RESULT_FAILURE:
+      return nullptr;
+    case adaptive::AdaptiveTree::PREPARE_RESULT_DRMCHANGED:
+      if (!InitializeDRM())
+        return nullptr;
+      stream->encrypted = stream->stream_.getRepresentation()->pssh_set_ > 0;
+      needRefetch = true;
+      break;
+    default:;
+  }
 
-  if (stream->stream_.getRepresentation()->containerType_ == adaptive::AdaptiveTree::CONTAINERTYPE_MP4
-    && (stream->stream_.getRepresentation()->flags_ & adaptive::AdaptiveTree::Representation::INITIALIZATION_PREFIXED) == 0
-    && stream->stream_.getRepresentation()->get_initialization() == nullptr)
+  if (stream->stream_.getRepresentation()->containerType_ ==
+          adaptive::AdaptiveTree::CONTAINERTYPE_MP4 &&
+      (stream->stream_.getRepresentation()->flags_ &
+       adaptive::AdaptiveTree::Representation::INITIALIZATION_PREFIXED) == 0 &&
+      stream->stream_.getRepresentation()->get_initialization() == nullptr)
   {
     //We'll create a Movie out of the things we got from manifest file
     //note: movie will be deleted in destructor of stream->input_file_
-    AP4_Movie *movie = new AP4_Movie();
+    AP4_Movie* movie = new AP4_Movie();
 
     AP4_SyntheticSampleTable* sample_table = new AP4_SyntheticSampleTable();
 
-    AP4_SampleDescription *sample_descryption;
+    AP4_SampleDescription* sample_descryption;
     if (strcmp(stream->info_.m_codecName, "h264") == 0)
     {
-      const std::string &extradata(stream->stream_.getRepresentation()->codec_private_data_);
+      const std::string& extradata(stream->stream_.getRepresentation()->codec_private_data_);
       AP4_MemoryByteStream ms((const uint8_t*)extradata.data(), extradata.size());
-      AP4_AvccAtom *atom = AP4_AvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms);
-      sample_descryption = new AP4_AvcSampleDescription(AP4_SAMPLE_FORMAT_AVC1, stream->info_.m_Width, stream->info_.m_Height, 0, nullptr, atom);
+      AP4_AvccAtom* atom = AP4_AvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms);
+      sample_descryption = new AP4_AvcSampleDescription(
+          AP4_SAMPLE_FORMAT_AVC1, stream->info_.m_Width, stream->info_.m_Height, 0, nullptr, atom);
     }
     else if (strcmp(stream->info_.m_codecName, "hevc") == 0)
     {
-      const std::string &extradata(stream->stream_.getRepresentation()->codec_private_data_);
+      const std::string& extradata(stream->stream_.getRepresentation()->codec_private_data_);
       AP4_MemoryByteStream ms((const uint8_t*)extradata.data(), extradata.size());
-      AP4_HvccAtom *atom = AP4_HvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms);
-      sample_descryption = new AP4_HevcSampleDescription(AP4_SAMPLE_FORMAT_HEV1, stream->info_.m_Width, stream->info_.m_Height, 0, nullptr, atom);
+      AP4_HvccAtom* atom = AP4_HvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms);
+      sample_descryption = new AP4_HevcSampleDescription(
+          AP4_SAMPLE_FORMAT_HEV1, stream->info_.m_Width, stream->info_.m_Height, 0, nullptr, atom);
     }
     else if (strcmp(stream->info_.m_codecName, "srt") == 0)
-      sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_SUBTITLES, AP4_SAMPLE_FORMAT_STPP, 0);
+      sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_SUBTITLES,
+                                                     AP4_SAMPLE_FORMAT_STPP, 0);
     else
       sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_UNKNOWN, 0, 0);
 
     if (stream->stream_.getRepresentation()->get_psshset() > 0)
     {
       AP4_ContainerAtom schi(AP4_ATOM_TYPE_SCHI);
-      schi.AddChild(new AP4_TencAtom(AP4_CENC_ALGORITHM_ID_CTR, 8, GetDefaultKeyId(stream->stream_.getRepresentation()->get_psshset())));
-      sample_descryption = new AP4_ProtectedSampleDescription(0, sample_descryption, 0, AP4_PROTECTION_SCHEME_TYPE_PIFF, 0, "", &schi);
+      schi.AddChild(
+          new AP4_TencAtom(AP4_CENC_ALGORITHM_ID_CTR, 8,
+                           GetDefaultKeyId(stream->stream_.getRepresentation()->get_psshset())));
+      sample_descryption = new AP4_ProtectedSampleDescription(
+          0, sample_descryption, 0, AP4_PROTECTION_SCHEME_TYPE_PIFF, 0, "", &schi);
     }
     sample_table->AddSampleDescription(sample_descryption);
 
-    movie->AddTrack(new AP4_Track(TIDC[stream->stream_.get_type()], sample_table, ~0, stream->stream_.getRepresentation()->timescale_, 0, stream->stream_.getRepresentation()->timescale_, 0, "", 0, 0));
+    movie->AddTrack(new AP4_Track(TIDC[stream->stream_.get_type()], sample_table, ~0,
+                                  stream->stream_.getRepresentation()->timescale_, 0,
+                                  stream->stream_.getRepresentation()->timescale_, 0, "", 0, 0));
     //Create a dumy MOOV Atom to tell Bento4 its a fragmented stream
-    AP4_MoovAtom *moov = new AP4_MoovAtom();
+    AP4_MoovAtom* moov = new AP4_MoovAtom();
     moov->AddChild(new AP4_ContainerAtom(AP4_ATOM_TYPE_MVEX));
     movie->SetMoovAtom(moov);
     return movie;
@@ -2665,8 +2810,12 @@ uint64_t Session::PTSToElapsed(uint64_t pts)
 {
   if (timing_stream_)
   {
-    uint64_t manifest_time = (pts - timing_stream_->reader_->GetPTSDiff() > 0) ? pts - timing_stream_->reader_->GetPTSDiff() : 0;
-    return (manifest_time > timing_stream_->stream_.GetAbsolutePTSOffset()) ? manifest_time - timing_stream_->stream_.GetAbsolutePTSOffset() : 0ULL;
+    uint64_t manifest_time = (pts - timing_stream_->reader_->GetPTSDiff() > 0)
+                                 ? pts - timing_stream_->reader_->GetPTSDiff()
+                                 : 0;
+    return (manifest_time > timing_stream_->stream_.GetAbsolutePTSOffset())
+               ? manifest_time - timing_stream_->stream_.GetAbsolutePTSOffset()
+               : 0ULL;
   }
   else
     return pts;
@@ -2680,15 +2829,15 @@ uint64_t Session::GetTimeshiftBufferStart()
     return 0ULL;
 }
 
-SampleReader *Session::GetNextSample()
+SampleReader* Session::GetNextSample()
 {
   STREAM *res(0), *waiting(0);
   for (std::vector<STREAM*>::const_iterator b(streams_.begin()), e(streams_.end()); b != e; ++b)
   {
     bool bStarted(false);
-    if ((*b)->enabled && (*b)->reader_ && !(*b)->reader_->EOS()
-    && AP4_SUCCEEDED((*b)->reader_->Start(bStarted))
-    && (!res || (*b)->reader_->DTSorPTS() < res->reader_->DTSorPTS()))
+    if ((*b)->enabled && (*b)->reader_ && !(*b)->reader_->EOS() &&
+        AP4_SUCCEEDED((*b)->reader_->Start(bStarted)) &&
+        (!res || (*b)->reader_->DTSorPTS() < res->reader_->DTSorPTS()))
       ((*b)->stream_.waitingForSegment(true) ? waiting : res) = *b;
 
     if (bStarted && ((*b)->reader_->GetInformation((*b)->info_)))
@@ -2722,7 +2871,7 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
 
   // Check if we leave our current period
   double chapterTime(0);
-  std::vector<adaptive::AdaptiveTree::Period *>::const_iterator pi;
+  std::vector<adaptive::AdaptiveTree::Period*>::const_iterator pi;
   for (pi = adaptiveTree_->periods_.cbegin(); pi != adaptiveTree_->periods_.cend(); ++pi)
   {
     chapterTime += double((*pi)->duration_) / (*pi)->timescale_;
@@ -2765,14 +2914,15 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
       seekTimeCorrected = 0;
     else
       seekTimeCorrected += ptsDiff;
-
   }
 
   for (std::vector<STREAM*>::const_iterator b(streams_.begin()), e(streams_.end()); b != e; ++b)
     if ((*b)->enabled && (*b)->reader_ && (streamId == 0 || (*b)->info_.m_pID == streamId))
     {
       bool bReset;
-      if ((*b)->stream_.seek_time(static_cast<double>(seekTimeCorrected - (*b)->reader_->GetPTSDiff()) / DVD_TIME_BASE, preceeding, bReset))
+      if ((*b)->stream_.seek_time(
+              static_cast<double>(seekTimeCorrected - (*b)->reader_->GetPTSDiff()) / DVD_TIME_BASE,
+              preceeding, bReset))
       {
         if (bReset)
           (*b)->reader_->Reset(false);
@@ -2781,8 +2931,9 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
         else
         {
           double destTime(static_cast<double>(PTSToElapsed((*b)->reader_->PTS())) / DVD_TIME_BASE);
-          kodi::Log(ADDON_LOG_INFO, "seekTime(%0.1lf) for Stream:%d continues at %0.1lf (PTS: %llu)",
-            seekTime, (*b)->info_.m_pID, destTime, (*b)->reader_->PTS());
+          kodi::Log(ADDON_LOG_INFO,
+                    "seekTime(%0.1lf) for Stream:%d continues at %0.1lf (PTS: %llu)", seekTime,
+                    (*b)->info_.m_pID, destTime, (*b)->reader_->PTS());
           if ((*b)->info_.m_streamType == INPUTSTREAM_INFO::TYPE_VIDEO)
             seekTime = destTime, seekTimeCorrected = (*b)->reader_->PTS(), preceeding = false;
           ret = true;
@@ -2794,63 +2945,64 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
   return ret;
 }
 
-void Session::OnSegmentChanged(adaptive::AdaptiveStream *stream)
+void Session::OnSegmentChanged(adaptive::AdaptiveStream* stream)
 {
-  for (STREAM *s : streams_)
+  for (STREAM* s : streams_)
     if (&s->stream_ == stream)
     {
-      if(s->reader_)
+      if (s->reader_)
         s->reader_->SetPTSOffset(s->stream_.GetCurrentPTSOffset());
       s->segmentChanged = true;
       break;
     }
 }
 
-void Session::OnStreamChange(adaptive::AdaptiveStream *stream)
+void Session::OnStreamChange(adaptive::AdaptiveStream* stream)
 {
 }
 
-void Session::CheckFragmentDuration(STREAM &stream)
+void Session::CheckFragmentDuration(STREAM& stream)
 {
   uint64_t nextTs, nextDur;
   if (stream.segmentChanged && stream.reader_->GetNextFragmentInfo(nextTs, nextDur))
     adaptiveTree_->SetFragmentDuration(
-      stream.stream_.getAdaptationSet(),
-      stream.stream_.getRepresentation(),
-      stream.stream_.getSegmentPos(),
-      nextTs,
-      static_cast<uint32_t>(nextDur),
-      stream.reader_->GetTimeScale());
+        stream.stream_.getAdaptationSet(), stream.stream_.getRepresentation(),
+        stream.stream_.getSegmentPos(), nextTs, static_cast<uint32_t>(nextDur),
+        stream.reader_->GetTimeScale());
   stream.segmentChanged = false;
 }
 
-const AP4_UI08 *Session::GetDefaultKeyId(const uint16_t index) const
+const AP4_UI08* Session::GetDefaultKeyId(const uint16_t index) const
 {
-  static const AP4_UI08 default_key[16] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
+  static const AP4_UI08 default_key[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   if (adaptiveTree_->current_period_->psshSets_[index].defaultKID_.size() == 16)
-    return reinterpret_cast<const AP4_UI08 *>(adaptiveTree_->current_period_->psshSets_[index].defaultKID_.data());
+    return reinterpret_cast<const AP4_UI08*>(
+        adaptiveTree_->current_period_->psshSets_[index].defaultKID_.data());
   return default_key;
 }
 
 std::uint16_t Session::GetVideoWidth() const
 {
-  std::uint16_t ret(ignore_display_ ? 8192: width_);
+  std::uint16_t ret(ignore_display_ ? 8192 : width_);
   switch (secure_video_session_ ? max_secure_resolution_ : max_resolution_)
   {
-  case 1:
-    if (ret > 640) ret = 640;
-    break;
-  case 2:
-    if (ret > 960) ret = 960;
-    break;
-  case 3:
-    if (ret > 1280) ret = 1280;
-    break;
-  case 4:
-    if (ret > 1920) ret = 1920;
-    break;
-  default:
-    ;
+    case 1:
+      if (ret > 640)
+        ret = 640;
+      break;
+    case 2:
+      if (ret > 960)
+        ret = 960;
+      break;
+    case 3:
+      if (ret > 1280)
+        ret = 1280;
+      break;
+    case 4:
+      if (ret > 1920)
+        ret = 1920;
+      break;
+    default:;
   }
   return ret;
 }
@@ -2860,27 +3012,31 @@ std::uint16_t Session::GetVideoHeight() const
   std::uint16_t ret(ignore_display_ ? 8192 : height_);
   switch (secure_video_session_ ? max_secure_resolution_ : max_resolution_)
   {
-  case 1:
-    if (ret > 480) ret = 480;
-    break;
-  case 2:
-    if (ret > 640) ret = 640;
-    break;
-  case 3:
-    if (ret > 720) ret = 720;
-    break;
-  case 4:
-    if (ret > 1080) ret = 1080;
-    break;
-  default:
-    ;
+    case 1:
+      if (ret > 480)
+        ret = 480;
+      break;
+    case 2:
+      if (ret > 640)
+        ret = 640;
+      break;
+    case 3:
+      if (ret > 720)
+        ret = 720;
+      break;
+    case 4:
+      if (ret > 1080)
+        ret = 1080;
+      break;
+    default:;
   }
   return ret;
 }
 
-AP4_CencSingleSampleDecrypter *Session::GetSingleSampleDecrypter(std::string sessionId)
+AP4_CencSingleSampleDecrypter* Session::GetSingleSampleDecrypter(std::string sessionId)
 {
-  for (std::vector<CDMSESSION>::iterator b(cdm_sessions_.begin() + 1), e(cdm_sessions_.end()); b != e; ++b)
+  for (std::vector<CDMSESSION>::iterator b(cdm_sessions_.begin() + 1), e(cdm_sessions_.end());
+       b != e; ++b)
     if (b->cdm_session_str_ && sessionId == b->cdm_session_str_)
       return b->single_sample_decryptor_;
   return nullptr;
@@ -2888,7 +3044,9 @@ AP4_CencSingleSampleDecrypter *Session::GetSingleSampleDecrypter(std::string ses
 
 uint32_t Session::GetIncludedStreamMask() const
 {
-  const INPUTSTREAM_INFO::STREAM_TYPE adp2ips[] = { INPUTSTREAM_INFO::TYPE_NONE, INPUTSTREAM_INFO::TYPE_VIDEO, INPUTSTREAM_INFO::TYPE_AUDIO, INPUTSTREAM_INFO::TYPE_SUBTITLE};
+  const INPUTSTREAM_INFO::STREAM_TYPE adp2ips[] = {
+      INPUTSTREAM_INFO::TYPE_NONE, INPUTSTREAM_INFO::TYPE_VIDEO, INPUTSTREAM_INFO::TYPE_AUDIO,
+      INPUTSTREAM_INFO::TYPE_SUBTITLE};
   uint32_t res(0);
   for (unsigned int i(0); i < 4; ++i)
     if (adaptiveTree_->current_period_->included_types_ & (1U << i))
@@ -2906,18 +3064,17 @@ CRYPTO_INFO::CRYPTO_KEY_SYSTEM Session::GetCryptoKeySystem() const
 #endif
   else if (license_type_ == "com.microsoft.playready")
     return CRYPTO_INFO::CRYPTO_KEY_SYSTEM_PLAYREADY;
- else
-   return CRYPTO_INFO::CRYPTO_KEY_SYSTEM_NONE;
+  else
+    return CRYPTO_INFO::CRYPTO_KEY_SYSTEM_NONE;
 }
 
 int Session::GetChapter() const
 {
   if (adaptiveTree_)
   {
-    std::vector<adaptive::AdaptiveTree::Period *>::const_iterator res = std::find(
-      adaptiveTree_->periods_.cbegin(),
-      adaptiveTree_->periods_.cend(),
-      adaptiveTree_->current_period_);
+    std::vector<adaptive::AdaptiveTree::Period*>::const_iterator res =
+        std::find(adaptiveTree_->periods_.cbegin(), adaptiveTree_->periods_.cend(),
+                  adaptiveTree_->current_period_);
     if (res != adaptiveTree_->periods_.cend())
       return (res - adaptiveTree_->periods_.cbegin()) + 1;
   }
@@ -2934,7 +3091,7 @@ int Session::GetChapterCount() const
 const char* Session::GetChapterName(int ch) const
 {
   --ch;
-  if (ch >=0 && ch < static_cast<int>(adaptiveTree_->periods_.size()))
+  if (ch >= 0 && ch < static_cast<int>(adaptiveTree_->periods_.size()))
     return adaptiveTree_->periods_[ch]->id_.c_str();
   return "[Unknown]";
 }
@@ -2945,7 +3102,8 @@ int64_t Session::GetChapterPos(int ch) const
   --ch;
 
   for (; ch; --ch)
-    sum += (adaptiveTree_->periods_[ch - 1]->duration_ * DVD_TIME_BASE) / adaptiveTree_->periods_[ch - 1]->timescale_;
+    sum += (adaptiveTree_->periods_[ch - 1]->duration_ * DVD_TIME_BASE) /
+           adaptiveTree_->periods_[ch - 1]->timescale_;
   return sum / DVD_TIME_BASE;
 }
 
@@ -2955,11 +3113,11 @@ bool Session::SeekChapter(int ch)
     return true;
 
   --ch;
-  if (ch >= 0 && ch < static_cast<int>(adaptiveTree_->periods_.size())
-    && adaptiveTree_->periods_[ch] != adaptiveTree_->current_period_)
+  if (ch >= 0 && ch < static_cast<int>(adaptiveTree_->periods_.size()) &&
+      adaptiveTree_->periods_[ch] != adaptiveTree_->current_period_)
   {
     adaptiveTree_->next_period_ = adaptiveTree_->periods_[ch];
-    for (STREAM *stream : streams_)
+    for (STREAM* stream : streams_)
       if (stream->reader_)
         stream->reader_->Reset(true);
 
@@ -2977,19 +3135,18 @@ class CInputStreamAdaptive;
 /*                     VideoCodec                      */
 /*******************************************************/
 
-class CVideoCodecAdaptive
-  : public kodi::addon::CInstanceVideoCodec
+class CVideoCodecAdaptive : public kodi::addon::CInstanceVideoCodec
 {
 public:
   CVideoCodecAdaptive(KODI_HANDLE instance);
-  CVideoCodecAdaptive(KODI_HANDLE instance, CInputStreamAdaptive *parent);
+  CVideoCodecAdaptive(KODI_HANDLE instance, CInputStreamAdaptive* parent);
   virtual ~CVideoCodecAdaptive();
 
-  bool Open(VIDEOCODEC_INITDATA &initData) override;
-  bool Reconfigure(VIDEOCODEC_INITDATA &initData) override;
-  bool AddData(const DemuxPacket &packet) override;
-  VIDEOCODEC_RETVAL GetPicture(VIDEOCODEC_PICTURE &picture) override;
-  const char *GetName() override { return m_name.c_str(); };
+  bool Open(VIDEOCODEC_INITDATA& initData) override;
+  bool Reconfigure(VIDEOCODEC_INITDATA& initData) override;
+  bool AddData(const DemuxPacket& packet) override;
+  VIDEOCODEC_RETVAL GetPicture(VIDEOCODEC_PICTURE& picture) override;
+  const char* GetName() override { return m_name.c_str(); };
   void Reset() override;
 
 private:
@@ -3007,12 +3164,14 @@ private:
 /*                     InputStream                     */
 /*******************************************************/
 
-class CInputStreamAdaptive
-  : public kodi::addon::CInstanceInputStream
+class CInputStreamAdaptive : public kodi::addon::CInstanceInputStream
 {
 public:
   CInputStreamAdaptive(KODI_HANDLE instance, const std::string& kodiVersion);
-  ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance) override;
+  ADDON_STATUS CreateInstance(int instanceType,
+                              std::string instanceID,
+                              KODI_HANDLE instance,
+                              KODI_HANDLE& addonInstance) override;
 
   bool Open(INPUTSTREAM& props) override;
   void Close() override;
@@ -3053,14 +3212,18 @@ CInputStreamAdaptive::CInputStreamAdaptive(KODI_HANDLE instance, const std::stri
 #else
   : CInstanceInputStream(instance)
 #endif
-  , m_session(nullptr)
-  , m_width(1280)
-  , m_height(720)
+    ,
+    m_session(nullptr),
+    m_width(1280),
+    m_height(720)
 {
   memset(m_IncludedStreams, 0, sizeof(m_IncludedStreams));
 }
 
-ADDON_STATUS CInputStreamAdaptive::CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance)
+ADDON_STATUS CInputStreamAdaptive::CreateInstance(int instanceType,
+                                                  std::string instanceID,
+                                                  KODI_HANDLE instance,
+                                                  KODI_HANDLE& addonInstance)
 {
   if (instanceType == ADDON_INSTANCE_VIDEOCODEC)
   {
@@ -3081,38 +3244,49 @@ bool CInputStreamAdaptive::Open(INPUTSTREAM& props)
   MANIFEST_TYPE manifest(MANIFEST_TYPE_UNKNOWN);
   std::uint8_t config(0);
   uint32_t max_user_bandwidth = 0;
+  bool force_secure_decoder = false;
 
   for (unsigned int i(0); i < props.m_nCountInfoValues; ++i)
   {
     if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_type") == 0)
     {
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.license_type: %s", props.m_ListItemProperties[i].m_strValue);
+      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.license_type: %s",
+                props.m_ListItemProperties[i].m_strValue);
       lt = props.m_ListItemProperties[i].m_strValue;
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_key") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_key") ==
+             0)
     {
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.license_key: [not shown]");
       lk = props.m_ListItemProperties[i].m_strValue;
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_data") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_data") ==
+             0)
     {
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.license_data: [not shown]");
       ld = props.m_ListItemProperties[i].m_strValue;
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_flags") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.license_flags") ==
+             0)
     {
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.license_flags: %s", props.m_ListItemProperties[i].m_strValue);
+      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.license_flags: %s",
+                props.m_ListItemProperties[i].m_strValue);
       if (strstr(props.m_ListItemProperties[i].m_strValue, "persistent_storage") != nullptr)
         config |= SSD::SSD_DECRYPTER::CONFIG_PERSISTENTSTORAGE;
+      if (strstr(props.m_ListItemProperties[i].m_strValue, "force_secure_decoder") != nullptr)
+        force_secure_decoder = true;
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.server_certificate") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.server_certificate") == 0)
     {
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.server_certificate: [not shown]");
       lsc = props.m_ListItemProperties[i].m_strValue;
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.manifest_type") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.manifest_type") ==
+             0)
     {
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.manifest_type: %s", props.m_ListItemProperties[i].m_strValue);
+      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.manifest_type: %s",
+                props.m_ListItemProperties[i].m_strValue);
       if (strcmp(props.m_ListItemProperties[i].m_strValue, "mpd") == 0)
         manifest = MANIFEST_TYPE_MPD;
       else if (strcmp(props.m_ListItemProperties[i].m_strValue, "ism") == 0)
@@ -3120,39 +3294,49 @@ bool CInputStreamAdaptive::Open(INPUTSTREAM& props)
       else if (strcmp(props.m_ListItemProperties[i].m_strValue, "hls") == 0)
         manifest = MANIFEST_TYPE_HLS;
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.manifest_update_parameter") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.manifest_update_parameter") == 0)
     {
       mfup = props.m_ListItemProperties[i].m_strValue;
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.manifest_update_parameter: %s", mfup);
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.stream_headers") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.stream_headers") == 0)
     {
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.stream_headers: %s", props.m_ListItemProperties[i].m_strValue);
+      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.stream_headers: %s",
+                props.m_ListItemProperties[i].m_strValue);
       parseheader(manh, props.m_ListItemProperties[i].m_strValue);
       medh = manh;
       mpd_url = mpd_url.substr(0, mpd_url.find("|"));
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.original_audio_language") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.original_audio_language") == 0)
     {
       ov_audio = props.m_ListItemProperties[i].m_strValue;
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.original_audio_language: %s", ov_audio);
+      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.original_audio_language: %s",
+                ov_audio);
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.media_renewal_url") == 0)
-    {  
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.media_renewal_url") == 0)
+    {
       mru = props.m_ListItemProperties[i].m_strValue;
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.media_renewal_url: %s", mru);
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.media_renewal_time") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.media_renewal_time") == 0)
     {
       mrt = atoi(props.m_ListItemProperties[i].m_strValue);
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.media_renewal_time: %d", mrt);
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.max_bandwidth") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.max_bandwidth") ==
+             0)
     {
       max_user_bandwidth = atoi(props.m_ListItemProperties[i].m_strValue);
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.max_bandwidth: %d", max_user_bandwidth);
+      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.max_bandwidth: %d",
+                max_user_bandwidth);
     }
-    else if (strcmp(props.m_ListItemProperties[i].m_strKey, "inputstream.adaptive.play_timeshift_buffer") == 0)
+    else if (strcmp(props.m_ListItemProperties[i].m_strKey,
+                    "inputstream.adaptive.play_timeshift_buffer") == 0)
       m_playTimeshiftBuffer = stricmp(props.m_ListItemProperties[i].m_strValue, "true") == 0;
   }
 
@@ -3173,25 +3357,11 @@ bool CInputStreamAdaptive::Open(INPUTSTREAM& props)
   kodihost->SetProfilePath(props.m_profileFolder);
 
   m_session = std::shared_ptr<Session>(new Session(
-    manifest,
-    mpd_url.c_str(),
-    mfup,
-    lt,
-    lk,
-    ld,
-    lsc,
-    mru,
-    mrt,
-    manh,
-    medh,
-    props.m_profileFolder,
-    m_width,
-    m_height,
-    ov_audio,
-    m_playTimeshiftBuffer));
+      manifest, mpd_url.c_str(), mfup, lt, lk, ld, lsc, mru, mrt, manh, medh, props.m_profileFolder,
+      m_width, m_height, ov_audio, m_playTimeshiftBuffer, force_secure_decoder));
   m_session->SetVideoResolution(m_width, m_height);
 
-  if (!m_session->initialize(config, max_user_bandwidth))
+  if (!m_session->Initialize(config, max_user_bandwidth))
   {
     m_session = nullptr;
     return false;
@@ -3210,39 +3380,43 @@ struct INPUTSTREAM_IDS CInputStreamAdaptive::GetStreamIds()
   kodi::Log(ADDON_LOG_DEBUG, "GetStreamIds()");
   INPUTSTREAM_IDS iids;
 
-  if(m_session)
+  if (m_session)
   {
     int chapter = m_session->GetChapter();
     iids.m_streamCount = 0;
 
-    for (unsigned int i(1); i <= INPUTSTREAM_IDS::MAX_STREAM_COUNT && i <= m_session->GetStreamCount(); ++i)
+    for (unsigned int i(1);
+         i <= INPUTSTREAM_IDS::MAX_STREAM_COUNT && i <= m_session->GetStreamCount(); ++i)
     {
-      uint8_t cdmId(static_cast<uint8_t>(m_session->GetStream(i)->stream_.getRepresentation()->pssh_set_));
-      if (m_session->GetStream(i)->valid
-        && (m_session->GetMediaTypeMask() & static_cast<uint8_t>(1) << m_session->GetStream(i)->stream_.get_type()))
+      uint8_t cdmId(
+          static_cast<uint8_t>(m_session->GetStream(i)->stream_.getRepresentation()->pssh_set_));
+      if (m_session->GetStream(i)->valid &&
+          (m_session->GetMediaTypeMask() & static_cast<uint8_t>(1)
+                                               << m_session->GetStream(i)->stream_.get_type()))
       {
         if (m_session->GetMediaTypeMask() != 0xFF)
         {
-          const adaptive::AdaptiveTree::Representation *rep(m_session->GetStream(i)->stream_.getRepresentation());
+          const adaptive::AdaptiveTree::Representation* rep(
+              m_session->GetStream(i)->stream_.getRepresentation());
           if (rep->flags_ & adaptive::AdaptiveTree::Representation::INCLUDEDSTREAM)
             continue;
         }
         iids.m_streamIds[iids.m_streamCount++] = i + chapter * 1000;
       }
     }
-  } else
-      iids.m_streamCount = 0;
+  }
+  else
+    iids.m_streamCount = 0;
   return iids;
 }
 
-void CInputStreamAdaptive::GetCapabilities(INPUTSTREAM_CAPABILITIES &caps)
+void CInputStreamAdaptive::GetCapabilities(INPUTSTREAM_CAPABILITIES& caps)
 {
   kodi::Log(ADDON_LOG_DEBUG, "GetCapabilities()");
   caps.m_mask = INPUTSTREAM_CAPABILITIES::SUPPORTS_IDEMUX |
-    INPUTSTREAM_CAPABILITIES::SUPPORTS_IDISPLAYTIME |
-    INPUTSTREAM_CAPABILITIES::SUPPORTS_IPOSTIME |
-    INPUTSTREAM_CAPABILITIES::SUPPORTS_SEEK |
-    INPUTSTREAM_CAPABILITIES::SUPPORTS_PAUSE;
+                INPUTSTREAM_CAPABILITIES::SUPPORTS_IDISPLAYTIME |
+                INPUTSTREAM_CAPABILITIES::SUPPORTS_IPOSTIME |
+                INPUTSTREAM_CAPABILITIES::SUPPORTS_SEEK | INPUTSTREAM_CAPABILITIES::SUPPORTS_PAUSE;
 #if INPUTSTREAM_VERSION_LEVEL > 1
   caps.m_mask |= INPUTSTREAM_CAPABILITIES::SUPPORTS_ICHAPTER;
 #endif
@@ -3250,15 +3424,35 @@ void CInputStreamAdaptive::GetCapabilities(INPUTSTREAM_CAPABILITIES &caps)
 
 struct INPUTSTREAM_INFO CInputStreamAdaptive::GetStream(int streamid)
 {
-  static struct INPUTSTREAM_INFO dummy_info = {
-    INPUTSTREAM_INFO::TYPE_NONE, 0, 0, "", "", "", STREAMCODEC_PROFILE::CodecProfileUnknown, 0, 0, 0, "",
-    0, 0, 0, 0, 0.0f,
-    0, 0, 0, 0, 0,
-    CRYPTO_INFO::CRYPTO_KEY_SYSTEM_NONE ,0 ,0 ,0};
+  static struct INPUTSTREAM_INFO dummy_info = {INPUTSTREAM_INFO::TYPE_NONE,
+                                               0,
+                                               0,
+                                               "",
+                                               "",
+                                               "",
+                                               STREAMCODEC_PROFILE::CodecProfileUnknown,
+                                               0,
+                                               0,
+                                               0,
+                                               "",
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0.0f,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               CRYPTO_INFO::CRYPTO_KEY_SYSTEM_NONE,
+                                               0,
+                                               0,
+                                               0};
 
   kodi::Log(ADDON_LOG_DEBUG, "GetStream(%d)", streamid);
 
-  Session::STREAM *stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
+  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
 
   if (stream)
   {
@@ -3272,12 +3466,16 @@ struct INPUTSTREAM_INFO CInputStreamAdaptive::GetStream(int streamid)
       stream->info_.m_cryptoInfo.m_CryptoSessionIdSize = static_cast<uint16_t>(strlen(sessionId));
       stream->info_.m_cryptoInfo.m_CryptoSessionId = sessionId;
 
-      if(m_session->GetDecrypterCaps(cdmId).flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SUPPORTS_DECODING)
+      if (m_session->GetDecrypterCaps(cdmId).flags &
+          SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SUPPORTS_DECODING)
         stream->info_.m_features = INPUTSTREAM_INFO::FEATURE_DECODE;
       else
-       stream->info_.m_features = 0;
+        stream->info_.m_features = 0;
 
-      stream->info_.m_cryptoInfo.flags = (m_session->GetDecrypterCaps(cdmId).flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER) ? CRYPTO_INFO::FLAG_SECURE_DECODER : 0;
+      stream->info_.m_cryptoInfo.flags = (m_session->GetDecrypterCaps(cdmId).flags &
+                                          SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER)
+                                             ? CRYPTO_INFO::FLAG_SECURE_DECODER
+                                             : 0;
     }
     return stream->info_;
   }
@@ -3286,22 +3484,22 @@ struct INPUTSTREAM_INFO CInputStreamAdaptive::GetStream(int streamid)
 
 void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
 {
-  kodi::Log(ADDON_LOG_DEBUG, "EnableStream(%d: %s)", streamid, enable?"true":"false");
+  kodi::Log(ADDON_LOG_DEBUG, "EnableStream(%d: %s)", streamid, enable ? "true" : "false");
 
   if (!m_session)
     return;
 
-  Session::STREAM *stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
+  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
 
   if (!enable && stream && stream->enabled)
   {
     if (stream->mainId_)
     {
-      Session::STREAM *mainStream(m_session->GetStream(stream->mainId_));
+      Session::STREAM* mainStream(m_session->GetStream(stream->mainId_));
       if (mainStream->reader_)
         mainStream->reader_->RemoveStreamType(stream->info_.m_streamType);
     }
-    const adaptive::AdaptiveTree::Representation *rep(stream->stream_.getRepresentation());
+    const adaptive::AdaptiveTree::Representation* rep(stream->stream_.getRepresentation());
     if (rep->flags_ & adaptive::AdaptiveTree::Representation::INCLUDEDSTREAM)
       m_IncludedStreams[stream->info_.m_streamType] = 0;
     m_session->EnableStream(stream, false);
@@ -3316,21 +3514,22 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (!m_session)
     return false;
 
-  Session::STREAM *stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
+  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
 
   if (!stream || stream->enabled)
     return false;
 
   stream->enabled = true;
 
-  stream->stream_.start_stream(~0, m_session->GetVideoWidth(), m_session->GetVideoHeight(), m_playTimeshiftBuffer);
-  const adaptive::AdaptiveTree::Representation *rep(stream->stream_.getRepresentation());
+  stream->stream_.start_stream(~0, m_session->GetVideoWidth(), m_session->GetVideoHeight(),
+                               m_playTimeshiftBuffer);
+  const adaptive::AdaptiveTree::Representation* rep(stream->stream_.getRepresentation());
 
   // If we select a dummy (=inside video) stream, open the video part
   // Dummy streams will be never enabled, they will only enable / activate audio track.
   if (rep->flags_ & adaptive::AdaptiveTree::Representation::INCLUDEDSTREAM)
   {
-    Session::STREAM *mainStream;
+    Session::STREAM* mainStream;
     stream->mainId_ = 0;
     while ((mainStream = m_session->GetStream(++stream->mainId_)))
       if (mainStream->info_.m_streamType == INPUTSTREAM_INFO::TYPE_VIDEO && mainStream->enabled)
@@ -3347,7 +3546,8 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   }
 
   kodi::Log(ADDON_LOG_DEBUG, "Selecting stream with conditions: w: %u, h: %u, bw: %u",
-    stream->stream_.getWidth(), stream->stream_.getHeight(), stream->stream_.getBandwidth());
+            stream->stream_.getWidth(), stream->stream_.getHeight(),
+            stream->stream_.getBandwidth());
 
   if (!stream->stream_.select_stream(true, false, stream->info_.m_pID >> 16))
   {
@@ -3358,17 +3558,28 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
 
   if (rep != stream->stream_.getRepresentation())
   {
-    m_session->UpdateStream(*stream, m_session->GetDecrypterCaps(stream->stream_.getRepresentation()->pssh_set_));
+    m_session->UpdateStream(
+        *stream, m_session->GetDecrypterCaps(stream->stream_.getRepresentation()->pssh_set_));
     m_session->CheckChange(true);
   }
 
   if (rep->flags_ & adaptive::AdaptiveTree::Representation::SUBTITLESTREAM)
   {
-    stream->reader_ = new SubtitleSampleReader(rep->url_, streamid, stream->info_.m_codecInternalName);
+    stream->reader_ =
+        new SubtitleSampleReader(rep->url_, streamid, stream->info_.m_codecInternalName);
     return false;
   }
 
-  AP4_Movie* movie(m_session->PrepareStream(stream));
+  if (rep->containerType_ == adaptive::AdaptiveTree::CONTAINERTYPE_TEXT)
+  {
+    stream->input_ = new AP4_DASHStream(&stream->stream_);
+    stream->reader_ =
+        new SubtitleSampleReader(stream->input_, streamid, stream->info_.m_codecInternalName);
+    return false;
+  }
+
+  bool needRefetch; //Make sure that Kodi fetches changes
+  AP4_Movie* movie(m_session->PrepareStream(stream, needRefetch));
 
   // We load fragments on PrepareTime for HLS manifests and have to reevaluate the start-segment
   if (m_session->GetManifestType() == MANIFEST_TYPE_HLS)
@@ -3377,8 +3588,9 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (rep->containerType_ == adaptive::AdaptiveTree::CONTAINERTYPE_TS)
   {
     stream->input_ = new AP4_DASHStream(&stream->stream_);
-    stream->reader_ = new TSSampleReader(stream->input_, stream->info_.m_streamType, streamid,
-      (1U << stream->info_.m_streamType) | m_session->GetIncludedStreamMask());
+    stream->reader_ =
+        new TSSampleReader(stream->input_, stream->info_.m_streamType, streamid,
+                           (1U << stream->info_.m_streamType) | m_session->GetIncludedStreamMask());
     if (!static_cast<TSSampleReader*>(stream->reader_)->Initialize())
     {
       stream->disable();
@@ -3403,7 +3615,8 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   else if (rep->containerType_ == adaptive::AdaptiveTree::CONTAINERTYPE_MP4)
   {
     stream->input_ = new AP4_DASHStream(&stream->stream_);
-    stream->input_file_ = new AP4_File(*stream->input_, AP4_DefaultAtomFactory::Instance, true, movie);
+    stream->input_file_ =
+        new AP4_File(*stream->input_, AP4_DefaultAtomFactory::Instance, true, movie);
     movie = stream->input_file_->GetMovie();
 
     if (movie == NULL)
@@ -3413,7 +3626,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       return false;
     }
 
-    AP4_Track *track = movie->GetTrack(TIDC[stream->stream_.get_type()]);
+    AP4_Track* track = movie->GetTrack(TIDC[stream->stream_.get_type()]);
     if (!track)
     {
       if (stream->stream_.get_type() == adaptive::AdaptiveTree::SUBTITLE)
@@ -3426,9 +3639,10 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       }
     }
 
-    stream->reader_ = new FragmentedSampleReader(stream->input_, movie, track, streamid,
-      m_session->GetSingleSampleDecryptor(stream->stream_.getRepresentation()->pssh_set_),
-      m_session->GetDecrypterCaps(stream->stream_.getRepresentation()->pssh_set_));
+    stream->reader_ = new FragmentedSampleReader(
+        stream->input_, movie, track, streamid,
+        m_session->GetSingleSampleDecryptor(stream->stream_.getRepresentation()->pssh_set_),
+        m_session->GetDecrypterCaps(stream->stream_.getRepresentation()->pssh_set_));
   }
   else
   {
@@ -3441,12 +3655,14 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     for (uint16_t i(0); i < 16; ++i)
       if (m_IncludedStreams[i])
       {
-        stream->reader_->AddStreamType(static_cast<INPUTSTREAM_INFO::STREAM_TYPE>(i), m_IncludedStreams[i]);
-        stream->reader_->GetInformation(m_session->GetStream(m_IncludedStreams[i] - m_session->GetChapter() * 1000)->info_);
+        stream->reader_->AddStreamType(static_cast<INPUTSTREAM_INFO::STREAM_TYPE>(i),
+                                       m_IncludedStreams[i]);
+        stream->reader_->GetInformation(
+            m_session->GetStream(m_IncludedStreams[i] - m_session->GetChapter() * 1000)->info_);
       }
   }
   m_session->EnableStream(stream, true);
-  return stream->reader_->GetInformation(stream->info_);
+  return stream->reader_->GetInformation(stream->info_) || needRefetch;
 }
 
 
@@ -3465,11 +3681,11 @@ DemuxPacket* CInputStreamAdaptive::DemuxRead(void)
     }
   }
 
-  SampleReader *sr(m_session->GetNextSample());
+  SampleReader* sr(m_session->GetNextSample());
 
   if (m_session->CheckChange())
   {
-    DemuxPacket *p = AllocateDemuxPacket(0);
+    DemuxPacket* p = AllocateDemuxPacket(0);
     p->iStreamId = DMX_SPECIALID_STREAMCHANGE;
     kodi::Log(ADDON_LOG_DEBUG, "DMX_SPECIALID_STREAMCHANGE");
     return p;
@@ -3478,12 +3694,13 @@ DemuxPacket* CInputStreamAdaptive::DemuxRead(void)
   if (sr)
   {
     AP4_Size iSize(sr->GetSampleDataSize());
-    const AP4_UI08 *pData(sr->GetSampleData());
-    DemuxPacket *p;
+    const AP4_UI08* pData(sr->GetSampleData());
+    DemuxPacket* p;
 
     if (iSize && pData && sr->IsEncrypted())
     {
-      unsigned int numSubSamples(*((unsigned int*)pData)); pData += sizeof(numSubSamples);
+      unsigned int numSubSamples(*((unsigned int*)pData));
+      pData += sizeof(numSubSamples);
       p = AllocateEncryptedDemuxPacket(iSize, numSubSamples);
       memcpy(p->cryptoInfo->clearBytes, pData, numSubSamples * sizeof(uint16_t));
       pData += (numSubSamples * sizeof(uint16_t));
@@ -3520,10 +3737,11 @@ DemuxPacket* CInputStreamAdaptive::DemuxRead(void)
   if (m_session->SeekChapter(currentChapter + 1))
   {
     m_checkChapterSeek = true;
-    for (unsigned int i(1); i <= INPUTSTREAM_IDS::MAX_STREAM_COUNT && i <= m_session->GetStreamCount(); ++i)
+    for (unsigned int i(1);
+         i <= INPUTSTREAM_IDS::MAX_STREAM_COUNT && i <= m_session->GetStreamCount(); ++i)
       EnableStream(i + currentChapter * 1000, false);
     m_session->InitializePeriod();
-    DemuxPacket *p = AllocateDemuxPacket(0);
+    DemuxPacket* p = AllocateDemuxPacket(0);
     p->iStreamId = DMX_SPECIALID_STREAMCHANGE;
     kodi::Log(ADDON_LOG_DEBUG, "DMX_SPECIALID_STREAMCHANGE");
     return p;
@@ -3532,7 +3750,7 @@ DemuxPacket* CInputStreamAdaptive::DemuxRead(void)
 }
 
 // Accurate search (PTS based)
-bool CInputStreamAdaptive::DemuxSeekTime(double time, bool backwards, double &startpts)
+bool CInputStreamAdaptive::DemuxSeekTime(double time, bool backwards, double& startpts)
 {
   return true;
 }
@@ -3611,17 +3829,15 @@ bool CInputStreamAdaptive::SeekChapter(int ch)
 /*****************************************************************************************************/
 
 CVideoCodecAdaptive::CVideoCodecAdaptive(KODI_HANDLE instance)
-  : CInstanceVideoCodec(instance)
-  , m_session(nullptr)
-  , m_state(0)
-  , m_name("inputstream.adaptive.decoder")
+  : CInstanceVideoCodec(instance),
+    m_session(nullptr),
+    m_state(0),
+    m_name("inputstream.adaptive.decoder")
 {
 }
 
-CVideoCodecAdaptive::CVideoCodecAdaptive(KODI_HANDLE instance, CInputStreamAdaptive *parent)
-  : CInstanceVideoCodec(instance)
-  , m_session(parent->GetSession())
-  , m_state(0)
+CVideoCodecAdaptive::CVideoCodecAdaptive(KODI_HANDLE instance, CInputStreamAdaptive* parent)
+  : CInstanceVideoCodec(instance), m_session(parent->GetSession()), m_state(0)
 {
 }
 
@@ -3629,12 +3845,13 @@ CVideoCodecAdaptive::~CVideoCodecAdaptive()
 {
 }
 
-bool CVideoCodecAdaptive::Open(VIDEOCODEC_INITDATA &initData)
+bool CVideoCodecAdaptive::Open(VIDEOCODEC_INITDATA& initData)
 {
   if (!m_session || !m_session->GetDecrypter())
     return false;
 
-  if (initData.codec == VIDEOCODEC_INITDATA::CodecH264 && !initData.extraDataSize && !(m_state & STATE_WAIT_EXTRADATA))
+  if (initData.codec == VIDEOCODEC_INITDATA::CodecH264 && !initData.extraDataSize &&
+      !(m_state & STATE_WAIT_EXTRADATA))
   {
     kodi::Log(ADDON_LOG_INFO, "VideoCodec::Open: Wait ExtraData");
     m_state |= STATE_WAIT_EXTRADATA;
@@ -3647,24 +3864,32 @@ bool CVideoCodecAdaptive::Open(VIDEOCODEC_INITDATA &initData)
   m_name = "inputstream.adaptive";
   switch (initData.codec)
   {
-  case VIDEOCODEC_INITDATA::CodecVp8: m_name += ".vp8"; break;
-  case VIDEOCODEC_INITDATA::CodecH264: m_name += ".h264"; break;
-  case VIDEOCODEC_INITDATA::CodecVp9: m_name += ".vp9"; break;
-  default:;
+    case VIDEOCODEC_INITDATA::CodecVp8:
+      m_name += ".vp8";
+      break;
+    case VIDEOCODEC_INITDATA::CodecH264:
+      m_name += ".h264";
+      break;
+    case VIDEOCODEC_INITDATA::CodecVp9:
+      m_name += ".vp9";
+      break;
+    default:;
   }
   m_name += ".decoder";
 
-  std::string sessionId(initData.cryptoInfo.m_CryptoSessionId, initData.cryptoInfo.m_CryptoSessionIdSize);
-  AP4_CencSingleSampleDecrypter *ssd(m_session->GetSingleSampleDecrypter(sessionId));
-  return m_session->GetDecrypter()->OpenVideoDecoder(ssd, reinterpret_cast<SSD::SSD_VIDEOINITDATA*>(&initData));
+  std::string sessionId(initData.cryptoInfo.m_CryptoSessionId,
+                        initData.cryptoInfo.m_CryptoSessionIdSize);
+  AP4_CencSingleSampleDecrypter* ssd(m_session->GetSingleSampleDecrypter(sessionId));
+  return m_session->GetDecrypter()->OpenVideoDecoder(
+      ssd, reinterpret_cast<SSD::SSD_VIDEOINITDATA*>(&initData));
 }
 
-bool CVideoCodecAdaptive::Reconfigure(VIDEOCODEC_INITDATA &initData)
+bool CVideoCodecAdaptive::Reconfigure(VIDEOCODEC_INITDATA& initData)
 {
   return false;
 }
 
-bool CVideoCodecAdaptive::AddData(const DemuxPacket &packet)
+bool CVideoCodecAdaptive::AddData(const DemuxPacket& packet)
 {
   if (!m_session || !m_session->GetDecrypter())
     return false;
@@ -3688,24 +3913,23 @@ bool CVideoCodecAdaptive::AddData(const DemuxPacket &packet)
     sample.iv = sample.kid = nullptr;
   }
 
-  return m_session->GetDecrypter()->DecodeVideo(dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this), &sample, nullptr) != SSD::VC_ERROR;
+  return m_session->GetDecrypter()->DecodeVideo(
+             dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this), &sample, nullptr) !=
+         SSD::VC_ERROR;
 }
 
-VIDEOCODEC_RETVAL CVideoCodecAdaptive::GetPicture(VIDEOCODEC_PICTURE &picture)
+VIDEOCODEC_RETVAL CVideoCodecAdaptive::GetPicture(VIDEOCODEC_PICTURE& picture)
 {
   if (!m_session || !m_session->GetDecrypter())
     return VIDEOCODEC_RETVAL::VC_ERROR;
 
-  static VIDEOCODEC_RETVAL vrvm[] =
-  {
-    VIDEOCODEC_RETVAL::VC_NONE,
-    VIDEOCODEC_RETVAL::VC_ERROR,
-    VIDEOCODEC_RETVAL::VC_BUFFER,
-    VIDEOCODEC_RETVAL::VC_PICTURE,
-    VIDEOCODEC_RETVAL::VC_EOF
-  };
+  static VIDEOCODEC_RETVAL vrvm[] = {VIDEOCODEC_RETVAL::VC_NONE, VIDEOCODEC_RETVAL::VC_ERROR,
+                                     VIDEOCODEC_RETVAL::VC_BUFFER, VIDEOCODEC_RETVAL::VC_PICTURE,
+                                     VIDEOCODEC_RETVAL::VC_EOF};
 
-  return vrvm[m_session->GetDecrypter()->DecodeVideo(dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this), nullptr, reinterpret_cast<SSD::SSD_PICTURE*>(&picture))];
+  return vrvm[m_session->GetDecrypter()->DecodeVideo(
+      dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this), nullptr,
+      reinterpret_cast<SSD::SSD_PICTURE*>(&picture))];
 }
 
 void CVideoCodecAdaptive::Reset()
@@ -3718,19 +3942,26 @@ void CVideoCodecAdaptive::Reset()
 
 /*****************************************************************************************************/
 
-class CMyAddon
-  : public kodi::addon::CAddonBase
+class CMyAddon : public kodi::addon::CAddonBase
 {
 public:
   CMyAddon();
   virtual ~CMyAddon();
-  ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance) override;
-  ADDON_STATUS CreateInstanceEx(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance, const std::string &version) override;
+  ADDON_STATUS CreateInstance(int instanceType,
+                              std::string instanceID,
+                              KODI_HANDLE instance,
+                              KODI_HANDLE& addonInstance) override;
+  ADDON_STATUS CreateInstanceEx(int instanceType,
+                                std::string instanceID,
+                                KODI_HANDLE instance,
+                                KODI_HANDLE& addonInstance,
+                                const std::string& version) override;
 };
 
 CMyAddon::CMyAddon()
 {
-  kodihost = nullptr;;
+  kodihost = nullptr;
+  ;
 }
 
 CMyAddon::~CMyAddon()
@@ -3738,12 +3969,19 @@ CMyAddon::~CMyAddon()
   delete kodihost;
 }
 
-ADDON_STATUS CMyAddon::CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance)
+ADDON_STATUS CMyAddon::CreateInstance(int instanceType,
+                                      std::string instanceID,
+                                      KODI_HANDLE instance,
+                                      KODI_HANDLE& addonInstance)
 {
   return CreateInstanceEx(instanceType, instanceID, instance, addonInstance, "");
 }
 
-ADDON_STATUS CMyAddon::CreateInstanceEx(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance, const std::string &version)
+ADDON_STATUS CMyAddon::CreateInstanceEx(int instanceType,
+                                        std::string instanceID,
+                                        KODI_HANDLE instance,
+                                        KODI_HANDLE& addonInstance,
+                                        const std::string& version)
 {
   if (instanceType == ADDON_INSTANCE_INPUTSTREAM)
   {

--- a/src/main.h
+++ b/src/main.h
@@ -80,23 +80,25 @@ class Session: public adaptive::AdaptiveStreamObserver
 {
 public:
   Session(MANIFEST_TYPE manifestType,
-    const char *strURL,
-    const char *strUpdateParam,
-    const char *strLicType,
-    const char* strLicKey,
-    const char* strLicData,
-    const char* strCert,
-    const char* strMediaRenewalUrl,
-    const uint32_t intMediaRenewalTime,
-    const std::map<std::string, std::string> &manifestHeaders,
-    const std::map<std::string, std::string> &mediaHeaders,
-    const char* profile_path,
-    uint16_t display_width,
-    uint16_t display_height,
-    const char *ov_audio,
-    bool play_timeshift_buffer);
+          const char* strURL,
+          const char* strUpdateParam,
+          const char* strLicType,
+          const char* strLicKey,
+          const char* strLicData,
+          const char* strCert,
+          const char* strMediaRenewalUrl,
+          const uint32_t intMediaRenewalTime,
+          const std::map<std::string, std::string>& manifestHeaders,
+          const std::map<std::string, std::string>& mediaHeaders,
+          const char* profile_path,
+          uint16_t display_width,
+          uint16_t display_height,
+          const char* ov_audio,
+          bool play_timeshift_buffer,
+          bool force_secure_decoder);
   virtual ~Session();
-  bool initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
+  bool Initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
+  bool InitializeDRM();
   bool InitializePeriod();
   SampleReader *GetNextSample();
 
@@ -130,7 +132,7 @@ public:
   };
 
   void UpdateStream(STREAM &stream, const SSD::SSD_DECRYPTER::SSD_CAPS &caps);
-  AP4_Movie *PrepareStream(STREAM *stream);
+  AP4_Movie* PrepareStream(STREAM* stream, bool& needRefetch);
 
   STREAM* GetStream(unsigned int sid)const { return sid - 1 < streams_.size() ? streams_[sid - 1] : 0; };
   void EnableStream(STREAM* stream, bool enable);
@@ -213,4 +215,5 @@ private:
   uint8_t drmConfig_;
   bool ignore_display_;
   bool play_timeshift_buffer_;
+  bool force_secure_decoder_;
 };

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1460,18 +1460,21 @@ bool DASHTree::write_data(void *buffer, size_t buffer_size, void *opaque)
 }
 
 //Called each time before we switch to a new segment
-void DASHTree::RefreshSegments(Representation *rep, StreamType type)
+void DASHTree::RefreshSegments(Period* period,
+                               AdaptationSet* adp,
+                               Representation* rep,
+                               StreamType type)
 {
   if ((type == VIDEO || type == AUDIO))
   {
     lastUpdated_ = std::chrono::system_clock::now();
     RefreshUpdateThread();
-    RefreshSegments();
+    RefreshLiveSegments();
   }
 }
 
 //Can be called form update-thread!
-void DASHTree::RefreshSegments()
+void DASHTree::RefreshLiveSegments()
 {
   if (has_timeshift_buffer_ && !update_parameter_.empty())
   {

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -29,13 +29,16 @@ namespace adaptive
     DASHTree();
     virtual bool open(const std::string &url, const std::string &manifestUpdateParam) override;
     virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) override;
-    virtual void RefreshSegments(Representation *rep, StreamType type) override;
+    virtual void RefreshSegments(Period* period,
+                                 AdaptationSet* adp,
+                                 Representation* rep,
+                                 StreamType type) override;
 
     void SetUpdateInterval(uint32_t interval) { updateInterval_ = interval; };
     uint64_t pts_helper_;
     uint32_t firstStartNumber_;
     std::string current_playready_wrmheader_;
   protected:
-    virtual void RefreshSegments() override;
+    virtual void RefreshLiveSegments() override;
   };
 }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -149,7 +149,7 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
 
   // NO VALID
   Log(LOGLEVEL_WARNING, "Unsupported encryption method: %s with keyformat %s", map["METHOD"].c_str(), map["KEYFORMAT"].c_str());
-  return ENCRYPTIONTYPE_UNKNOWN;
+  return ENCRYPTIONTYPE_UNSUPPORTED;
 }
 
 bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam)

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -347,8 +347,6 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
       uint32_t encryption_type;
       switch (encryption_type = processEncryption(base_url_, map))
       {
-        case ENCRYPTIONTYPE_INVALID:
-          return false;
         case ENCRYPTIONTYPE_AES128:
         case ENCRYPTIONTYPE_WIDEVINE:
           // #EXT-X-SESSION-KEY is meant for preparing DRM without
@@ -616,8 +614,6 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           parseLine(line, 11, map);
           switch (processEncryption(base_url, map))
           {
-            case ENCRYPTIONTYPE_INVALID:
-              return PREPARE_RESULT_FAILURE;
             case ENCRYPTIONTYPE_AES128:
               currentEncryptionType = ENCRYPTIONTYPE_AES128;
               break;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -91,65 +91,64 @@ HLSTree::~HLSTree()
 
 int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::string>& map)
 {
-  if (map["METHOD"] != "NONE")
-  {
-    if (map["METHOD"] != "AES-128" && map["METHOD"] != "SAMPLE-AES-CTR")
-    {
-      Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
-      return ENCRYPTIONTYPE_INVALID;
-    }
-    if (map["URI"].empty())
-    {
-      Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
-      return ENCRYPTIONTYPE_INVALID;
-    }
-    if (!map["KEYFORMAT"].empty())
-    {
-      if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed")
-      {
-        if (!map["KEYID"].empty())
-        {
-          std::string keyid = map["KEYID"].substr(2);
-          const char* defaultKID = keyid.c_str();
-          current_defaultKID_.resize(16);
-          for (unsigned int i(0); i < 16; ++i)
-          {
-            current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
-            ++defaultKID;
-            current_defaultKID_[i] |= HexNibble(*defaultKID);
-            ++defaultKID;
-          }
-        }
-        current_pssh_ = map["URI"].substr(23);
-        // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
-        if (current_defaultKID_.empty() && current_pssh_.size() == 68)
-        {
-          unsigned int bufLen = 52;
-          uint8_t buf[52];
-          b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
-          if (bufLen == 50)
-            current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
-        }
-        return ENCRYPTIONTYPE_WIDEVINE;
-      }
-    }
-    else
-    {
-      current_pssh_ = map["URI"];
-      if (current_pssh_[0] == '/')
-        current_pssh_ = base_domain_ + current_pssh_;
-      else if (current_pssh_.find("://", 0) == std::string::npos)
-        current_pssh_ = baseUrl + current_pssh_;
-
-      current_iv_ = m_decrypter->convertIV(map["IV"]);
-      return ENCRYPTIONTYPE_AES128;
-    }
-  }
-  else
+  // NO ENCRYPTION
+  if (map["METHOD"] == "NONE")
   {
     current_pssh_.clear();
+
+    Log(LOGLEVEL_DEBUG, "Supported encryption method found: NON-ENCRYPTED");
     return ENCRYPTIONTYPE_CLEAR;
   }
+
+  // WIDEVINE
+  if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed" && !map["URI"].empty())
+  {
+    if (!map["KEYID"].empty())
+    {
+      std::string keyid = map["KEYID"].substr(2);
+      const char* defaultKID = keyid.c_str();
+      current_defaultKID_.resize(16);
+      for (unsigned int i(0); i < 16; ++i)
+      {
+        current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
+        ++defaultKID;
+        current_defaultKID_[i] |= HexNibble(*defaultKID);
+        ++defaultKID;
+      }
+    }
+
+    current_pssh_ = map["URI"].substr(23);
+    // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
+    if (current_defaultKID_.empty() && current_pssh_.size() == 68)
+    {
+      unsigned int bufLen = 52;
+      uint8_t buf[52];
+      b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
+      if (bufLen == 50)
+        current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
+    }
+  
+    Log(LOGLEVEL_DEBUG, "Supported encryption method found: WIDEVINE");
+    return ENCRYPTIONTYPE_WIDEVINE;
+  }
+
+  // AES-128
+  if (map["METHOD"] == "AES-128")
+  {
+    current_pssh_ = map["URI"];
+    if (current_pssh_[0] == '/')
+      current_pssh_ = base_domain_ + current_pssh_;
+    else if (current_pssh_.find("://", 0) == std::string::npos)
+      current_pssh_ = baseUrl + current_pssh_;
+
+    current_iv_ = m_decrypter->convertIV(map["IV"]);
+
+    Log(LOGLEVEL_DEBUG, "Supported encryption method found: AES-128");
+    return ENCRYPTIONTYPE_AES128;
+  }
+
+  // NO VALID
+  Log(LOGLEVEL_WARNING, "Unsupported encryption method: %s with keyformat %s", map["METHOD"].c_str(), map["KEYFORMAT"].c_str());
   return ENCRYPTIONTYPE_UNKNOWN;
 }
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -32,24 +32,33 @@ namespace adaptive
   public:
     enum
     {
-      ENCRYPTIONTYPE_CLEAR = 0,
-      ENCRYPTIONTYPE_AES128 = 1,
-      ENCRYPTIONTYPE_WIDEVINE = 2
+      ENCRYPTIONTYPE_INVALID = 0,
+      ENCRYPTIONTYPE_CLEAR = 1,
+      ENCRYPTIONTYPE_AES128 = 2,
+      ENCRYPTIONTYPE_WIDEVINE = 3,
+      ENCRYPTIONTYPE_UNKNOWN = 4,
     };
     HLSTree(AESDecrypter *decrypter) : AdaptiveTree(), m_decrypter(decrypter) {};
     virtual ~HLSTree();
 
     virtual bool open(const std::string &url, const std::string &manifestUpdateParam) override;
-    virtual bool prepareRepresentation(Representation *rep, bool update = false) override;
+    virtual PREPARE_RESULT prepareRepresentation(Period* period,
+                                                 AdaptationSet* adp,
+                                                 Representation* rep,
+                                                 bool update = false) override;
     virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) override;
     virtual void OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize) override;
-    virtual void RefreshSegments(Representation *rep, StreamType type) override;
+    virtual void RefreshSegments(Period* period,
+                                 AdaptationSet* adp,
+                                 Representation* rep,
+                                 StreamType type) override;
     virtual bool processManifest(std::stringstream& stream, const std::string &url);
 
   protected:
-    virtual void RefreshSegments() override;
+    virtual void RefreshLiveSegments() override;
 
   private:
+    int processEncryption(std::string baseUrl, std::map<std::string, std::string>& map);
     std::string m_audioCodec;
 
     struct EXTGROUP

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -32,11 +32,10 @@ namespace adaptive
   public:
     enum
     {
-      ENCRYPTIONTYPE_INVALID = 0,
+      ENCRYPTIONTYPE_UNSUPPORTED = 0,
       ENCRYPTIONTYPE_CLEAR = 1,
       ENCRYPTIONTYPE_AES128 = 2,
       ENCRYPTIONTYPE_WIDEVINE = 3,
-      ENCRYPTIONTYPE_UNKNOWN = 4,
     };
     HLSTree(AESDecrypter *decrypter) : AdaptiveTree(), m_decrypter(decrypter) {};
     virtual ~HLSTree();

--- a/src/parser/WebVTT.cpp
+++ b/src/parser/WebVTT.cpp
@@ -66,7 +66,12 @@ bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t b
 
       if (webvtt_visited)
       {
-        if (wait_start)
+        if (*cbuf == '\n' || *cbuf == '\r')
+        {
+          strText.clear();
+          wait_start = true;
+        }
+        else if (wait_start)
         {
           unsigned int thb, tmb, tsb, tmsb, the, tme, tse, tmse;
           char delb, dele;
@@ -116,8 +121,6 @@ bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t b
           replaceAll(strText, "&rlm;", "\xE2\x80\xAB", true);
           if (!strText.empty())
             m_subTitles.back().text.push_back(strText);
-          else
-            wait_start = true;
         }
       }
       else

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -321,7 +321,7 @@ WV_DRM::WV_DRM(const char* licenseURL, const AP4_DataBuffer &serverCert, const u
   char cSep = strBasePath.back();
   strBasePath += "widevine";
   strBasePath += cSep;
-  host->CreateDirectory(strBasePath.c_str());
+  host->CreateDir(strBasePath.c_str());
 
   //Build up a CDM path to store decrypter specific stuff. Each domain gets it own path
   const char* bspos(strchr(license_url_.c_str(), ':'));
@@ -341,7 +341,7 @@ WV_DRM::WV_DRM(const char* licenseURL, const AP4_DataBuffer &serverCert, const u
 
   strBasePath += buffer;
   strBasePath += cSep;
-  host->CreateDirectory(strBasePath.c_str());
+  host->CreateDir(strBasePath.c_str());
 
   wv_adapter = std::shared_ptr<media::CdmAdapter>(new media::CdmAdapter(
     "com.widevine.alpha",

--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -100,7 +100,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
   char cSep = strBasePath.back();
   strBasePath += ks == WIDEVINE ? "widevine" : ks == PLAYREADY ? "playready" : "wiseplay";
   strBasePath += cSep;
-  host->CreateDirectory(strBasePath.c_str());
+  host->CreateDir(strBasePath.c_str());
 
   //Build up a CDM path to store decrypter specific stuff. Each domain gets it own path
   const char* bspos(strchr(license_url_.c_str(), ':'));
@@ -120,7 +120,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
 
   strBasePath += buffer;
   strBasePath += cSep;
-  host->CreateDirectory(strBasePath.c_str());
+  host->CreateDir(strBasePath.c_str());
   m_strBasePath = strBasePath;
 
   int64_t mostSigBits(0), leastSigBits(0);


### PR DESCRIPTION
@peak3d 
This should be a bit more tidier :)

I have found Apple TV+ playlists have a valid encryption after a non-valid encryption.
Currently IA will fail as soon as it hits a non-valid encryption.
This PR changes the behavior to keep checking for a valid encryption.

If someone is using IA, they should already know what encryptions are supported.
If playback fails, the log will show unsupported type.
Just "fails" a little less quickly than before.
Small trade-off to fix the issue of failing on playlists with valid encryptions.

I find it easier to view the processEncryption with the changes as a whole:
https://github.com/matthuisman/inputstream.adaptive/blob/f2f5d210f6e506054fe22e946d14e6e5d0e8f398/src/parser/HLSTree.cpp#L92

A lot less nesting and easier to follow.
Also easy to add a new encryption method just under the others