### PR TITLE
Added audio/video format to SetFragmentInfo()

### DIFF
--- a/lib/libbento4/Core/Ap4CommonEncryption.h
+++ b/lib/libbento4/Core/Ap4CommonEncryption.h
@@ -519,7 +519,7 @@ public:
 		AP4_CencSingleSampleDecrypter(AP4_StreamCipher* cipher) : m_Cipher(cipher), m_FullBlocksOnly(false), m_ParentIsOwner(true){}
 		virtual ~AP4_CencSingleSampleDecrypter();
     virtual AP4_Result SetFragmentInfo(AP4_UI32 poolid, const AP4_UI08* keyid, const AP4_UI08 nalu_length_size,
-      AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags) { return AP4_ERROR_NOT_SUPPORTED; };
+      AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat) { return AP4_ERROR_NOT_SUPPORTED; };
     virtual AP4_UI32 AddPool() { return 0; };
     virtual void RemovePool(AP4_UI32 poolid) {};
     virtual const char* GetSessionId() { return NULL; };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1443,7 +1443,7 @@ protected:
     if (m_singleSampleDecryptor && m_codecHandler)
       m_singleSampleDecryptor->SetFragmentInfo(m_poolId, m_defaultKey,
                                                m_codecHandler->naluLengthSize,
-                                               m_codecHandler->extra_data, m_decrypterCaps.flags);
+                                               m_codecHandler->extra_data, m_decrypterCaps.flags, m_sampleFormat);
 
     return AP4_SUCCESS;
   }
@@ -1494,6 +1494,8 @@ private:
         break;
     }
 
+    m_sampleFormat = desc->GetFormat();
+
     if ((m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED) != 0)
       m_codecHandler->ExtraDataToAnnexB();
   }
@@ -1506,6 +1508,7 @@ private:
   SSD::SSD_DECRYPTER::SSD_CAPS m_decrypterCaps;
   unsigned int m_failCount;
   AP4_UI32 m_poolId;
+  AP4_UI32 m_sampleFormat;
 
   bool m_eos, m_started;
   int64_t m_dts, m_pts, m_ptsDiff;

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -186,7 +186,7 @@ public:
   bool HasKeyId(const uint8_t *keyid);
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size,
-    AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags)override;
+    AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat)override;
   virtual AP4_UI32 AddPool() override;
   virtual void RemovePool(AP4_UI32 poolid) override;
 
@@ -940,7 +940,7 @@ bool WV_CencSingleSampleDecrypter::HasKeyId(const uint8_t *keyid)
   return false;
 }
 
-AP4_Result WV_CencSingleSampleDecrypter::SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags)
+AP4_Result WV_CencSingleSampleDecrypter::SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat)
 {
   if (pool_id >= fragment_pool_.size())
     return AP4_ERROR_OUT_OF_RANGE;

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -177,7 +177,7 @@ public:
   virtual const char *GetSessionId() override;
   virtual bool HasLicenseKey(const uint8_t *keyid);
 
-  virtual AP4_Result SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags)override;
+  virtual AP4_Result SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat)override;
   virtual AP4_UI32 AddPool() override;
   virtual void RemovePool(AP4_UI32 poolid) override;
 
@@ -793,7 +793,7 @@ SSMFAIL:
 +---------------------------------------------------------------------*/
 
 AP4_Result WV_CencSingleSampleDecrypter::SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key,
-  const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags)
+  const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat)
 {
   if (pool_id >= fragment_pool_.size())
     return AP4_ERROR_OUT_OF_RANGE;

--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -284,7 +284,7 @@ public:
   virtual const char *GetSessionId() override;
   virtual bool HasLicenseKey(const uint8_t *keyid);
 
-  virtual AP4_Result SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags)override;
+  virtual AP4_Result SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key, const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat)override;
   virtual AP4_UI32 AddPool() override;
   virtual void RemovePool(AP4_UI32 poolid) override;
 
@@ -976,7 +976,7 @@ SSMFAIL:
 +---------------------------------------------------------------------*/
 
 AP4_Result WV_CencSingleSampleDecrypter::SetFragmentInfo(AP4_UI32 pool_id, const AP4_UI08 *key,
-  const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags)
+  const AP4_UI08 nal_length_size, AP4_DataBuffer &annexb_sps_pps, AP4_UI32 flags, AP4_UI32 sampleFormat)
 {
   if (pool_id >= fragment_pool_.size())
     return AP4_ERROR_OUT_OF_RANGE;


### PR DESCRIPTION
Added audio/video format to SetFragmentInfo()

This adds support for informing a hardware based decoder running in the secure world of the stream properties.
It's necessary to prime the decoder before passing frames