### PR TITLE
[Leia] Use the full BaseUrl if it's a real url inside an AdaptationSet

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1306,8 +1306,12 @@ static void XMLCALL end(void* data, const char* el)
         {
           if (strcmp(el, "BaseURL") == 0)
           {
-            dash->current_adaptationset_->base_url_ =
-                dash->current_period_->base_url_ + dash->strXMLText_;
+            if (dash->strXMLText_.compare(0, 1, "/") == 0 ||
+                dash->strXMLText_.compare(0, 7, "http://") == 0 ||
+                dash->strXMLText_.compare(0, 8, "https://") == 0)
+              dash->current_adaptationset_->base_url_ = dash->strXMLText_;
+            else
+              dash->current_adaptationset_->base_url_ = dash->current_period_->base_url_ + dash->strXMLText_;
             dash->currentNode_ &= ~MPDNODE_BASEURL;
           }
         }


### PR DESCRIPTION
Backport of https://github.com/peak3d/inputstream.adaptive/pull/565