### PR TITLE
Try retry the download when CURLOpen fail on stream download

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -89,7 +89,7 @@ void AdaptiveStream::worker()
     if (type_ == AdaptiveTree::SUBTITLE)
       retryCount = 1;
 
-    while (!ret && !stopped_ && retryCount-- && tree_.has_timeshift_buffer_)
+    while (!ret && !stopped_ && retryCount--)
     {
       std::this_thread::sleep_for(std::chrono::seconds(1));
       Log(LOGLEVEL_DEBUG, "AdaptiveStream: trying to reload segment ...");


### PR DESCRIPTION
I have noticed that on days with heavy server traffic (on december/jennuary for christmas days/new year's days) the stream download sometime failed causing unexpected behaviour to Kodi like my issue #583

the problem is that when CURLOpen fails the download will be interrupted
so let's make at least 2 attempts before breaking the playback
