### PR TITLE
[Dash] Remove old testTime (used for old internal testing)

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1034,8 +1034,6 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         dash->available_time_ = getTime((const char*)*(attr + 1));
       else if (strcmp((const char*)*attr, "publishTime") == 0)
         dash->publish_time_ = getTime((const char*)*(attr + 1));
-      else if (strcmp((const char*)*attr, "testTime") == 0)
-        dash->stream_start_ = getTime((const char*)*(attr + 1));
       else if (strcmp((const char*)*attr, "minimumUpdatePeriod") == 0)
       {
         uint64_t dur(0);


### PR DESCRIPTION
this was originally used in the old testing framework to set the clock time in the manifest itself.
The new framework overrides GetNowTime function so this is no longer required