### PR TITLE
Support "tag:dolby.com...audio_channel_configuration"

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -82,7 +82,8 @@ static uint8_t GetChannels(const char** attr)
   {
     if (strcmp(schemeIdUri, "urn:mpeg:dash:23003:3:audio_channel_configuration:2011") == 0)
       return atoi(value);
-    else if (strcmp(schemeIdUri, "urn:dolby:dash:audio_channel_configuration:2011") == 0)
+    else if (strcmp(schemeIdUri, "urn:dolby:dash:audio_channel_configuration:2011") == 0 ||
+             strcmp(schemeIdUri, "tag:dolby.com,2014:dash:audio_channel_configuration:2011") == 0)
     {
       if (strcmp(value, "F801") == 0)
         return 6;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -16,17 +16,19 @@
 *
 */
 
-#include <string>
-#include <cstring>
-#include <time.h>
-#include <float.h>
-#include <thread>
-
 #include "DASHTree.h"
-#include "../oscompat.h"
+
 #include "../helpers.h"
 #include "../log.h"
+#include "../oscompat.h"
 #include "PRProtectionParser.h"
+
+#include <cstring>
+#include <float.h>
+#include <string>
+#include <thread>
+#include <time.h>
+
 
 using namespace adaptive;
 
@@ -53,10 +55,9 @@ enum
 
 static const char* CONTENTPROTECTION_TAG = "ContentProtection";
 
-static const char* ltranslate(const char * in)
+static const char* ltranslate(const char* in)
 {
-  if (strlen(in) == 2 || strlen(in) == 3
-  || (strlen(in) > 3 && in[2] == '-'))
+  if (strlen(in) == 2 || strlen(in) == 3 || (strlen(in) > 3 && in[2] == '-'))
     return in;
   return "unk";
 }
@@ -65,7 +66,7 @@ DASHTree::DASHTree()
 {
 }
 
-static uint8_t GetChannels(const char **attr)
+static uint8_t GetChannels(const char** attr)
 {
   const char *schemeIdUri(0), *value(0);
 
@@ -92,7 +93,10 @@ static uint8_t GetChannels(const char **attr)
   return 0;
 }
 
-static unsigned int ParseSegmentTemplate(const char **attr, std::string baseURL, std::string baseDomain, DASHTree::SegmentTemplate &tpl)
+static unsigned int ParseSegmentTemplate(const char** attr,
+                                         std::string baseURL,
+                                         std::string baseDomain,
+                                         DASHTree::SegmentTemplate& tpl)
 {
   unsigned int startNumber(1);
   for (; *attr;)
@@ -113,8 +117,7 @@ static unsigned int ParseSegmentTemplate(const char **attr, std::string baseURL,
   if (!tpl.timescale) // if not specified timescale defaults to seconds
     tpl.timescale = 1;
 
-  if (tpl.media.compare(0, 7, "http://") != 0
-    && tpl.media.compare(0, 8, "https://") != 0)
+  if (tpl.media.compare(0, 7, "http://") != 0 && tpl.media.compare(0, 8, "https://") != 0)
   {
     if (!tpl.media.empty() && tpl.media[0] == '/')
       tpl.media = baseDomain + tpl.media;
@@ -122,9 +125,8 @@ static unsigned int ParseSegmentTemplate(const char **attr, std::string baseURL,
       tpl.media = baseURL + tpl.media;
   }
 
-  if (!tpl.initialization.empty()
-    && tpl.initialization.compare(0, 7, "http://") != 0
-    && tpl.initialization.compare(0, 8, "https://") != 0)
+  if (!tpl.initialization.empty() && tpl.initialization.compare(0, 7, "http://") != 0 &&
+      tpl.initialization.compare(0, 8, "https://") != 0)
   {
     if (!tpl.initialization.empty() && tpl.initialization[0] == '/')
       tpl.initialization = baseDomain + tpl.initialization;
@@ -141,7 +143,7 @@ static time_t getTime(const char* timeStr)
   {
     struct tm tmd;
 
-    memset(&tmd,0,sizeof(tmd));
+    memset(&tmd, 0, sizeof(tmd));
     tmd.tm_year = year - 1900;
     tmd.tm_mon = mon - 1;
     tmd.tm_mday = day;
@@ -158,8 +160,9 @@ static void AddDuration(const char* dur, uint64_t& retVal, uint32_t scale)
   if (dur && dur[0] == 'P')
   {
     ++dur;
-    const char *next = strchr(dur, 'D');
-    if (next) {
+    const char* next = strchr(dur, 'D');
+    if (next)
+    {
       retVal += static_cast<uint64_t>(atof(dur) * 86400 * scale);
       dur = next + 1;
     }
@@ -171,12 +174,14 @@ static void AddDuration(const char* dur, uint64_t& retVal, uint32_t scale)
       return;
 
     next = strchr(dur, 'H');
-    if (next) {
+    if (next)
+    {
       retVal += static_cast<uint64_t>(atof(dur) * 3600 * scale);
       dur = next + 1;
     }
     next = strchr(dur, 'M');
-    if (next) {
+    if (next)
+    {
       retVal += static_cast<uint64_t>(atof(dur) * 60 * scale);
       dur = next + 1;
     }
@@ -186,12 +191,12 @@ static void AddDuration(const char* dur, uint64_t& retVal, uint32_t scale)
   }
 }
 
-bool ParseContentProtection(const char **attr, DASHTree *dash)
+bool ParseContentProtection(const char** attr, DASHTree* dash)
 {
   dash->strXMLText_.clear();
   dash->current_period_->encryptionState_ |= DASHTree::ENCRYTIONSTATE_ENCRYPTED;
   bool urnFound(false), mpdFound(false);
-  const char *defaultKID(0);
+  const char* defaultKID(0);
   for (; *attr;)
   {
     if (strcmp((const char*)*attr, "schemeIdUri") == 0)
@@ -217,8 +222,10 @@ bool ParseContentProtection(const char **attr, DASHTree *dash)
     {
       if (i == 4 || i == 6 || i == 8 || i == 10)
         ++defaultKID;
-      dash->current_defaultKID_[i] = HexNibble(*defaultKID) << 4; ++defaultKID;
-      dash->current_defaultKID_[i] |= HexNibble(*defaultKID); ++defaultKID;
+      dash->current_defaultKID_[i] = HexNibble(*defaultKID) << 4;
+      ++defaultKID;
+      dash->current_defaultKID_[i] |= HexNibble(*defaultKID);
+      ++defaultKID;
     }
   }
   // Return if we have URN or not
@@ -229,7 +236,7 @@ bool ParseContentProtection(const char **attr, DASHTree *dash)
 |   expat start
 +---------------------------------------------------------------------*/
 
-static void ReplacePlaceHolders(std::string &rep, const std::string &id, uint32_t bandwidth)
+static void ReplacePlaceHolders(std::string& rep, const std::string& id, uint32_t bandwidth)
 {
   std::string::size_type repPos = rep.find("$RepresentationID$");
   if (repPos != std::string::npos)
@@ -244,10 +251,9 @@ static void ReplacePlaceHolders(std::string &rep, const std::string &id, uint32_
   }
 }
 
-static void XMLCALL
-start(void *data, const char *el, const char **attr)
+static void XMLCALL start(void* data, const char* el, const char** attr)
 {
-  DASHTree *dash(reinterpret_cast<DASHTree*>(data));
+  DASHTree* dash(reinterpret_cast<DASHTree*>(data));
 
   if (dash->currentNode_ & MPDNODE_MPD)
   {
@@ -293,7 +299,8 @@ start(void *data, const char *el, const char **attr)
               if (dash->current_representation_->segments_.data.empty())
                 seg.startPTS_ = dash->base_time_ + dash->current_representation_->ptsOffset_;
               else
-                seg.startPTS_ = dash->current_representation_->nextPts_ + dash->current_representation_->duration_;
+                seg.startPTS_ = dash->current_representation_->nextPts_ +
+                                dash->current_representation_->duration_;
 
               dash->current_representation_->nextPts_ = seg.startPTS_;
               dash->current_representation_->segments_.data.push_back(seg);
@@ -338,7 +345,7 @@ start(void *data, const char *el, const char **attr)
                 else if (strcmp((const char*)*attr, "d") == 0)
                   d = atoi((const char*)*(attr + 1));
                 if (strcmp((const char*)*attr, "r") == 0)
-                  r = atoi((const char*)*(attr + 1))+1;
+                  r = atoi((const char*)*(attr + 1)) + 1;
                 attr += 2;
               }
               if (d && r)
@@ -346,11 +353,20 @@ start(void *data, const char *el, const char **attr)
                 DASHTree::Segment s;
                 if (dash->current_representation_->segments_.data.empty())
                 {
-                  uint64_t overallSeconds = dash->current_period_->duration_ ? dash->current_period_->duration_ / dash->current_period_->timescale_ : dash->overallSeconds_;
-                  if (dash->current_representation_->segtpl_.duration && dash->current_representation_->segtpl_.timescale)
-                    dash->current_representation_->segments_.data.reserve((unsigned int)((double)overallSeconds / (((double)dash->current_representation_->segtpl_.duration) / dash->current_representation_->segtpl_.timescale)) + 1);
+                  uint64_t overallSeconds =
+                      dash->current_period_->duration_
+                          ? dash->current_period_->duration_ / dash->current_period_->timescale_
+                          : dash->overallSeconds_;
+                  if (dash->current_representation_->segtpl_.duration &&
+                      dash->current_representation_->segtpl_.timescale)
+                    dash->current_representation_->segments_.data.reserve(
+                        (unsigned int)((double)overallSeconds /
+                                       (((double)dash->current_representation_->segtpl_.duration) /
+                                        dash->current_representation_->segtpl_.timescale)) +
+                        1);
 
-                  if (dash->current_representation_->flags_ & DASHTree::Representation::INITIALIZATION)
+                  if (dash->current_representation_->flags_ &
+                      DASHTree::Representation::INITIALIZATION)
                   {
                     s.range_begin_ = 0ULL, s.range_end_ = 0;
                     dash->current_representation_->initialization_ = s;
@@ -358,9 +374,10 @@ start(void *data, const char *el, const char **attr)
                   s.range_end_ = dash->current_representation_->startNumber_;
                 }
                 else
-                  s.range_end_ = dash->current_representation_->segments_.data.back().range_end_ + 1;
+                  s.range_end_ =
+                      dash->current_representation_->segments_.data.back().range_end_ + 1;
                 s.range_begin_ = s.startPTS_ = t;
-                s.startPTS_ -= dash->base_time_*dash->current_representation_->segtpl_.timescale;
+                s.startPTS_ -= dash->base_time_ * dash->current_representation_->segtpl_.timescale;
 
                 for (; r; --r)
                 {
@@ -392,7 +409,8 @@ start(void *data, const char *el, const char **attr)
               for (; *attr;)
               {
                 if (strcmp((const char*)*attr, "robustness_level") == 0)
-                  dash->current_period_->need_secure_decoder_ = strncmp((const char*)*(attr + 1), "HW", 2) == 0;
+                  dash->current_period_->need_secure_decoder_ =
+                      strncmp((const char*)*(attr + 1), "HW", 2) == 0;
                 attr += 2;
               }
             }
@@ -432,14 +450,14 @@ start(void *data, const char *el, const char **attr)
             {
               dash->current_representation_->duration_ = dur;
               dash->current_representation_->timescale_ = ts;
-              dash->current_representation_->segments_.data.reserve(dash->estimate_segcount(
-                dash->current_representation_->duration_,
-                dash->current_representation_->timescale_));
+              dash->current_representation_->segments_.data.reserve(
+                  dash->estimate_segcount(dash->current_representation_->duration_,
+                                          dash->current_representation_->timescale_));
             }
             else if (dash->current_adaptationset_->segment_durations_.data.size())
             {
               dash->current_representation_->segments_.data.reserve(
-                dash->current_adaptationset_->segment_durations_.data.size());
+                  dash->current_adaptationset_->segment_durations_.data.size());
             }
             else
               return;
@@ -451,34 +469,46 @@ start(void *data, const char *el, const char **attr)
             for (; *attr;)
             {
               if (strcmp((const char*)*attr, "indexRange") == 0)
-                sscanf((const char*)*(attr + 1), "%u-%u" , &dash->current_representation_->indexRangeMin_, &dash->current_representation_->indexRangeMax_);
-              else if (strcmp((const char*)*attr, "indexRangeExact") == 0 && strcmp((const char*)*(attr + 1), "true") == 0)
+                sscanf((const char*)*(attr + 1), "%u-%u",
+                       &dash->current_representation_->indexRangeMin_,
+                       &dash->current_representation_->indexRangeMax_);
+              else if (strcmp((const char*)*attr, "indexRangeExact") == 0 &&
+                       strcmp((const char*)*(attr + 1), "true") == 0)
                 dash->current_representation_->flags_ |= DASHTree::Representation::INDEXRANGEEXACT;
               dash->current_representation_->flags_ |= DASHTree::Representation::SEGMENTBASE;
               attr += 2;
             }
-            if(dash->current_representation_->indexRangeMax_)
+            if (dash->current_representation_->indexRangeMax_)
               dash->currentNode_ |= MPDNODE_SEGMENTLIST;
           }
           else if (strcmp(el, "SegmentTemplate") == 0)
           {
             dash->current_representation_->segtpl_ = dash->current_adaptationset_->segtpl_;
 
-            dash->current_representation_->startNumber_ = ParseSegmentTemplate(attr, dash->current_representation_->url_, dash->base_domain_, dash->current_representation_->segtpl_);
-            ReplacePlaceHolders(dash->current_representation_->segtpl_.media, dash->current_representation_->id, dash->current_representation_->bandwidth_);
+            dash->current_representation_->startNumber_ =
+                ParseSegmentTemplate(attr, dash->current_representation_->url_, dash->base_domain_,
+                                     dash->current_representation_->segtpl_);
+            ReplacePlaceHolders(dash->current_representation_->segtpl_.media,
+                                dash->current_representation_->id,
+                                dash->current_representation_->bandwidth_);
             dash->current_representation_->flags_ |= DASHTree::Representation::TEMPLATE;
             if (!dash->current_representation_->segtpl_.initialization.empty())
             {
-              ReplacePlaceHolders(dash->current_representation_->segtpl_.initialization, dash->current_representation_->id, dash->current_representation_->bandwidth_);
+              ReplacePlaceHolders(dash->current_representation_->segtpl_.initialization,
+                                  dash->current_representation_->id,
+                                  dash->current_representation_->bandwidth_);
               dash->current_representation_->flags_ |= DASHTree::Representation::INITIALIZATION;
-              dash->current_representation_->url_ = dash->current_representation_->segtpl_.initialization;
-              dash->current_representation_->timescale_ = dash->current_representation_->segtpl_.timescale;
+              dash->current_representation_->url_ =
+                  dash->current_representation_->segtpl_.initialization;
+              dash->current_representation_->timescale_ =
+                  dash->current_representation_->segtpl_.timescale;
             }
             dash->currentNode_ |= MPDNODE_SEGMENTTEMPLATE;
           }
           else if (strcmp(el, CONTENTPROTECTION_TAG) == 0)
           {
-            if (!dash->current_representation_->pssh_set_ || dash->current_representation_->pssh_set_ == 0xFF)
+            if (!dash->current_representation_->pssh_set_ ||
+                dash->current_representation_->pssh_set_ == 0xFF)
             {
               //Mark protected but invalid
               dash->current_representation_->pssh_set_ = 0xFF;
@@ -501,16 +531,17 @@ start(void *data, const char *el, const char **attr)
               else if (strcmp((const char*)*attr, "d") == 0)
                 d = atoi((const char*)*(attr + 1));
               if (strcmp((const char*)*attr, "r") == 0)
-                r = atoi((const char*)*(attr + 1))+1;
+                r = atoi((const char*)*(attr + 1)) + 1;
               attr += 2;
             }
-            if(dash->current_adaptationset_->segment_durations_.data.empty())
+            if (dash->current_adaptationset_->segment_durations_.data.empty())
               dash->current_adaptationset_->startPTS_ = dash->pts_helper_ = t;
             else if (t)
             {
               //Go back to the previous timestamp to calculate the real gap.
               dash->pts_helper_ -= dash->current_adaptationset_->segment_durations_.data.back();
-              dash->current_adaptationset_->segment_durations_.data.back() = static_cast<uint32_t>(t - dash->pts_helper_);
+              dash->current_adaptationset_->segment_durations_.data.back() =
+                  static_cast<uint32_t>(t - dash->pts_helper_);
               dash->pts_helper_ = t;
             }
             if (d && r)
@@ -531,7 +562,8 @@ start(void *data, const char *el, const char **attr)
         else if (dash->currentNode_ & MPDNODE_SEGMENTDURATIONS)
         {
           if (strcmp(el, "S") == 0 && *(const char*)*attr == 'd')
-            dash->current_adaptationset_->segment_durations_.data.push_back(atoi((const char*)*(attr + 1)));
+            dash->current_adaptationset_->segment_durations_.data.push_back(
+                atoi((const char*)*(attr + 1)));
         }
         else if (dash->currentNode_ & MPDNODE_CONTENTPROTECTION)
         {
@@ -542,7 +574,8 @@ start(void *data, const char *el, const char **attr)
             for (; *attr;)
             {
               if (strcmp((const char*)*attr, "robustness_level") == 0)
-                dash->current_period_->need_secure_decoder_ = strncmp((const char*)*(attr + 1), "HW", 2) == 0;
+                dash->current_period_->need_secure_decoder_ =
+                    strncmp((const char*)*(attr + 1), "HW", 2) == 0;
               attr += 2;
             }
           }
@@ -554,10 +587,12 @@ start(void *data, const char *el, const char **attr)
             if (strcmp((const char*)*attr, "contentType") == 0)
             {
               dash->current_adaptationset_->type_ =
-                stricmp((const char*)*(attr + 1), "video") == 0 ? DASHTree::VIDEO
-                : stricmp((const char*)*(attr + 1), "audio") == 0 ? DASHTree::AUDIO
-                : stricmp((const char*)*(attr + 1), "text") == 0 ? DASHTree::SUBTITLE
-                : DASHTree::NOTYPE;
+                  stricmp((const char*)*(attr + 1), "video") == 0
+                      ? DASHTree::VIDEO
+                      : stricmp((const char*)*(attr + 1), "audio") == 0
+                            ? DASHTree::AUDIO
+                            : stricmp((const char*)*(attr + 1), "text") == 0 ? DASHTree::SUBTITLE
+                                                                             : DASHTree::NOTYPE;
               break;
             }
             attr += 2;
@@ -568,8 +603,11 @@ start(void *data, const char *el, const char **attr)
         }
         else if (strcmp(el, "SegmentTemplate") == 0)
         {
-          dash->current_adaptationset_->startNumber_ = ParseSegmentTemplate(attr, dash->current_adaptationset_->base_url_, dash->base_domain_, dash->current_adaptationset_->segtpl_);
-          dash->current_adaptationset_->timescale_ = dash->current_adaptationset_->segtpl_.timescale;
+          dash->current_adaptationset_->startNumber_ =
+              ParseSegmentTemplate(attr, dash->current_adaptationset_->base_url_,
+                                   dash->base_domain_, dash->current_adaptationset_->segtpl_);
+          dash->current_adaptationset_->timescale_ =
+              dash->current_adaptationset_->segtpl_.timescale;
           dash->currentNode_ |= MPDNODE_SEGMENTTEMPLATE;
         }
         else if (strcmp(el, "SegmentList") == 0)
@@ -636,20 +674,28 @@ start(void *data, const char *el, const char **attr)
             else if (strcmp((const char*)*attr, "codecs") == 0)
               dash->current_representation_->codecs_ = (const char*)*(attr + 1);
             else if (strcmp((const char*)*attr, "width") == 0)
-              dash->current_representation_->width_ = static_cast<uint16_t>(atoi((const char*)*(attr + 1)));
+              dash->current_representation_->width_ =
+                  static_cast<uint16_t>(atoi((const char*)*(attr + 1)));
             else if (strcmp((const char*)*attr, "height") == 0)
-              dash->current_representation_->height_ = static_cast<uint16_t>(atoi((const char*)*(attr + 1)));
+              dash->current_representation_->height_ =
+                  static_cast<uint16_t>(atoi((const char*)*(attr + 1)));
             else if (strcmp((const char*)*attr, "audioSamplingRate") == 0)
-              dash->current_representation_->samplingRate_ = static_cast<uint32_t>(atoi((const char*)*(attr + 1)));
+              dash->current_representation_->samplingRate_ =
+                  static_cast<uint32_t>(atoi((const char*)*(attr + 1)));
             else if (strcmp((const char*)*attr, "frameRate") == 0)
-              sscanf((const char*)*(attr + 1), "%" SCNu32 "/%" SCNu32, &dash->current_representation_->fpsRate_, &dash->current_representation_->fpsScale_);
+              sscanf((const char*)*(attr + 1), "%" SCNu32 "/%" SCNu32,
+                     &dash->current_representation_->fpsRate_,
+                     &dash->current_representation_->fpsScale_);
             else if (strcmp((const char*)*attr, "id") == 0)
               dash->current_representation_->id = (const char*)*(attr + 1);
             else if (strcmp((const char*)*attr, "codecPrivateData") == 0)
-              dash->current_representation_->codec_private_data_ = annexb_to_avc((const char*)*(attr + 1));
+              dash->current_representation_->codec_private_data_ =
+                  annexb_to_avc((const char*)*(attr + 1));
             else if (strcmp((const char*)*attr, "hdcp") == 0)
-              dash->current_representation_->hdcpVersion_ = static_cast<uint16_t>(atof((const char*)*(attr + 1))*10);
-            else if (dash->current_adaptationset_->mimeType_.empty() && strcmp((const char*)*attr, "mimeType") == 0)
+              dash->current_representation_->hdcpVersion_ =
+                  static_cast<uint16_t>(atof((const char*)*(attr + 1)) * 10);
+            else if (dash->current_adaptationset_->mimeType_.empty() &&
+                     strcmp((const char*)*attr, "mimeType") == 0)
             {
               dash->current_adaptationset_->mimeType_ = (const char*)*(attr + 1);
               if (dash->current_adaptationset_->type_ == DASHTree::NOTYPE)
@@ -658,20 +704,22 @@ start(void *data, const char *el, const char **attr)
                   dash->current_adaptationset_->type_ = DASHTree::VIDEO;
                 else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "audio", 5) == 0)
                   dash->current_adaptationset_->type_ = DASHTree::AUDIO;
-                else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "application", 11) == 0)
+                else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "application",
+                                 11) == 0)
                   dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
               }
               if (strstr(dash->current_adaptationset_->mimeType_.c_str(), "/webm"))
                 dash->current_representation_->containerType_ = AdaptiveTree::CONTAINERTYPE_WEBM;
               else if (strstr(dash->current_adaptationset_->mimeType_.c_str(), "/x-matroska"))
-                dash->current_representation_->containerType_ = AdaptiveTree::CONTAINERTYPE_MATROSKA;
+                dash->current_representation_->containerType_ =
+                    AdaptiveTree::CONTAINERTYPE_MATROSKA;
             }
             attr += 2;
           }
 
-          if (dash->current_adaptationset_->type_ == DASHTree::SUBTITLE
-          && (dash->current_adaptationset_->mimeType_ == "application/ttml+xml"
-            || dash->current_adaptationset_->mimeType_ == "text/vtt"))
+          if (dash->current_adaptationset_->type_ == DASHTree::SUBTITLE &&
+              (dash->current_adaptationset_->mimeType_ == "application/ttml+xml" ||
+               dash->current_adaptationset_->mimeType_ == "text/vtt"))
           {
             if (dash->current_adaptationset_->segment_durations_.empty())
               dash->current_representation_->flags_ |= DASHTree::Representation::SUBTITLESTREAM;
@@ -692,16 +740,17 @@ start(void *data, const char *el, const char **attr)
           {
             dash->current_representation_->flags_ |= DASHTree::Representation::TEMPLATE;
             ReplacePlaceHolders(dash->current_representation_->segtpl_.media,
-              dash->current_representation_->id,
-              dash->current_representation_->bandwidth_);
+                                dash->current_representation_->id,
+                                dash->current_representation_->bandwidth_);
 
             if (!dash->current_representation_->segtpl_.initialization.empty())
             {
               dash->current_representation_->flags_ |= DASHTree::Representation::INITIALIZATION;
               ReplacePlaceHolders(dash->current_representation_->segtpl_.initialization,
-                dash->current_representation_->id,
-                dash->current_representation_->bandwidth_);
-              dash->current_representation_->url_ = dash->current_representation_->segtpl_.initialization;
+                                  dash->current_representation_->id,
+                                  dash->current_representation_->bandwidth_);
+              dash->current_representation_->url_ =
+                  dash->current_representation_->segtpl_.initialization;
             }
           }
           dash->currentNode_ |= MPDNODE_REPRESENTATION;
@@ -722,7 +771,7 @@ start(void *data, const char *el, const char **attr)
         }
         else if (strcmp(el, CONTENTPROTECTION_TAG) == 0)
         {
-          if (!dash->adp_pssh_set_ || dash->adp_pssh_set_== 0xFF)
+          if (!dash->adp_pssh_set_ || dash->adp_pssh_set_ == 0xFF)
           {
             //Mark protected but invalid
             dash->adp_pssh_set_ = 0xFF;
@@ -765,14 +814,16 @@ start(void *data, const char *el, const char **attr)
           if (dash->current_period_->segment_durations_.data.empty())
           {
             if (!dash->current_period_->duration_ && d)
-              dash->current_period_->segment_durations_.data.reserve(dash->estimate_segcount(d, dash->current_period_->timescale_));
+              dash->current_period_->segment_durations_.data.reserve(
+                  dash->estimate_segcount(d, dash->current_period_->timescale_));
             dash->current_period_->startPTS_ = dash->pts_helper_ = t;
           }
           else if (t)
           {
             //Go back to the previous timestamp to calculate the real gap.
             dash->pts_helper_ -= dash->current_adaptationset_->segment_durations_.data.back();
-            dash->current_period_->segment_durations_.data.back() = static_cast<uint32_t>(t - dash->pts_helper_);
+            dash->current_period_->segment_durations_.data.back() =
+                static_cast<uint32_t>(t - dash->pts_helper_);
             dash->pts_helper_ = t;
           }
           if (d && r)
@@ -808,7 +859,8 @@ start(void *data, const char *el, const char **attr)
         dash->adp_timelined_ = dash->period_timelined_;
         dash->current_adaptationset_->timescale_ = dash->current_period_->timescale_;
         dash->current_adaptationset_->duration_ = dash->current_period_->duration_;
-        dash->current_adaptationset_->segment_durations_ = dash->current_period_->segment_durations_;
+        dash->current_adaptationset_->segment_durations_ =
+            dash->current_period_->segment_durations_;
         dash->current_adaptationset_->segtpl_ = dash->current_period_->segtpl_;
         dash->current_adaptationset_->startNumber_ = dash->current_period_->startNumber_;
         dash->current_playready_wrmheader_.clear();
@@ -817,10 +869,12 @@ start(void *data, const char *el, const char **attr)
         {
           if (strcmp((const char*)*attr, "contentType") == 0)
             dash->current_adaptationset_->type_ =
-            stricmp((const char*)*(attr + 1), "video") == 0 ? DASHTree::VIDEO
-            : stricmp((const char*)*(attr + 1), "audio") == 0 ? DASHTree::AUDIO
-            : stricmp((const char*)*(attr + 1), "text") == 0 ? DASHTree::SUBTITLE
-            : DASHTree::NOTYPE;
+                stricmp((const char*)*(attr + 1), "video") == 0
+                    ? DASHTree::VIDEO
+                    : stricmp((const char*)*(attr + 1), "audio") == 0
+                          ? DASHTree::AUDIO
+                          : stricmp((const char*)*(attr + 1), "text") == 0 ? DASHTree::SUBTITLE
+                                                                           : DASHTree::NOTYPE;
           else if (strcmp((const char*)*attr, "id") == 0)
             dash->current_adaptationset_->id_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "group") == 0)
@@ -862,8 +916,9 @@ start(void *data, const char *el, const char **attr)
             dash->current_adaptationset_->type_ = DASHTree::VIDEO;
           else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "audio", 5) == 0)
             dash->current_adaptationset_->type_ = DASHTree::AUDIO;
