### PR TITLE
[Dash] Support ttml subs without codecs

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -710,7 +710,8 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
                 else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "audio", 5) == 0)
                   dash->current_adaptationset_->type_ = DASHTree::AUDIO;
                 else if (strncmp(dash->current_adaptationset_->mimeType_.c_str(), "application",
-                                 11) == 0)
+                                 11) == 0 ||
+                         strncmp(dash->current_adaptationset_->mimeType_.c_str(), "text", 4) == 0)
                   dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
               }
               if (strstr(dash->current_adaptationset_->mimeType_.c_str(), "/webm"))
@@ -722,6 +723,28 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
             attr += 2;
           }
 
+          if (dash->current_representation_->codecs_.empty())
+          {
+            if (dash->current_adaptationset_->mimeType_ == "text/vtt")
+              dash->current_representation_->codecs_ = "wvtt";
+            else if (dash->current_adaptationset_->mimeType_ == "application/ttml+xml")
+              dash->current_representation_->codecs_ = "ttml";
+          }
+
+          if (dash->current_adaptationset_->type_ != DASHTree::SUBTITLE)
+          {
+            if (dash->current_representation_->codecs_ == "wvtt")
+            {
+              dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
+              dash->current_adaptationset_->mimeType_ = "text/vtt";
+            }
+            else if (dash->current_representation_->codecs_ == "ttml")
+            {
+              dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
+              dash->current_adaptationset_->mimeType_ = "application/ttml+xml";
+            }
+          }
+
           if (dash->current_adaptationset_->type_ == DASHTree::SUBTITLE &&
               (dash->current_adaptationset_->mimeType_ == "application/ttml+xml" ||
                dash->current_adaptationset_->mimeType_ == "text/vtt"))
@@ -731,14 +754,6 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
             else
               dash->current_representation_->containerType_ = AdaptiveTree::CONTAINERTYPE_TEXT;
           }
-
-          if (dash->current_adaptationset_->type_ != DASHTree::SUBTITLE &&
-              dash->current_representation_->codecs_ == "wvtt")
-            dash->current_adaptationset_->type_ = DASHTree::SUBTITLE;
-
-          if (dash->current_adaptationset_->mimeType_ == "text/vtt" &&
-              dash->current_representation_->codecs_.empty())
-            dash->current_representation_->codecs_ = "wvtt";
 
           dash->current_representation_->segtpl_ = dash->current_adaptationset_->segtpl_;
           if (!dash->current_adaptationset_->segtpl_.media.empty())

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -336,3 +336,71 @@ TEST_F(DASHTreeTest, CalculatePsshDefaultKid)
   EXPECT_EQ(tree->periods_[0]->psshSets_[2].pssh_, "HGFEDCBA");
   EXPECT_EQ(tree->periods_[0]->psshSets_[2].defaultKID_.length(), 16);
 }
+
+TEST_F(DASHTreeAdaptiveStreamTest, subtitles)
+{
+  OpenTestFile("mpd/subtitles.mpd", "https://foo.bar/subtitles.mpd", "");
+
+  // Required as gtest can not access the hidden attribute directly in EXPECT_EQ
+  static const uint16_t SUBTITLESTREAM = DASHTestTree::Representation::SUBTITLESTREAM;
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->codecs_, "ttml");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->codecs_, "ttml");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[3]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[3]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[3]->representations_[0]->codecs_, "ttml");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->representations_[0]->codecs_, "ttml");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[5]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[5]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[5]->representations_[0]->codecs_, "wvtt");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[6]->representations_[0]->codecs_, "wvtt");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[7]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[7]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[7]->representations_[0]->codecs_, "wvtt");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[8]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[8]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[8]->representations_[0]->codecs_, "wvtt");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[9]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[9]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[9]->representations_[0]->codecs_, "my_codec");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[10]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[10]->representations_[0]->flags_, SUBTITLESTREAM);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[10]->representations_[0]->codecs_, "ttml");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[11]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[11]->mimeType_, "application/mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[11]->representations_[0]->codecs_, "stpp");
+  videoStream->prepare_stream(tree->periods_[0]->adaptationSets_[11], 0, 0, 0, 0, 0, 0, 0,
+                              mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/11/0001.m4s");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/11/0005.m4s");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[12]->type_, DASHTestTree::SUBTITLE);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[12]->mimeType_, "application/mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[12]->representations_[0]->codecs_, "stpp.ttml.im1t");
+  videoStream->prepare_stream(tree->periods_[0]->adaptationSets_[12], 0, 0, 0, 0, 0, 0, 0,
+                              mediaHeaders);
+  videoStream->start_stream(~0, 0, 0, true);
+  ReadSegments(videoStream, 16, 5);
+  EXPECT_EQ(downloadedUrls[0], "https://foo.bar/tears-of-steel-multiple-subtitles-12-0.dash");
+  EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/tears-of-steel-multiple-subtitles-12-16000.dash");
+}

