### PR TITLE
Don't overwrite manifest headers with stream_headers & default stream_headers to manifest headers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3359,7 +3359,6 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
                 prop.second.c_str());
       parseheader(manh, prop.second);
       medh = manh;
-      mpd_url = mpd_url.substr(0, mpd_url.find("|"));
     }
     else if (prop.first == "inputstream.adaptive.original_audio_language")
     {
@@ -3400,6 +3399,9 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
     parseheader(manh, mpd_url.substr(posHeader + 1));
     mpd_url = mpd_url.substr(0, posHeader);
   }
+
+  if (medh.empty())
+    medh = manh;
 
   kodihost->SetProfilePath(props.GetProfileFolder());
 


### PR DESCRIPTION
Fixes https://github.com/xbmc/inputstream.adaptive/issues/624

**1**
Currently if you provide stream_headers and also | headers on manifest url, the stream_headers will overwrite those manifest headers.

This is because it removes them from the manifest url before they get processed further down.
Lets stop that behaviour.

If you provide | headers on the manifest url, you expect them to be used regardless of stream_headers

**2**
It makes sense to set the stream_headers to the manifest headers if they aren't provided.
They are part of the manifest (children), so many assume this would be the behaviour (inherit parents headers)
(It would be nice to also set the default headers for license url, but they are processed much later on in the ssd decrypter class.)

**3**
This PR keeps the current behaviour of using stream_headers for manifest headers if they aren't provided
So is backwards compatible with anyone using just stream_headers.
(Not sure if this is wanted correct behaviour though)