### PR TITLE
[Leia][Backport][TTML] Don't stack subtitle if begin and end are equal

### DIFF
--- a/src/parser/TTML.cpp
+++ b/src/parser/TTML.cpp
@@ -328,6 +328,10 @@ bool TTML2SRT::StackSubTitle(const char *s, const char *e, const char *id)
   if (!s || !e || !*s || !*e)
     return false;
 
+  // Don't stack subtitle if begin and end are equal
+  if (strcmp(s, e) == 0)
+    return false;
+
   m_subTitles.push_back(SUBTITLE());
   SUBTITLE &sub(m_subTitles.back());
 


### PR DESCRIPTION
Leia backport of https://github.com/peak3d/inputstream.adaptive/pull/502
