### PR TITLE
Refactor / Simplify effective (redirect) logic

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|media_renewal_url|media_renewal_time|max_bandwidth|play_timeshift_buffer"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">InputStream client for adaptive streams</summary>

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -39,7 +39,6 @@ AdaptiveStream::AdaptiveStream(AdaptiveTree& tree, AdaptiveTree::StreamType type
     currentPTSOffset_(0),
     absolutePTSOffset_(0),
     lastUpdated_(std::chrono::system_clock::now()),
-    lastMediaRenewal_(std::chrono::system_clock::now()),
     m_fixateInitialization(false),
     m_segmentFileOffset(0),
     play_timeshift_buffer_(false)
@@ -115,21 +114,6 @@ int AdaptiveStream::SecondsSinceUpdate() const
   return static_cast<int>(
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - tPoint)
           .count());
-}
-
-uint32_t AdaptiveStream::SecondsSinceMediaRenewal() const
-{
-  const std::chrono::time_point<std::chrono::system_clock>& tPoint(
-      lastMediaRenewal_ > tree_.GetLastMediaRenewal() ? lastMediaRenewal_
-                                                      : tree_.GetLastMediaRenewal());
-  return static_cast<int>(
-      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - tPoint)
-          .count());
-}
-
-void AdaptiveStream::UpdateSecondsSinceMediaRenewal()
-{
-  lastMediaRenewal_ = std::chrono::system_clock::now();
 }
 
 bool AdaptiveStream::write_data(const void* buffer, size_t buffer_size)

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -294,7 +294,7 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Segment* seg)
       if (current_rep_->flags_ & AdaptiveTree::Representation::URLSEGMENTS)
       {
         download_url_ = seg->url;
-        if (download_url_.find("://", 0) == std::string::npos)
+        if (download_url_.find("://") == std::string::npos)
           download_url_ = current_rep_->url_ + download_url_;
       }
       else

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -89,10 +89,6 @@ namespace adaptive
     virtual bool parseIndexRange() { return false; };
     bool write_data(const void *buffer, size_t buffer_size);
     bool prepareDownload(const AdaptiveTree::Segment *seg);
-    const std::string& getMediaRenewalUrl() const { return tree_.media_renewal_url_; };
-    const uint32_t& getMediaRenewalTime() const { return tree_.media_renewal_time_; };
-    uint32_t SecondsSinceMediaRenewal() const;
-    void UpdateSecondsSinceMediaRenewal();
     adaptive::AdaptiveTree& GetTree() { return tree_; };
 
   private:
@@ -144,7 +140,6 @@ namespace adaptive
     uint64_t absolute_position_;
     uint64_t currentPTSOffset_, absolutePTSOffset_;
     std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
-    std::chrono::time_point<std::chrono::system_clock> lastMediaRenewal_;
 
     uint16_t width_, height_;
     uint32_t bandwidth_;

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -56,7 +56,6 @@ namespace adaptive
     , updateInterval_(~0)
     , updateThread_(nullptr)
     , lastUpdated_(std::chrono::system_clock::now())
-    , lastMediaRenewal_(std::chrono::system_clock::now())
   {
   }
 
@@ -319,8 +318,6 @@ namespace adaptive
   {
     size_t paramPos = url.find('?');
     base_url_ = (paramPos == std::string::npos) ? url : url.substr(0, paramPos);
-    if (paramPos != std::string::npos)
-      manifest_parameter_= url.substr(paramPos);
 
     paramPos = base_url_.find_last_of('/', base_url_.length());
     if (paramPos == std::string::npos)

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -40,7 +40,6 @@ namespace adaptive
   AdaptiveTree::AdaptiveTree()
     : current_period_(nullptr)
     , next_period_(nullptr)
-    , update_parameter_pos_(std::string::npos)
     , parser_(0)
     , currentNode_(0)
     , segcount_(0)
@@ -170,7 +169,7 @@ namespace adaptive
   }
 
   void AdaptiveTree::OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize)
