### PR TITLE
[DASH] Support ec-3 channel count (urn:mpeg:mpegB:cicp:ChannelConfiguration)

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -79,7 +79,8 @@ static uint8_t GetChannels(const char** attr)
   }
   if (schemeIdUri && value)
   {
-    if (strcmp(schemeIdUri, "urn:mpeg:dash:23003:3:audio_channel_configuration:2011") == 0)
+    if (strcmp(schemeIdUri, "urn:mpeg:dash:23003:3:audio_channel_configuration:2011") == 0 ||
+             strcmp(schemeIdUri, "urn:mpeg:mpegB:cicp:ChannelConfiguration") == 0)
       return atoi(value);
     else if (strcmp(schemeIdUri, "urn:dolby:dash:audio_channel_configuration:2011") == 0 ||
              strcmp(schemeIdUri, "tag:dolby.com,2014:dash:audio_channel_configuration:2011") == 0)


### PR DESCRIPTION
**urn:mpeg:mpegB:cicp:ChannelConfiguration** is used for Dolby AC-4 channel configurations and is an integer between 1 and 20.
https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Documentation/Specs/AC4_DASH/help_files/topics/c_mpd_auchlconfig_ac4.html

example MPD
```
<Representation audioSamplingRate="48000" bandwidth="770322" codecs="ec-3" id="14" mimeType="audio/mp4">
	<BaseURL>http://cmaf.lv3.us.hbomaxcdn.com/videos/GYDAnZgLI55bDwwEAAAAT/5/e64dbd/a/a4_cenc.mp4</BaseURL>
	<AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration" value="6"/>
	<SupplementalProperty schemeIdUri="tag:dolby.com,2018:dash:EC3_ExtensionType:2018" value="JOC"/>
	<SupplementalProperty schemeIdUri="tag:dolby.com,2018:dash:EC3_ExtensionComplexityIndex:2018" value="16"/>
	<SegmentBase indexRange="1338-44965" timescale="48000" xmlns="urn:mpeg:dash:schema:mpd:2011">
		<Initialization range="0-1337" xmlns="urn:mpeg:dash:schema:mpd:2011"/>
	</SegmentBase>
</Representation>
```

also related to this is this PR (Seperate ac3 (DD) and eac3 (DD+)) https://github.com/xbmc/inputstream.adaptive/pull/563