### PR TITLE
Refactor / Simplify effective (redirect) logic

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|media_renewal_url|media_renewal_time|max_bandwidth|play_timeshift_buffer"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">InputStream client for adaptive streams</summary>

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -39,7 +39,6 @@ AdaptiveStream::AdaptiveStream(AdaptiveTree& tree, AdaptiveTree::StreamType type
     currentPTSOffset_(0),
     absolutePTSOffset_(0),
     lastUpdated_(std::chrono::system_clock::now()),
-    lastMediaRenewal_(std::chrono::system_clock::now()),
     m_fixateInitialization(false),
     m_segmentFileOffset(0),
     play_timeshift_buffer_(false)
@@ -115,21 +114,6 @@ int AdaptiveStream::SecondsSinceUpdate() const
   return static_cast<int>(
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - tPoint)
           .count());
-}
-
-uint32_t AdaptiveStream::SecondsSinceMediaRenewal() const
-{
-  const std::chrono::time_point<std::chrono::system_clock>& tPoint(
-      lastMediaRenewal_ > tree_.GetLastMediaRenewal() ? lastMediaRenewal_
-                                                      : tree_.GetLastMediaRenewal());
-  return static_cast<int>(
-      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - tPoint)
-          .count());
-}
-
-void AdaptiveStream::UpdateSecondsSinceMediaRenewal()
-{
-  lastMediaRenewal_ = std::chrono::system_clock::now();
 }
 
 bool AdaptiveStream::write_data(const void* buffer, size_t buffer_size)

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -89,10 +89,6 @@ namespace adaptive
     virtual bool parseIndexRange() { return false; };
     bool write_data(const void *buffer, size_t buffer_size);
     bool prepareDownload(const AdaptiveTree::Segment *seg);
-    const std::string& getMediaRenewalUrl() const { return tree_.media_renewal_url_; };
-    const uint32_t& getMediaRenewalTime() const { return tree_.media_renewal_time_; };
-    uint32_t SecondsSinceMediaRenewal() const;
-    void UpdateSecondsSinceMediaRenewal();
     adaptive::AdaptiveTree& GetTree() { return tree_; };
 
   private:
@@ -144,7 +140,6 @@ namespace adaptive
     uint64_t absolute_position_;
     uint64_t currentPTSOffset_, absolutePTSOffset_;
     std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
-    std::chrono::time_point<std::chrono::system_clock> lastMediaRenewal_;
 
     uint16_t width_, height_;
     uint32_t bandwidth_;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -412,13 +412,9 @@ public:
   }*current_period_, *next_period_;
 
   std::vector<Period*> periods_;
-  std::string manifest_url_, base_url_, effective_url_, base_domain_, effective_domain_,
-      update_parameter_;
+  std::string manifest_url_, base_url_, base_domain_, update_parameter_;
   std::string::size_type update_parameter_pos_;
   std::string etag_, last_modified_;
-  std::string media_renewal_url_;
-  uint32_t media_renewal_time_;
-  std::string manifest_parameter_;
 
   /* XML Parsing*/
   XML_Parser parser_;
@@ -490,7 +486,6 @@ public:
   bool HasUpdateThread() const { return updateThread_ != 0 && has_timeshift_buffer_ && updateInterval_ && !update_parameter_.empty(); };
   void RefreshUpdateThread();
   const std::chrono::time_point<std::chrono::system_clock> GetLastUpdated() const { return lastUpdated_; };
-  const std::chrono::time_point<std::chrono::system_clock> GetLastMediaRenewal() const { return lastMediaRenewal_; };
 
 protected:
   virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr, bool scanEffectiveURL = true);
@@ -507,7 +502,6 @@ protected:
   std::condition_variable updateVar_;
   std::thread *updateThread_;
   std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
-  std::chrono::time_point<std::chrono::system_clock> lastMediaRenewal_;
 
 private:
   void SegmentUpdateWorker();

--- a/src/main.h
+++ b/src/main.h
@@ -87,8 +87,6 @@ public:
           const std::string& strLicKey,
           const std::string& strLicData,
           const std::string& strCert,
-          const std::string& strMediaRenewalUrl,
-          const uint32_t intMediaRenewalTime,
           const std::map<std::string, std::string>& manifestHeaders,
           const std::map<std::string, std::string>& mediaHeaders,
           const std::string& profile_path,

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1631,8 +1631,6 @@ void DASHTree::RefreshLiveSegments()
     updateTree.supportedKeySystem_ = supportedKeySystem_;
     //Location element should be used on updates
     updateTree.location_ = location_;
