### PR TITLE
Version bump to 2.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# inputstream.adaptive (2.6.5)
+# inputstream.adaptive (2.6.6)
 
 This is an adaptive file addon for kodi's new InputStream Interface.
 

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.5"
+  version="2.6.6"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -18,7 +18,10 @@
     <description lang="en_GB">InputStream client for adaptive streams</description>
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
-    <news>v2.6.5 (2020-11-09)
+    <news>v2.6.6 (2020-11-21)
+- Matrix VideoCodec API change to v2.0.2 - Fix crypto session id handling
+
+v2.6.5 (2020-11-09)
 - Matrix API change to v3.0.1 - Fix wrong flags bit shift
 
 v2.6.4 (2020-10-31)


### PR DESCRIPTION
Addon needs a version bump and a new release to pull in https://github.com/xbmc/xbmc/pull/18809.