### PR TITLE
Remove cmake debug flags from ssd_wv

### DIFF
--- a/wvdecrypter/CMakeLists.txt
+++ b/wvdecrypter/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 project(wvdecrypter)
 
 if(CORE_SYSTEM_NAME STREQUAL android)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-undefined -O0 -g")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-undefined")
   include_directories (
     ${CMAKE_CURRENT_SOURCE_DIR}/../lib/libbento4/Core
     jni/jutils

--- a/wvdecrypter/CMakeLists.txt.ndk
+++ b/wvdecrypter/CMakeLists.txt.ndk
@@ -10,7 +10,7 @@ endif()
 project(wvdecrypter)
 
 if(CORE_SYSTEM_NAME STREQUAL android)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-undefined -O0 -g")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-undefined")
   include_directories (
     ${CMAKE_CURRENT_SOURCE_DIR}/../lib/libbento4/Core
 #    jni/jutils


### PR DESCRIPTION
looks like these flags may have been left in by mistake from this commit https://github.com/peak3d/inputstream.adaptive/commit/f1c71f9374d2c561adbee16b208ed3d7afbe628f#diff-f460ed815c36ad806aa337fae6d47295L13

They force ssd_wv to always include debug symbols even on Release.