--- a/src/test/manifests/mpd/subtitles.mpd
+++ b/src/test/manifests/mpd/subtitles.mpd
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H10M54.00S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011,http://dashif.org/guidelines/dash264">
+ <Period id="" duration="PT0H10M54.00S">
+  <AdaptationSet segmentAlignment="true" maxWidth="1280" maxHeight="720" maxFrameRate="24" par="16:9" subsegmentStartsWithSAP="1">
+   <Representation id="0" mimeType="video/mp4" codecs="avc1.4d401f" width="1280" height="720" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="4076826">
+    <BaseURL>ED_720_4M_MPEG2_video_init.mp4</BaseURL>
+    <SegmentBase indexRangeExact="true" indexRange="885-2488"/>
+   </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en" mimeType="application/ttml+xml">
+    <Representation id="1">
+      <BaseURL>English_track.xml</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en">
+    <Representation id="2" mimeType="application/ttml+xml">
+      <BaseURL>English_track.xml</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en" codecs="ttml">
+    <Representation id="3">
+      <BaseURL>English_track.xml</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en">
+    <Representation id="4" codecs="ttml">
+      <BaseURL>English_track.xml</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en" mimeType="text/vtt">
+    <Representation id="5">
+      <BaseURL>English_track.vtt</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en">
+    <Representation id="6" mimeType="text/vtt">
+      <BaseURL>English_track.vtt</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en" codecs="wvtt">
+    <Representation id="7">
+      <BaseURL>English_track.vtt</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en">
+    <Representation id="8" codecs="wvtt">
+      <BaseURL>English_track.vtt</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <AdaptationSet lang="en" mimeType="text/vtt">
+    <Representation id="9" codecs="my_codec">
+      <BaseURL>English_track.vtt</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <!-- http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd -->
+  <AdaptationSet mimeType="application/ttml+xml" lang="en">
+    <Role schemeIdUri="urn:mpeg:dash:role" value="subtitle" />
+    <Representation id="10" bandwidth="268" >
+      <BaseURL>English_track.xml</BaseURL>
+    </Representation>
+  </AdaptationSet>
+
+  <!-- http://media.axprod.net/dash/ED_TTML_NEW/Clear/Manifest_sub_in.mpd -->
+  <!-- https://livesim.dashif.org/dash/vod/testpic_2s/multi_subs.mpd -->
+	<AdaptationSet segmentAlignment="true" par="1:1" lang="en">
+		<SegmentTemplate timescale="1000" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="4000" initialization="$RepresentationID$/init.mp4" />
+		<Representation id="11" mimeType="application/mp4" codecs="stpp" startWithSAP="1" bandwidth="845"></Representation>
+	</AdaptationSet>
+
+  <!-- https://demo.unified-streaming.com/video/tears-of-steel/tears-of-steel-multiple-subtitles.ism/.mpd -->
+  <AdaptationSet contentType="text" lang="en" mimeType="application/mp4" codecs="stpp.ttml.im1t" startWithSAP="1">
+    <Role schemeIdUri="urn:mpeg:dash:role:2011" value="subtitle" />
+    <SegmentTemplate timescale="1000" initialization="tears-of-steel-multiple-subtitles-$RepresentationID$.dash" media="tears-of-steel-multiple-subtitles-$RepresentationID$-$Time$.dash">
+      <SegmentTimeline>
+        <S t="0" d="4000" r="140" />
+        <S d="3000" />
+      </SegmentTimeline>
+    </SegmentTemplate>
+    <Representation id="12" bandwidth="1000"></Representation>
+  </AdaptationSet>
+ </Period>
+</MPD>


### PR DESCRIPTION
Allow the same behaviour as wvtt by setting the codec to ttml for mimeType=application/ttml+xml
This also adds support for mimeType="text/vtt" on representations (not adaptionset) to work correctly
Also fixes a bug where using codecs="wvtt" without a mimeType, SUBTITLESTREAM would not be set.