### PR TITLE
Fix Base Domain (fixes uri=/path/)

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -331,7 +331,7 @@ namespace adaptive
     }
     base_url_.resize(paramPos + 1);
 
-    paramPos = base_url_.find("://", 0, 8);
+    paramPos = base_url_.find("://");
     if (paramPos != std::string::npos)
     {
       base_domain_ = base_url_;


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/591

without this commit, base_domain_ is always empty 
causing any URI=/path/ to not have the base domain prepended.

Current code: **paramPos = base_url_.find("://", 0, 8);**
http://www.cplusplus.com/reference/string/string/find/
size_t find (const char* s, size_t pos, size_t n) const;

str = sequence to find
pos = start position to start looking
n = length of sequence of characters to match

the length of our sequence is only 3 - "://"
So, it's failing when trying to get 8 characters of that sequence.
The if statement below never gets executed and we end up with no base_domain_ 

without pos, start of string is used (what we want)
without n, all the sequence is used (what we want)

ie:
paramPos = base_url_.find("://");
is the same as
paramPos = base_url_.find("://", 0, 3);

This could also fix other issues where urls are relying on base domain

UPDATE:
It also fixes DASH manifests using media or init urls starting with "/" as well: https://github.com/xbmc/inputstream.adaptive/issues/608