### PR TITLE
cdm_adapter: log error if LoadNativeLibrary fails

### DIFF
--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
@@ -160,7 +160,11 @@ void CdmAdapter::Initialize()
   library_ = base::LoadNativeLibrary(cdm_path_, &error);
 
   if (!library_)
+  {
+    std::string log_error = "CDM LoadNativeLibrary error: " + error.ToString();
+    client_->CDMLog(log_error.c_str());
     return;
+  }
 
   init_cdm_func = reinterpret_cast<InitializeCdmModuleFunc>(base::GetFunctionPointerFromNativeLibrary(library_, MAKE_STRING(INITIALIZE_CDM_MODULE)));
   deinit_cdm_func = reinterpret_cast<DeinitializeCdmModuleFunc>(base::GetFunctionPointerFromNativeLibrary(library_, "DeinitializeCdmModule"));


### PR DESCRIPTION
In case loading libwidevine fails, we should print the reason to log. This simple patch allows to print the error to the debug log.

Related to https://github.com/xbmc/inputstream.adaptive/issues/678