### PR TITLE
Bump to v2.6.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# inputstream.adaptive (2.6.14)
+# inputstream.adaptive (2.6.15)
 
 This is an adaptive file addon for kodi's new InputStream Interface.
 

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.14"
+  version="2.6.15"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -19,6 +19,14 @@
     <description lang="es_ES">Cliente InputStream para flujo de datos adaptativos</description>
     <platform>@PLATFORM@</platform>
     <news>
+v2.6.15 (2021-05-18)
+- [HLS] support webvtt subtitle extensions
+- [DASH] fix segmentTemplate calculation
+- [HEVC] use constant frame rate if average is 0
+- [HLS] don't reset pts on new periods
+- Don't remove secure decoder cap if not requested in manifest_type
+- [Android] fallback to widevine L3 if L1 provisioning fails
+
 v2.6.14 (2021-04-22)
 - Don't overwrite manifest headers with stream headers
 - Stream headers default to manifest headers


### PR DESCRIPTION
This is a call out to all users and stakeholders to test the incoming Matrix inputstream.adaptive v2.6.15 with your add-on(s) and report back.

You can find various v2.6.15 builds at:
* [Most platforms (Android, iOS, macOS and Windows)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-683/1/artifacts)
* Linux platforms can be compiled from source - please see [here (incomplete)](https://github.com/xbmc/inputstream.adaptive/wiki/How-to-build). When building from source be sure to checkout this commit https://github.com/xbmc/inputstream.adaptive/commit/b437272f5d85e2de072df897aed3c82115a3c40c

If you want to do extensive testing with your add-on(s), you can find a list of tasks to complete to test the behaviour: https://github.com/xbmc/inputstream.adaptive/wiki/Test-plan

And you can report back success or failure at the Wiki at: https://github.com/xbmc/inputstream.adaptive/wiki/Test-results

The main features introduced in this release are:
* Automatically retrying widevine streams that fail on L1 provisioning with an attempt at L3. This stops 'blank screen' for users that have the typical 'cheap' Android box with 'fake' L1, and they instead get to at least watch the SD L3 stream.
* Secure decoder will automatically be tried on devices with secure decoders/L1 capabilities rather than add-ons having to 'force' the secure decoder. Old behaviour is still available through an IA expert setting.

There are reports that the secure decoder is causing stuttering where non-secure decoding did not. Please report if you encounter this.