### PR TITLE
[WebVTT] Fix binary representation

### DIFF
--- a/src/parser/WebVTT.cpp
+++ b/src/parser/WebVTT.cpp
@@ -42,7 +42,7 @@ bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t b
         cbuf += 4, buffer_size -= 4;
 
       std::string text(cbuf + 12, buffer_size - 12);
-      if (m_subTitles.empty() || text != m_subTitles.back().text[0])
+      if (m_subTitles.empty() || ~m_subTitles.back().end)
       {
         m_subTitles.push_back(SUBTITLE(pts));
         m_subTitles.back().text.push_back(text);


### PR DESCRIPTION
This fixes an issue where in some cases binary WebVTT subtitles are not shown or suddenly disappear.

The current implementation looks at the text content of the previous subtitle to decide if the next subtitle needs to be added to the vector. This is a bad practice as it sometimes throws away subtitles that should be displayed.
For instance, when someone is calling a name, it's totally possible that  the name is called several times in a row:
```
00:08:08,888 --> 00:08:10,368
Malu?

00:08:12,928 --> 00:08:14,488
Malu?
```
In this case **Malu?** should be displayed twice.

Checking if the previous subtitle end timestamp is set to decide if we need to add the new subtitle is a more failsafe approach.