### PR TITLE
Version bump 2.6.7

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.6"
+  version="2.6.7"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -18,7 +18,11 @@
     <description lang="en_GB">InputStream client for adaptive streams</description>
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
-    <news>v2.6.6 (2020-11-21)
+    <news>v2.6.7 (2021-02-10)
+- Fix build for ios/tvos
+- Use the full BaseUrl if it's a real url inside an AdaptationSet
+
+v2.6.6 (2020-11-21)
 - Matrix VideoCodec API change to v2.0.2 - Fix crypto session id handling
 
 v2.6.5 (2020-11-09)


### PR DESCRIPTION
v2.6.7 (2021-02-10)
- Fix build for ios/tvos
- Use the full BaseUrl if it's a real url inside an AdaptationSet