### PR TITLE
Support Dolby Vision in HLS

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -70,6 +70,11 @@ static std::string getVideoCodec(const std::string& codecs)
     return "hvc1";
   else if (codecs.find("hev1.") != std::string::npos)
     return "hev1";
+  else if (codecs.find("dvh1.") != std::string::npos)
+    // Kodi only supports dvhe so return that
+    return "dvhe";
+  else if (codecs.find("dvhe.") != std::string::npos)
+    return "dvhe";
   else
     return "";
 }


### PR DESCRIPTION
Referencing your commit for DV support: https://github.com/peak3d/inputstream.adaptive/commit/f61409ee6a3205cc1dc21b34e2dfd5dee146692f AP4 format for Dolby Vision is **dvhe** & **dvh1**

https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-streams-within-the-http-live-streaming-format-v1.1.pdf

Example HLS codecs

**CODECS="dvhe.05.07,ec-3"
CODECS="dvh1.05.06,ec-3,mp4a.40.2"**


Side note: 

According to the dolby pdf, you can also have
CODECS="hvc1.1.0.L120.00,dvh1.04.09,ec-3"

"In this example, the highlighted string indicates that the video element is a dual-layer Dolby
Vision stream encoded as 10-bit HEVC video in each layer with a max resolution of 3840 ×
2160 at 60 fps, where the base layer is a backward-compatible, SDR Rec.709–compliant
signal."

Current HLS code will return hvc1 instead of dvh1
So not sure if we would want to re-arrange so dvh1 is check and returned first? 

**Always return the best codec? Or always return the most likely to be supported?**

I guess you would need to know what the device supports...
Same issue as having multiple audio codecs listed
But that's a problem for a different day.

For this PR, I just followed the same existing order ("worst" to "best")