### PR TITLE
[Android] only request and log (max)securitylevel and querykeystatus...

### DIFF
--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -431,11 +431,14 @@ RETRY_OPEN:
   memcpy(session_id_char_, session_id_.data(), session_id_.size());
   session_id_char_[session_id_.size()] = 0;
 
-  int maxSecuritylevel = media_drm_.GetMediaDrm()->getMaxSecurityLevel();
-  xbmc_jnienv()->ExceptionClear();
+  if (media_drm_.GetKeySystemType() != PLAYREADY)
+  {
+    int maxSecuritylevel = media_drm_.GetMediaDrm()->getMaxSecurityLevel();
+    xbmc_jnienv()->ExceptionClear();
 
-  Log(SSD_HOST::LL_DEBUG, "SessionId: %s, MaxSecurityLevel: %d",
-    session_id_char_, maxSecuritylevel);
+    Log(SSD_HOST::LL_DEBUG, "SessionId: %s, MaxSecurityLevel: %d",
+      session_id_char_, maxSecuritylevel);
+  }
 }
 
 WV_CencSingleSampleDecrypter::~WV_CencSingleSampleDecrypter()
@@ -580,14 +583,17 @@ bool WV_CencSingleSampleDecrypter::KeyUpdateRequest(bool waitKeys)
   }
   Log(SSD_HOST::LL_DEBUG, "License update successful");
 
-  int securityLevel = media_drm_.GetMediaDrm()->getSecurityLevel(session_id_);
-  xbmc_jnienv()->ExceptionClear();
-  Log(SSD_HOST::LL_DEBUG, "SecurityLevel: %d", securityLevel);
+  if (media_drm_.GetKeySystemType() != PLAYREADY)
+  {
+    int securityLevel = media_drm_.GetMediaDrm()->getSecurityLevel(session_id_);
+    xbmc_jnienv()->ExceptionClear();
+    Log(SSD_HOST::LL_DEBUG, "SecurityLevel: %d", securityLevel);
 
-  std::map<std::string, std::string> keyStatus = media_drm_.GetMediaDrm()->queryKeyStatus(session_id_);
-  Log(SSD_HOST::LL_DEBUG, "Key Status (%ld):", keyStatus.size());
-  for (auto const& ks : keyStatus)
-    Log(SSD_HOST::LL_DEBUG, "-> %s -> %s", ks.first.c_str(), ks.second.c_str());
+    std::map<std::string, std::string> keyStatus = media_drm_.GetMediaDrm()->queryKeyStatus(session_id_);
+    Log(SSD_HOST::LL_DEBUG, "Key Status (%ld):", keyStatus.size());
+    for (auto const& ks : keyStatus)
+      Log(SSD_HOST::LL_DEBUG, "-> %s -> %s", ks.first.c_str(), ks.second.c_str());
+  }
   return true;
 }
 


### PR DESCRIPTION
... if playready is not used

This PR fixes a Kodi crash when playing a stream on android and PlayReady is used.
kodinerds.net users have confirmed this fix for Shield TV and Philips ATV.