### PR TITLE
Update audio codec name from esds atom

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1287,6 +1287,29 @@ public:
       edchanged = true;
     }
 
+    AP4_SampleDescription* desc(m_track->GetSampleDescription(0));
+    if (desc->GetType() == AP4_SampleDescription::TYPE_MPEG)
+    {
+      switch (static_cast<AP4_MpegSampleDescription*>(desc)->GetObjectTypeId())
+      {
+      case AP4_OTI_MPEG4_AUDIO:
+      case AP4_OTI_MPEG2_AAC_AUDIO_MAIN:
+      case AP4_OTI_MPEG2_AAC_AUDIO_LC:
+      case AP4_OTI_MPEG2_AAC_AUDIO_SSRP:
+        strcpy(info.m_codecName, "aac");
+        break;
+      case AP4_OTI_DTS_AUDIO:
+      case AP4_OTI_DTS_HIRES_AUDIO:
+      case AP4_OTI_DTS_MASTER_AUDIO:
+      case AP4_OTI_DTS_EXPRESS_AUDIO:
+        strcpy(info.m_codecName, "dca");
+      case AP4_OTI_AC3_AUDIO:
+      case AP4_OTI_EAC3_AUDIO:
+        strcpy(info.m_codecName, "eac3");
+        break;
+      }
+    }
+
     m_bSampleDescChanged = false;
 
     if (m_codecHandler->GetInformation(info))


### PR DESCRIPTION
Hi @peak3d 

There is an issue afflicting certain HLS playlists where a master playlist has variant streams which reference audio groups containing more than 1 codec. The limitation in HLS is that within the audio groups they do not describe which audio variant stream uses which codec, we only know what they *might* use from the CODECS in the video variant stream.

Eg. - a small snippet from a master playlist:
```
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="eac-3",NAME="Dansk",LANGUAGE="da",AUTOSELECT=YES,CHANNELS="2",URI="r/composite_128k_mp4a.40.2_da_PRIMARY_edb6c652-bcee-4891-a034-9bfcd81f1706_501d4c73-fcf5-43f4-b155-ffd3e6b8e4ac.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="eac-3",NAME="Deutsch",LANGUAGE="de",AUTOSELECT=YES,CHANNELS="6",URI="r/composite_256k_ec-3_de_PRIMARY_0d283d35-0c4d-49ff-9d88-f0d386688670_501d4c73-fcf5-43f4-b155-ffd3e6b8e4ac.m3u8"

#EXT-X-STREAM-INF:BANDWIDTH=2176167,AVERAGE-BANDWIDTH=1406054,CODECS="avc1.4d401f,ec-3,mp4a.40.2",RESOLUTION=854x480,FRAME-RATE=23.976,AUDIO="eac-3",SUBTITLES="sub-main"
r/composite_1200k_CENC_CTR_FHD_SDR_87cb9adb-38e1-4145-8063-a9a70321e4b8_501d4c73-fcf5-43f4-b155-ffd3e6b8e4ac.m3u8
```
In this example we have both ec-3 and aac, and in HLSTree.cpp getAudioCodec() will always short circuit and return "ec-3" - result in screenshot with the Dansk "DD+" 2.0 stream:
![codec4](https://user-images.githubusercontent.com/11909320/81033548-6281ad80-8ed7-11ea-9ac3-4cb7a83b94b5.jpg) however we can see the hint in the URI from the snippet above that it is actually an AAC stream.

Selecting this stream in Kodi 18 results in no audio, and in Kodi 19 latest nightly results in a silent crash.

We can't know what the codec is until we start reading the stream, so the solution in this PR is to update stream->info_.m_codecName with the *actual* codec used in the mp4 after the stream reader has been set up. This has been accomplished in the same way that TSReader does it/implemented at the same point.

The end result is that while we still don't know if the codec is correct or not before starting the audio stream, the stream will now play and Kodi updates the stream info upon next opening of the stream list:
![codec3](https://user-images.githubusercontent.com/11909320/81033883-93161700-8ed8-11ea-925c-cffbf07d4325.jpg)

To test this please try in Disney+: Series -> All Series A-Z -> Austin & Ally -> S01E01

Thanks for your time!


