### PR TITLE
Return secure path and decoder flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1261,6 +1261,7 @@ public:
   bool IsEncrypted() const override
   {
     return (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0 &&
+           (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER) != 0 &&
            m_decrypter != nullptr;
   };
   bool GetInformation(INPUTSTREAM_INFO& info) override


### PR DESCRIPTION
The secure path is used to indicate that we support trusted video pathway and can handle Widevine L1.
The decoder flag indicates that we can decrypt Widevine L1 content.

At the moment, if the stream is L3, InputStream adaptive removes the decoder flag.

This causes the IsEncrypted() flag to report that the stream is encrypted, even after we have decrypted it because it only checks for the secure path flag. This patch changes this behaviour so that isEncrypted() returns the correct value.
