### PR TITLE
[Leia] License Renewal for Youtube movies

### DIFF
--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
@@ -71,11 +71,13 @@ void timerfunc(std::shared_ptr<CdmAdapter> adp, uint64_t delay, void* context)
 {
   timer_thread_running = true;
   uint64_t waited = 0;
-  while (!exit_thread_flag && delay > waited) {
+  while (!exit_thread_flag && delay > waited) 
+  {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     waited += 100;
   }
-  if (!exit_thread_flag) {
+  if (!exit_thread_flag) 
+  {
     adp->TimerExpired(context);
   }
   timer_thread_running = false;
@@ -141,7 +143,8 @@ CdmAdapter::CdmAdapter(
 CdmAdapter::~CdmAdapter()
 {
   exit_thread_flag = true;
-  while (timer_thread_running) {
+  while (timer_thread_running) 
+  {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   if (cdm9_)
@@ -326,7 +329,8 @@ void CdmAdapter::CloseSession(uint32_t promise_id,
   uint32_t session_id_size)
 {
   exit_thread_flag = true;
-  while (timer_thread_running) {
+  while (timer_thread_running) 
+  {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   if (cdm9_)

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -1200,7 +1200,8 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
   CdmDecryptedBlock cdm_out;
   cdm_out.SetDecryptedBuffer(&buf);
 
-  //LICENSERENEWAL: CheckLicenseRenewal();
+  //LICENSERENEWAL: 
+  CheckLicenseRenewal();
   cdm::Status ret = drm_.GetCdmAdapter()->Decrypt(cdm_in, &cdm_out);
 
   if (ret == cdm::Status::kSuccess && useSingleDecrypt)
@@ -1296,7 +1297,8 @@ SSD_DECODE_RETVAL WV_CencSingleSampleDecrypter::DecodeVideo(void* hostInstance, 
       drained_ = false;
 
     //DecryptAndDecode calls Alloc wich cals kodi VideoCodec. Set instance handle.
-    //LICENSERENEWAL: CheckLicenseRenewal();
+    //LICENSERENEWAL:
+    CheckLicenseRenewal();
     media::CdmVideoFrame frame;
     cdm::Status ret = drm_.DecryptAndDecodeFrame(hostInstance, cdm_in, &frame);
 


### PR DESCRIPTION
At least purchased movies in Youtube addon stopped working. Always after 5 minutes we can see in the logs that there is no decryption key. Surprisingly I was only able to get this license behavior only on Windows and Linux ARM. On Linux x64 the license renewal was not required.
See the corresponding bug in YT addon: https://github.com/anxdpanic/plugin.video.youtube/issues/35 

I figured out with EME logger of Chrome that the CDM is sending periodically a session message to renew the license.
IAS is not doing that at the moment which results in the behavior that playback always stops after 5 minutes. I found in the code the commented-out parts for the license renewal and activated them. The additional adjustments were required to ensure that the thread is stopped correctly. Otherwise Kodi crashes when the playback is finished or is stopped.

We can argue about the sleep duration, but I could not observe a high CPU increase or high delay when playback stopped with the 100ms.

Corresponding Matrix PR: https://github.com/peak3d/inputstream.adaptive/pull/589