### PR TITLE
Don't remove SECURE_DECODER from decrypter_caps

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -67,6 +67,10 @@ msgctxt "#30121"
 msgid "Enable Pre-Release Features"
 msgstr ""
 
+msgctxt "#30122"
+msgid "Don't use secure decoder if possible"
+msgstr ""
+
 msgctxt "#30150"
 msgid "Max"
 msgstr ""

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -96,6 +96,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="NOSECUREDECODER" type="boolean" label="30122">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2080,6 +2080,9 @@ Session::Session(MANIFEST_TYPE manifestType,
   if (preReleaseFeatures)
     kodi::Log(ADDON_LOG_INFO, "PRERELEASEFEATURES enabled!");
 
+  allow_no_secure_decoder_ = kodi::GetSettingBoolean("NOSECUREDECODER");
+  kodi::Log(ADDON_LOG_DEBUG, "FORCENONSECUREDECODER selected: %d ", allow_no_secure_decoder_);
+
   int buf = kodi::GetSettingInt("MEDIATYPE");
   switch (buf)
   {
@@ -2493,8 +2496,9 @@ bool Session::InitializeDRM()
         {
           session.cdm_session_str_ = session.single_sample_decryptor_->GetSessionId();
           secure_video_session_ = true;
-          // Override this setting by information passed in manifest
-          if (!force_secure_decoder_ && !adaptiveTree_->current_period_->need_secure_decoder_)
+
+          if (allow_no_secure_decoder_
+              && !force_secure_decoder_ && !adaptiveTree_->current_period_->need_secure_decoder_)
             session.decrypter_caps_.flags &= ~SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER;
         }
       }

--- a/src/main.h
+++ b/src/main.h
@@ -212,4 +212,5 @@ private:
   bool ignore_display_;
   bool play_timeshift_buffer_;
   bool force_secure_decoder_;
+  bool allow_no_secure_decoder_;
 };


### PR DESCRIPTION
Many Android 10 L1 devices cannot use L1 Widevine decrypter to provide data to non-secure decoder. To prevent this, we should use the secure decoder if decrypter declares support in its capabilities.

This should be safe on Linux because `wvdecrypter.cpp` does not declare `SECURE_DECODER` in caps.

User-friendly alternative to https://github.com/xbmc/inputstream.adaptive/pull/661
May fix https://github.com/xbmc/inputstream.adaptive/issues/638 and https://github.com/xbmc/inputstream.adaptive/issues/582

Confirmed to fix the issue on my L1 Android device.