### PR TITLE
Dont set static when mediaPresentationDuration found

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1015,7 +1015,6 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       if (strcmp((const char*)*attr, "mediaPresentationDuration") == 0)
       {
         mpt = (const char*)*(attr + 1);
-        bStatic = true;
       }
       else if (strcmp((const char*)*attr, "type") == 0)
       {
@@ -1024,7 +1023,6 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       else if (strcmp((const char*)*attr, "timeShiftBufferDepth") == 0)
       {
         tsbd = (const char*)*(attr + 1);
-        dash->has_timeshift_buffer_ = true;
       }
       else if (strcmp((const char*)*attr, "availabilityStartTime") == 0)
         dash->available_time_ = getTime((const char*)*(attr + 1));
@@ -1041,7 +1039,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       attr += 2;
     }
 
-    if (!mpt)
+    if (!mpt || !bStatic)
       mpt = tsbd;
     dash->has_timeshift_buffer_ = !bStatic;
 


### PR DESCRIPTION
With this line present, IA is setting the below MPD to Static (vod) instead of live.

it has type="dynamic" but then mediaPresentationDuration="PT9000.000000S" after that.
So, the bStatic is correctly being set to False, but then being set to True when mediaPresentationDuration is found.

If mediaPresentationDuration was before type in the attributes, it would work fine.

So, if this fix isn't correct, then we need a way to make sure "type" overrides mediaPresentationDuration 

```
<?xml version="1.0" encoding="UTF-8"?>
<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:dvb="urn:dvb:dash:dash-extensions:2014-1" xmlns:move="http://www.movenetworks.com/dash/v1" xmlns:ms="urn:microsoft" xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" maxSegmentDuration="PT2.048000S" minBufferTime="PT2.048000S" publishTime="2020-12-07T20:30:00Z" type="dynamic" minimumUpdatePeriod="PT2.048000S" availabilityStartTime="2020-12-07T20:30:15Z" mediaPresentationDuration="PT9000.000000S" suggestedPresentationDelay="PT4.096000S">
    <ProgramInformation>
        <Linear xmlns="http://www.movenetworks.com/dash/v1">true</Linear>
        <Gaps xmlns="http://www.movenetworks.com/dash/v1" possible="true"></Gaps>
    </ProgramInformation>
    <Period id="1" duration="PT9000.000000S" start="PT0.000000S">
        <BaseURL serviceLocation="A-Akamai" dvb:priority="1" dvb:weight="34">http://p-cdn1-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Fastly" dvb:priority="1" dvb:weight="33">http://p-cdn4-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Level3" dvb:priority="1" dvb:weight="33">http://p-cdn3-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Akamai" dvb:priority="2" dvb:weight="34">http://p-cdn1-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Fastly" dvb:priority="2" dvb:weight="33">http://p-cdn4-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Level3" dvb:priority="2" dvb:weight="33">http://p-cdn3-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Akamai" dvb:priority="3" dvb:weight="34">http://p-cdn1-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Fastly" dvb:priority="3" dvb:weight="33">http://p-cdn4-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <BaseURL serviceLocation="A-Level3" dvb:priority="3" dvb:weight="33">http://p-cdn3-a-cg14-linear-cbd46b77.movetv.com/15803/live/AMCSTR/eb8b58c8386f11eba0930025b5471112/</BaseURL>
        <AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" codecs="mp4a.40.2" lang="en">
            <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="8f1e379b-07ae-4cee-b53a-6c402c2bdbd4" xmlns:v1="http://www.movenetworks.com/dash/v1" v1:widevineProxy="http://p-drmwv.movetv.com/widevine/proxy"></ContentProtection>
            <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
                <cenc:pssh>AAADMnBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAxISAwAAAQABAAgDPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwATABBAF8AVQBSAEwAPgBoAHQAdABwADoALwAvAHAALQBwAGwAYQB5AHIAZQBhAGQAeQAuAG0AbwB2AGUAdAB2AC4AYwBvAG0ALwBwAGwAYQB5AHIAZQBhAGQAeQAvAHIAaQBnAGgAdABzAG0AYQBuAGEAZwBlAHIALgBhAHMAbQB4ADwALwBMAEEAXwBVAFIATAA+ADwATABVAEkAXwBVAFIATAA+AGgAdAB0AHAAOgAvAC8AcAAtAHAAbABhAHkAcgBlAGEAZAB5AC4AbQBvAHYAZQB0AHYALgBjAG8AbQAvAGwAbwBnAGkAbgAuAGEAcwBwAHgAPAAvAEwAVQBJAF8AVQBSAEwAPgA8AEsASQBEAD4AbQB6AGMAZQBqADYANABIADcAawB5ADEATwBtAHgAQQBMAEMAdgBiADEAQQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBaAGIATABCADEATgBFAHAAMABGAEEAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
            </ContentProtection>
            <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
                <cenc:pssh>AAAAXHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADwIARIgOGYxZTM3OWIwN2FlNGNlZWI1M2E2YzQwMmMyYmRiZDQaB3NsaW5ndHYiBkFNQ1NUUioFU0RfSEQ=</cenc:pssh>
                <ms:laurl licenseUrl="http://p-drmwv.movetv.com/widevine/proxy"/>
            </ContentProtection>
            <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
                <cenc:pssh>AAAAIHBzc2gAAAAAEHfv7MCyTQKs4zweUuL7SwAAAAA=</cenc:pssh>
            </ContentProtection>
            <SegmentTemplate timescale="1000" duration="2048" startNumber="19101" initialization="audio/$RepresentationID$/init.mp4" media="audio/$RepresentationID$/$Number%08x$.m4s"></Representation>
        </AdaptationSet>
    </Period>
</MPD>
```