### PR TITLE
[Dash] Allow both $Time and $Number in URL

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -262,19 +262,15 @@ bool AdaptiveStream::restart_stream()
   return true;
 }
 
-void AdaptiveStream::ReplacePlacehoder(std::string& url, uint64_t index, uint64_t timeStamp)
+void AdaptiveStream::ReplacePlaceholder(std::string& url, const std::string placeholder, uint64_t value)
 {
-  std::string::size_type lenReplace(7);
-  std::string::size_type np(url.find("$Number"));
-  uint64_t value(index); //StartNumber
+  std::string::size_type lenReplace(placeholder.length());
+  std::string::size_type np(url.find(placeholder));
   char rangebuf[128];
 
   if (np == std::string::npos)
-  {
-    lenReplace = 5;
-    np = url.find("$Time");
-    value = timeStamp; //Timestamp
-  }
+    return;
+
   np += lenReplace;
 
   std::string::size_type npe(url.find('$', np));
@@ -333,7 +329,8 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment* seg)
     else if (seg != &current_rep_->initialization_) //templated segment
     {
       download_url_ = current_rep_->segtpl_.media;
-      ReplacePlacehoder(download_url_, seg->range_end_, seg->range_begin_);
+      ReplacePlaceholder(download_url_, "$Number", seg->range_end_);
+      ReplacePlaceholder(download_url_, "$Time", seg->range_begin_);
     }
     else //templated initialization segment
       download_url_ = current_rep_->url_;
@@ -344,7 +341,8 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment* seg)
         seg != &current_rep_->initialization_)
     {
       download_url_ = current_rep_->segtpl_.media;
-      ReplacePlacehoder(download_url_, current_rep_->startNumber_, 0);
+      ReplacePlaceholder(download_url_, "$Number", current_rep_->startNumber_);
+      ReplacePlaceholder(download_url_, "$Time", 0);
     }
     else
       download_url_ = current_rep_->url_;

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -101,8 +101,7 @@ namespace adaptive
     bool download_segment();
     void worker();
     int SecondsSinceUpdate() const;
-    static void ReplacePlacehoder(std::string &url, uint64_t index, uint64_t timeStamp);
-
+    static void ReplacePlaceholder(std::string &url, const std::string placeholder, uint64_t value);
 
     struct THREADDATA
     {

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -240,3 +240,57 @@ TEST_F(DASHTreeTest, CalculateCorrectFpsScaleFromAdaptionSet)
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->representations_[0]->fpsRate_, 25000);
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->representations_[0]->fpsScale_, 1000);
 }
+
+TEST_F(DASHTreeAdaptiveStreamTest, replacePlaceHolders)
+{
+  OpenTestFile("mpd/placeholders.mpd", "https://foo.bar/placeholders.mpd", "");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[0], 0, 0, 0, 0, 0, 0, 0,
+                              mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_487050.m4s");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_487054.m4s");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[1], 0, 0, 0, 0, 0, 0, 0,
+                               mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_00487050.m4s");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_00487054.m4s");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[2], 0, 0, 0, 0, 0, 0, 0,
+                               mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_263007000000.m4s");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_263009160000.m4s");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[3], 0, 0, 0, 0, 0, 0, 0,
+                               mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_00263007000000");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_00263009160000");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[4], 0, 0, 0, 0, 0, 0, 0,
+                               mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_487050.m4s?t=263007000000");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_487054.m4s?t=263009160000");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[5], 0, 0, 0, 0, 0, 0, 0,
+                               mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_00487050.m4s?t=00263007000000");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_00487054.m4s?t=00263009160000");
+
+  videoStream->prepare_stream(tree->current_period_->adaptationSets_[6], 0, 0, 0, 0, 0, 0, 0,
+                               mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment.m4s");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment.m4s");
+}

--- a/src/test/manifests/mpd/placeholders.mpd
+++ b/src/test/manifests/mpd/placeholders.mpd
@@ -1,0 +1,62 @@
+<?xml version="1.0" ?>
+<!-- Just In Time Delivered by Quortex Solution -->
+<MPD availabilityStartTime="1970-01-01T00:00:06Z" minBufferTime="PT6S" minimumUpdatePeriod="PT6S" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:hbbtv:dash:profile:isoff-live:2012" publishTime="2020-06-07T11:59:55Z" suggestedPresentationDelay="PT12S" timeShiftBufferDepth="PT1M18S" type="dynamic" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+	<Period id="0" start="PT1588628086S">
+		<AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number$.m4s" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+		<AdaptationSet id="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number%08d$.m4s" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+		<AdaptationSet id="3" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Time$.m4s" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+		<AdaptationSet id="4" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Time%014llu$" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+		<AdaptationSet id="5" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number$.m4s?t=$Time$" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+		<AdaptationSet id="6" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number%08d$.m4s?t=$Time%014llu$" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+		<AdaptationSet id="7" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment.m4s" startNumber="487050" timescale="90000">
+				<SegmentTimeline>
+					<S d="540000" r="12" t="263007000000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/629 (confirmed)
fixes: https://github.com/xbmc/inputstream.adaptive/issues/644 (confirmed)

Currently, we can only have $Time$ OR $Number$ templates in a segment url.
However, both are possible to have in the same url.

Also fix spelling (old function was ReplacePlacehoder)

**Also, the current function segfaults if a url has neither $Number or $Time$.**
This is due to never checking for std::string::npos after the $Time$ block (which runs if no $Number$)

[Backport Required]