### PR TITLE
[Dash] Remove reliance on namespace for pssh and default_kid

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -529,3 +529,13 @@ void parseheader(std::map<std::string, std::string>& headerMap, const std::strin
       headerMap[trimcp(b->substr(0, pos))] = url_decode(trimcp(b->substr(pos+1)));
   }
 }
+
+int endswith(const char* in, const char* suffix)
+{
+  int l1 = strlen(suffix);
+  int l2 = strlen(in);
+  if (l1 > l2)
+    return 0;
+
+  return strcmp(suffix, in + (l2 - l1)) == 0;
+}

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -47,6 +47,7 @@ void prkid2wvkid(const char *input, char *output);
 char* KIDtoUUID(const uint8_t* kid, char* dst);
 bool create_ism_license(std::string key, std::string license_data, std::vector<uint8_t>& init_data);
 void parseheader(std::map<std::string, std::string>& headerMap, const std::string& headerString);
+int endswith(const char* in, const char* suffix);
 
 extern bool preReleaseFeatures;
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -204,7 +204,7 @@ bool ParseContentProtection(const char** attr, DASHTree* dash)
       else
         urnFound = stricmp(dash->supportedKeySystem_.c_str(), (const char*)*(attr + 1)) == 0;
     }
-    else if (strcmp((const char*)*attr, "cenc:default_KID") == 0)
+    else if (endswith((const char*)*attr, "default_KID"))
       defaultKID = (const char*)*(attr + 1);
     attr += 2;
   }
@@ -399,7 +399,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           }
           else if (dash->currentNode_ & MPDNODE_CONTENTPROTECTION)
           {
-            if (strcmp(el, "cenc:pssh") == 0)
+            if (endswith(el, "pssh"))
               dash->currentNode_ |= MPDNODE_PSSH;
             else if (strcmp(el, "widevine:license") == 0)
             {
@@ -568,7 +568,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         }
         else if (dash->currentNode_ & MPDNODE_CONTENTPROTECTION)
         {
-          if (strcmp(el, "cenc:pssh") == 0)
+          if (endswith(el, "pssh"))
             dash->currentNode_ |= MPDNODE_PSSH;
           else if (strcmp(el, "widevine:license") == 0)
           {
@@ -1146,7 +1146,7 @@ static void XMLCALL end(void* data, const char* el)
           {
             if (dash->currentNode_ & MPDNODE_PSSH)
             {
-              if (strcmp(el, "cenc:pssh") == 0)
+              if (endswith(el, "pssh"))
               {
                 dash->current_pssh_ = dash->strXMLText_;
                 dash->currentNode_ &= ~MPDNODE_PSSH;
@@ -1340,7 +1340,7 @@ static void XMLCALL end(void* data, const char* el)
         {
           if (dash->currentNode_ & MPDNODE_PSSH)
           {
-            if (strcmp(el, "cenc:pssh") == 0)
+            if (endswith(el, "pssh"))
             {
               dash->current_pssh_ = dash->strXMLText_;
               dash->currentNode_ &= ~MPDNODE_PSSH;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -325,3 +325,14 @@ TEST_F(DASHTreeTest, updateParameterVODSegmentTemplate)
   OpenTestFile("mpd/segtpl_baseurl_noslashs.mpd", "", "");
   EXPECT_EQ(tree->update_parameter_, "");
 }
+
+TEST_F(DASHTreeTest, CalculatePsshDefaultKid)
+{
+  OpenTestFile("mpd/pssh_default_kid.mpd", "", "");
+
+  EXPECT_EQ(tree->periods_[0]->psshSets_[1].pssh_, "ABCDEFGH");
+  EXPECT_EQ(tree->periods_[0]->psshSets_[1].defaultKID_.length(), 16);
+
+  EXPECT_EQ(tree->periods_[0]->psshSets_[2].pssh_, "HGFEDCBA");
+  EXPECT_EQ(tree->periods_[0]->psshSets_[2].defaultKID_.length(), 16);
+}

--- a/src/test/manifests/mpd/pssh_default_kid.mpd
+++ b/src/test/manifests/mpd/pssh_default_kid.mpd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_xmlns="xmlns" _xmlns:cenc="urn:mpeg:cenc:2013" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT14528.0556640625S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0">
+    <AdaptationSet id="0" contentType="video">
+      <Role value="main" schemeIdUri="urn:mpeg:dash:role:2011"/>
+      <Representation id="0" bandwidth="664362" width="416" height="234" codecs="avc1.4d400d" mimeType="video/mp4" sar="1:1">
+        <BaseURL>v/v30_cenc.mp4</BaseURL>
+        <SegmentBase xmlns="urn:mpeg:dash:schema:mpd:2011" indexRange="1478-45093" timescale="24000">
+          <Initialization xmlns="urn:mpeg:dash:schema:mpd:2011" range="0-1477"/>
+        </SegmentBase>
+      </Representation>
+      <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_="urn:mpeg:cenc:2013" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" _:default_KID="0101f49e-117c-ec8e-d606-27d7cb46ae38"/>
+      <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <pssh xmlns="urn:mpeg:cenc:2013">ABCDEFGH</pssh>
+      </ContentProtection>
+    </AdaptationSet>
+    <AdaptationSet id="1" contentType="video">
+      <Role value="main" schemeIdUri="urn:mpeg:dash:role:2011"/>
+      <Representation id="0" bandwidth="664362" width="416" height="234" codecs="avc1.4d400d" mimeType="video/mp4" sar="1:1">
+        <BaseURL>v/v31_cenc.mp4</BaseURL>
+        <SegmentBase xmlns="urn:mpeg:dash:schema:mpd:2011" indexRange="1478-45093" timescale="24000">
+          <Initialization xmlns="urn:mpeg:dash:schema:mpd:2011" range="0-1477"/>
+        </SegmentBase>
+      </Representation>
+      <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_="urn:mpeg:cenc:2013" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="01004b6f-0835-b807-9098-c070dc30a6c7"/>
+      <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cenc:pssh xmlns="urn:mpeg:cenc:2013">HGFEDCBA</cenc:pssh>
+      </ContentProtection>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
fixes https://github.com/xbmc/inputstream.adaptive/issues/553
fixes https://github.com/xbmc/inputstream.adaptive/issues/554

- add new endswith helper function
- use endswith function to check element / attribute name ends with default_KID / pssh

This allows for mpd elements like the below (found in HBO Max)
as well as maintaining compatibility with the most common <cenc:pssh and cenc:default_KID

`<pssh xmlns="urn:mpeg:cenc:2013" _xmlns:cenc="urn:mpeg:cenc:2013" _xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">AAAAinBzc2gBAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAMBABjPrw1FrZKp3Uaklub1AQFA6rnmTx2Vc6TOTwKt2wEC6NEQrkqOnj8BE9GY8RcAAAA2EhABABjPrw1FrZKp3Uaklub1EhABAUDqueZPHZVzpM5PAq3bEhABAujREK5Kjp4/ARPRmPEX</pssh>`

`<ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_="urn:mpeg:cenc:2013" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" _:default_KID="010018CF-AF0D-45AD-92A9-DD46A496E6F5" _xmlns:cenc="urn:mpeg:cenc:2013"/>`