-          else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "application", 11) == 0
-          || strncmp(dash->current_adaptationset_->mimeType_.c_str(), "text", 4) == 0)
+          else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "application", 11) ==
+                       0 ||
+                   strncmp(dash->current_adaptationset_->mimeType_.c_str(), "text", 4) == 0)
             dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
         }
 
@@ -877,7 +932,9 @@ start(void *data, const char *el, const char **attr)
       }
       else if (strcmp(el, "SegmentTemplate") == 0)
       {
-        dash->current_period_->startNumber_ = ParseSegmentTemplate(attr, dash->current_period_->base_url_, dash->base_domain_, dash->current_period_->segtpl_);
+        dash->current_period_->startNumber_ =
+            ParseSegmentTemplate(attr, dash->current_period_->base_url_, dash->base_domain_,
+                                 dash->current_period_->segtpl_);
         dash->current_period_->timescale_ = dash->current_period_->segtpl_.timescale;
         dash->currentNode_ |= MPDNODE_SEGMENTTEMPLATE;
       }
@@ -897,8 +954,7 @@ start(void *data, const char *el, const char **attr)
         {
           if (dash->current_period_->duration_)
             dash->current_period_->segment_durations_.data.reserve(dash->estimate_segcount(
-              dash->current_period_->duration_,
-              dash->current_period_->timescale_));
+                dash->current_period_->duration_, dash->current_period_->timescale_));
           dash->currentNode_ |= MPDNODE_SEGMENTLIST;
         }
       }
