### PR TITLE
Stop intermittent crashing on AdaptiveStream tests

### DIFF
--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -44,9 +44,9 @@ protected:
 
   void TearDown() override
   {
-    DASHTreeTest::TearDown();
     delete videoStream;
     videoStream = nullptr;
+    DASHTreeTest::TearDown();
   }
 
   void ReadSegments(TestAdaptiveStream* stream,


### PR DESCRIPTION
adaptiveTree was being destroyed before adaptiveStream, when adaptiveStream's destructor still needs access to the tree.