### PR TITLE
Fix url decoder

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -239,7 +239,7 @@ std::string url_decode(std::string text) {
 
   for (auto i = text.begin(), n = text.end(); i != n; ++i) {
     std::string::value_type c = (*i);
-    if (c == '%' && (n - i) > 3)
+    if (c == '%' && (n - i) >= 3)
     {
       if (i[1] && i[2]) {
         h = from_hex(i[1]) << 4 | from_hex(i[2]);


### PR DESCRIPTION
This fixes https://github.com/peak3d/inputstream.adaptive/issues/469

There was a bug introduced in the url decoder function in https://github.com/peak3d/inputstream.adaptive/commit/1af70f8f09523fcc186991f24c07edf1d0123099 where a final curly bracket got not decoded.

For instance
```
%7B%22token%22%3A%22vrt%7C2020-06-15T20%3A45%3A53Z%7CJQ%2B5wYy/Tp9XH%2BZTKSAoNEVid6kPznYl6noAaJxgq6G2oJlDx4Dt7hA1ctuYQDKyStOdCAcQC25FGtwJvqGNSbxdvLKIeLPiml%2B7XvAXbkWmX7tM4pR10v/3BYBTTenNSxm%2BjsgmbxsoFee3/B26guvbGkXFJjaKuE4ghiIGCAlobStTWYsDYiHuArUpx/Cm%7C5c19445a441ad87f76e4a43ad64d593dcf198e65%22%2C%22drm_info%22%3A%5BD%7BSSM%7D%5D%2C%22kid%22%3A%22%7BKID%7D%22%7D
```
got incompletely decoded to
```
{"token":"vrt|2020-06-15T20:45:53Z|JQ+5wYy/Tp9XH+ZTKSAoNEVid6kPznYl6noAaJxgq6G2oJlDx4Dt7hA1ctuYQDKyStOdCAcQC25FGtwJvqGNSbxdvLKIeLPiml+7XvAXbkWmX7tM4pR10v/3BYBTTenNSxm+jsgmbxsoFee3/B26guvbGkXFJjaKuE4ghiIGCAlobStTWYsDYiHuArUpx/Cm|5c19445a441ad87f76e4a43ad64d593dcf198e65","drm_info":[D{SSM}],"kid":"{KID}"%7D

```

