### PR TITLE
Refactor processEncryption & Regression Fix

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -96,65 +96,69 @@ HLSTree::~HLSTree()
 
 int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::string>& map)
 {
-  if (map["METHOD"] != "NONE")
-  {
-    if (map["METHOD"] != "AES-128" && map["METHOD"] != "SAMPLE-AES-CTR")
-    {
-      Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
-      return ENCRYPTIONTYPE_INVALID;
-    }
-    if (map["URI"].empty())
-    {
-      Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
-      return ENCRYPTIONTYPE_INVALID;
-    }
-    if (!map["KEYFORMAT"].empty())
-    {
-      if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed")
-      {
-        if (!map["KEYID"].empty())
-        {
-          std::string keyid = map["KEYID"].substr(2);
-          const char* defaultKID = keyid.c_str();
-          current_defaultKID_.resize(16);
-          for (unsigned int i(0); i < 16; ++i)
-          {
-            current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
-            ++defaultKID;
-            current_defaultKID_[i] |= HexNibble(*defaultKID);
-            ++defaultKID;
-          }
-        }
-        current_pssh_ = map["URI"].substr(23);
-        // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
-        if (current_defaultKID_.empty() && current_pssh_.size() == 68)
-        {
-          unsigned int bufLen = 52;
-          uint8_t buf[52];
-          b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
-          if (bufLen == 50)
-            current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
-        }
-        return ENCRYPTIONTYPE_WIDEVINE;
-      }
-    }
-    else
-    {
-      current_pssh_ = map["URI"];
-      if (current_pssh_[0] == '/')
-        current_pssh_ = base_domain_ + current_pssh_;
-      else if (current_pssh_.find("://", 0) == std::string::npos)
-        current_pssh_ = baseUrl + current_pssh_;
-
-      current_iv_ = m_decrypter->convertIV(map["IV"]);
-      return ENCRYPTIONTYPE_AES128;
-    }
-  }
-  else
+  // NO ENCRYPTION
+  if (map["METHOD"] == "NONE")
   {
     current_pssh_.clear();
+
     return ENCRYPTIONTYPE_CLEAR;
   }
+
+  // AES-128
+  if (map["METHOD"] == "AES-128" && !map["URI"].empty())
+  {
+    current_pssh_ = map["URI"];
+    if (current_pssh_[0] == '/')
+      current_pssh_ = base_domain_ + current_pssh_;
+    else if (current_pssh_.find("://", 0) == std::string::npos)
+      current_pssh_ = baseUrl + current_pssh_;
+
+    current_iv_ = m_decrypter->convertIV(map["IV"]);
+
+    return ENCRYPTIONTYPE_AES128;
+  }
+
+  // WIDEVINE
+  if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed" && !map["URI"].empty())
+  {
+    if (!map["KEYID"].empty())
+    {
+      std::string keyid = map["KEYID"].substr(2);
+      const char* defaultKID = keyid.c_str();
+      current_defaultKID_.resize(16);
+      for (unsigned int i(0); i < 16; ++i)
+      {
+        current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
+        ++defaultKID;
+        current_defaultKID_[i] |= HexNibble(*defaultKID);
+        ++defaultKID;
+      }
+    }
+
+    current_pssh_ = map["URI"].substr(23);
+    // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
+    if (current_defaultKID_.empty() && current_pssh_.size() == 68)
+    {
+      unsigned int bufLen = 52;
+      uint8_t buf[52];
+      b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
+      if (bufLen == 50)
+        current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
+    }
+
+    return ENCRYPTIONTYPE_WIDEVINE;
+  }
+
+  // KNOWN UNSUPPORTED
+  if (map["METHOD"] == "SAMPLE-AES")
+  {
+    Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
+    return ENCRYPTIONTYPE_INVALID;
+  }
+
+  // UNKNOWN
+  Log(LOGLEVEL_WARNING, "Unknown encryption method: %s with keyformat %s",
+      map["METHOD"].c_str(), map["KEYFORMAT"].c_str());
   return ENCRYPTIONTYPE_UNKNOWN;
 }
 


### PR DESCRIPTION
This removes a lot of nesting etc and makes it a bit easier to read.
Also makes it easier to add new supported encryptions in the future.

Easier to see what it does by viewing the entire updated function here:
https://github.com/peak3d/inputstream.adaptive/blob/00850dbdff6d66e4142697b733cdc0056814d178/src/parser/HLSTree.cpp#L97

This will also fix regression issue here:
https://github.com/peak3d/inputstream.adaptive/pull/395#issuecomment-640109313
where IA is treating a HLS AES-128 stream with a keyformat as non-encrypted.