-    updateTree.effective_url_ = effective_url_;
-    updateTree.effective_domain_ = effective_domain_;
 
     if (!~update_parameter_pos_)
     {

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -61,13 +61,13 @@ public:
                                AdaptationSet* adp,
                                Representation* rep,
                                StreamType type) override;
-  virtual bool processManifest(std::stringstream& stream, const std::string& url);
+  virtual bool processManifest(std::stringstream& stream);
 
 protected:
   virtual void RefreshLiveSegments() override;
 
 private:
-  int processEncryption(std::string baseUrl, std::map<std::string, std::string>& map);
+  int processEncryption(std::map<std::string, std::string>& map);
   std::string m_audioCodec;
 
   struct EXTGROUP

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -91,13 +91,12 @@ TEST_F(DASHTreeTest, CalculateBaseDomain)
   EXPECT_EQ(tree->base_domain_, "https://foo.bar");
 }
 
-TEST_F(DASHTreeTest, CalculateEffectiveUrlFromRedirect)
+TEST_F(DASHTreeTest, CalculateBaseUrlFromRedirect)
 {
-  // like base_url_, effective_url_ should be path, not including filename
   testHelper::effectiveUrl = "https://foo.bar/mpd/stream.mpd";
   OpenTestFile("mpd/segtpl.mpd", "https://bit.ly/abcd", "");
-
-  EXPECT_EQ(tree->effective_url_, "https://foo.bar/mpd/");
+  EXPECT_EQ(tree->base_url_, "https://foo.bar/mpd/");
+  EXPECT_EQ(tree->manifest_url_, "https://foo.bar/mpd/stream.mpd");
 }
 
 TEST_F(DASHTreeTest, CalculateBaseURLFromBaseURLTag)

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -43,7 +43,6 @@ protected:
 };
 
 
-
 TEST_F(HLSTreeTest, CalculateSourceUrl)
 {
   OpenTestFileMaster("hls/1a2v_master.m3u8", "https://foo.bar/master.m3u8?param=foo", "");
@@ -53,34 +52,29 @@ TEST_F(HLSTreeTest, CalculateSourceUrl)
 
   std::string rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  EXPECT_EQ(tree->base_url_, "https://foo.bar/");
   EXPECT_EQ(rep_url, "https://foo.bar/stream_2/out.m3u8");
 }
-
 
 TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterRelativeUri)
 {
   testHelper::effectiveUrl = "https://foo.bar/master.m3u8";
 
   OpenTestFileMaster("hls/1a2v_master.m3u8", "https://baz.qux/master.m3u8", "");
-  
+
   std::string rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
 
   EXPECT_EQ(rep_url, "https://foo.bar/stream_2/out.m3u8");
-  
+
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/fmp4_noenc_v_stream_2.m3u8", "https://foo.bar/stream_2/out.m3u8", tree->current_period_,
       tree->current_adaptationset_, tree->current_representation_);
-  
+
   rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  // base_url_ should never change after opening stream regardless of redirects
-  EXPECT_EQ(tree->base_url_, "https://baz.qux/");
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
   EXPECT_EQ(rep_url, "https://foo.bar/stream_2/out.m3u8");
 }
-
 
 TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedVariantAbsoluteUri)
 {
@@ -88,22 +82,21 @@ TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedVariantAbsoluteUri)
 
   std::string rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  
+
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 
   testHelper::effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
-  
+
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/fmp4_noenc_v_stream_2.m3u8", "https://bit.ly/abcd",
       tree->current_period_, tree->current_adaptationset_, tree->current_representation_);
 
   rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  EXPECT_EQ(tree->base_url_, "https://baz.qux/");
+
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 }
-
 
 TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAbsoluteUri)
 {
@@ -113,7 +106,7 @@ TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAb
 
   std::string rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  
+
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 
   testHelper::effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
@@ -124,23 +117,20 @@ TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAb
 
   rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  EXPECT_EQ(tree->base_url_, "https://link.to/");
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 }
 
