### PR TITLE
Only enable testing if BUILD_TESTING is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(inputstream.adaptive)
+option(BUILD_TESTING "Build the testing tree." ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ build_addon(inputstream.adaptive ADP DEPLIBS)
 
 include(CPack)
 
-if(NOT CMAKE_CROSSCOMPILING)
+if(NOT CMAKE_CROSSCOMPILING AND BUILD_TESTING)
   list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
   enable_testing()
   include(FindGtest)


### PR DESCRIPTION
BUILD_TESTING is the convention for enabling test building.

This condition allows building without gtest.

See https://cliutils.gitlab.io/modern-cmake/chapters/testing.html