### PR TITLE
Fix / Clean Up Effective (redirected) URLS

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -368,21 +368,7 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment* seg)
   else
     download_headers_.erase("Range");
 
-  if (!tree_.effective_url_.empty() && download_url_.find(tree_.base_url_) == 0)
-    download_url_.replace(0, tree_.base_url_.size(), tree_.effective_url_);
-
   return true;
-}
-
-std::string AdaptiveStream::buildDownloadUrl(const std::string& url)
-{
-  if (!tree_.effective_url_.empty() && url.find(tree_.base_url_) == 0)
-  {
-    std::string newUrl(url);
-    newUrl.replace(0, tree_.base_url_.size(), tree_.effective_url_);
-    return newUrl;
-  }
-  return url;
 }
 
 bool AdaptiveStream::ensureSegment()

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -87,10 +87,8 @@ namespace adaptive
     virtual bool parseIndexRange() { return false; };
     bool write_data(const void *buffer, size_t buffer_size);
     bool prepareDownload(const AdaptiveTree::Segment *seg);
-    void setEffectiveURL(const std::string url) { tree_.effective_url_ = url; if (tree_.effective_url_.back() != '/') tree_.effective_url_ += '/'; };
     const std::string& getMediaRenewalUrl() const { return tree_.media_renewal_url_; };
     const uint32_t& getMediaRenewalTime() const { return tree_.media_renewal_time_; };
-    std::string buildDownloadUrl(const std::string &url);
     uint32_t SecondsSinceMediaRenewal() const;
     void UpdateSecondsSinceMediaRenewal();
   private:

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <chrono>
+#include <sstream>
 
 namespace adaptive
 {
@@ -410,7 +411,7 @@ public:
   }*current_period_, *next_period_;
 
   std::vector<Period*> periods_;
-  std::string manifest_url_, base_url_, effective_url_, effective_filename_, base_domain_, update_parameter_;
+  std::string manifest_url_, base_url_, effective_url_, base_domain_, update_parameter_;
   std::string::size_type update_parameter_pos_;
   std::string etag_, last_modified_;
   std::string media_renewal_url_;
@@ -485,7 +486,7 @@ public:
   const std::chrono::time_point<std::chrono::system_clock> GetLastMediaRenewal() const { return lastMediaRenewal_; };
 
 protected:
-  virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr, bool scanEffectiveURL = true);
+  virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr);
   virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) = 0;
   bool PreparePaths(const std::string &url, const std::string &manifestUpdateParam);
   void SortTree();

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -33,6 +33,7 @@ namespace adaptive
                                  AdaptationSet* adp,
                                  Representation* rep,
                                  StreamType type) override;
+    virtual bool processManifest(std::stringstream& stream);
 
     void SetUpdateInterval(uint32_t interval) { updateInterval_ = interval; };
     uint64_t pts_helper_;

--- a/src/parser/DASHTreeTest.cpp
+++ b/src/parser/DASHTreeTest.cpp
@@ -29,8 +29,7 @@ void Log(const LogLevel loglevel, const char* format, ...)
 
 bool adaptive::AdaptiveTree::download(const char* url,
                                       const std::map<std::string, std::string>& manifestHeaders,
-                                      void* opaque,
-                                      bool scanEffectiveURL)
+                                      void* opaque)
 {
   FILE* f = fopen(testfile.c_str(), "rb");
   if (!f)

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -164,17 +164,21 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
 
 bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
-  PreparePaths(url, manifestUpdateParam);
-  if (download(manifest_url_.c_str(), manifest_headers_, &manifest_stream))
-    return processManifest(manifest_stream, url);
-  return false;
+  std::stringstream manifest_stream;
+  bool ret = download(url.c_str(), manifest_headers_, &manifest_stream);
+  PreparePaths(effective_url_, manifestUpdateParam);
+
+  if (!ret)
+    return false;
+
+  return processManifest(manifest_stream, effective_url_);
 }
 
 bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
 {
 #if FILEDEBUG
   FILE* f = fopen("inputstream_adaptive_master.m3u8", "w");
-  fwrite(m_stream.str().data(), 1, m_stream.str().size(), f);
+  fwrite(stream.str().data(), 1, stream.str().size(), f);
   fclose(f);
 #endif
 
@@ -319,10 +323,7 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
       current_representation_->bandwidth_ = 0;
       current_representation_->codecs_ = getVideoCodec("");
       current_representation_->containerType_ = CONTAINERTYPE_NOTYPE;
-      if (!effective_url_.empty())
-        current_representation_->source_url_ = effective_url_ + effective_filename_;
-      else
-        current_representation_->source_url_ = url;
+      current_representation_->source_url_ = url;
       current_adaptationset_->representations_.push_back(current_representation_);
 
       // We assume audio is included
@@ -426,16 +427,13 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
     uint32_t discont_count = 0;
     PREPARE_RESULT retVal = PREPARE_RESULT_OK;
 
-    if (!effective_url_.empty() && download_url.find(base_url_) == 0)
-      download_url.replace(0, base_url_.size(), effective_url_);
-
     if (rep->flags_ & Representation::DOWNLOADED)
       ;
-    else if (download(download_url.c_str(), manifest_headers_, &stream, false))
+    else if (download(download_url.c_str(), manifest_headers_, &stream))
     {
 #if FILEDEBUG
       FILE* f = fopen("inputstream_adaptive_sub.m3u8", "w");
-      fwrite(m_stream.str().data(), 1, m_stream.str().size(), f);
+      fwrite(stream.str().data(), 1, stream.str().size(), f);
       fclose(f);
 #endif
       bool byteRange(false);
@@ -803,10 +801,7 @@ void HLSTree::OnDataArrived(unsigned int segNum,
         if (keyParts.size() > 1)
           parseheader(headers, keyParts[1].c_str());
 
-        if (!effective_url_.empty() && url.find(base_url_) == 0)
-          url.replace(0, base_url_.size(), effective_url_);
-
-        if (download(url.c_str(), headers, &stream, false))
+        if (download(url.c_str(), headers, &stream))
         {
           pssh.defaultKID_ = stream.str();
         }

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "../common/AdaptiveTree.h"
-#include <sstream>
 #include <map>
 
 class AESDecrypter;
@@ -81,7 +80,6 @@ namespace adaptive
     bool m_refreshPlayList = true;
     uint8_t m_segmentIntervalSec = 4;
     AESDecrypter *m_decrypter;
-    std::stringstream manifest_stream;
   };
 
 } // namespace

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -29,6 +29,7 @@ namespace adaptive
     SmoothTree();
     virtual bool open(const std::string &url, const std::string &manifestUpdateParam) override;
     virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) override;
+    virtual bool processManifest(std::stringstream& stream);
 
     enum
     {


### PR DESCRIPTION
This makes redirected playlists work correctly.
fixes issue: https://github.com/peak3d/inputstream.adaptive/issues/473

no need to track both original and redirected url.

Simply download the manifest then PreparePaths after using the effective url

This removes a lot of need to url.replace etc further on.
Remove effective_filename_ as no longer used and scanEffectiveURL not required either
Cleaned up the Renewed url.

Have tested this on as many streams / add-on as I could.

It even worked with a redirect > master playlist then has a redirect > sub playlist