### PR TITLE
[HLS] EXT-X-DISCONTINUITY-SEQUENCE support

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -190,7 +190,7 @@ bool AdaptiveStream::start_stream(const uint32_t seg_offset,
                                   bool play_timeshift_buffer)
 {
   if (!play_timeshift_buffer && !~seg_offset && tree_.has_timeshift_buffer_ &&
-      current_rep_->segments_.data.size() > 1)
+      current_rep_->segments_.data.size() > 1 && tree_.periods_.size() == 1)
   {
     std::int32_t pos;
     if (tree_.has_timeshift_buffer_ || tree_.available_time_ >= tree_.stream_start_)
@@ -414,7 +414,7 @@ bool AdaptiveStream::ensureSegment()
       ResetSegment();
       thread_data_->signal_dl_.notify_one();
     }
-    else if (tree_.HasUpdateThread())
+    else if (tree_.HasUpdateThread() && current_period_ == tree_.periods_.back())
     {
       current_rep_->flags_ |= AdaptiveTree::Representation::WAITFORSEGMENT;
       Log(LOGLEVEL_DEBUG, "Begin WaitForSegment stream %s", current_rep_->id.c_str());

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -79,11 +79,11 @@ namespace adaptive
       delete *bp;
   }
 
-  void AdaptiveTree::FreeSegments(Representation *rep)
+  void AdaptiveTree::FreeSegments(Period* period, Representation* rep)
   {
     for (std::vector<Segment>::iterator bs(rep->segments_.data.begin()), es(rep->segments_.data.end()); bs != es; ++bs)
     {
-      --current_period_->psshSets_[bs->pssh_set_].use_count_;
+      --period->psshSets_[bs->pssh_set_].use_count_;
       if (rep->flags_ & Representation::URLSEGMENTS)
         delete[] bs->url;
     }

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -464,7 +464,7 @@ public:
                                StreamType type){};
 
   bool has_type(StreamType t);
-  void FreeSegments(Representation *rep);
+  void FreeSegments(Period* period, Representation* rep);
   uint32_t estimate_segcount(uint64_t duration, uint32_t timescale);
   double get_download_speed() const { return download_speed_; };
   double get_average_download_speed() const { return average_download_speed_; };

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -398,7 +398,7 @@ public:
 
     std::vector<AdaptationSet*> adaptationSets_;
     std::string base_url_, id_;
-    uint32_t timescale_ = 1000, startNumber_ = 1;
+    uint32_t timescale_ = 1000, startNumber_ = 1, sequence_ = 0;
     uint64_t start_ = 0;
     uint64_t startPTS_ = 0;
     uint64_t duration_ = 0;
@@ -421,6 +421,7 @@ public:
   XML_Parser parser_;
   uint32_t currentNode_;
   uint32_t segcount_;
+  uint32_t initial_sequence_ = ~0UL;
   uint64_t overallSeconds_, stream_start_, available_time_, publish_time_, base_time_;
   uint64_t minPresentationOffset;
   bool has_timeshift_buffer_, has_overall_seconds_;

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -239,7 +239,7 @@ std::string url_decode(std::string text) {
 
   for (auto i = text.begin(), n = text.end(); i != n; ++i) {
     std::string::value_type c = (*i);
-    if (c == '%' && (n - i) > 3)
+    if (c == '%' && (n - i) >= 3)
     {
       if (i[1] && i[2]) {
         h = from_hex(i[1]) << 4 | from_hex(i[2]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1045,8 +1045,8 @@ public:
   virtual const AP4_Byte* GetSampleData() const = 0;
   virtual uint64_t GetDuration() const = 0;
   virtual bool IsEncrypted() const = 0;
-  virtual void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid){};
-  virtual void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid){};
+  virtual void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint32_t sid){};
+  virtual void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint32_t sid){};
   virtual bool RemoveStreamType(INPUTSTREAM_INFO::STREAM_TYPE type) { return true; };
 };
 
@@ -1075,8 +1075,8 @@ public:
   const AP4_Byte* GetSampleData() const override { return nullptr; }
   uint64_t GetDuration() const override { return 0; }
   bool IsEncrypted() const override { return false; }
