### PR TITLE
Use the full BaseUrl if it's a real url inside an AdaptationSet

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1308,8 +1308,12 @@ static void XMLCALL end(void* data, const char* el)
         {
           if (strcmp(el, "BaseURL") == 0)
           {
-            dash->current_adaptationset_->base_url_ =
-                dash->current_period_->base_url_ + dash->strXMLText_;
+            if (dash->strXMLText_.compare(0, 1, "/") == 0 ||
+                dash->strXMLText_.compare(0, 7, "http://") == 0 ||
+                dash->strXMLText_.compare(0, 8, "https://") == 0)
+                dash->current_adaptationset_->base_url_ = dash->strXMLText_;
+            else
+                dash->current_adaptationset_->base_url_ = dash->current_period_->base_url_ + dash->strXMLText_;
             dash->currentNode_ &= ~MPDNODE_BASEURL;
           }
         }


### PR DESCRIPTION
I saw Inputstream was trying to download files from `https://dcs-vod.apis.anvato.net/vod/p/session/https://dcs-jite.cdn.anvato.net/prod/v97/media/4D7ACFAA6F654F40999164950F4ABE37/4200000/fmp4-init-video.mp4`

Manifest can be viewed here: https://github.com/add-ons/plugin.video.vtm.go/files/5634435/manifest.mpd.txt

The code wasn't using the `baseUrl` if it is a real url. This was done correctly when parsing a `Representation`, but not when parsing an `AdaptationSet`.