### PR TITLE
[Dash] Fix Multiple SegmentTemplate Issues

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -90,9 +90,9 @@ static uint8_t GetChannels(const char** attr)
 static unsigned int ParseSegmentTemplate(const char** attr,
                                          std::string baseURL,
                                          std::string baseDomain,
-                                         DASHTree::SegmentTemplate& tpl)
+                                         DASHTree::SegmentTemplate& tpl,
+                                         unsigned int startNumber)
 {
-  unsigned int startNumber(1);
   for (; *attr;)
   {
     if (strcmp((const char*)*attr, "timescale") == 0)
@@ -482,9 +482,9 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           {
             dash->current_representation_->segtpl_ = dash->current_adaptationset_->segtpl_;
 
-            dash->current_representation_->startNumber_ =
-                ParseSegmentTemplate(attr, dash->current_representation_->url_, dash->base_domain_,
-                                     dash->current_representation_->segtpl_);
+            dash->current_representation_->startNumber_ = ParseSegmentTemplate(
+                attr, dash->current_adaptationset_->base_url_, dash->base_domain_,
+                dash->current_representation_->segtpl_, dash->current_adaptationset_->startNumber_);
             ReplacePlaceHolders(dash->current_representation_->segtpl_.media,
                                 dash->current_representation_->id,
                                 dash->current_representation_->bandwidth_);
@@ -604,9 +604,9 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         }
         else if (strcmp(el, "SegmentTemplate") == 0)
         {
-          dash->current_adaptationset_->startNumber_ =
-              ParseSegmentTemplate(attr, dash->current_adaptationset_->base_url_,
-                                   dash->base_domain_, dash->current_adaptationset_->segtpl_);
+          dash->current_adaptationset_->startNumber_ = ParseSegmentTemplate(
+              attr, dash->current_adaptationset_->base_url_, dash->base_domain_,
+              dash->current_adaptationset_->segtpl_, dash->current_adaptationset_->startNumber_);
           dash->current_adaptationset_->timescale_ =
               dash->current_adaptationset_->segtpl_.timescale;
           dash->currentNode_ |= MPDNODE_SEGMENTTEMPLATE;
@@ -957,9 +957,9 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       }
       else if (strcmp(el, "SegmentTemplate") == 0)
       {
-        dash->current_period_->startNumber_ =
-            ParseSegmentTemplate(attr, dash->current_period_->base_url_, dash->base_domain_,
-                                 dash->current_period_->segtpl_);
+        dash->current_period_->startNumber_ = ParseSegmentTemplate(
+            attr, dash->current_period_->base_url_, dash->base_domain_,
+            dash->current_period_->segtpl_, dash->current_period_->startNumber_);
         dash->current_period_->timescale_ = dash->current_period_->segtpl_.timescale;
         dash->currentNode_ |= MPDNODE_SEGMENTTEMPLATE;
       }

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -106,7 +106,7 @@ TEST_F(DASHTreeTest, CalculateBaseURLFromBaseURLTag)
   EXPECT_EQ(tree->current_period_->base_url_, "https://foo.bar/mpd/");
 }
 
-TEST_F(DASHTreeTest, CalculateSegTplWithNoSlashs)
+TEST_F(DASHTreeTest, CalculateSegTplWithNoSlashes)
 {
   // BaseURL inside period with no trailing slash, uses segtpl, media/init doesn't start with slash
   OpenTestFile("mpd/segtpl_baseurl_noslashs.mpd", "https://foo.bar/initialpath/test.mpd", "");
@@ -403,4 +403,31 @@ TEST_F(DASHTreeAdaptiveStreamTest, subtitles)
   ReadSegments(videoStream, 16, 5);
   EXPECT_EQ(downloadedUrls[0], "https://foo.bar/tears-of-steel-multiple-subtitles-12-0.dash");
   EXPECT_EQ(downloadedUrls.back(), "https://foo.bar/tears-of-steel-multiple-subtitles-12-16000.dash");
+}
+
+TEST_F(DASHTreeTest, CalculateMultipleSegTpl)
+{
+  OpenTestFile("mpd/segtpl_multiple.mpd", "https://foo.bar/dash/multiple.mpd", "");
+
+  EXPECT_EQ(tree->base_url_, "https://foo.bar/dash/");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.initialization, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.timescale, 120000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segments_[0]->range_end_, 3);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.initialization, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.media, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.timescale, 90000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segments_[0]->range_end_, 5);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_aac1init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_aac1_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.timescale, 48000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segments_[0]->range_end_, 1);
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.initialization, "https://foo.bar/dash/abc_aac1init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.media, "https://foo.bar/dash/abc2_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.timescale, 68000);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segments_[0]->range_end_, 5);
 }