-  void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override{};
-  void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override{};
+  void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint32_t sid) override{};
+  void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint32_t sid) override{};
   bool RemoveStreamType(INPUTSTREAM_INFO::STREAM_TYPE type) override { return true; };
 } DummyReader;
 
@@ -1677,7 +1677,7 @@ public:
     m_typeMap[type] = m_typeMap[INPUTSTREAM_INFO::TYPE_NONE] = streamId;
   };
 
-  void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override
+  void AddStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint32_t sid) override
   {
     m_typeMap[type] = sid;
     m_typeMask |= (1 << type);
@@ -1685,7 +1685,7 @@ public:
       StartStreaming(m_typeMask);
   };
 
-  void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint16_t sid) override
+  void SetStreamType(INPUTSTREAM_INFO::STREAM_TYPE type, uint32_t sid) override
   {
     m_typeMap[type] = sid;
     m_typeMask = (1 << type);
@@ -1772,7 +1772,7 @@ public:
 
 private:
   uint32_t m_typeMask; //Bit representation of INPUTSTREAM_INFO::STREAM_TYPES
-  uint16_t m_typeMap[16];
+  uint32_t m_typeMap[16];
   bool m_eos = false;
   bool m_started = false;
 
@@ -2508,12 +2508,7 @@ bool Session::InitializePeriod()
     adaptiveTree_->next_period_ = nullptr;
   }
 
-  chapter_start_time_ = 0;
-  for (adaptive::AdaptiveTree::Period* p : adaptiveTree_->periods_)
-    if (p == adaptiveTree_->current_period_)
-      break;
-    else
-      chapter_start_time_ += (p->duration_ * DVD_TIME_BASE) / p->timescale_;
+  chapter_start_time_ = GetChapterStartTime();
 
   if (adaptiveTree_->current_period_->encryptionState_ ==
       adaptive::AdaptiveTree::ENCRYTIONSTATE_ENCRYPTED)
@@ -2876,7 +2871,7 @@ SampleReader* Session::GetNextSample()
     if (res->reader_->GetInformation(res->info_))
       changed_ = true;
     if (res->reader_->PTS() != DVD_NOPTS_VALUE)
-      elapsed_time_ = PTSToElapsed(res->reader_->PTS()) + chapter_start_time_;
+      elapsed_time_ = PTSToElapsed(res->reader_->PTS()) + GetChapterStartTime();
     return res->reader_;
   }
   else if (waiting)
@@ -3135,6 +3130,29 @@ int64_t Session::GetChapterPos(int ch) const
   return sum / DVD_TIME_BASE;
 }
 
+uint64_t Session::GetChapterStartTime() const
+{
+  uint64_t start_time = 0;
+  for (adaptive::AdaptiveTree::Period* p : adaptiveTree_->periods_)
+    if (p == adaptiveTree_->current_period_)
+      break;
+    else
+      start_time += (p->duration_ * DVD_TIME_BASE) / p->timescale_;
+  return start_time;
+}
+
+int Session::GetPeriodId() const
+{
+  if (adaptiveTree_)
+    if (IsLive())
+      return adaptiveTree_->current_period_->sequence_ == adaptiveTree_->initial_sequence_
+                 ? 1
+                 : adaptiveTree_->current_period_->sequence_ + 1;
+    else
+      return GetChapter();
+  return -1;
+}
+
 bool Session::SeekChapter(int ch)
 {
   if (adaptiveTree_->next_period_)
@@ -3232,7 +3250,7 @@ public:
 private:
   std::shared_ptr<Session> m_session;
   int m_width, m_height;
-  uint16_t m_IncludedStreams[16];
+  uint32_t m_IncludedStreams[16];
   bool m_checkChapterSeek = false;
   bool m_playTimeshiftBuffer = false;
   int m_failedSeekTime = ~0;
@@ -3415,7 +3433,7 @@ struct INPUTSTREAM_IDS CInputStreamAdaptive::GetStreamIds()
 
   if (m_session)
   {
-    int chapter = m_session->GetChapter();
+    int period_id = m_session->GetPeriodId();
     iids.m_streamCount = 0;
 
     for (unsigned int i(1);
@@ -3434,7 +3452,10 @@ struct INPUTSTREAM_IDS CInputStreamAdaptive::GetStreamIds()
           if (rep->flags_ & adaptive::AdaptiveTree::Representation::INCLUDEDSTREAM)
             continue;
         }
-        iids.m_streamIds[iids.m_streamCount++] = i + chapter * 1000;
+        iids.m_streamIds[iids.m_streamCount++] =
+            m_session->IsLive()
+                ? i + (m_session->GetStream(i)->stream_.getPeriod()->sequence_ + 1) * 1000
+                : i + period_id * 1000;
       }
     }
   }