-  { 
+  {
     memcpy(dst + dstOffset, src, dataSize);
   }
 
@@ -314,15 +313,17 @@ namespace adaptive
           ++br;
   }
 
-  bool AdaptiveTree::PreparePaths(const std::string &url, const std::string &manifestUpdateParam)
+  bool AdaptiveTree::PreparePaths(const std::string &url)
   {
+    manifest_url_ = url;
+
     size_t paramPos = url.find('?');
     base_url_ = (paramPos == std::string::npos) ? url : url.substr(0, paramPos);
 
     paramPos = base_url_.find_last_of('/', base_url_.length());
     if (paramPos == std::string::npos)
     {
-      Log(LOGLEVEL_ERROR, "Invalid mpdURL: / expected (%s)", manifest_url_.c_str());
+      Log(LOGLEVEL_ERROR, "Invalid url: / expected (%s)", url.c_str());
       return false;
     }
     base_url_.resize(paramPos + 1);
@@ -338,6 +339,11 @@ namespace adaptive
     else
       base_domain_.clear();
 
+    return true;
+  }
+
+  void AdaptiveTree::PrepareManifestUrl(const std::string &url, const std::string &manifestUpdateParam)
+  {
     manifest_url_ = url;
 
     if (manifestUpdateParam.empty())
@@ -359,63 +365,19 @@ namespace adaptive
     }
     else
       update_parameter_ = manifestUpdateParam;
-
-    if (!update_parameter_.empty())
-    {
-      if (update_parameter_ != "full")
-      {
-        if ((update_parameter_pos_ = update_parameter_.find("$START_NUMBER$")) != std::string::npos)
-        {
-          if (update_parameter_[0] == '&' && manifest_url_.find("?") == std::string::npos)
-            update_parameter_[0] = '?';
-        }
-        else
-          update_parameter_.clear();
-      }
-    }
-    return true;
-  }
-
-  void AdaptiveTree::SetEffectiveURL(const std::string& url)
-  {
-    effective_url_ = url;
-    effective_domain_.clear();
-    std::string::size_type paramPos = effective_url_.find_first_of('?');
-    if (paramPos != std::string::npos)
-      effective_url_.resize(paramPos);
-
-    paramPos = effective_url_.find_last_of('/');
-    if (paramPos != std::string::npos)
-      effective_url_.resize(paramPos + 1);
-    else
-      effective_url_.clear();
-
-    if (effective_url_ == base_url_)
-      effective_url_.clear();
-
-    if (!effective_url_.empty())
-    {
-      paramPos = effective_url_.find_first_of('/', 8);
-      effective_domain_ = effective_url_.substr(0, paramPos);
-    }
   }
 
   std::string AdaptiveTree::BuildDownloadUrl(const std::string& url) const
   {
     if (!url.empty())
     {
-      if (url.front() == '/')
-        return effective_domain_.empty() ? base_domain_ + url : effective_domain_ + url;
-      else if (!effective_url_.empty() && url.compare(0, base_url_.size(), base_url_) == 0)
-      {
-        std::string newUrl(url);
-        newUrl.replace(0, base_url_.size(), effective_url_);
-        return newUrl;
-      }
+      if (url.front() != '/' && url.find("://") == std::string::npos)
+        return base_url_ + url;
+      else if (url.front() == '/')
+        return base_domain_ + url;
     }
     return url;
   }
-
 
   void AdaptiveTree::SortTree()
   {

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -416,9 +416,6 @@ public:
       update_parameter_;
   std::string::size_type update_parameter_pos_;
   std::string etag_, last_modified_;
-  std::string media_renewal_url_;
-  uint32_t media_renewal_time_;
-  std::string manifest_parameter_;
 
   /* XML Parsing*/
   XML_Parser parser_;
@@ -490,7 +487,6 @@ public:
   bool HasUpdateThread() const { return updateThread_ != 0 && has_timeshift_buffer_ && updateInterval_ && !update_parameter_.empty(); };
   void RefreshUpdateThread();
   const std::chrono::time_point<std::chrono::system_clock> GetLastUpdated() const { return lastUpdated_; };
-  const std::chrono::time_point<std::chrono::system_clock> GetLastMediaRenewal() const { return lastMediaRenewal_; };
 
 protected:
   virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr, bool scanEffectiveURL = true);