--- a/src/test/manifests/mpd/segtpl_multiple.mpd
+++ b/src/test/manifests/mpd/segtpl_multiple.mpd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD mediaPresentationDuration="PT1M38.624S" minBufferTime="PT4S" profiles="urn:mpeg:dash:profile:isoff-main:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd">
+	<Period duration="PT1M38.624S" id="1" start="PT0S">
+		<AdaptationSet bitstreamSwitching="false" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1" xmlns:cenc="urn:mpeg:cenc:2013">
+			<SegmentTemplate startNumber="5" timescale="120000"/>
+			<Representation bandwidth="600000" codecs="avc1.4d4015" frameRate="30000/1001" height="252" id="1" width="448">
+				<SegmentTemplate initialization="3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252init.mp4" media="3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252_$Number%09d$.mp4" startNumber="3">
+					<SegmentTimeline>
+						<S d="360360" r="23" t="0"/>
+						<S d="225225" t="8648640"/>
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation bandwidth="7000000" codecs="avc1.64002a" frameRate="60000/1001" height="1080" id="2" width="1920">
+				<SegmentTemplate initialization="3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080init.mp4" media="3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080_$Number%09d$.mp4" timescale="90000">
+					<SegmentTimeline>
+						<S d="480480" r="23" t="0"/>
+						<S d="298298" t="11531520"/>
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet lang="eng" mimeType="audio/mp4" segmentAlignment="0" xmlns:cenc="urn:mpeg:cenc:2013">
+			<SegmentTemplate initialization="abc_aac1init.mp4" media="abc2_$Number%09d$.mp4" timescale="48000"/>
+			<Label>AAC1</Label>
+			<Representation audioSamplingRate="48000" bandwidth="96000" codecs="mp4a.40.2" id="3">
+				<SegmentTemplate initialization="3c1055cb-a842-4449-b393-7f31693b4a8f_aac1init.mp4" media="3c1055cb-a842-4449-b393-7f31693b4a8f_aac1_$Number%09d$.mp4">
+					<SegmentTimeline>
+						<S d="194560" t="0"/>
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet lang="fr" mimeType="audio/mp4" segmentAlignment="0" xmlns:cenc="urn:mpeg:cenc:2013">
+			<SegmentTemplate initialization="abc_aac1init.mp4" media="abc2_$Number%09d$.mp4" timescale="48000"/>
+			<Label>AAC1</Label>
+			<Representation audioSamplingRate="48000" bandwidth="96000" codecs="mp4a.40.2" id="4">
+				<SegmentTemplate startNumber="5" timescale="68000">
+					<SegmentTimeline>
+						<S d="194560" t="0"/>
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>


### PR DESCRIPTION
1) 
Fixes issue of wrong url calculated for init and media for the 2nd SegmentTemplate found.
 This is due to it using dash->current_representation_->url_ as the baseurl agument for ParseSegmentTemplate.
 This should actually be using dash->current_adaptationset_->base_url_

 dash->current_representation_->url_ is getting set to the previous initialization below when it starts on the Reprensentation
 https://github.com/xbmc/inputstream.adaptive/blob/Matrix/src/parser/DASHTree.cpp#L772
 So further on its using the previous initialisation  url as a baseurl for the new initialisation url

2) 
Fixes if startnumber provided in adaptionset SegmentTemplate but not provided in representation SegmentTemplate .
   Currently it will always use 1 if not found. With this PR, it will use the existing startnumber 