### PR TITLE
HEVC: Use constant frame rate if average is 0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -890,9 +890,15 @@ public:
               AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, sample_description))
       {
         bool ret = false;
-        if (hevc->GetConstantFrameRate() && hevc->GetAverageFrameRate())
+        if (hevc->GetAverageFrameRate())
         {
           info.SetFpsRate(hevc->GetAverageFrameRate());
+          info.SetFpsScale(256);
+          ret = true;
+        }
+        else if (hevc->GetConstantFrameRate())
+        {
+          info.SetFpsRate(hevc->GetConstantFrameRate());
           info.SetFpsScale(256);
           ret = true;
         }


### PR DESCRIPTION
When playing HEVC stream, `hints.fpsrate` is `0` if average frame rate from `Ap4HvccAtom` is `0`. This can be fixed by trying to use `ConstantFpsRate` when average is 0.

Even if IA reports `0` in `hints.fpsrate` this does not prevent playback as decoder eventually detects the real frame rate and switches accordingly but without the frame rate hint at the beginning Kodi will not adjust display refresh rate at the stream start but after an update from decoder - that for most TVs results in a black screen at that event, seconds after the stream started.