@@ -507,7 +503,6 @@ protected:
   std::condition_variable updateVar_;
   std::thread *updateThread_;
   std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
-  std::chrono::time_point<std::chrono::system_clock> lastMediaRenewal_;
 
 private:
   void SegmentUpdateWorker();

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -412,10 +412,13 @@ public:
   }*current_period_, *next_period_;
 
   std::vector<Period*> periods_;
-  std::string manifest_url_, base_url_, effective_url_, base_domain_, effective_domain_,
-      update_parameter_;
-  std::string::size_type update_parameter_pos_;
-  std::string etag_, last_modified_;
+  std::string manifest_url_;
+  std::string base_url_;
+  std::string effective_url_;
+  std::string base_domain_;
+  std::string update_parameter_;
+  std::string etag_;
+  std::string last_modified_;
 
   /* XML Parsing*/
   XML_Parser parser_;
@@ -480,7 +483,6 @@ public:
                : 0;
   };
 
-  void SetEffectiveURL(const std::string& url);
   std::string BuildDownloadUrl(const std::string& url) const;
 
   std::mutex &GetTreeMutex() { return treeMutex_; };
@@ -489,9 +491,13 @@ public:
   const std::chrono::time_point<std::chrono::system_clock> GetLastUpdated() const { return lastUpdated_; };
 
 protected:
-  virtual bool download(const char* url, const std::map<std::string, std::string> &manifestHeaders, void *opaque = nullptr, bool scanEffectiveURL = true);
+  virtual bool download(const char* url,
+                        const std::map<std::string, std::string>& manifestHeaders,
+                        void* opaque = nullptr,
+                        bool isManifest = true);
   virtual bool write_data(void *buffer, size_t buffer_size, void *opaque) = 0;
