### PR TITLE
[Dash] Fix missing audio languages

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -54,13 +54,6 @@ enum
 
 static const char* CONTENTPROTECTION_TAG = "ContentProtection";
 
-static const char* ltranslate(const char* in)
-{
-  if (strlen(in) == 2 || strlen(in) == 3 || (strlen(in) > 3 && in[2] == '-'))
-    return in;
-  return "unk";
-}
-
 DASHTree::DASHTree()
 {
 }
@@ -882,7 +875,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           else if (strcmp((const char*)*attr, "group") == 0)
             dash->current_adaptationset_->group_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "lang") == 0)
-            dash->current_adaptationset_->language_ = ltranslate((const char*)*(attr + 1));
+            dash->current_adaptationset_->language_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "mimeType") == 0)
             dash->current_adaptationset_->mimeType_ = (const char*)*(attr + 1);
           else if (strcmp((const char*)*attr, "name") == 0)


### PR DESCRIPTION
thanks @glennguy for helping me find the correct place for the fix

### **Problem**
With the below MPD sample - Kodi will only have the Spanish audio stream.
The English stream is missing. Also, the Spanish stream will show as "Unknown"
```
<AdaptationSet lang="English" mimeType="audio/mp4" segmentAlignment="true">
    <Representation audioSamplingRate="48000" bandwidth="160000" codecs="mp4a.40.2" id="925b5f3d-4b89-4057-b0df-46242fcc37c5">
        <SegmentTemplate duration="192000" initialization="audio/full/en/init.mp4" media="audio/full/en/seg_$Number$.m4s" startNumber="0" timescale="48000"/>
        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    </Representation>
</AdaptationSet>
<AdaptationSet lang="Spanish" mimeType="audio/mp4" segmentAlignment="true">
    <Representation audioSamplingRate="48000" bandwidth="160000" codecs="mp4a.40.2" id="d4560312-19d3-40b0-85e6-c7d71c2ce401">
        <SegmentTemplate duration="192000" initialization="audio/full/es/base/init.mp4" media="audio/full/es/base/seg_$Number$.m4s" startNumber="0" timescale="48000"/>
        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
    </Representation>
</AdaptationSet>
```
![screenshot00000](https://user-images.githubusercontent.com/6225961/107453285-8e8d3600-6baf-11eb-9e39-810a897959e4.png)

### **Cause**
This is due to them not conforming to the standard IA wants (2 or 3 letters) in the below parsing function
https://github.com/xbmc/inputstream.adaptive/blob/Matrix/src/parser/DASHTree.cpp#L57
This function sets them both as "unk"

Since they are both now "unk", IA thinks they are the same language and merges them below:
https://github.com/xbmc/inputstream.adaptive/blob/Matrix/src/common/AdaptiveTree.cpp#L430
This results in only the last language actually getting passed to Kodi.

### **Fix**
By removing the parsing function and just sending Kodi the lang as is, we have two positive results

1) IA no longer merges the two audio streams so we get both streams in Kodi
2) Bonus: Kodi actually supports "English" and "Spanish" and correctly identifies the streams!

![screenshot00002](https://user-images.githubusercontent.com/6225961/107453570-183d0380-6bb0-11eb-8136-d27d9c2c60af.png)

### **Notes**
1) HLS doesn't appear to try to parse it's language attribute, so this brings both dash and hls more in-line with each other as well

2) If the lang is something Kodi doesn't understand. eg "Español" - it still just shows as "Unknown".
![screenshot00001](https://user-images.githubusercontent.com/6225961/107454381-c6957880-6bb1-11eb-855a-7a5c318938c0.png)