@@ -3485,7 +3506,7 @@ struct INPUTSTREAM_INFO CInputStreamAdaptive::GetStream(int streamid)
 
   kodi::Log(ADDON_LOG_DEBUG, "GetStream(%d)", streamid);
 
-  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
+  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
 
   if (stream)
   {
@@ -3522,7 +3543,7 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
   if (!m_session)
     return;
 
-  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
+  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
 
   if (!enable && stream && stream->enabled)
   {
@@ -3547,7 +3568,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (!m_session)
     return false;
 
-  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetChapter() * 1000));
+  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
 
   if (!stream || stream->enabled)
     return false;
@@ -3689,7 +3710,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
         stream->reader_->AddStreamType(static_cast<INPUTSTREAM_INFO::STREAM_TYPE>(i),
                                        m_IncludedStreams[i]);
         stream->reader_->GetInformation(
-            m_session->GetStream(m_IncludedStreams[i] - m_session->GetChapter() * 1000)->info_);
+            m_session->GetStream(m_IncludedStreams[i] - m_session->GetPeriodId() * 1000)->info_);
       }
   }
   m_session->EnableStream(stream, true);
@@ -3771,13 +3792,12 @@ DemuxPacket* CInputStreamAdaptive::DemuxRead(void)
     return p;
   }
 
-  int currentChapter = m_session->GetChapter();
-  if (m_session->SeekChapter(currentChapter + 1))
+  if (m_session->SeekChapter(m_session->GetChapter() + 1))
   {
     m_checkChapterSeek = true;
     for (unsigned int i(1);
          i <= INPUTSTREAM_IDS::MAX_STREAM_COUNT && i <= m_session->GetStreamCount(); ++i)
-      EnableStream(i + currentChapter * 1000, false);
+      EnableStream(i + m_session->GetPeriodId() * 1000, false);
     m_session->InitializePeriod();
     DemuxPacket* p = AllocateDemuxPacket(0);
     p->iStreamId = DMX_SPECIALID_STREAMCHANGE;

--- a/src/main.h
+++ b/src/main.h
@@ -162,8 +162,9 @@ public:
   int GetChapterCount() const;
   const char* GetChapterName(int ch) const;
   int64_t GetChapterPos(int ch) const;
+  int GetPeriodId() const;
   bool SeekChapter(int ch);
-  uint64_t GetChapterStartTime() { return chapter_start_time_; };
+  uint64_t GetChapterStartTime() const;
   double GetChapterSeekTime() { return chapter_seek_time_; };
   void ResetChapterSeekTime() { chapter_seek_time_ = 0; };
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -619,7 +619,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
             rep->initialization_.range_end_ = newSegments.data[0].range_begin_ - 1;
             rep->initialization_.pssh_set_ = 0;
           }
-          FreeSegments(rep);
+          FreeSegments(period, rep);
           rep->segments_.swap(newSegments);
           rep->startNumber_ = newStartNumber;
 
@@ -729,11 +729,11 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         rep->initialization_.pssh_set_ = 0;
       }
 
-      FreeSegments(rep);
+      FreeSegments(period, rep);
 
       if (newSegments.data.empty())
       {
-        FreeSegments(rep);
+        FreeSegments(period, rep);
         rep->flags_ = 0;
         return PREPARE_RESULT_FAILURE;
       }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -157,8 +157,8 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
   }
 
   // UNKNOWN
-  Log(LOGLEVEL_WARNING, "Unknown encryption method: %s with keyformat %s",
-      map["METHOD"].c_str(), map["KEYFORMAT"].c_str());
+  Log(LOGLEVEL_WARNING, "Unknown encryption method: %s with keyformat %s", map["METHOD"].c_str(),
+      map["KEYFORMAT"].c_str());
   return ENCRYPTIONTYPE_UNKNOWN;
 }
 
