### PR TITLE
Use CDllHelper for opening ssd_wv

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <kodi/addon-instance/Inputstream.h>
+#include <kodi/tools/DllHelper.h>
 
 #include "common/AdaptiveTree.h"
 #include "common/AdaptiveStream.h"
@@ -185,7 +186,7 @@ private:
   AP4_DataBuffer server_certificate_;
   std::string profile_path_;
   std::string ov_audio_;
-  void * decrypterModule_;
+  kodi::tools::CDllHelper* decrypterModule_;
   SSD::SSD_DECRYPTER *decrypter_;
 
   struct CDMSESSION


### PR DESCRIPTION
Hi Peak3d

This should pave the way for being able to update inputstream.adaptive running on Android rather than relying on it being packaged.

Not included is changing the searchpaths for ssd_wv, I thought I'd ask for some input of yours first. What works is changing to `special://home/addons/inputstream.adaptive/` for Android, I'm mindful that this would need to be coordinated with the repo. Can add this to the PR if you want.