### PR TITLE
Remove static declaration of 't' variable in SegmentTimeline

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -338,7 +338,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
             {
               // <S t="3600" d="900000" r="2398"/>
               unsigned int d(0), r(1);
-              static uint64_t t(0);
+              uint64_t t(0);
 
               for (; *attr;)
               {


### PR DESCRIPTION
Fixes #543 
Some SegmentTimelines will have an implicit `t="0"` for the first `S` tag e.g
```
<SegmentTimeline>
  <S d="314"/>
  <S t="314" d="256"/>
  <S t="570" d="430"/>
  <S t="1000" d="261"/>
  <S t="1262" d="253"/>
  etc...
```

This change will allow for this first segment to have `range_begin_` correctly set to 0 for representations other than the first one parsed.

Further explanation here if needed: https://github.com/peak3d/inputstream.adaptive/issues/543#issuecomment-719534565