### PR TITLE
[TTML] Don't stack subtitle if begin and end are equal

### DIFF
--- a/src/parser/TTML.cpp
+++ b/src/parser/TTML.cpp
@@ -328,6 +328,10 @@ bool TTML2SRT::StackSubTitle(const char *s, const char *e, const char *id)
   if (!s || !e || !*s || !*e)
     return false;
 
+  // Don't stack subtitle if begin and end are equal
+  if (strcmp(s, e) == 0)
+    return false;
+
   m_subTitles.push_back(SUBTITLE());
   SUBTITLE &sub(m_subTitles.back());
 


### PR DESCRIPTION
Sometimes content providers (wrongly) provide TTML subtitles where begin and end timestamps are equal. In that case, these subtitles shouldn't be displayed. For some reason Kodi shows them anyway, but one above the other.
**Wrong behaviour:**
![subs](https://user-images.githubusercontent.com/45148099/90952594-2dd53a00-e465-11ea-8fe2-47528bc09eab.png)

**Wanted behaviour with this fix:**
![subs2](https://user-images.githubusercontent.com/45148099/90952714-2d896e80-e466-11ea-8ed7-8345db4b0e95.png)


This PR throws away these faulty subtitles before Kodi sees them, because it makes no sense to process a subtitle where begin and end timestamps are equal and the display time is zero.
