### PR TITLE
release v2.6.11

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.10"
+  version="2.6.11"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -19,11 +19,14 @@
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
     <news>
+v2.6.11 (2021-04-08)
+- Fix ampersand in changelog causing issues from v2.6.9 and v2.6.10
+
 v2.6.10 (2021-04-08)
 - Fix release build
 
 v2.6.9 (2021-04-08)
-- Fix MPD Timing (remove publishTime & presentationTimeOffset)
+- Fix MPD Timing (remove publishTime and presentationTimeOffset)
 - [Dash] Correctly set timeshift_buffer (live)
 - [Dash] Support fpsScale in AdaptationSets
 - [Dash] Fix missing audio languages


### PR DESCRIPTION
v2.6.11 (2021-04-08)
- Fix ampersand in changelog causing issues from v2.6.9 and v2.6.10