### PR TITLE
Add parsing DASH adaptionSet "name" parameter

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -885,6 +885,8 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
             dash->current_adaptationset_->language_ = ltranslate((const char*)*(attr + 1));
           else if (strcmp((const char*)*attr, "mimeType") == 0)
             dash->current_adaptationset_->mimeType_ = (const char*)*(attr + 1);
+          else if (strcmp((const char*)*attr, "name") == 0)
+            dash->current_adaptationset_->name_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "codecs") == 0)
             dash->current_adaptationset_->codecs_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "width") == 0)


### PR DESCRIPTION
Reintroduced the possibility to add custom text to the streams
had been broken for a while

(FYI Matrix only, Kodi Leia is not patched to work)

Example:
![image](https://user-images.githubusercontent.com/3257156/90379077-86c65c00-e07a-11ea-800c-178c34fae2d2.png)
