### PR TITLE
Fix for HLS playlists with valid encryption after non-valid encryption and cosmetics

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -91,65 +91,64 @@ HLSTree::~HLSTree()
 
 int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::string>& map)
 {
-  if (map["METHOD"] != "NONE")
-  {
-    if (map["METHOD"] != "AES-128" && map["METHOD"] != "SAMPLE-AES-CTR")
-    {
-      Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
-      return ENCRYPTIONTYPE_INVALID;
-    }
-    if (map["URI"].empty())
-    {
-      Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
-      return ENCRYPTIONTYPE_INVALID;
-    }
-    if (!map["KEYFORMAT"].empty())
-    {
-      if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed")
-      {
-        if (!map["KEYID"].empty())
-        {
-          std::string keyid = map["KEYID"].substr(2);
-          const char* defaultKID = keyid.c_str();
-          current_defaultKID_.resize(16);
-          for (unsigned int i(0); i < 16; ++i)
-          {
-            current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
-            ++defaultKID;
-            current_defaultKID_[i] |= HexNibble(*defaultKID);
-            ++defaultKID;
-          }
-        }
-        current_pssh_ = map["URI"].substr(23);
-        // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
-        if (current_defaultKID_.empty() && current_pssh_.size() == 68)
-        {
-          unsigned int bufLen = 52;
-          uint8_t buf[52];
-          b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
-          if (bufLen == 50)
-            current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
-        }
-        return ENCRYPTIONTYPE_WIDEVINE;
-      }
-    }
-    else
-    {
-      current_pssh_ = map["URI"];
-      if (current_pssh_[0] == '/')
-        current_pssh_ = base_domain_ + current_pssh_;
-      else if (current_pssh_.find("://", 0) == std::string::npos)
-        current_pssh_ = baseUrl + current_pssh_;
-
-      current_iv_ = m_decrypter->convertIV(map["IV"]);
-      return ENCRYPTIONTYPE_AES128;
-    }
-  }
-  else
+  // NO ENCRYPTION
+  if (map["METHOD"] == "NONE")
   {
     current_pssh_.clear();
+
+    Log(LOGLEVEL_DEBUG, "Supported encryption method found: NON-ENCRYPTED");
     return ENCRYPTIONTYPE_CLEAR;
   }
+
+  // WIDEVINE
+  if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed" && !map["URI"].empty())
+  {
+    if (!map["KEYID"].empty())
+    {
+      std::string keyid = map["KEYID"].substr(2);
+      const char* defaultKID = keyid.c_str();
+      current_defaultKID_.resize(16);
+      for (unsigned int i(0); i < 16; ++i)
+      {
+        current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
+        ++defaultKID;
+        current_defaultKID_[i] |= HexNibble(*defaultKID);
+        ++defaultKID;
+      }
+    }
+
+    current_pssh_ = map["URI"].substr(23);
+    // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
+    if (current_defaultKID_.empty() && current_pssh_.size() == 68)
+    {
+      unsigned int bufLen = 52;
+      uint8_t buf[52];
+      b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
+      if (bufLen == 50)
+        current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
+    }
+  
+    Log(LOGLEVEL_DEBUG, "Supported encryption method found: WIDEVINE");
+    return ENCRYPTIONTYPE_WIDEVINE;
+  }
+
+  // AES-128
+  if (map["METHOD"] == "AES-128")
+  {
+    current_pssh_ = map["URI"];
+    if (current_pssh_[0] == '/')
+      current_pssh_ = base_domain_ + current_pssh_;
+    else if (current_pssh_.find("://", 0) == std::string::npos)
+      current_pssh_ = baseUrl + current_pssh_;
+
+    current_iv_ = m_decrypter->convertIV(map["IV"]);
+
+    Log(LOGLEVEL_DEBUG, "Supported encryption method found: AES-128");
+    return ENCRYPTIONTYPE_AES128;
+  }
+
+  // UNSUPPORTED
+  Log(LOGLEVEL_WARNING, "Unsupported encryption method: %s with keyformat %s", map["METHOD"].c_str(), map["KEYFORMAT"].c_str());
   return ENCRYPTIONTYPE_UNKNOWN;
 }
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -149,7 +149,7 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
 
   // UNSUPPORTED
   Log(LOGLEVEL_WARNING, "Unsupported encryption method: %s with keyformat %s", map["METHOD"].c_str(), map["KEYFORMAT"].c_str());
-  return ENCRYPTIONTYPE_UNKNOWN;
+  return ENCRYPTIONTYPE_UNSUPPORTED;
 }
 
 bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam)

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -347,8 +347,6 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
       uint32_t encryption_type;
       switch (encryption_type = processEncryption(base_url_, map))
       {
-        case ENCRYPTIONTYPE_INVALID:
-          return false;
         case ENCRYPTIONTYPE_AES128:
         case ENCRYPTIONTYPE_WIDEVINE:
           // #EXT-X-SESSION-KEY is meant for preparing DRM without
@@ -616,8 +614,6 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           parseLine(line, 11, map);
           switch (processEncryption(base_url, map))
           {
-            case ENCRYPTIONTYPE_INVALID:
-              return PREPARE_RESULT_FAILURE;
             case ENCRYPTIONTYPE_AES128:
               currentEncryptionType = ENCRYPTIONTYPE_AES128;
               break;

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -32,11 +32,10 @@ namespace adaptive
   public:
     enum
     {
-      ENCRYPTIONTYPE_INVALID = 0,
+      ENCRYPTIONTYPE_UNSUPPORTED = 0,
       ENCRYPTIONTYPE_CLEAR = 1,
       ENCRYPTIONTYPE_AES128 = 2,
       ENCRYPTIONTYPE_WIDEVINE = 3,
-      ENCRYPTIONTYPE_UNKNOWN = 4,
     };
     HLSTree(AESDecrypter *decrypter) : AdaptiveTree(), m_decrypter(decrypter) {};
     virtual ~HLSTree();


### PR DESCRIPTION
@peak3d 
Here is my old PR based off latest Master

I have found Apple TV+ playlists have a valid encryption after a non-valid encryption.
Currently IA will fail as soon as it hits a non-valid encryption.
This PR changes the behavior to keep checking for a valid encryption.

If someone is using IA, they should already know what encryptions are supported.
If playback fails, the log will show unsupported type.
Just "fails" a little less quickly than before.
Small trade-off to fix the issue of failing on playlists with valid encryptions.

I find it easier to view the processEncryption with the changes as a whole:
https://github.com/matthuisman/inputstream.adaptive/blob/f2f5d210f6e506054fe22e946d14e6e5d0e8f398/src/parser/HLSTree.cpp#L92

A lot less nesting and easier to follow.
Also easy to add a new encryption method just under the others