### PR TITLE
Fix if aes-128 has keyformat

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -108,35 +108,32 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
       Log(LOGLEVEL_ERROR, "Unsupported encryption method: %s", map["METHOD"].c_str());
       return ENCRYPTIONTYPE_INVALID;
     }
-    if (!map["KEYFORMAT"].empty())
+    if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed")
     {
-      if (map["KEYFORMAT"] == "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed")
+      if (!map["KEYID"].empty())
       {
-        if (!map["KEYID"].empty())
+        std::string keyid = map["KEYID"].substr(2);
+        const char* defaultKID = keyid.c_str();
+        current_defaultKID_.resize(16);
+        for (unsigned int i(0); i < 16; ++i)
         {
-          std::string keyid = map["KEYID"].substr(2);
-          const char* defaultKID = keyid.c_str();
-          current_defaultKID_.resize(16);
-          for (unsigned int i(0); i < 16; ++i)
-          {
-            current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
-            ++defaultKID;
-            current_defaultKID_[i] |= HexNibble(*defaultKID);
-            ++defaultKID;
-          }
+          current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
+          ++defaultKID;
+          current_defaultKID_[i] |= HexNibble(*defaultKID);
+          ++defaultKID;
         }
-        current_pssh_ = map["URI"].substr(23);
-        // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
-        if (current_defaultKID_.empty() && current_pssh_.size() == 68)
-        {
-          unsigned int bufLen = 52;
-          uint8_t buf[52];
-          b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
-          if (bufLen == 50)
-            current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
-        }
-        return ENCRYPTIONTYPE_WIDEVINE;
       }
+      current_pssh_ = map["URI"].substr(23);
+      // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
+      if (current_defaultKID_.empty() && current_pssh_.size() == 68)
+      {
+        unsigned int bufLen = 52;
+        uint8_t buf[52];
+        b64_decode(current_pssh_.c_str(), current_pssh_.size(), buf, bufLen);
+        if (bufLen == 50)
+          current_defaultKID_ = std::string(reinterpret_cast<const char*>(&buf[34]), 16);
+      }
+      return ENCRYPTIONTYPE_WIDEVINE;
     }
     else
     {


### PR DESCRIPTION
If AES-128 has a keyformat, it would pass as ENCRYPTIONTYPE_UNKNOWN

https://github.com/peak3d/inputstream.adaptive/pull/461 also sorts this out.
But this has less changes so may be preferred.

@peak3d 
Take your pick :)

Once you've picked, I can backport PR if you like?