### PR TITLE
Don't log unknown encryption methods

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -155,9 +155,6 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
     return ENCRYPTIONTYPE_INVALID;
   }
 
-  // UNKNOWN
-  Log(LOGLEVEL_WARNING, "Unknown encryption method: %s with keyformat %s", map["METHOD"].c_str(),
-      map["KEYFORMAT"].c_str());
   return ENCRYPTIONTYPE_UNKNOWN;
 }
 


### PR DESCRIPTION
This log message was introduced in my PR to refactor the processEncryption method.

However, it has caused confusion when Disney+ playback didn't work and they thought the below log messages were the cause.

> WARNING: AddOnLog: InputStream Adaptive: Unknown encryption method: SAMPLE-AES-CTR with keyformat com.microsoft.playready
> WARNING: AddOnLog: InputStream Adaptive: Unknown encryption method: SAMPLE-AES-CTR with keyformat PRMNAGRA

So, let's just revert to old behaviour of not logging on unknown methods.

Also, on live streams, the above could spam the log every time the playlist is processed.