### PR TITLE
[DASH] default timescale to seconds when not in segmenttemplate

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -110,6 +110,9 @@ static unsigned int ParseSegmentTemplate(const char **attr, std::string baseURL,
     attr += 2;
   }
 
+  if (!tpl.timescale) // if not specified timescale defaults to seconds
+    tpl.timescale = 1;
+
   if (tpl.media.compare(0, 7, "http://") != 0
     && tpl.media.compare(0, 8, "https://") != 0)
   {


### PR DESCRIPTION
Hi @peak3d 

This should fix the issue in #413. Test stream to try:
```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
http://livesim.dashif.org/livesim/testpic_2s/Manifest.mpd
```

Please note there is also another issue affecting this test stream (unsigned int seg.range_end_ wrap below zero causing seg 404) however that is not the focus of this PR.

DASH spec says that timescale is optional in segmenttemplate, and should default to seconds if not given, having it at 0 was causing the wrong path of execution to be taken for this case.

I am worried though about the condition of tpl.timescale > 0 at https://github.com/peak3d/inputstream.adaptive/blob/Matrix/src/parser/DASHTree.cpp#L1118 . Since this commit will make timescale always greater than 0, would you be able to advise if this will affect a case of mpd that I'm not considering here?

Thanks!

Glenn
