### PR TITLE
[HLS] Support .webvtt subtitle file extension

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -485,7 +485,8 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
                 rep->containerType_ = CONTAINERTYPE_ADTS;
               else if (strncmp(line.c_str() + ext, ".mp4", 4) == 0)
                 rep->containerType_ = CONTAINERTYPE_MP4;
-              else if (strncmp(line.c_str() + ext, ".vtt", 4) == 0)
+              else if (strncmp(line.c_str() + ext, ".vtt", 4) == 0 ||
+                       strncmp(line.c_str() + ext, ".webvtt", 7) == 0)
                 rep->containerType_ = CONTAINERTYPE_TEXT;
               else
               {


### PR DESCRIPTION
test.strm below
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
http://cdn.theoplayer.com/video/elephants-dream/playlist-single-audio.m3u8
```
Subtitles links to:
http://cdn.theoplayer.com/video/elephants-dream/chinese/ed.ttml (not actually a ttml file)
which then contains chunked webvtt subs
```
#EXTINF:150.0,
subtitlechunk_lzho_w2018715716_b160000_slen_t64RW5nbGlzaA==_0.webvtt
```
Without this PR, IA picks up on the two subs but no subs are shown.
This is due to IA currently only looking for .vtt extension, not .webvtt