### PR TITLE
Change decrypter search path for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,11 +86,7 @@ else()
   set(ADP_ADDITIONAL_BINARY $<TARGET_FILE:ssd_wv>)
 endif()
 
-if(CORE_SYSTEM_NAME STREQUAL android)
-  set(DECRYPTERPATH "special://xbmcbinaddons")
-else()
-  set(DECRYPTERPATH "special://home/cdm")
-endif()
+set(DECRYPTERPATH "special://home/cdm")
 
 list(APPEND DEPLIBS bento4)
 list(APPEND DEPLIBS mpegts)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix", deploy: ['osx-x86_64', 'windows-i686', 'windows-x86_64', 'ubuntu-ppa'])
+buildPlugin(version: "Matrix")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# inputstream.adaptive (2.6.6)
+# inputstream.adaptive (2.6.12)
 
 This is an adaptive file addon for kodi's new InputStream Interface.
 

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.11"
+  version="2.6.12"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -19,6 +19,9 @@
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
     <news>
+v2.6.12 (2021-04-09)
+- Remove Android specific decrypter search paths
+
 v2.6.11 (2021-04-08)
 - Fix ampersand in changelog causing issues from v2.6.9 and v2.6.10
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2137,14 +2137,8 @@ void Session::GetSupportedDecrypterURN(std::string& key_system)
   kodihost->SetLibraryPath(kodi::vfs::TranslateSpecialProtocol(specialpath).c_str());
 
   std::vector<std::string> searchPaths(2);
-#ifdef ANDROID
-  searchPaths[0] = getenv("KODI_ANDROID_LIBS")
-                       ? getenv("KODI_ANDROID_LIBS")
-                       : kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/");
-#else
   searchPaths[0] =
       kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/");
-#endif
   searchPaths[1] = kodi::GetAddonInfo("path");
 
   std::vector<kodi::vfs::CDirEntry> items;


### PR DESCRIPTION
@ksooo 

As requested this one-liner will direct inputstream.adaptive to search in the user addons folder instead of packaged folder for libssd_wv.so

Now installations and updates from the official repo will function correctly, myself and @matthuisman have verified using a parallel installation with a different add-on id.

One potential issue that I haven't investigated and don't have immediate time for is how things work when upgrading from an Android installation of Kodi packaged with IA to a package without - will the packaged IA libraries and other add-on files remain and cause conflict? Or are they removed? If this is an unfamiliar scenario I'll find time in the next few days to setup and test it.

