### PR TITLE
[Dash] Support fpsScale in AdaptationSets

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -438,7 +438,7 @@ public:
 
   uint8_t adpChannelCount_, adp_pssh_set_;
   uint16_t adpwidth_, adpheight_;
-  uint32_t adpfpsRate_;
+  uint32_t adpfpsRate_, adpfpsScale_;
   float adpaspect_;
   ContainerType adpContainerType_;
   bool adp_timelined_, period_timelined_;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -659,6 +659,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           dash->current_representation_->width_ = dash->adpwidth_;
           dash->current_representation_->height_ = dash->adpheight_;
           dash->current_representation_->fpsRate_ = dash->adpfpsRate_;
+          dash->current_representation_->fpsScale_ = dash->adpfpsScale_;
           dash->current_representation_->aspect_ = dash->adpaspect_;
           dash->current_representation_->containerType_ = dash->adpContainerType_;
 
@@ -681,9 +682,12 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
               dash->current_representation_->samplingRate_ =
                   static_cast<uint32_t>(atoi((const char*)*(attr + 1)));
             else if (strcmp((const char*)*attr, "frameRate") == 0)
+            {
+              dash->current_representation_->fpsScale_ = 1;
               sscanf((const char*)*(attr + 1), "%" SCNu32 "/%" SCNu32,
                      &dash->current_representation_->fpsRate_,
                      &dash->current_representation_->fpsScale_);
+            }
             else if (strcmp((const char*)*attr, "id") == 0)
               dash->current_representation_->id = (const char*)*(attr + 1);
             else if (strcmp((const char*)*attr, "codecPrivateData") == 0)
@@ -850,6 +854,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         dash->adpwidth_ = 0;
         dash->adpheight_ = 0;
         dash->adpfpsRate_ = 0;
+        dash->adpfpsScale_ = 1;
         dash->adpaspect_ = 0.0f;
         dash->adp_pssh_set_ = 0;
         dash->adpContainerType_ = AdaptiveTree::CONTAINERTYPE_MP4;
@@ -890,7 +895,9 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           else if (strcmp((const char*)*attr, "height") == 0)
             dash->adpheight_ = static_cast<uint16_t>(atoi((const char*)*(attr + 1)));
           else if (strcmp((const char*)*attr, "frameRate") == 0)
-            dash->adpfpsRate_ = static_cast<uint32_t>(atoi((const char*)*(attr + 1)));
+            sscanf((const char*)*(attr + 1), "%" SCNu32 "/%" SCNu32,
+                    &dash->adpfpsRate_,
+                    &dash->adpfpsScale_);
           else if (strcmp((const char*)*attr, "par") == 0)
           {
             int w, h;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -169,3 +169,29 @@ TEST_F(DASHTreeTest, CalculateStaticWithPresentationDuration)
   OpenTestFile("mpd/segtpl_slash_baseurl_slash.mpd", "", "");
   EXPECT_EQ(tree->has_timeshift_buffer_, false);
 }
+
+TEST_F(DASHTreeTest, CalculateCorrectFpsScaleFromAdaptionSet)
+{
+  OpenTestFile("mpd/fps_scale_adaptset.mpd", "", "");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->fpsRate_, 24000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->fpsScale_, 1001);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->fpsRate_, 30);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->fpsScale_, 1);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->fpsRate_, 25);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->fpsScale_, 1);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[3]->representations_[0]->fpsRate_, 25000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[3]->representations_[0]->fpsScale_, 1000);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->representations_[0]->fpsRate_, 25);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->representations_[0]->fpsScale_, 1);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[5]->representations_[0]->fpsRate_, 30);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[5]->representations_[0]->fpsScale_, 1);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->representations_[0]->fpsRate_, 25000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->representations_[0]->fpsScale_, 1000);
+}

--- a/src/test/manifests/mpd/fps_scale_adaptset.mpd
+++ b/src/test/manifests/mpd/fps_scale_adaptset.mpd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD _xmlns:ns2="http://www.w3.org/1999/xlink" mediaPresentationDuration="PT1H45M47.904S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_xmlns="xmlns">
+	<Period duration="PT1H45M47.904S">
+		<AdaptationSet contentType="video" frameRate="24000/1001">
+			<Representation bandwidth="3203000" codecs="avc1.4D401F" height="544" id="video=2492922" scanType="progressive" width="1280">
+				<BaseURL>video/23.98p/r0/vid01.mp4</BaseURL>
+				<SegmentBase indexRange="1796-20859" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1795"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet contentType="video" frameRate="30">
+			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416">
+				<BaseURL>video/23.98p/r0/vid02.mp4</BaseURL>
+				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1791"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet contentType="video">
+			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25">
+				<BaseURL>video/23.98p/r0/vid03.mp4</BaseURL>
+				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1791"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet contentType="video">
+			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25000/1000">
+				<BaseURL>video/23.98p/r0/vid04.mp4</BaseURL>
+				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1791"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet contentType="video" frameRate="30">
+			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25">
+				<BaseURL>video/23.98p/r0/vid05.mp4</BaseURL>
+				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1791"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet contentType="video" frameRate="24000/1001">
+			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="30">
+				<BaseURL>video/23.98p/r0/vid05.mp4</BaseURL>
+				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1791"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet contentType="video" frameRate="24000/1001">
+			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25000/1000">
+				<BaseURL>video/23.98p/r0/vid05.mp4</BaseURL>
+				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
+					<Initialization range="0-1791"/>
+				</SegmentBase>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>


### PR DESCRIPTION
Below MPD uses frameRate="24000/1001" in AdaptationSet.
Currently IA only supports framerate/framescale on Reprensentations.
This adds support for it on AdaptationSet as well

[proxy.mpd.txt](https://github.com/peak3d/inputstream.adaptive/files/5705549/proxy.mpd.txt)

Without this, the above MPD I suspect will get its framerate set to 24000 / 1 = 24000fps instead of correct 24000/1001 = 23.976fps