@@ -424,6 +424,8 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
     uint32_t rep_pos = std::find(adp->representations_.begin(), adp->representations_.end(), rep) -
                        adp->representations_.begin();
     uint32_t discont_count = 0;
+    bool cp_lost(false);
+    Representation* entry_rep = rep;
     PREPARE_RESULT retVal = PREPARE_RESULT_OK;
 
     if (!effective_url_.empty() && download_url.find(base_url_) == 0)
@@ -569,14 +571,47 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           if (newInterval < updateInterval_)
             updateInterval_ = newInterval;
         }
+        else if (line.compare(0, 30, "#EXT-X-DISCONTINUITY-SEQUENCE:") == 0)
+        {
+          m_discontSeq = atol(line.c_str() + 30);
+          if (!~initial_sequence_)
+            initial_sequence_ = m_discontSeq;
+          m_hasDiscontSeq = true;
+          // make sure first period has a sequence on initial prepare
+          if (!update && m_discontSeq && !periods_.back()->sequence_)
+            periods_[0]->sequence_ = m_discontSeq;
+
+          auto bp = periods_.begin();
+          while (bp != periods_.end())
+          {
+            if ((*bp)->sequence_ < m_discontSeq)
+              if (*bp != current_period_)
+              {
+                delete *bp;
+                *bp = nullptr;
+                bp = periods_.erase(bp);
+              }
+              // we end up here after pausing for some time
+              // remove from periods_ for now and reattach later
+              else
+              {
+                cp_lost = true;
+                bp = periods_.erase(bp);
+              }
+            else
+              bp++;
+          }
+          period = periods_[0];
+          adp = period->adaptationSets_[adp_pos];
+          rep = adp->representations_[rep_pos];
+        }
         else if (line.compare(0, 21, "#EXT-X-DISCONTINUITY") == 0)
         {
-          if (newSegments.size() == 0)
-            continue;
-          period->duration_ = pts - newSegments[0]->startPTS_;
+          period->sequence_ = m_discontSeq + discont_count;
+          period->duration_ = newSegments.size() ? pts - newSegments[0]->startPTS_ : 0;
           if (!byteRange)
             rep->flags_ |= Representation::URLSEGMENTS;
-          if (rep->containerType_ == CONTAINERTYPE_MP4 && byteRange &&
+          if (rep->containerType_ == CONTAINERTYPE_MP4 && byteRange && newSegments.size() &&
               newSegments.data[0].range_begin_ > 0)
           {
             rep->flags_ |= Representation::INITIALIZATION;
@@ -604,13 +639,13 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           else
             period = periods_[discont_count];
 
+          newStartNumber += rep->segments_.data.size();
           adp = period->adaptationSets_[adp_pos];
           rep = adp->representations_[rep_pos];
           segment.range_begin_ = ~0ULL;
           segment.range_end_ = 0;
           segment.startPTS_ = ~0ULL;
           segment.pssh_set_ = 0;
-          newStartNumber = 0;
           pts = 0;
 
           if (currentEncryptionType == ENCRYPTIONTYPE_WIDEVINE)
@@ -711,9 +746,11 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
 
       rep->duration_ = rep->segments_[0] ? (pts - rep->segments_[0]->startPTS_) : 0;
 
-      if (discont_count)
+      period->sequence_ = m_discontSeq + discont_count;
+      if (discont_count || m_hasDiscontSeq)
       {
-        periods_[discont_count]->duration_ = (rep->duration_ * periods_[discont_count]->timescale_) / rep->timescale_;
+        periods_[discont_count]->duration_ =
+            (rep->duration_ * periods_[discont_count]->timescale_) / rep->timescale_;
         overallSeconds_ = 0;
         for (auto p : periods_)
         {
@@ -733,7 +770,8 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
 
     if (update)
     {
-      if (!segmentId || segmentId < rep->startNumber_)
+      rep = entry_rep;
+      if (!segmentId || segmentId < rep->startNumber_ || !~segmentId)
         rep->current_segment_ = nullptr;
       else
       {
@@ -742,12 +780,17 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         rep->current_segment_ = rep->get_segment(segmentId - rep->startNumber_);
       }
       if ((rep->flags_ & Representation::WAITFORSEGMENT) &&
-          rep->get_next_segment(rep->current_segment_))
+          (rep->get_next_segment(rep->current_segment_) || current_period_ != periods_.back()))
         rep->flags_ &= ~Representation::WAITFORSEGMENT;
     }
     else
       StartUpdateThread();
 
+    if (cp_lost)
+      periods_.insert(periods_.begin(), current_period_);
+    period = current_period_;
+    adp = period->adaptationSets_[adp_pos];
+    rep = adp->representations_[rep_pos];
     return retVal;
   }
   return PREPARE_RESULT_FAILURE;
@@ -851,6 +894,8 @@ void HLSTree::RefreshSegments(Period* period,
 {
   if (m_refreshPlayList)
   {
+    if (rep->flags_ & Representation::INCLUDEDSTREAM)
+      return;
     RefreshUpdateThread();
     prepareRepresentation(period, adp, rep, true);
   }
@@ -861,15 +906,16 @@ void HLSTree::RefreshLiveSegments()
 {
   if (m_refreshPlayList)
   {
-    for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep;
-         ++bp)
-      for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()),
-           ea((*bp)->adaptationSets_.end());
-           ba != ea; ++ba)
-        for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()),
-             er((*ba)->representations_.end());
-             br != er; ++br)
-          if ((*br)->flags_ & Representation::ENABLED)
-            prepareRepresentation((*bp), (*ba), (*br), true);
+    std::vector<std::tuple<AdaptationSet*, Representation*>> refresh_list;
+    for (std::vector<AdaptationSet*>::const_iterator ba(current_period_->adaptationSets_.begin()),
+         ea(current_period_->adaptationSets_.end());
+         ba != ea; ++ba)
+      for (std::vector<Representation*>::iterator br((*ba)->representations_.begin()),
+           er((*ba)->representations_.end());
+           br != er; ++br)
+        if ((*br)->flags_ & Representation::ENABLED)
+          refresh_list.push_back(std::make_tuple(*ba, *br));
+    for (auto t : refresh_list)
+      prepareRepresentation(current_period_, std::get<0>(t), std::get<1>(t), true);
   }
 }

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -82,6 +82,8 @@ namespace adaptive
     uint8_t m_segmentIntervalSec = 4;
     AESDecrypter *m_decrypter;
     std::stringstream manifest_stream;