-
 TEST_F(HLSTreeTest,
        CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAbsoluteUriSameDomains)
 {
-  GTEST_SKIP();
   testHelper::effectiveUrl = "https://baz.qux/master.m3u8";
 
   OpenTestFileMaster("hls/redirect_absolute_1v_master.m3u8", "https://bit.ly/1234", "");
 
   std::string rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  
+
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 
   testHelper::effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
@@ -151,12 +141,9 @@ TEST_F(HLSTreeTest,
 
   rep_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
-  EXPECT_EQ(tree->base_url_, "https://bit.ly/");
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 }
-
-
 
 TEST_F(HLSTreeTest, OpenVariant)
 {
@@ -170,12 +157,11 @@ TEST_F(HLSTreeTest, OpenVariant)
   EXPECT_EQ(tree->base_url_, "https://foo.bar/");
 }
 
-
 TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
 {
   OpenTestFileMaster("hls/1v_master.m3u8",
                      "https://foo.bar/hls/video/stream_name/master.m3u8", "");
-  
+
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/ts_aes_keyuriwithslash_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->current_period_,
@@ -183,7 +169,6 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
 
   std::string pssh_url = tree->BuildDownloadUrl(tree->current_period_->psshSets_[1].pssh_);
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(tree->base_url_, "https://foo.bar/hls/video/stream_name/");
   EXPECT_EQ(pssh_url,
             "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
@@ -202,34 +187,30 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
 
   std::string pssh_url = tree->BuildDownloadUrl(tree->current_period_->psshSets_[1].pssh_);
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(tree->base_url_, "https://baz.qux/hls/video/stream_name/");
   EXPECT_EQ(pssh_url,
             "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
-
 
 TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
 {
   OpenTestFileMaster("hls/1v_master.m3u8",
                      "https://foo.bar/hls/video/stream_name/master.m3u8", "");
-  
+
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/ts_aes_keyuriabsolute_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->current_period_,
       tree->current_adaptationset_, tree->current_representation_);
 
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(tree->base_url_, "https://foo.bar/hls/video/stream_name/");
   EXPECT_EQ(tree->current_period_->psshSets_[1].pssh_,
             "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
-
 
 TEST_F(HLSTreeTest, ParseKeyUriRelative)
 {
   OpenTestFileMaster("hls/1v_master.m3u8", "https://foo.bar/hls/video/stream_name/master.m3u8",
                      "");
-  
+
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/ts_aes_keyurirelative_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->current_period_,
@@ -237,11 +218,9 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
 
   std::string pssh_url = tree->BuildDownloadUrl(tree->current_period_->psshSets_[1].pssh_);
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(tree->base_url_, "https://foo.bar/hls/video/stream_name/");
   EXPECT_EQ(pssh_url,
             "https://foo.bar/hls/video/stream_name/../../key/key.php?stream=stream_name");
 }
-
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
 {
@@ -255,14 +234,13 @@ TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
           ->source_url_); // https://baz.qux/hls/video/stream_name/ts_aes_uriwithslash_chunklist.m3u8
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/ts_aes_keyurirelative_stream_0.m3u8",
-      var_download_url, 
+      var_download_url,
       tree->current_period_,
       tree->current_adaptationset_,
       tree->current_representation_);
 
   std::string pssh_url = tree->BuildDownloadUrl(tree->current_period_->psshSets_[1].pssh_);
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(tree->base_url_, "https://baz.qux/hls/video/stream_name/");
   EXPECT_EQ(pssh_url,
             "https://foo.bar/hls/video/stream_name/../../key/key.php?stream=stream_name");
 }


### PR DESCRIPTION
This fixes: https://github.com/xbmc/inputstream.adaptive/issues/617

Changes

- removed manifest_parameter_ as not used
- dont track original url and effective (redircted) url. Simply update all the url variables to the effective url
- move base_url appending into BuildDownloadUrl. This removes a lot of duplicate code from HLSTree
- no more newUrl.replace(0, base_url_.size(), effective_url_);  replacing parts of urls with other urls "yuckiness"
- HLS: when playing a substream playlist directly, use manifest_url_ as this will be the effective url 
This stops doing the redirect again when IA requests the suburl
- HLS: have substream update effective urls so no longer needs to track its own base_url
- HLS: store the full urls for substreams when parsing the master playlist to allow switching substreams. 
Without this, due to the above - we no longer have access to the master url to calculate the substream url
- **Remove media_renewal_url & media_renewal_time** as no longer work with above due to relying on replacing domains (yuck)
Peak himself said this was a workaround https://github.com/xbmc/inputstream.adaptive/issues/226#issuecomment-494290363. Correct approach would be manifest_update_param="full" or a Python proxy if that won't work.

TEST BUILDS HERE:
**https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-620/13/artifacts**

Looking for anything that plays in current 19 that then doesn't play with this build
(Dont expect it to fix any currently broken streams)

Apart from media_renewal_url  - No actual behaviour should have changed