### PR TITLE
[HLS] Copy fpsScale for new periods

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -217,6 +217,7 @@ namespace adaptive
     width_ = src->width_;
     height_ = src->height_;
     fpsRate_ = src->fpsRate_;
+    fpsScale_ = src->fpsScale_;
     aspect_ = src->aspect_;
     flags_ = src->flags_;
     hdcpVersion_ = src->hdcpVersion_;


### PR DESCRIPTION
fixes issue mentioned in #448 where we get for eg. 23976 fps instead of 23.976 in periods > 0