+    bool m_hasDiscontSeq = false;
+    uint32_t m_discontSeq = 0;
   };
 
 } // namespace


### PR DESCRIPTION
Hi @peak3d 

I only had to modify 2 lines in adaptivestream.cpp to have success in period transitions (same as before the rework branch)

There is a new member variable for Period:  `sequence_` for storing the discontinuity sequence number of a period.
I decided against using Period->id_ as I have seen several examples of mpd manifests that use characters or even whole words here, so I believe a future implementation for live dash multiperiod would be better off not directly using this.
The sequence number of the first period on initial playback is also stored in AdaptiveTree, this is because because with hls workflow the streamid will always be 1001, 1002 etc. but this period's sequence will not always remain 0. This way we can still know which period relates to streamid 1001, 1002...

In HLSTree.cpp there are a few things of note apart from the obvious extra parsing. Sorry if it's already obvious to you but just in case there's any concern...

RefreshLiveSegments no longer iterates through periods, only uses current_period_. Because of the logical layout of HLS where periods are described inside of representations we would otherwise end up checking the same thing multiple times. And as we can never delete current_period_ it avoids a potential crash.
We also prepare a list of representations to refresh and do after finishing iterating to again avoid erasing elements while iterating.

In the example strm below it's quite easy to pause for 5 minutes and end up with a condition where current_period_ is not longer a part of the playlist. current_period_ is removed from periods_ so it doesn't interfere with parsing the playlist then once finished parsing it is inserted at the beginning of periods_ to avoid a memory leak.

Manual stream switching was working fine before the rework branch and still is now however I've noticed that in its current form all streams point to the same representation: 
![image](https://user-images.githubusercontent.com/11909320/85822912-663afd80-b7bf-11ea-8a77-2aed39a14834.png)
I'm sure you know about this, just writing for the benefit of other readers.


strm file for testing (period count fluctuates between 1 and 7, occasionally there will be a 10 minute featurette)
```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
https://dai.google.com/linear/hls/event/YakHdnr_RpyszducVuHOpQ/master.m3u8
```

Thanks for your time and help with this!

Glenn
