### PR TITLE
bump v2.6.8

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.7"
+  version="2.6.8"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -18,7 +18,12 @@
     <description lang="en_GB">InputStream client for adaptive streams</description>
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
-    <news>v2.6.7 (2021-02-10)
+    <news>
+v2.6.8 (2021-03-26)
+- [Dash] Append / to baseurl if required
+- Fix Base Domain (fixes uri=/path/)
+
+v2.6.7 (2021-02-10)
 - Fix build for ios/tvos
 - Use the full BaseUrl if it's a real url inside an AdaptationSet
 


### PR DESCRIPTION
Release bump 

v2.6.8 (2021-03-26)
- [Dash] Append / to baseurl if required
- Fix Base Domain (fixes uri=/path/)