### PR TITLE
Implement sorting of VIDEO adaption sets

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -377,8 +377,6 @@ namespace adaptive
   {
     for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep; ++bp)
     {
-      std::stable_sort((*bp)->adaptationSets_.begin(), (*bp)->adaptationSets_.end(), AdaptationSet::compare);
-
       // Merge AUDIO streams, some provider pass everythng in own Audio sets
       for (std::vector<AdaptationSet*>::iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea;)
       {
@@ -403,6 +401,8 @@ namespace adaptive
         for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()), er((*ba)->representations_.end()); br != er; ++br)
           (*br)->SetScaling();
       }
+
+      std::stable_sort((*bp)->adaptationSets_.begin(), (*bp)->adaptationSets_.end(), AdaptationSet::compare);
     }
   }
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -330,6 +330,11 @@ public:
         if (a->forced_ != b->forced_)
           return a->forced_;
       }
+      else if (a->type_ == VIDEO)
+      {
+        if (a->representations_[0]->bandwidth_ != b->representations_[0]->bandwidth_)
+          return a->representations_[0]->bandwidth_ < b->representations_[0]->bandwidth_;
+      }
 
       return false;
     };


### PR DESCRIPTION
Currently IA does not try to sort Video adaption sets.
It just uses the first it finds.

eg.
IA is choosing the 32x32 adaption set in the attached mpd as default instead of the better adpation set with up-to 1080 quality. 

This PR implements sorting of VIDEO adaption sets.
It simply sorts by which has the representation with the highest bandwidth.

[OT093821-1584420245535.mpd.txt](https://github.com/peak3d/inputstream.adaptive/files/4574453/OT093821-1584420245535.mpd.txt)