@@ -993,7 +1049,8 @@ start(void *data, const char *el, const char **attr)
     dash->has_overall_seconds_ = dash->overallSeconds_ > 0;
 
     uint64_t overallsecs(dash->overallSeconds_ ? dash->overallSeconds_ + 60 : 86400);
-    if (!dash->base_time_ && dash->publish_time_ && dash->available_time_ && dash->publish_time_ - dash->available_time_ > overallsecs)
+    if (!dash->base_time_ && dash->publish_time_ && dash->available_time_ &&
+        dash->publish_time_ - dash->available_time_ > overallsecs)
       dash->base_time_ = dash->publish_time_ - dash->available_time_ - overallsecs;
     dash->minPresentationOffset = ~0ULL;
 
@@ -1004,11 +1061,11 @@ start(void *data, const char *el, const char **attr)
 /*----------------------------------------------------------------------
 |   expat text
 +---------------------------------------------------------------------*/
-static void XMLCALL
-text(void *data, const char *s, int len)
+static void XMLCALL text(void* data, const char* s, int len)
 {
-  DASHTree *dash(reinterpret_cast<DASHTree*>(data));
-  if (dash->currentNode_ & (MPDNODE_BASEURL | MPDNODE_PSSH | MPDNODE_PLAYREADYWRMHEADER | MPDNODE_LOCATION))
+  DASHTree* dash(reinterpret_cast<DASHTree*>(data));
+  if (dash->currentNode_ &
+      (MPDNODE_BASEURL | MPDNODE_PSSH | MPDNODE_PLAYREADYWRMHEADER | MPDNODE_LOCATION))
     dash->strXMLText_ += std::string(s, len);
 }
 
