### PR TITLE
Fix / Clean Up Effective (redirected) URLS

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -368,21 +368,7 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment* seg)
   else
     download_headers_.erase("Range");
 
-  if (!tree_.effective_url_.empty() && download_url_.find(tree_.base_url_) == 0)
-    download_url_.replace(0, tree_.base_url_.size(), tree_.effective_url_);
-
   return true;
-}
-
-std::string AdaptiveStream::buildDownloadUrl(const std::string& url)
-{
-  if (!tree_.effective_url_.empty() && url.find(tree_.base_url_) == 0)
-  {
-    std::string newUrl(url);
-    newUrl.replace(0, tree_.base_url_.size(), tree_.effective_url_);
-    return newUrl;
-  }
-  return url;
 }
 
 bool AdaptiveStream::ensureSegment()

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -87,10 +87,8 @@ namespace adaptive
     virtual bool parseIndexRange() { return false; };
     bool write_data(const void *buffer, size_t buffer_size);
     bool prepareDownload(const AdaptiveTree::Segment *seg);
-    void setEffectiveURL(const std::string url) { tree_.effective_url_ = url; if (tree_.effective_url_.back() != '/') tree_.effective_url_ += '/'; };
     const std::string& getMediaRenewalUrl() const { return tree_.media_renewal_url_; };
     const uint32_t& getMediaRenewalTime() const { return tree_.media_renewal_time_; };
-    std::string buildDownloadUrl(const std::string &url);
     uint32_t SecondsSinceMediaRenewal() const;
     void UpdateSecondsSinceMediaRenewal();
   private:

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -410,7 +410,7 @@ public:
   }*current_period_, *next_period_;
 
   std::vector<Period*> periods_;
-  std::string manifest_url_, base_url_, effective_url_, effective_filename_, base_domain_, update_parameter_;
+  std::string manifest_url_, base_url_, effective_url_, base_domain_, update_parameter_;
   std::string::size_type update_parameter_pos_;
   std::string etag_, last_modified_;
   std::string media_renewal_url_;
@@ -485,7 +485,7 @@ public:
   const std::chrono::time_point<std::chrono::system_clock> GetLastMediaRenewal() const { return lastMediaRenewal_; };
 
 protected:
-  virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr, bool scanEffectiveURL = true);
+  virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr);
   virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) = 0;
   bool PreparePaths(const std::string &url, const std::string &manifestUpdateParam);
   void SortTree();

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1540,7 +1540,6 @@ static void XMLCALL end(void* data, const char* el)
 +---------------------------------------------------------------------*/
 bool DASHTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
-  PreparePaths(url, manifestUpdateParam);
   parser_ = XML_ParserCreate(NULL);
   if (!parser_)
     return false;
@@ -1551,11 +1550,8 @@ bool DASHTree::open(const std::string& url, const std::string& manifestUpdatePar
   currentNode_ = 0;
   strXMLText_.clear();
 
-  std::string download_url = manifest_url_;
-  if (!effective_url_.empty() && download_url.find(base_url_) == 0)
-    download_url.replace(0, base_url_.size(), effective_url_);
-
-  bool ret = download(download_url.c_str(), manifest_headers_) && !periods_.empty();
+  bool ret = download(url.c_str(), manifest_headers_) && !periods_.empty();
+  PreparePaths(effective_url_, manifestUpdateParam);
 
   XML_ParserFree(parser_);
   parser_ = 0;
@@ -1638,8 +1634,6 @@ void DASHTree::RefreshLiveSegments()
     updateTree.supportedKeySystem_ = supportedKeySystem_;
     //Location element should be used on updates
     updateTree.location_ = location_;
-    updateTree.effective_url_ = effective_url_;
-    updateTree.effective_filename_ = effective_filename_;
 
     if (!~update_parameter_pos_)
     {

--- a/src/parser/DASHTreeTest.cpp
+++ b/src/parser/DASHTreeTest.cpp
@@ -29,8 +29,7 @@ void Log(const LogLevel loglevel, const char* format, ...)
 
 bool adaptive::AdaptiveTree::download(const char* url,
                                       const std::map<std::string, std::string>& manifestHeaders,
-                                      void* opaque,
-                                      bool scanEffectiveURL)
+                                      void* opaque)
 {
   FILE* f = fopen(testfile.c_str(), "rb");
   if (!f)

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -349,8 +349,6 @@ static void XMLCALL end(void* data, const char* el)
 
 bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
-  PreparePaths(url, manifestUpdateParam);
-
   parser_ = XML_ParserCreate(NULL);
   if (!parser_)
     return false;
@@ -360,7 +358,8 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
   currentNode_ = 0;
   strXMLText_.clear();
 
-  bool ret = download(manifest_url_.c_str(), manifest_headers_);
+  bool ret = download(url.c_str(), manifest_headers_);
+  PreparePaths(effective_url_, manifestUpdateParam);
 
   XML_ParserFree(parser_);
   parser_ = 0;


### PR DESCRIPTION
no need to track both original and redirected url.

Simply download the manifest then PreparePaths after using the effective url

This removes a lot of need to url.replace etc further on.
Remove effective_filename_ as no longer used and scanEffectiveURL not required either
Cleaned up the Renewed url.

Have tested this on as many streams / add-on as I could.

It even worked with a redirect > master playlist then has a redirect > sub playlist