### PR TITLE
[Darwinembedded] Fix build for ios/tvos v19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,12 +75,12 @@ add_subdirectory(lib/mpegts)
 
 add_subdirectory(lib/webm_parser)
 
-if(NOT CORE_SYSTEM_NAME STREQUAL ios)
-  add_subdirectory(wvdecrypter)
-  set(ADP_ADDITIONAL_BINARY $<TARGET_FILE:ssd_wv>)
-else()
+if(CORE_SYSTEM_NAME STREQUAL ios OR CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   set(BENTOUSESTCFS 1)
   add_subdirectory(lib/libbento4)
+else()
+  add_subdirectory(wvdecrypter)
+  set(ADP_ADDITIONAL_BINARY $<TARGET_FILE:ssd_wv>)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL android)


### PR DESCRIPTION
For Kodi Matrix, CORE_SYSTEM_NAME was changed to darwin_embedded instead of ios
https://github.com/xbmc/xbmc/pull/16039

This change keeps backward compat with v18