-  bool PreparePaths(const std::string &url, const std::string &manifestUpdateParam);
+  bool PreparePaths(const std::string &url);
+  void PrepareManifestUrl(const std::string &url, const std::string &manifestUpdateParam);
   void SortTree();
 
   // Live segment update section

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,7 +264,7 @@ Kodi Streams implementation
 bool adaptive::AdaptiveTree::download(const char* url,
                                       const std::map<std::string, std::string>& manifestHeaders,
                                       void* opaque,
-                                      bool scanEffectiveURL)
+                                      bool isManifest)
 {
   // open the file
   kodi::vfs::CFile file;
@@ -281,15 +281,16 @@ bool adaptive::AdaptiveTree::download(const char* url,
 
   if (!file.CURLOpen(ADDON_READ_CHUNKED | ADDON_READ_NO_CACHE))
   {
-    kodi::Log(ADDON_LOG_ERROR, "Cannot download %s", url);
+    kodi::Log(ADDON_LOG_ERROR, "Download failed: %s", url);
     return false;
   }
 
-  if (scanEffectiveURL)
+  effective_url_ = file.GetPropertyValue(ADDON_FILE_PROPERTY_EFFECTIVE_URL, "");
+
+  if (isManifest && !PreparePaths(effective_url_))
   {
-    std::string effective_url = file.GetPropertyValue(ADDON_FILE_PROPERTY_EFFECTIVE_URL, "");
-    kodi::Log(ADDON_LOG_DEBUG, "Effective URL %s", effective_url.c_str());
-    SetEffectiveURL(effective_url);
+    file.Close();
+    return false;
   }
 
   // read the file
@@ -307,7 +308,7 @@ bool adaptive::AdaptiveTree::download(const char* url,
 
   file.Close();
 
-  kodi::Log(ADDON_LOG_DEBUG, "Download %s finished", url);
+  kodi::Log(ADDON_LOG_DEBUG, "Download finished: %s", effective_url_.c_str());
 
   return nbRead == 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -315,12 +315,8 @@ bool adaptive::AdaptiveTree::download(const char* url,
 bool KodiAdaptiveStream::download(const char* url,
                                   const std::map<std::string, std::string>& mediaHeaders)
 {
-  bool retry_403 = true;
-  bool retry_MRT = true;
   kodi::vfs::CFile file;
-  std::string newUrl;
 
-RETRY:
   // open the file
   if (!file.CURLCreate(url))
     return false;
@@ -346,37 +342,9 @@ RETRY:
 
     size_t nbRead = ~0UL;
 
-    if (((returnCode == 403 && retry_403) ||
-         (getMediaRenewalTime() > 0 && SecondsSinceMediaRenewal() >= getMediaRenewalTime() &&
-          retry_MRT)) &&
-        !getMediaRenewalUrl().empty())
+    if (returnCode >= 400)
     {
-      UpdateSecondsSinceMediaRenewal();
-
-      if (returnCode == 403)
-        retry_403 = false;
-      else
-        retry_MRT = false;
-
-      std::vector<kodi::vfs::CDirEntry> items;
-      if (kodi::vfs::GetDirectory(getMediaRenewalUrl(), "", items) && items.size() == 1)
-      {
-        std::string effective_url = items[0].Path();
-        if (effective_url.back() != '/')
-          effective_url += '/';
-        kodi::Log(ADDON_LOG_DEBUG, "Renewed URL: %s", effective_url.c_str());
-        GetTree().SetEffectiveURL(effective_url);
-        newUrl = GetTree().BuildDownloadUrl(url);
-        url = newUrl.c_str();
-        goto RETRY;
-      }
-      else
-        kodi::Log(ADDON_LOG_ERROR, "Retrieving renewal URL failed (%s)",
-                  getMediaRenewalUrl().c_str());
-    }
-    else if (returnCode >= 400)
-    {
-      kodi::Log(ADDON_LOG_ERROR, "Download %s failed with error: %d", url, returnCode);
+      kodi::Log(ADDON_LOG_ERROR, "Download failed with error %d: %s", returnCode, url);
     }
     else
     {
@@ -389,7 +357,7 @@ RETRY:
 
       if (!nbReadOverall)
       {
-        kodi::Log(ADDON_LOG_ERROR, "Download %s doesn't provide any data: invalid", url);
+        kodi::Log(ADDON_LOG_ERROR, "Download doesn't provide any data: %s", url);
         return false;
       }
 
@@ -405,7 +373,7 @@ RETRY:
                            current_download_speed_ * ratio);
       }
       kodi::Log(ADDON_LOG_DEBUG,
-                "Download %s finished, avg speed: %0.2lfbyte/s, current speed: %0.2lfbyte/s", url,
+                "Download finished: %s , avg speed: %0.2lfbyte/s, current speed: %0.2lfbyte/s", url,
                 get_download_speed(), current_download_speed_);
     }
     file.Close();
@@ -2002,8 +1970,6 @@ Session::Session(MANIFEST_TYPE manifestType,
                  const std::string& strLicKey,
                  const std::string& strLicData,
                  const std::string& strCert,
-                 const std::string& strMediaRenewalUrl,
-                 const uint32_t intMediaRenewalTime,
                  const std::map<std::string, std::string>& manifestHeaders,
                  const std::map<std::string, std::string>& mediaHeaders,
                  const std::string& profile_path,
@@ -2013,8 +1979,8 @@ Session::Session(MANIFEST_TYPE manifestType,
                  bool play_timeshift_buffer,
                  bool force_secure_decoder)
   : manifest_type_(manifestType),
-    mpdFileURL_(strURL),
-    mpdUpdateParam_(strUpdateParam),
+    manifestURL_(strURL),
+    manifestUpdateParam_(strUpdateParam),
     license_key_(strLicKey),
     license_type_(strLicType),
     license_data_(strLicData),
@@ -2110,8 +2076,6 @@ Session::Session(MANIFEST_TYPE manifestType,
     server_certificate_.SetDataSize(dstsz);
   }
   adaptiveTree_->manifest_headers_ = manifestHeaders;
-  adaptiveTree_->media_renewal_url_ = strMediaRenewalUrl;
-  adaptiveTree_->media_renewal_time_ = intMediaRenewalTime;
 }
 
 Session::~Session()
@@ -2244,16 +2208,16 @@ bool Session::Initialize(const std::uint8_t config, uint32_t max_user_bandwidth)
     kodi::Log(ADDON_LOG_DEBUG, "Supported URN: %s", adaptiveTree_->supportedKeySystem_.c_str());
   }
 
-  // Open mpd file with mpd location redirect support  bool mpdSuccess;
-  std::string mpdUrl =
-      adaptiveTree_->location_.empty() ? mpdFileURL_.c_str() : adaptiveTree_->location_;
-  if (!adaptiveTree_->open(mpdUrl.c_str(), mpdUpdateParam_.c_str()) || adaptiveTree_->empty())
+  // Open manifest file with location redirect support  bool mpdSuccess;
+  std::string manifestUrl =
+      adaptiveTree_->location_.empty() ? manifestURL_.c_str() : adaptiveTree_->location_;
+  if (!adaptiveTree_->open(manifestUrl.c_str(), manifestUpdateParam_.c_str()) || adaptiveTree_->empty())
   {
-    kodi::Log(ADDON_LOG_ERROR, "Could not open / parse mpdURL (%s)", mpdFileURL_.c_str());
+    kodi::Log(ADDON_LOG_ERROR, "Could not open / parse manifest (%s)", manifestUrl.c_str());
     return false;
   }
   kodi::Log(ADDON_LOG_INFO,
-            "Successfully parsed .mpd file. #Periods: %ld, #Streams in first period: %ld, Type: "
+            "Successfully parsed manifest file. #Periods: %ld, #Streams in first period: %ld, Type: "
             "%s, Download speed: %0.4f Bytes/s",
             adaptiveTree_->periods_.size(), adaptiveTree_->current_period_->adaptationSets_.size(),
             adaptiveTree_->has_timeshift_buffer_ ? "live" : "VOD", adaptiveTree_->download_speed_);
@@ -3305,10 +3269,9 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
 {
   kodi::Log(ADDON_LOG_DEBUG, "Open()");
 
-  std::string lt, lk, ld, lsc, mfup, ov_audio, mru;
-  uint32_t mrt = 0;
+  std::string lt, lk, ld, lsc, mfup, ov_audio;
   std::map<std::string, std::string> manh, medh;
-  std::string mpd_url = props.GetURL();
+  std::string url = props.GetURL();
   MANIFEST_TYPE manifest(MANIFEST_TYPE_UNKNOWN);
   std::uint8_t config(0);
   uint32_t max_user_bandwidth = 0;
@@ -3375,16 +3338,6 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
       kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.original_audio_language: %s",
                 ov_audio.c_str());
     }
-    else if (prop.first == "inputstream.adaptive.media_renewal_url")
-    {
-      mru = prop.second;
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.media_renewal_url: %s", mru.c_str());
-    }
-    else if (prop.first == "inputstream.adaptive.media_renewal_time")
-    {
-      mrt = std::stoi(prop.second);
-      kodi::Log(ADDON_LOG_DEBUG, "found inputstream.adaptive.media_renewal_time: %d", mrt);
-    }
     else if (prop.first == "inputstream.adaptive.max_bandwidth")
     {
       max_user_bandwidth = std::stoi(prop.second);
@@ -3401,12 +3354,12 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
     return false;
   }
 
-  std::string::size_type posHeader(mpd_url.find("|"));
+  std::string::size_type posHeader(url.find("|"));
   if (posHeader != std::string::npos)
   {
     manh.clear();
-    parseheader(manh, mpd_url.substr(posHeader + 1));
-    mpd_url = mpd_url.substr(0, posHeader);
+    parseheader(manh, url.substr(posHeader + 1));
+    url = url.substr(0, posHeader);
   }
 
   if (medh.empty())
@@ -3414,8 +3367,8 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
 
   kodihost->SetProfilePath(props.GetProfileFolder());
 
-  m_session = std::shared_ptr<Session>(new Session(manifest, mpd_url.c_str(), mfup, lt, lk, ld, lsc,
-                                                   mru, mrt, manh, medh, props.GetProfileFolder(),
+  m_session = std::shared_ptr<Session>(new Session(manifest, url.c_str(), mfup, lt, lk, ld, lsc,
+                                                   manh, medh, props.GetProfileFolder(),
                                                    m_width, m_height, ov_audio,
                                                    m_playTimeshiftBuffer, force_secure_decoder));
   m_session->SetVideoResolution(m_width, m_height);

--- a/src/main.h
+++ b/src/main.h
@@ -87,8 +87,6 @@ public:
           const std::string& strLicKey,
           const std::string& strLicData,
           const std::string& strCert,
-          const std::string& strMediaRenewalUrl,
-          const uint32_t intMediaRenewalTime,
           const std::map<std::string, std::string>& manifestHeaders,
           const std::map<std::string, std::string>& mediaHeaders,
           const std::string& profile_path,
@@ -175,7 +173,7 @@ protected:
 
 private:
   MANIFEST_TYPE manifest_type_;
-  std::string mpdFileURL_, mpdUpdateParam_;
+  std::string manifestURL_, manifestUpdateParam_;
   std::string license_key_, license_type_, license_data_;
   std::map<std::string, std::string> media_headers_;
   AP4_DataBuffer server_certificate_;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1650,8 +1650,6 @@ void DASHTree::RefreshLiveSegments()
     updateTree.supportedKeySystem_ = supportedKeySystem_;
     //Location element should be used on updates
     updateTree.location_ = location_;
-    updateTree.effective_url_ = effective_url_;
-    updateTree.effective_domain_ = effective_domain_;
 
     if (!~update_parameter_pos_)
     {

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -107,7 +107,7 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
   if (map["METHOD"] == "AES-128" && !map["URI"].empty())
   {
     current_pssh_ = map["URI"];
-    if (current_pssh_[0] != '/' && current_pssh_.find("://", 0) == std::string::npos)
+    if (current_pssh_[0] != '/' && current_pssh_.find("://") == std::string::npos)
       current_pssh_ = baseUrl + current_pssh_;
 
     current_iv_ = m_decrypter->convertIV(map["IV"]);
@@ -158,13 +158,13 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
 
 bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
-  PreparePaths(url, manifestUpdateParam);
+  PrepareManifestUrl(url, manifestUpdateParam);
   if (download(manifest_url_.c_str(), manifest_headers_, &manifest_stream))
-    return processManifest(manifest_stream, url);
+    return processManifest(manifest_stream);
   return false;
 }
 
-bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
+bool HLSTree::processManifest(std::stringstream& stream)
 {
 #if FILEDEBUG
   FILE* f = fopen("inputstream_adaptive_master.m3u8", "w");
@@ -232,10 +232,7 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
       std::map<std::string, std::string>::iterator res;
       if ((res = map.find("URI")) != map.end())
       {
-        if (res->second[0] != '/' && res->second.find("://", 0) == std::string::npos)
-          rep->source_url_ = base_url_ + res->second;
-        else
-          rep->source_url_ = res->second;
+        rep->source_url_ = BuildDownloadUrl(res->second);
 
         // default to WebVTT
         if (type == SUBTITLE)
@@ -306,7 +303,7 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
       current_representation_->bandwidth_ = 0;
       current_representation_->codecs_ = getVideoCodec("");
       current_representation_->containerType_ = CONTAINERTYPE_NOTYPE;
-      current_representation_->source_url_ = url;
+      current_representation_->source_url_ = manifest_url_;
       current_adaptationset_->representations_.push_back(current_representation_);
 
       // We assume audio is included
@@ -316,10 +313,7 @@ bool HLSTree::processManifest(std::stringstream& stream, const std::string& url)
     }
     else if (!line.empty() && line.compare(0, 1, "#") != 0 && current_representation_)
     {
-      if (line[0] != '/' && line.find("://", 0) == std::string::npos)
-        current_representation_->source_url_ = base_url_ + line;
-      else
-        current_representation_->source_url_ = line;
+      current_representation_->source_url_ = BuildDownloadUrl(line);
 
       //Ignore duplicate reps
       for (auto const* rep : current_adaptationset_->representations_)
@@ -394,7 +388,6 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
     Segment newInitialization;
     uint32_t segmentId(rep->getCurrentSegmentNumber());
     std::stringstream stream;
-    std::string download_url = BuildDownloadUrl(rep->source_url_);
     uint32_t adp_pos =
         std::find(period->adaptationSets_.begin(), period->adaptationSets_.end(), adp) -
         period->adaptationSets_.begin();
@@ -407,7 +400,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
 
     if (rep->flags_ & Representation::DOWNLOADED)
       ;
-    else if (download(download_url.c_str(), manifest_headers_, &stream, false))
+    else if (download(rep->source_url_.c_str(), manifest_headers_, &stream, false))
     {
 #if FILEDEBUG
       FILE* f = fopen("inputstream_adaptive_sub.m3u8", "w");
@@ -434,9 +427,9 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
       segment.startPTS_ = ~0ULL;
       segment.pssh_set_ = 0;
 
-      std::string::size_type paramPos = rep->source_url_.find('?');
+      std::string::size_type paramPos = effective_url_.find('?');
       base_url =
-          (paramPos == std::string::npos) ? rep->source_url_ : rep->source_url_.substr(0, paramPos);
+          (paramPos == std::string::npos) ? effective_url_ : effective_url_.substr(0, paramPos);
 
       paramPos = base_url.rfind('/');
       if (paramPos != std::string::npos)
@@ -504,7 +497,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           if (!byteRange || rep->url_.empty())
           {
             std::string url;
-            if (line[0] != '/' && line.find("://", 0) == std::string::npos)
+            if (line[0] != '/' && line.find("://") == std::string::npos)
               url = base_url + line;
             else
               url = line;
@@ -671,7 +664,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
               delete[] newInitialization.url;
             segmentInitialization = true;
             std::string uri = map["URI"];
-            if (uri[0] != '/' && uri.find("://", 0) == std::string::npos)
+            if (uri[0] != '/' && uri.find("://") == std::string::npos)
               map_url = base_url + uri;
             else
               map_url = uri;

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -61,7 +61,7 @@ public:
                                AdaptationSet* adp,
                                Representation* rep,
                                StreamType type) override;
-  virtual bool processManifest(std::stringstream& stream, const std::string& url);
+  virtual bool processManifest(std::stringstream& stream);
 
 protected:
   virtual void RefreshLiveSegments() override;

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -349,8 +349,6 @@ static void XMLCALL end(void* data, const char* el)
 
 bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
-  PreparePaths(url, manifestUpdateParam);
-
   parser_ = XML_ParserCreate(NULL);
   if (!parser_)
     return false;
@@ -360,6 +358,7 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
   currentNode_ = 0;
   strXMLText_.clear();
 
+  PrepareManifestUrl(url, manifestUpdateParam);
   bool ret = download(manifest_url_.c_str(), manifest_headers_);
 
   XML_ParserFree(parser_);

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -23,14 +23,22 @@ void SetFileName(std::string& file, std::string name)
 bool adaptive::AdaptiveTree::download(const char* url,
                                       const std::map<std::string, std::string>& manifestHeaders,
                                       void* opaque,
-                                      bool scanEffectiveURL)
+                                      bool isManifest)
 {
   FILE* f = fopen(testHelper::testFile.c_str(), "rb");
   if (!f)
     return false;
 
-  if (scanEffectiveURL && !testHelper::effectiveUrl.empty())
-    SetEffectiveURL(testHelper::effectiveUrl);
+  if (!testHelper::effectiveUrl.empty())
+    effective_url_ = testHelper::effectiveUrl;
+  else
+    effective_url_ = url;
+
+  if (isManifest && !PreparePaths(effective_url_))
+  {
+    fclose(f);
+    return false;
+  }
 
   // read the file
   static const unsigned int CHUNKSIZE = 16384;

--- a/src/test/manifests/mpd/segtpl.mpd
+++ b/src/test/manifests/mpd/segtpl.mpd
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" availabilityStartTime="1970-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" publishTime="2020-06-08T18:54:24Z" timeShiftBufferDepth="PT5M" type="dynamic" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
   <Period id="p0" start="PT0S">
-    <AdaptationSet contentType="audio" lang="en" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
-      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation audioSamplingRate="48000" bandwidth="48000" codecs="mp4a.40.2" id="A48">
-        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
-      </Representation>
-    </AdaptationSet>
     <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640" mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true" startWithSAP="1">
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360" id="V300" sar="1:1" width="640" />
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" lang="en" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate duration="2" initialization="/$RepresentationID$/init.mp4" media="/$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation audioSamplingRate="48000" bandwidth="48000" codecs="mp4a.40.2" id="A48">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+      </Representation>
     </AdaptationSet>
   </Period>
 </MPD>

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -774,7 +774,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
 
   if (!resLimit.empty())
   {
-    std::string::size_type posMax = resLimit.find("max=", 0);
+    std::string::size_type posMax = resLimit.find("max=");
     if (posMax != std::string::npos)
       resolution_limit_ = atoi(resLimit.data() + (posMax + 4));
   }

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -645,7 +645,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(AMediaDrmByteArray &sessio
   resLimit = host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "X-Limit-Video");
   if (!resLimit.empty())
   {
-    std::string::size_type posMax = resLimit.find("max=", 0);
+    std::string::size_type posMax = resLimit.find("max=");
     if (posMax != std::string::npos)
       resolution_limit_ = atoi(resLimit.data() + (posMax + 4));
   }

--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -821,7 +821,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
 
   if (!resLimit.empty())
   {
-    std::string::size_type posMax = resLimit.find("max=", 0);
+    std::string::size_type posMax = resLimit.find("max=");
     if (posMax != std::string::npos)
       resolution_limit_ = atoi(resLimit.data() + (posMax + 4));
   }


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/617
fixes: https://github.com/xbmc/inputstream.adaptive/issues/672

Commit 1 Changes
- Remove media_renewal_url & media_renewal_time as no longer work with commit 2 changes due to relying on replacing domain strings (unreliable and often doesnt work). Peak himself said this was a workaround (hack) https://github.com/xbmc/inputstream.adaptive/issues/226#issuecomment-494290363. 
Correct approach would be manifest_update_param="full" or a Python proxy if that won't work.
Only add-on I could find using this was Ziggo IPTV. That author has now changed to using a proxy https://github.com/xbmc/inputstream.adaptive/pull/620#issuecomment-809036063
- rename "mpd" to "manifest" in main due to supporting more than mpd - also update log messages
- removed manifest_parameter_ as not used

Commit 2 Changes
- create a valid url from filename for tests that pass in empty url
- updated all .find("", 0); to .find(""); as 0 is default parameter
- merge SetEffectiveURL code into PreparePaths and remove SetEffectiveURL function as not used
- move base_url appending into BuildDownloadUrl. This removes a lot of duplicate code from elsewhere.
- update download function to call PreparePaths so the final redirected URL is correctly used
- add new PrepareManifestUrl function that is called before downloading manifest to correctly update_parameter_ and remove it from the url
- allow update_parameter_ to work correctly with redirect by moving ? or & check into RefreshLiveSegments
- make update_parameter_pos_ into a local variable as only needed in RefreshLiveSegments
- HLS: remove url parameter from processManifest as not used
- HLS: use BuildDownloadUrl to remove duplicate code
- HLS: when playing a substream playlist directly, use manifest_url_ as this will be the effective url 
This stops doing the redirect again when IA requests it a 2nd time
(could also use effective_url_ instead of manifest_url_ if that makes more sense?)
With some bigger changes, we could probably stop the 2nd request - but that's out of this PR scope and IMO be quite hacky
as it would skip the normal HLS flow
- HLS: use the effective_url_ as basis for calculating substreams
- update tests - enable HLS skipped test

**Test builds here (Matrix only):
https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-675/36/artifacts**