### PR TITLE
[Dash] Correctly set timeshift_buffer (live)

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1004,7 +1004,6 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
   else if (strcmp(el, "MPD") == 0)
   {
     const char *mpt(0), *tsbd(0);
-    bool bStatic(false);
 
     dash->firstStartNumber_ = 0;
 
@@ -1017,11 +1016,11 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       if (strcmp((const char*)*attr, "mediaPresentationDuration") == 0)
       {
         mpt = (const char*)*(attr + 1);
-        bStatic = true;
       }
-      else if (strcmp((const char*)*attr, "type") == 0)
+      else if (strcmp((const char*)*attr, "type") == 0 &&
+               strcmp((const char*)*(attr + 1), "dynamic") == 0)
       {
-        bStatic = strcmp((const char*)*(attr + 1), "static") == 0;
+        dash->has_timeshift_buffer_ = true;
       }
       else if (strcmp((const char*)*attr, "timeShiftBufferDepth") == 0)
       {
@@ -1041,7 +1040,6 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
 
     if (!mpt)
       mpt = tsbd;
-    dash->has_timeshift_buffer_ = !bStatic;
 
     AddDuration(mpt, dash->overallSeconds_, 1);
     dash->has_overall_seconds_ = dash->overallSeconds_ > 0;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -13,14 +13,14 @@ protected:
   }
 
   void TearDown() override
-  { 
+  {
     effectiveUrl.clear();
     delete tree;
     tree = nullptr;
   }
 
   void OpenTestFile(std::string testfilename, std::string url, std::string manifestHeaders)
-  { 
+  {
     SetFileName(testFile, testfilename);
     if (!tree->open(url, manifestHeaders))
     {
@@ -68,7 +68,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithNoSlashs)
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
       tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
-  
+
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
 }
@@ -156,4 +156,16 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTimelineWithOldPub
   EXPECT_EQ(segments.size(), 31);
   EXPECT_EQ(segments[0]->range_end_, 603272);
   EXPECT_EQ(segments[30]->range_end_, 603302);
+}
+
+TEST_F(DASHTreeTest, CalculateLiveWithPresentationDuration)
+{
+  OpenTestFile("mpd/segtimeline_live_pd.mpd", "", "");
+  EXPECT_EQ(tree->has_timeshift_buffer_, true);
+}
+
+TEST_F(DASHTreeTest, CalculateStaticWithPresentationDuration)
+{
+  OpenTestFile("mpd/segtpl_slash_baseurl_slash.mpd", "", "");
+  EXPECT_EQ(tree->has_timeshift_buffer_, false);
 }

--- a/src/test/manifests/mpd/segtimeline_live_pd.mpd
+++ b/src/test/manifests/mpd/segtimeline_live_pd.mpd
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<MPD availabilityStartTime="1970-01-01T00:00:06Z" minBufferTime="PT6S" minimumUpdatePeriod="PT6S" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:hbbtv:dash:profile:isoff-live:2012" publishTime="2020-06-07T11:59:55Z" suggestedPresentationDelay="PT12S" timeShiftBufferDepth="PT1M18S" type="dynamic" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" mediaPresentationDuration="PT9000.000000S">
+	<Period id="0" start="PT1588628086S">
+		<AdaptationSet contentType="video" id="1" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4?id=8c1bbb709229e110fbb0d1e544266504" media="$RepresentationID$/segment_$Number$.m4s" presentationTimeOffset="1738747575" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400">
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="2020-06-07T11:59:55Z"/>
+</MPD>


### PR DESCRIPTION
Fixes: https://github.com/d21spike/plugin.video.sling/issues/22 (also needs PR: https://github.com/xbmc/inputstream.adaptive/pull/564)

With the below MPD, currently IA will set the stream to VOD when it is actually LIVE

```
<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:dvb="urn:dvb:dash:dash-extensions:2014-1" xmlns:move="http://www.movenetworks.com/dash/v1" xmlns:ms="urn:microsoft" xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" maxSegmentDuration="PT2.048000S" minBufferTime="PT2.048000S" publishTime="2020-12-07T20:30:00Z" type="dynamic" minimumUpdatePeriod="PT2.048000S" availabilityStartTime="2020-12-07T20:30:15Z" mediaPresentationDuration="PT9000.000000S" suggestedPresentationDelay="PT4.096000S">
```

This is because "mediaPresentationDuration" comes after "type".
mediaPresentationDuration sets bStatic to true

So, currently it goes
1) "type"="dynamic" which makes bStatic = false
2) "mediaPresentationDuration" which sets bStatic = true
3) dash->has_timeshift_buffer_ is set to NOT bStatic = false
4) IA think it's VOD

The order or attributes should be irrelevant.

With this PR, VOD is default and it's ever only setting LIVE to true when either dynamic or timeShiftBufferDepth found
It doesn't unset LIVE.