@@ -1016,10 +1073,9 @@ text(void *data, const char *s, int len)
 |   expat end
 +---------------------------------------------------------------------*/
 
-static void XMLCALL
-end(void *data, const char *el)
+static void XMLCALL end(void* data, const char* el)
 {
-  DASHTree *dash(reinterpret_cast<DASHTree*>(data));
+  DASHTree* dash(reinterpret_cast<DASHTree*>(data));
 
   if (dash->currentNode_ & MPDNODE_MPD)
   {
@@ -1033,12 +1089,13 @@ end(void *data, const char *el)
           {
             if (strcmp(el, "BaseURL") == 0)
             {
-              while (dash->strXMLText_.size() && (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
+              while (dash->strXMLText_.size() &&
+                     (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
                 dash->strXMLText_.erase(dash->strXMLText_.begin());
 
               std::string url;
-              if (dash->strXMLText_.compare(0, 7, "http://") == 0
-                || dash->strXMLText_.compare(0, 8, "https://") == 0)
+              if (dash->strXMLText_.compare(0, 7, "http://") == 0 ||
+                  dash->strXMLText_.compare(0, 8, "https://") == 0)
                 url = dash->strXMLText_;
               else if (!dash->strXMLText_.empty() && dash->strXMLText_[0] == '/')
                 url = dash->base_domain_ + dash->strXMLText_;
@@ -1047,9 +1104,14 @@ end(void *data, const char *el)
 
               if (dash->current_representation_->flags_ & AdaptiveTree::Representation::TEMPLATE)
               {
-                if (dash->current_representation_->flags_ & AdaptiveTree::Representation::INITIALIZATION)
-                  dash->current_representation_->url_ = url + dash->current_representation_->url_.substr(dash->current_adaptationset_->base_url_.size());
-                dash->current_representation_->segtpl_.media = url + dash->current_representation_->segtpl_.media.substr(dash->current_adaptationset_->base_url_.size());
+                if (dash->current_representation_->flags_ &
+                    AdaptiveTree::Representation::INITIALIZATION)
+                  dash->current_representation_->url_ =
+                      url + dash->current_representation_->url_.substr(
+                                dash->current_adaptationset_->base_url_.size());
+                dash->current_representation_->segtpl_.media =
+                    url + dash->current_representation_->segtpl_.media.substr(
+                              dash->current_adaptationset_->base_url_.size());
               }
               else
                 dash->current_representation_->url_ = url;
@@ -1066,7 +1128,9 @@ end(void *data, const char *el)
               if (!dash->current_period_->duration_ && dash->current_representation_->timescale_)
               {
                 dash->current_period_->timescale_ = dash->current_representation_->timescale_;
-                dash->current_period_->duration_ = dash->current_representation_->duration_ * dash->current_representation_->segments_.data.size();
+                dash->current_period_->duration_ =
+                    dash->current_representation_->duration_ *
+                    dash->current_representation_->segments_.data.size();
               }
             }
           }
@@ -1096,7 +1160,8 @@ end(void *data, const char *el)
             {
               if (dash->current_pssh_.empty())
                 dash->current_pssh_ = "FILE";
-              dash->current_representation_->pssh_set_ = static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
+              dash->current_representation_->pssh_set_ =
+                  static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
               dash->currentNode_ &= ~MPDNODE_CONTENTPROTECTION;
             }
           }
@@ -1111,7 +1176,8 @@ end(void *data, const char *el)
               if (!dash->current_hasRepURN_)
               {
                 dash->current_pssh_ = "FILE";
-                dash->current_representation_->pssh_set_ = static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
+                dash->current_representation_->pssh_set_ =
+                    static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
                 dash->current_period_->encryptionState_ |= DASHTree::ENCRYTIONSTATE_SUPPORTED;
               }
               else
@@ -1124,14 +1190,22 @@ end(void *data, const char *el)
 
             if (dash->current_representation_->segments_.data.empty())
             {
-              DASHTree::SegmentTemplate &tpl(dash->current_representation_->segtpl_);
+              DASHTree::SegmentTemplate& tpl(dash->current_representation_->segtpl_);
 
-              uint64_t overallSeconds = dash->current_period_->duration_ ? dash->current_period_->duration_ / dash->current_period_->timescale_ : dash->overallSeconds_;
+              uint64_t overallSeconds =
+                  dash->current_period_->duration_
+                      ? dash->current_period_->duration_ / dash->current_period_->timescale_
+                      : dash->overallSeconds_;
               if (!tpl.media.empty() && overallSeconds > 0 && tpl.timescale > 0 &&
-                (tpl.duration > 0 || dash->current_adaptationset_->segment_durations_.data.size()))
+                  (tpl.duration > 0 ||
+                   dash->current_adaptationset_->segment_durations_.data.size()))
               {
-                unsigned int countSegs = !dash->current_adaptationset_->segment_durations_.data.empty()? dash->current_adaptationset_->segment_durations_.data.size():
-                  (unsigned int)((double)overallSeconds / (((double)tpl.duration) / tpl.timescale)) + 1;
+                unsigned int countSegs =
+                    !dash->current_adaptationset_->segment_durations_.data.empty()
+                        ? dash->current_adaptationset_->segment_durations_.data.size()
+                        : (unsigned int)((double)overallSeconds /
+                                         (((double)tpl.duration) / tpl.timescale)) +
+                              1;
 
                 if (countSegs < 65536)
                 {
@@ -1144,18 +1218,22 @@ end(void *data, const char *el)
                   {
                     seg.range_end_ = ~0;
                     dash->current_representation_->initialization_ = seg;
-                    dash->current_representation_->flags_ |= DASHTree::Representation::INITIALIZATION;
+                    dash->current_representation_->flags_ |=
+                        DASHTree::Representation::INITIALIZATION;
                   }
 
-                  std::vector<uint32_t>::const_iterator sdb(dash->current_adaptationset_->segment_durations_.data.begin()),
-                    sde(dash->current_adaptationset_->segment_durations_.data.end());
-                  bool timeBased = sdb!=sde && tpl.media.find("$Time") != std::string::npos;
+                  std::vector<uint32_t>::const_iterator sdb(
+                      dash->current_adaptationset_->segment_durations_.data.begin()),
+                      sde(dash->current_adaptationset_->segment_durations_.data.end());
+                  bool timeBased = sdb != sde && tpl.media.find("$Time") != std::string::npos;
                   if (dash->adp_timelined_)
                     dash->current_representation_->flags_ |= AdaptiveTree::Representation::TIMELINE;
 
                   seg.range_end_ = dash->current_representation_->startNumber_;
-                  if (dash->current_adaptationset_->startPTS_ > dash->base_time_*dash->current_adaptationset_->timescale_)
-                    seg.startPTS_ = dash->current_adaptationset_->startPTS_ - dash->base_time_*dash->current_adaptationset_->timescale_;
+                  if (dash->current_adaptationset_->startPTS_ >
+                      dash->base_time_ * dash->current_adaptationset_->timescale_)
+                    seg.startPTS_ = dash->current_adaptationset_->startPTS_ -
+                                    dash->base_time_ * dash->current_adaptationset_->timescale_;
                   else
                     seg.startPTS_ = 0;
                   seg.range_begin_ = dash->current_adaptationset_->startPTS_;
@@ -1163,12 +1241,19 @@ end(void *data, const char *el)
                   if (!timeBased && dash->has_timeshift_buffer_ && dash->available_time_)
                   {
                     if (!tpl.duration)
-                      tpl.duration = static_cast<unsigned int>((overallSeconds * tpl.timescale) / dash->current_adaptationset_->segment_durations_.data.size());
-                    seg.range_end_ += (static_cast<int64_t>(dash->stream_start_ - dash->available_time_ - overallSeconds)*tpl.timescale) / tpl.duration;
-                    seg.range_end_ -= (dash->current_period_->start_ * tpl.timescale) / (1000 * tpl.duration);
+                      tpl.duration = static_cast<unsigned int>(
+                          (overallSeconds * tpl.timescale) /
+                          dash->current_adaptationset_->segment_durations_.data.size());
+                    seg.range_end_ +=
+                        (static_cast<int64_t>(dash->stream_start_ - dash->available_time_ -
+                                              overallSeconds) *
+                         tpl.timescale) /
+                        tpl.duration;
+                    seg.range_end_ -=
+                        (dash->current_period_->start_ * tpl.timescale) / (1000 * tpl.duration);
                   }
 
-                  for (;countSegs;--countSegs)
+                  for (; countSegs; --countSegs)
                   {
                     dash->current_representation_->segments_.data.push_back(seg);
                     uint32_t duration((sdb != sde) ? *(sdb++) : tpl.duration);
@@ -1179,9 +1264,11 @@ end(void *data, const char *el)
                   return;
                 }
               }
-              else if (!(dash->current_representation_->flags_ & (DASHTree::Representation::SEGMENTBASE | DASHTree::Representation::SUBTITLESTREAM)))
+              else if (!(dash->current_representation_->flags_ &
+                         (DASHTree::Representation::SEGMENTBASE |
+                          DASHTree::Representation::SUBTITLESTREAM)))
               {
-                //Let us try to extract the fragments out of SIDX atom  
+                //Let us try to extract the fragments out of SIDX atom
                 dash->current_representation_->flags_ |= DASHTree::Representation::SEGMENTBASE;
                 dash->current_representation_->indexRangeMin_ = 0;
                 dash->current_representation_->indexRangeMax_ = 1024 * 200;
@@ -1189,13 +1276,20 @@ end(void *data, const char *el)
             }
             else
             {
-              ReplacePlaceHolders(dash->current_representation_->url_, dash->current_representation_->id, dash->current_representation_->bandwidth_);
-              ReplacePlaceHolders(dash->current_representation_->segtpl_.media, dash->current_representation_->id, dash->current_representation_->bandwidth_);
+              ReplacePlaceHolders(dash->current_representation_->url_,
+                                  dash->current_representation_->id,
+                                  dash->current_representation_->bandwidth_);
+              ReplacePlaceHolders(dash->current_representation_->segtpl_.media,
+                                  dash->current_representation_->id,
+                                  dash->current_representation_->bandwidth_);
             }
 
-            if ((dash->current_representation_->flags_ & AdaptiveTree::Representation::INITIALIZATION) == 0 && !dash->current_representation_->segments_.empty())
+            if ((dash->current_representation_->flags_ &
+                 AdaptiveTree::Representation::INITIALIZATION) == 0 &&
+                !dash->current_representation_->segments_.empty())
               // we assume that we have a MOOV atom included in each segment (max 100k = youtube)
-              dash->current_representation_->flags_ |= AdaptiveTree::Representation::INITIALIZATION_PREFIXED;
+              dash->current_representation_->flags_ |=
+                  AdaptiveTree::Representation::INITIALIZATION_PREFIXED;
 
             if (dash->current_representation_->startNumber_ > dash->firstStartNumber_)
               dash->firstStartNumber_ = dash->current_representation_->startNumber_;
@@ -1210,7 +1304,8 @@ end(void *data, const char *el)
         {
           if (strcmp(el, "BaseURL") == 0)
           {
-            dash->current_adaptationset_->base_url_ = dash->current_period_->base_url_ + dash->strXMLText_;
+            dash->current_adaptationset_->base_url_ =
+                dash->current_period_->base_url_ + dash->strXMLText_;
             dash->currentNode_ &= ~MPDNODE_BASEURL;
           }
         }
@@ -1220,7 +1315,8 @@ end(void *data, const char *el)
           {
             if (strcmp(el, "SegmentTimeline") == 0)
             {
-              if (!dash->current_period_->duration_ && dash->current_adaptationset_->segtpl_.timescale)
+              if (!dash->current_period_->duration_ &&
+                  dash->current_adaptationset_->segtpl_.timescale)
               {
                 dash->current_period_->timescale_ = dash->current_adaptationset_->segtpl_.timescale;
                 uint64_t sum(0);
@@ -1254,7 +1350,8 @@ end(void *data, const char *el)
           {
             if (dash->current_pssh_.empty())
               dash->current_pssh_ = "FILE";
-            dash->adp_pssh_set_ = static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
+            dash->adp_pssh_set_ =
+                static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
             dash->currentNode_ &= ~MPDNODE_CONTENTPROTECTION;
           }
         }
@@ -1266,9 +1363,9 @@ end(void *data, const char *el)
         else if (strcmp(el, "AdaptationSet") == 0)
         {
           dash->currentNode_ &= ~MPDNODE_ADAPTIONSET;
-          if (dash->current_adaptationset_->type_ == DASHTree::NOTYPE
-          || (dash->adp_pssh_set_ == 0xFF && dash->current_hasRepURN_)
-          || dash->current_adaptationset_->representations_.empty())
+          if (dash->current_adaptationset_->type_ == DASHTree::NOTYPE ||
+              (dash->adp_pssh_set_ == 0xFF && dash->current_hasRepURN_) ||
+              dash->current_adaptationset_->representations_.empty())
           {
             delete dash->current_adaptationset_;
             dash->current_period_->adaptationSets_.pop_back();
@@ -1280,25 +1377,30 @@ end(void *data, const char *el)
               if (dash->adp_pssh_set_ == 0xFF)
               {
                 dash->current_pssh_ = "FILE";
-                if (dash->current_defaultKID_.empty() && !dash->current_playready_wrmheader_.empty())
-                  dash->current_defaultKID_ = PRProtectionParser(dash->current_playready_wrmheader_).getKID();
-                dash->adp_pssh_set_ = static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
+                if (dash->current_defaultKID_.empty() &&
+                    !dash->current_playready_wrmheader_.empty())
+                  dash->current_defaultKID_ =
+                      PRProtectionParser(dash->current_playready_wrmheader_).getKID();
+                dash->adp_pssh_set_ =
+                    static_cast<uint8_t>(dash->insert_psshset(dash->current_adaptationset_->type_));
                 dash->current_period_->encryptionState_ |= DASHTree::ENCRYTIONSTATE_SUPPORTED;
               }
 
               for (std::vector<DASHTree::Representation*>::iterator
-                b(dash->current_adaptationset_->representations_.begin()),
-                e(dash->current_adaptationset_->representations_.end()); b != e; ++b)
+                       b(dash->current_adaptationset_->representations_.begin()),
+                   e(dash->current_adaptationset_->representations_.end());
+                   b != e; ++b)
                 if (!(*b)->pssh_set_)
                   (*b)->pssh_set_ = dash->adp_pssh_set_;
             }
 
-            if (dash->current_adaptationset_->segment_durations_.data.empty()
-              && !dash->current_adaptationset_->segtpl_.media.empty())
+            if (dash->current_adaptationset_->segment_durations_.data.empty() &&
+                !dash->current_adaptationset_->segtpl_.media.empty())
             {
-              for (std::vector<DASHTree::Representation*>::iterator 
-                b(dash->current_adaptationset_->representations_.begin()), 
-                e(dash->current_adaptationset_->representations_.end()); b != e; ++b)
+              for (std::vector<DASHTree::Representation*>::iterator
+                       b(dash->current_adaptationset_->representations_.begin()),
+                   e(dash->current_adaptationset_->representations_.end());
+                   b != e; ++b)
               {
                 if (!(*b)->duration_ || !(*b)->timescale_)
                 {
@@ -1311,15 +1413,19 @@ end(void *data, const char *el)
             //If representation are not timelined, we have to adjust startPTS_ in rep::segments
             {
               for (std::vector<DASHTree::Representation*>::iterator
-                b(dash->current_adaptationset_->representations_.begin()),
-                e(dash->current_adaptationset_->representations_.end()); b != e; ++b)
+                       b(dash->current_adaptationset_->representations_.begin()),
+                   e(dash->current_adaptationset_->representations_.end());
+                   b != e; ++b)
               {
                 if ((*b)->flags_ & DASHTree::Representation::TIMELINE)
                   continue;
-                std::vector<uint32_t>::const_iterator sdb(dash->current_adaptationset_->segment_durations_.data.begin()),
-                  sde(dash->current_adaptationset_->segment_durations_.data.end());
+                std::vector<uint32_t>::const_iterator sdb(
+                    dash->current_adaptationset_->segment_durations_.data.begin()),
+                    sde(dash->current_adaptationset_->segment_durations_.data.end());
                 uint64_t spts(0);
-                for (std::vector<DASHTree::Segment>::iterator sb((*b)->segments_.data.begin()), se((*b)->segments_.data.end()); sb != se && sdb != sde; ++sb, ++sdb)
+                for (std::vector<DASHTree::Segment>::iterator sb((*b)->segments_.data.begin()),
+                     se((*b)->segments_.data.end());
+                     sb != se && sdb != sde; ++sb, ++sdb)
                 {
                   sb->startPTS_ = spts;
                   spts += *sdb;
@@ -1334,10 +1440,11 @@ end(void *data, const char *el)
       {
         if (strcmp(el, "BaseURL") == 0)
         {
-          while (dash->strXMLText_.size() && (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
+          while (dash->strXMLText_.size() &&
+                 (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
             dash->strXMLText_.erase(dash->strXMLText_.begin());
-          if (dash->strXMLText_.compare(0, 7, "http://") == 0
-            || dash->strXMLText_.compare(0, 8, "https://") == 0)
+          if (dash->strXMLText_.compare(0, 7, "http://") == 0 ||
+              dash->strXMLText_.compare(0, 8, "https://") == 0)
             dash->current_period_->base_url_ = dash->strXMLText_;
           else if (!dash->strXMLText_.empty() && dash->strXMLText_[0] == '/')
             dash->current_period_->base_url_ = dash->base_domain_ + dash->strXMLText_;
@@ -1352,7 +1459,6 @@ end(void *data, const char *el)
         {
           if (strcmp(el, "SegmentTimeline") == 0)
             dash->currentNode_ &= ~MPDNODE_SEGMENTTIMELINE;
-
         }
         else if (strcmp(el, "SegmentList") == 0)
           dash->currentNode_ &= ~MPDNODE_SEGMENTLIST;
@@ -1368,10 +1474,11 @@ end(void *data, const char *el)
     {
       if (strcmp(el, "BaseURL") == 0)
       {
-        while (dash->strXMLText_.size() && (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
+        while (dash->strXMLText_.size() &&
+               (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
           dash->strXMLText_.erase(dash->strXMLText_.begin());
-        if (dash->strXMLText_.compare(0, 7, "http://") == 0
-          || dash->strXMLText_.compare(0, 8, "https://") == 0)
+        if (dash->strXMLText_.compare(0, 7, "http://") == 0 ||
+            dash->strXMLText_.compare(0, 8, "https://") == 0)
           dash->base_url_ = dash->strXMLText_;
         else if (!dash->strXMLText_.empty() && dash->strXMLText_[0] == '/')
           dash->base_url_ = dash->base_domain_ + dash->strXMLText_;
@@ -1384,10 +1491,11 @@ end(void *data, const char *el)
     {
       if (strcmp(el, "Location") == 0)
       {
-        while (dash->strXMLText_.size() && (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
+        while (dash->strXMLText_.size() &&
+               (dash->strXMLText_[0] == '\n' || dash->strXMLText_[0] == '\r'))
           dash->strXMLText_.erase(dash->strXMLText_.begin());
-        if (dash->strXMLText_.compare(0, 7, "http://") == 0
-          || dash->strXMLText_.compare(0, 8, "https://") == 0)
+        if (dash->strXMLText_.compare(0, 7, "http://") == 0 ||
+            dash->strXMLText_.compare(0, 8, "https://") == 0)
           dash->location_ = dash->strXMLText_;
         dash->currentNode_ &= ~MPDNODE_LOCATION;
       }
@@ -1395,14 +1503,16 @@ end(void *data, const char *el)
     else if (strcmp(el, "MPD") == 0)
     {
       //cleanup periods
-      for (std::vector<AdaptiveTree::Period*>::iterator b(dash->periods_.begin()); b != dash->periods_.end();)
+      for (std::vector<AdaptiveTree::Period*>::iterator b(dash->periods_.begin());
+           b != dash->periods_.end();)
       {
         if (dash->has_overall_seconds_ && !(*b)->duration_)
         {
           if (b + 1 == dash->periods_.end())
-            (*b)->duration_ = ((dash->overallSeconds_ * 1000 - (*b)->start_) * (*b)->timescale_) / 1000;
+            (*b)->duration_ =
+                ((dash->overallSeconds_ * 1000 - (*b)->start_) * (*b)->timescale_) / 1000;
           else
-            (*b)->duration_ = (((*(b+1))->start_ - (*b)->start_) * (*b)->timescale_) / 1000;
+            (*b)->duration_ = (((*(b + 1))->start_ - (*b)->start_) * (*b)->timescale_) / 1000;
         }
         if ((*b)->adaptationSets_.empty())
         {
@@ -1427,7 +1537,7 @@ end(void *data, const char *el)
 |   DASHTree
 +---------------------------------------------------------------------*/
 
-bool DASHTree::open(const std::string &url, const std::string &manifestUpdateParam)
+bool DASHTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
   PreparePaths(url, manifestUpdateParam);
   parser_ = XML_ParserCreate(NULL);
@@ -1458,7 +1568,7 @@ bool DASHTree::open(const std::string &url, const std::string &manifestUpdatePar
   return ret;
 }
 
-bool DASHTree::write_data(void *buffer, size_t buffer_size, void *opaque)
+bool DASHTree::write_data(void* buffer, size_t buffer_size, void* opaque)
 {
   bool done(false);
   XML_Status retval = XML_Parse(parser_, (const char*)buffer, buffer_size, done);
@@ -1496,9 +1606,14 @@ void DASHTree::RefreshLiveSegments()
 
     if (~update_parameter_pos_)
     {
-      for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep; ++bp)
-        for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea; ++ba)
-          for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()), er((*ba)->representations_.end()); br != er; ++br)
+      for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep;
+           ++bp)
+        for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()),
+             ea((*bp)->adaptationSets_.end());
+             ba != ea; ++ba)
+          for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()),
+               er((*ba)->representations_.end());
+               br != er; ++br)
           {
             if ((*br)->startNumber_ + (*br)->segments_.size() < nextStartNumber)
               nextStartNumber = (*br)->startNumber_ + (*br)->segments_.size();
@@ -1541,15 +1656,20 @@ void DASHTree::RefreshLiveSegments()
 
       //Youtube returns last smallest number in case the requested data is not available
       if (~update_parameter_pos_ && updateTree.firstStartNumber_ < nextStartNumber)
-          return;
+        return;
 
       std::vector<Period*>::const_iterator bpd(periods_.begin()), epd(periods_.end());
-      for (std::vector<Period*>::const_iterator bp(updateTree.periods_.begin()), ep(updateTree.periods_.end()); bp != ep && bpd != epd; ++bp, ++bpd)
+      for (std::vector<Period*>::const_iterator bp(updateTree.periods_.begin()),
+           ep(updateTree.periods_.end());
+           bp != ep && bpd != epd; ++bp, ++bpd)
       {
-        for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea; ++ba)
+        for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()),
+             ea((*bp)->adaptationSets_.end());
+             ba != ea; ++ba)
         {
           //Locate adaptationset
-          std::vector<AdaptationSet*>::const_iterator bad((*bpd)->adaptationSets_.begin()), ead((*bpd)->adaptationSets_.end());
+          std::vector<AdaptationSet*>::const_iterator bad((*bpd)->adaptationSets_.begin()),
+              ead((*bpd)->adaptationSets_.end());
           for (; bad != ead &&
                  ((*bad)->id_ != (*ba)->id_ || (*bad)->group_ != (*ba)->group_ ||
                   (*bad)->type_ != (*ba)->type_ || (*bad)->mimeType_ != (*ba)->mimeType_ ||
@@ -1558,11 +1678,15 @@ void DASHTree::RefreshLiveSegments()
             ;
           if (bad != ead)
           {
-            for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()), er((*ba)->representations_.end()); br != er; ++br)
+            for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()),
+                 er((*ba)->representations_.end());
+                 br != er; ++br)
             {
               //Locate representation
-              std::vector<Representation*>::const_iterator brd((*bad)->representations_.begin()), erd((*bad)->representations_.end());
-              for (; brd != erd && (*brd)->id != (*br)->id; ++brd);
+              std::vector<Representation*>::const_iterator brd((*bad)->representations_.begin()),
+                  erd((*bad)->representations_.end());
+              for (; brd != erd && (*brd)->id != (*br)->id; ++brd)
+                ;
               if (brd != erd && !(*br)->segments_.empty())
               {
                 if (~update_parameter_pos_) // partitial update
@@ -1571,10 +1695,12 @@ void DASHTree::RefreshLiveSegments()
                   uint64_t ptsOffset = (*brd)->nextPts_ - (*br)->segments_[0]->startPTS_;
                   uint32_t currentPos = (*brd)->getCurrentSegmentPos();
                   unsigned int repFreeSegments(numReplace);
-                  std::vector<Segment>::iterator bs((*br)->segments_.data.begin()), es((*br)->segments_.data.end());
+                  std::vector<Segment>::iterator bs((*br)->segments_.data.begin()),
+                      es((*br)->segments_.data.end());
                   for (; bs != es && repFreeSegments; ++bs)
                   {
-                    Log(LOGLEVEL_DEBUG, "DASH Update: insert repid: %s url: %s", (*br)->id.c_str(), bs->url);
+                    Log(LOGLEVEL_DEBUG, "DASH Update: insert repid: %s url: %s", (*br)->id.c_str(),
+                        bs->url);
                     if ((*brd)->flags_ & Representation::URLSEGMENTS)
                       delete[](*brd)->segments_[0]->url;
                     bs->startPTS_ += ptsOffset;
@@ -1588,7 +1714,8 @@ void DASHTree::RefreshLiveSegments()
                   if (!repFreeSegments && numReplace == currentPos + 1)
                     (*brd)->current_segment_ = nullptr;
 
-                  if (((*brd)->flags_ & Representation::WAITFORSEGMENT) && (*brd)->get_next_segment((*brd)->current_segment_))
+                  if (((*brd)->flags_ & Representation::WAITFORSEGMENT) &&
+                      (*brd)->get_next_segment((*brd)->current_segment_))
                   {
                     (*brd)->flags_ &= ~Representation::WAITFORSEGMENT;
                     Log(LOGLEVEL_DEBUG, "End WaitForSegment stream %s", (*brd)->id.c_str());
@@ -1599,14 +1726,14 @@ void DASHTree::RefreshLiveSegments()
                   else
                     (*brd)->nextPts_ += bs->startPTS_;
                 }
-                else if ((*br)->startNumber_ <=1 ) //Full update, be careful with startnumbers!
+                else if ((*br)->startNumber_ <= 1) //Full update, be careful with startnumbers!
                 {
                   //TODO: check if first element or size differs
                   unsigned int segmentId((*brd)->getCurrentSegmentNumber());
                   if ((*br)->flags_ & DASHTree::Representation::TIMELINE)
                   {
                     uint64_t search_pts = (*br)->segments_[0]->range_begin_;
-                    for (const auto &s : (*brd)->segments_.data)
+                    for (const auto& s : (*brd)->segments_.data)
                     {
                       if (s.range_begin_ >= search_pts)
                         break;
@@ -1616,7 +1743,7 @@ void DASHTree::RefreshLiveSegments()
                   else if ((*br)->segments_[0]->startPTS_ == (*brd)->segments_[0]->startPTS_)
                   {
                     uint64_t search_re = (*br)->segments_[0]->range_end_;
-                    for (const auto &s : (*brd)->segments_.data)
+                    for (const auto& s : (*brd)->segments_.data)
                     {
                       if (s.range_end_ >= search_re)
                         break;
@@ -1626,7 +1753,7 @@ void DASHTree::RefreshLiveSegments()
                   else
                   {
                     uint64_t search_pts = (*br)->segments_[0]->startPTS_;
-                    for (const auto &s : (*brd)->segments_.data)
+                    for (const auto& s : (*brd)->segments_.data)
                     {
                       if (s.startPTS_ >= search_pts)
                         break;
@@ -1641,19 +1768,21 @@ void DASHTree::RefreshLiveSegments()
                   {
                     if (segmentId >= (*brd)->startNumber_ + (*brd)->segments_.size())
                       segmentId = (*brd)->startNumber_ + (*brd)->segments_.size() - 1;
-                    (*brd)->current_segment_ = (*brd)->get_segment(segmentId - (*brd)->startNumber_);
+                    (*brd)->current_segment_ =
+                        (*brd)->get_segment(segmentId - (*brd)->startNumber_);
                   }
 
-                  if (((*brd)->flags_ & Representation::WAITFORSEGMENT) && (*brd)->get_next_segment((*brd)->current_segment_))
+                  if (((*brd)->flags_ & Representation::WAITFORSEGMENT) &&
+                      (*brd)->get_next_segment((*brd)->current_segment_))
                     (*brd)->flags_ &= ~Representation::WAITFORSEGMENT;
 
                   Log(LOGLEVEL_DEBUG, "DASH Full update (w/o startnum): repid: %s current_start:%u",
-                    (*br)->id.c_str(), (*brd)->startNumber_);
+                      (*br)->id.c_str(), (*brd)->startNumber_);
                   overallSeconds_ = updateTree.overallSeconds_;
                 }
-                else if ((*br)->startNumber_ > (*brd)->startNumber_ 
-                  || ((*br)->startNumber_ == (*brd)->startNumber_ 
-                    && (*br)->segments_.size() > (*brd)->segments_.size()))
+                else if ((*br)->startNumber_ > (*brd)->startNumber_ ||
+                         ((*br)->startNumber_ == (*brd)->startNumber_ &&
+                          (*br)->segments_.size() > (*brd)->segments_.size()))
                 {
                   unsigned int segmentId((*brd)->getCurrentSegmentNumber());
                   (*br)->segments_.swap((*brd)->segments_);
@@ -1664,14 +1793,16 @@ void DASHTree::RefreshLiveSegments()
                   {
                     if (segmentId >= (*brd)->startNumber_ + (*brd)->segments_.size())
                       segmentId = (*brd)->startNumber_ + (*brd)->segments_.size() - 1;
-                    (*brd)->current_segment_ = (*brd)->get_segment(segmentId - (*brd)->startNumber_);
+                    (*brd)->current_segment_ =
+                        (*brd)->get_segment(segmentId - (*brd)->startNumber_);
                   }
 
-                  if (((*brd)->flags_ & Representation::WAITFORSEGMENT) && (*brd)->get_next_segment((*brd)->current_segment_))
+                  if (((*brd)->flags_ & Representation::WAITFORSEGMENT) &&
+                      (*brd)->get_next_segment((*brd)->current_segment_))
                     (*brd)->flags_ &= ~Representation::WAITFORSEGMENT;
 
                   Log(LOGLEVEL_DEBUG, "DASH Full update (w/ startnum): repid: %s current_start:%u",
-                    (*br)->id.c_str(), (*brd)->startNumber_);
+                      (*br)->id.c_str(), (*brd)->startNumber_);
                 }
               }
             }


### PR DESCRIPTION
Supports mpd like below

```
<Representation id="6" bandwidth="384000" audioSamplingRate="48000" codecs="ac-3">
<AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="F801"></AudioChannelConfiguration>
```

Testing with above mpd format and old style OK

Also did a clang-format commit separately.