### PR TITLE
[Dash] Support suggestedPresentationDelay & minBufferTime

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -203,10 +203,15 @@ bool AdaptiveStream::start_stream(const uint32_t seg_offset,
       if (!pos)
         pos = 1;
     }
-    //go at least 12 secs back
     uint64_t duration(current_rep_->get_segment(pos)->startPTS_ -
                       current_rep_->get_segment(pos - 1)->startPTS_);
-    pos -= static_cast<uint32_t>((12 * current_rep_->timescale_) / duration) + 1;
+
+    if (tree_.buffer_time_ > 0)
+      pos -= static_cast<uint32_t>((tree_.buffer_time_ * current_rep_->timescale_) / duration);
+    else
+      //go at least 12 secs back
+      pos -= static_cast<uint32_t>((12 * current_rep_->timescale_) / duration) + 1;
+
     current_rep_->current_segment_ = current_rep_->get_segment(pos < 0 ? 0 : pos);
   }
   else

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -48,6 +48,7 @@ namespace adaptive
     , stream_start_(0)
     , available_time_(0)
     , base_time_(0)
+    , buffer_time_(0)
     , minPresentationOffset(0)
     , has_timeshift_buffer_(false)
     , has_overall_seconds_(false)
@@ -171,7 +172,7 @@ namespace adaptive
   }
 
   void AdaptiveTree::OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize)
-  { 
+  {
     memcpy(dst + dstOffset, src, dataSize);
   }
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -425,7 +425,7 @@ public:
   uint32_t currentNode_;
   uint32_t segcount_;
   uint32_t initial_sequence_ = ~0UL;
-  uint64_t overallSeconds_, stream_start_, available_time_, base_time_;
+  uint64_t overallSeconds_, stream_start_, available_time_, base_time_, buffer_time_;
   uint64_t minPresentationOffset;
   bool has_timeshift_buffer_, has_overall_seconds_;
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1051,7 +1051,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       else if (strcmp((const char*)*attr, "minimumUpdatePeriod") == 0)
       {
         uint64_t dur(0);
-        AddDuration((const char*)*(attr + 1), dur, 1500);
+        AddDuration((const char*)*(attr + 1), dur, 1000);
         dash->SetUpdateInterval(static_cast<uint32_t>(dur));
       }
       attr += 2;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1048,10 +1048,15 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       }
       else if (strcmp((const char*)*attr, "availabilityStartTime") == 0)
         dash->available_time_ = getTime((const char*)*(attr + 1));
+      else if (strcmp((const char*)*attr, "suggestedPresentationDelay") == 0 ||
+               strcmp((const char*)*attr, "minBufferTime") == 0)
+      {
+        AddDuration((const char*)*(attr + 1), dash->buffer_time_, 1);
+      }
       else if (strcmp((const char*)*attr, "minimumUpdatePeriod") == 0)
       {
         uint64_t dur(0);
-        AddDuration((const char*)*(attr + 1), dur, 1000);
+        AddDuration((const char*)*(attr + 1), dur, 1500);
         dash->SetUpdateInterval(static_cast<uint32_t>(dur));
       }
       attr += 2;
@@ -1063,9 +1068,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
     AddDuration(mpt, dash->overallSeconds_, 1);
     dash->has_overall_seconds_ = dash->overallSeconds_ > 0;
 
-    uint64_t overallsecs(dash->overallSeconds_ ? dash->overallSeconds_ + 60 : 86400);
     dash->minPresentationOffset = ~0ULL;
-
     dash->currentNode_ |= MPDNODE_MPD;
   }
 }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -539,7 +539,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         }
         else if (line.compare(0, 22, "#EXT-X-TARGETDURATION:") == 0)
         {
-          uint32_t newInterval = atoi(line.c_str() + 22) * 1000;
+          uint32_t newInterval = atoi(line.c_str() + 22) * 1500;
           if (newInterval < updateInterval_)
             updateInterval_ = newInterval;
         }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -539,7 +539,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         }
         else if (line.compare(0, 22, "#EXT-X-TARGETDURATION:") == 0)
         {
-          uint32_t newInterval = atoi(line.c_str() + 22) * 1500;
+          uint32_t newInterval = atoi(line.c_str() + 22) * 1000;
           if (newInterval < updateInterval_)
             updateInterval_ = newInterval;
         }


### PR DESCRIPTION
Fixes: https://github.com/xbmc/inputstream.adaptive/issues/647

**Fix Update interval**
updateInterval_ is time to wait between manifest updates in ms https://github.com/xbmc/inputstream.adaptive/blob/dc047c3ba7e1e43adfe8110b5623bbed22fcbb67/src/common/AdaptiveTree.cpp#L476  In a dash file, it's set with minimumUpdatePeriod which is in "PT32S" format
  AddDuration returns the time in (seconds * timescale).
  We want ms - so correct timescale is 1000 not 1500
  In HLS, EXT-X-TARGETDURATION is provided as seconds. Again, we want in ms so need to times by 1000 not 1500

_when looking into this, I found updateInterval_ is usually never used as currently IA will refresh after every segment here:
https://github.com/xbmc/inputstream.adaptive/blob/Matrix/src/common/AdaptiveStream.cpp#L387

RefreshSegments will call RefreshUpdateThread which calls updateVar_.notify_one(); which breaks the updateVar_.wait_for.
Something we should look into. RefreshSegments also calls RefreshLiveSegments which the updatethread will also call basically at the same time. So - downloading and processing the manifest twice?_
  
**Add suggestedPresentationDelay** 
Then moved the current 12sec delay from head into an adaptivetree variable called presentation_delay_ .
This gets set to 12 by default which results in current behaviour.
Now in the dash file, we can set it to the value provided by suggestedPresentationDelay which is provided in "PT32S" format


[Needs Tests]