### PR TITLE
[HLS] Clear the effective URL if an absolute URI is specified.

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -410,12 +410,6 @@ namespace adaptive
     {
       if (url.front() == '/')
         return effective_domain_.empty() ? base_domain_ + url : effective_domain_ + url;
-      else if (!effective_url_.empty() && url.compare(0, base_url_.size(), base_url_) == 0)
-      {
-        std::string newUrl(url);
-        newUrl.replace(0, base_url_.size(), effective_url_);
-        return newUrl;
-      }
     }
     return url;
   }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -317,7 +317,7 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
     else if (!line.empty() && line.compare(0, 1, "#") != 0 && current_representation_)
     {
       if (line[0] != '/' && line.find("://", 0) == std::string::npos)
-        current_representation_->source_url_ = base_url_ + line;
+        current_representation_->source_url_ = effective_url_ + line;
       else
         current_representation_->source_url_ = line;
 


### PR DESCRIPTION
This fixes the HLS master playlist redirect edge case identified as issue #617.

Basically, if an absolute URI is specified, then drop the effective URL.