### PR TITLE
Fix aes128 HLS playlists with > 1 key

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -625,6 +625,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
               return PREPARE_RESULT_FAILURE;
             case ENCRYPTIONTYPE_AES128:
               currentEncryptionType = ENCRYPTIONTYPE_AES128;
+              segment.pssh_set_ = 0;
               break;
             case ENCRYPTIONTYPE_WIDEVINE:
               currentEncryptionType = ENCRYPTIONTYPE_WIDEVINE;


### PR DESCRIPTION
Hi @peak3d 

HLS streams with more than 1 KEY tag are failing to play. This is due to segment.pssh_set_ being stuck at a value of 1 - it was only being reset to 0 after a discontinuity and so in this case any future segments within the period they will always inherit the same pssh set (1), which ends up being the key/iv of the last KEY in the playlist.

Since the values of current_iv_ and current_pssh_ are retained following a new discontinuity we don't need to reset segment.pssh_set_ to 0. As before the large hls rework commit, the segment psshset is assigned to for every segment in the case of aes128.