### PR TITLE
Add capability to use AdaptiveStream in DASH tests

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${BINARY}
     ../parser/DASHTree.cpp
     ../parser/HLSTree.cpp
     ../parser/PRProtectionParser.cpp
+    ../common/AdaptiveStream.cpp
     ../common/AdaptiveTree.cpp
     ../helpers.cpp
     ../oscompat.cpp

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -14,14 +14,14 @@ protected:
 
   void TearDown() override
   {
-    effectiveUrl.clear();
+    testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;
   }
 
   void OpenTestFile(std::string testfilename, std::string url, std::string manifestHeaders)
   {
-    SetFileName(testFile, testfilename);
+    SetFileName(testHelper::testFile, testfilename);
     if (!tree->open(url, manifestHeaders))
     {
       printf("open() failed");
@@ -37,7 +37,7 @@ class DASHTreeAdaptiveStreamTest : public DASHTreeTest
 protected:
   void SetUp() override
   {
-    lastDownloadUrl.clear();
+    testHelper::lastDownloadUrl.clear();
     DASHTreeTest::SetUp();
     videoStream = new TestAdaptiveStream(*tree, adaptive::AdaptiveTree::StreamType::VIDEO);
   }
@@ -65,7 +65,7 @@ protected:
 
     for (unsigned int i = 0; i < reads; i++)
       if (stream->read(buf, bytesToRead))
-        downloadedUrls.push_back(lastDownloadUrl);
+        downloadedUrls.push_back(testHelper::lastDownloadUrl);
       else
         break;
   }
@@ -94,8 +94,9 @@ TEST_F(DASHTreeTest, CalculateBaseDomain)
 TEST_F(DASHTreeTest, CalculateEffectiveUrlFromRedirect)
 {
   // like base_url_, effective_url_ should be path, not including filename
-  effectiveUrl = "https://foo.bar/mpd/stream.mpd";
+  testHelper::effectiveUrl = "https://foo.bar/mpd/stream.mpd";
   OpenTestFile("mpd/segtpl.mpd", "https://bit.ly/abcd", "");
+
   EXPECT_EQ(tree->effective_url_, "https://foo.bar/mpd/");
 }
 

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -13,14 +13,14 @@ protected:
 
   void TearDown() override
   {
-    effectiveUrl.clear();
+    testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;
   }
 
   void OpenTestFileMaster(std::string testfilename, std::string url, std::string manifestHeaders)
   {
-    SetFileName(testFile, testfilename);
+    SetFileName(testHelper::testFile, testfilename);
     if (!tree->open(url, manifestHeaders))
     {
       printf("open() failed");
@@ -36,7 +36,7 @@ protected:
   {
     if (!url.empty())
       rep->source_url_ = url;
-    SetFileName(testFile, testfilename);
+    SetFileName(testHelper::testFile, testfilename);
     return tree->prepareRepresentation(per, adp, rep);
   }
   adaptive::HLSTree* tree;
@@ -60,7 +60,7 @@ TEST_F(HLSTreeTest, CalculateSourceUrl)
 
 TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterRelativeUri)
 {
-  effectiveUrl = "https://foo.bar/master.m3u8";
+  testHelper::effectiveUrl = "https://foo.bar/master.m3u8";
 
   OpenTestFileMaster("hls/1a2v_master.m3u8", "https://baz.qux/master.m3u8", "");
   
@@ -91,8 +91,8 @@ TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedVariantAbsoluteUri)
   
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 
-  effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
-
+  testHelper::effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
+  
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/fmp4_noenc_v_stream_2.m3u8", "https://bit.ly/abcd",
       tree->current_period_, tree->current_adaptationset_, tree->current_representation_);
@@ -107,7 +107,7 @@ TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedVariantAbsoluteUri)
 
 TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAbsoluteUri)
 {
-  effectiveUrl = "https://baz.qux/master.m3u8";
+  testHelper::effectiveUrl = "https://baz.qux/master.m3u8";
 
   OpenTestFileMaster("hls/redirect_absolute_1v_master.m3u8", "https://link.to/1234", "");
 
@@ -116,7 +116,7 @@ TEST_F(HLSTreeTest, CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAb
   
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 
-  effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
+  testHelper::effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
 
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/fmp4_noenc_v_stream_2.m3u8", "https://bit.ly/abcd", tree->current_period_,
@@ -134,7 +134,7 @@ TEST_F(HLSTreeTest,
        CalculateSourceUrlFromRedirectedMasterAndRedirectedVariantAbsoluteUriSameDomains)
 {
   GTEST_SKIP();
-  effectiveUrl = "https://baz.qux/master.m3u8";
+  testHelper::effectiveUrl = "https://baz.qux/master.m3u8";
 
   OpenTestFileMaster("hls/redirect_absolute_1v_master.m3u8", "https://bit.ly/1234", "");
 
@@ -143,7 +143,7 @@ TEST_F(HLSTreeTest,
   
   EXPECT_EQ(rep_url, "https://bit.ly/abcd");
 
-  effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
+  testHelper::effectiveUrl = "https://foo.bar/stream_2/out.m3u8";
 
   adaptive::HLSTree::PREPARE_RESULT res = OpenTestFileVariant(
       "hls/fmp4_noenc_v_stream_2.m3u8", "https://bit.ly/abcd", tree->current_period_,
@@ -190,7 +190,7 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
 
 TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
 {
-  effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
+  testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
   OpenTestFileMaster("hls/1v_master.m3u8", "https://baz.qux/hls/video/stream_name/master.m3u8",
                      "");
@@ -245,7 +245,7 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
 {
-  effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
+  testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
   OpenTestFileMaster("hls/1v_master.m3u8",
                      "https://baz.qux/hls/video/stream_name/master.m3u8", "");

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -2,6 +2,7 @@
 
 std::string testFile;
 std::string effectiveUrl;
+std::string lastDownloadUrl;
 
 
 void Log(const LogLevel loglevel, const char* format, ...){}
@@ -43,6 +44,25 @@ bool adaptive::AdaptiveTree::download(const char* url,
   fclose(f);
 
   SortTree();
+  return nbRead == 0;
+}
+
+bool TestAdaptiveStream::download(const char* url,
+                                  const std::map<std::string, std::string>& mediaHeaders)
+{
+  size_t nbRead = ~0UL;
+  std::stringstream ss("Sixteen bytes!!!");
+
+  char buf[16];
+  size_t nbReadOverall = 0;
+  while ((nbRead = ss.readsome(buf, 16)) > 0 && ~nbRead && write_data(buf, nbRead))
+    nbReadOverall += nbRead;
+
+  if (!nbReadOverall)
+  {
+    return false;
+  }      
+  lastDownloadUrl = url;
   return nbRead == 0;
 }
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -1,9 +1,8 @@
 #include "TestHelper.h"
 
-std::string testFile;
-std::string effectiveUrl;
-std::string lastDownloadUrl;
-
+std::string testHelper::testFile;
+std::string testHelper::effectiveUrl;
+std::string testHelper::lastDownloadUrl;
 
 void Log(const LogLevel loglevel, const char* format, ...){}
 
@@ -26,13 +25,13 @@ bool adaptive::AdaptiveTree::download(const char* url,
                                       void* opaque,
                                       bool scanEffectiveURL)
 {
-  FILE* f = fopen(testFile.c_str(), "rb");
+  FILE* f = fopen(testHelper::testFile.c_str(), "rb");
   if (!f)
     return false;
 
-  if (scanEffectiveURL && !effectiveUrl.empty())
-    SetEffectiveURL(effectiveUrl);
-
+  if (scanEffectiveURL && !testHelper::effectiveUrl.empty())
+    SetEffectiveURL(testHelper::effectiveUrl);
+ 
   // read the file
   static const unsigned int CHUNKSIZE = 16384;
   char buf[CHUNKSIZE];
@@ -62,7 +61,7 @@ bool TestAdaptiveStream::download(const char* url,
   {
     return false;
   }      
-  lastDownloadUrl = url;
+  testHelper::lastDownloadUrl = url;
   return nbRead == 0;
 }
 

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -4,13 +4,17 @@
 #include "../parser/DASHTree.h"
 #include "../parser/HLSTree.h"
 
-
-extern std::string testFile;
-extern std::string effectiveUrl;
-extern std::string lastDownloadUrl;
 std::string GetEnv(const std::string& var);
 void SetFileName(std::string& file, const std::string name);
 void Log(const LogLevel loglevel, const char* format, ...);
+
+class testHelper
+{
+public:
+  static std::string testFile;
+  static std::string effectiveUrl;
+  static std::string lastDownloadUrl;
+};
 
 class TestAdaptiveStream : public adaptive::AdaptiveStream
 {

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -1,14 +1,27 @@
 #include "../Iaes_decrypter.h"
 #include "../log.h"
+#include "../common/AdaptiveStream.h"
 #include "../parser/DASHTree.h"
 #include "../parser/HLSTree.h"
 
 
 extern std::string testFile;
 extern std::string effectiveUrl;
+extern std::string lastDownloadUrl;
 std::string GetEnv(const std::string& var);
 void SetFileName(std::string& file, const std::string name);
 void Log(const LogLevel loglevel, const char* format, ...);
+
+class TestAdaptiveStream : public adaptive::AdaptiveStream
+{
+public:
+  TestAdaptiveStream(adaptive::AdaptiveTree& tree, adaptive::AdaptiveTree::StreamType type)
+    : adaptive::AdaptiveStream(tree, type){};
+
+protected:
+  virtual bool download(const char* url,
+                        const std::map<std::string, std::string>& mediaHeaders) override;
+};
 
 class AESDecrypter : public IAESDecrypter
 {


### PR DESCRIPTION
Currently we can test most areas of parsing DASH/HLS manifests. There are however some functions that run in `AdaptiveStream` at 'stream time' as opposed to 'parse time', such as ReplacePlaceHolders (replaces eg. `$Number$` and `$Time$` variables that need to be calculated using current time) and we would like to be able to put these under test.

This PR brings the capability to create an `AdaptiveStream` under test in order to use its functions. The download function used for retrieving the segment files has been replaced allowing us to keep track of the eventual url that is requested to download, and a helper function in the test fixture is included to easily call x amount of read/segment requests and store all of the 'downloaded' urls in an array for later retrieval.

No tests included (Don't worry, @matthuisman will be itching to add some to his PRs 😄) but a sample test could be as such:
```
TEST_F(DASHTreeAdaptiveStreamTest, replacePlaceHolders)
{
  OpenTestFile("mpd/segtimeline_live_ast.mpd", "https://foo.bar/test.mpd", "");
  videoStream->prepare_stream(tree->current_period_->adaptationSets_[0], 0, 0, 0, 0, 0, 0, 0,
                              mediaHeaders);
  videoStream->start_stream(~0, 0, 0, true);

  ReadSegments(videoStream, 16, 16);

  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/videosd-400x224/segment_487050.m4s");
  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/videosd-400x224/segment_487062.m4s");
  EXPECT_EQ(downloadedUrls.size(), 13);
}
```

This will call `read` for 16 bytes on the stream 16 times. Note that the stream only contains 13 segments so `ReadSegments` will exit early.