### PR TITLE
Reduce retries to 3 and don't retry subtitle segments

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -77,7 +77,7 @@ void AdaptiveStream::worker()
     thread_data_->signal_dl_.wait(lckdl);
 
     bool ret(download_segment());
-    unsigned int retryCount(10);
+    unsigned int retryCount(3);
 
     while (!ret && !stopped_ && retryCount-- && tree_.has_timeshift_buffer_)
     {

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -79,6 +79,11 @@ void AdaptiveStream::worker()
     bool ret(download_segment());
     unsigned int retryCount(3);
 
+    //Dont retry failed subtitle segments
+    if (type_ == AdaptiveTree::SUBTITLE) {
+      retryCount = 0;
+    }
+
     while (!ret && !stopped_ && retryCount-- && tree_.has_timeshift_buffer_)
     {
       std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
Test builds here (matrix)
https://jenkins.kodi.tv/blue/organizations/jenkins/peak3d%2Finputstream.adaptive/detail/PR-445/1/artifacts/

Test strm here
https://raw.githubusercontent.com/matthuisman/ia_tests/master/mpd_415_subtitles/test.strm
You need to have Kodi Settings > Player > Language > Preferred Subtitle Language > Dutch

Without PR: 20+ second delay - live-text_track_0_dut tried 1+10 times before playback
With PR: less delay - live-text_track_0_dut only tried once

Pretty easy to read PR as well.
If subtitle - then set retries to 0.

Not sure if this is the best fix.
If IA didn't wait on the download thread for Subtitles - then that should also work.
@glennguy  looking into that when has time :)