### PR TITLE
Add a setting to always force secure decoder

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -59,6 +59,11 @@ msgctxt "#30115"
 msgid "Ignore Display Resolution"
 msgstr ""
 
+# Always use secure decoder for DRM-protected streams
+msgctxt "#30116"
+msgid "Force secure decoder"
+msgstr ""
+
 msgctxt "#30120"
 msgid "Expert"
 msgstr ""

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -76,6 +76,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="FORCESECUREDECODER" type="boolean" label="30116">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="1">
         <setting id="DECRYPTERPATH" type="string" label="30103">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3385,6 +3385,12 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
       m_playTimeshiftBuffer = stricmp(prop.second.c_str(), "true") == 0;
   }
 
+  if (kodi::GetSettingBoolean("FORCESECUREDECODER"))
+  {
+    force_secure_decoder = true;
+    kodi::Log(ADDON_LOG_DEBUG, "FORCESECUREDECODER enabled!");
+  }
+
   if (manifest == MANIFEST_TYPE_UNKNOWN)
   {
     kodi::Log(ADDON_LOG_ERROR, "Invalid / not given inputstream.adaptive.manifest_type");


### PR DESCRIPTION
Related to https://github.com/xbmc/inputstream.adaptive/issues/638

Some Android devices don't allow to pass decrypted data to non-secure decoder. Provide a setting to allow user always force using a secure decoder.