### PR TITLE
bump v2.6.9

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.8"
+  version="2.6.9"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -19,6 +19,13 @@
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
     <news>
+v2.6.9 (2021-04-08)
+- Fix MPD Timing (remove publishTime & presentationTimeOffset)
+- [Dash] Correctly set timeshift_buffer (live)
+- [Dash] Support fpsScale in AdaptationSets
+- [Dash] Fix missing audio languages
+- [DASH] Support ec-3 channel count (urn:mpeg:mpegB:cicp:ChannelConfiguration)
+
 v2.6.8 (2021-03-26)
 - [Dash] Append / to baseurl if required
 - Fix Base Domain (fixes uri=/path/)


### PR DESCRIPTION
v2.6.9 (2021-04-08)
- Fix MPD Timing (remove publishTime & presentationTimeOffset)
- [Dash] Correctly set timeshift_buffer (live)
- [Dash] Support fpsScale in AdaptationSets
- [Dash] Fix missing audio languages
- [DASH] Support ec-3 channel count (urn:mpeg:mpegB:cicp:ChannelConfiguration)