### PR TITLE
[HLS] Update base_domain when an effective_url (i.e. redirect) is being used.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,6 +303,14 @@ bool adaptive::AdaptiveTree::download(const char* url,
 
     if (effective_url_ == base_url_)
       effective_url_.clear();
+
+    if (!effective_url_.empty())
+    {
+      base_domain_ = effective_url_;
+      paramPos = base_domain_.find_first_of('/', 8);
+      if (paramPos != std::string::npos)
+        base_domain_.resize(paramPos);
+    }
   }
 
   // read the file


### PR DESCRIPTION
Fixes HLS problems of Issue #473

When a redirect is used, the base_domain should be updated to reflect the domain of the effective URL.