### PR TITLE
[Dash] set updateInterval to 30s if minimumUpdatePeriod is 0s

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1052,6 +1052,10 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       {
         uint64_t dur(0);
         AddDuration((const char*)*(attr + 1), dur, 1500);
+        // 0S minimumUpdatePeriod = refresh after every segment
+        // We already do that so lets set our minimum updateInterval to 30s
+        if (dur == 0)
+          dur = 30000;
         dash->SetUpdateInterval(static_cast<uint32_t>(dur));
       }
       attr += 2;


### PR DESCRIPTION
http://livesim.dashif.org/livesim/segtimeline_1/testpic_2s/Manifest.mpd uses minimumUpdatePeriod="0S"
this causes IA to download the manifest as fast as it can. which results in no playback and kodi freezing.

https://github.com/Dash-Industry-Forum/dash.js/issues/1141#issuecomment-181593261
"The minimumUpdatePeriod for this manifest is declared as 0s. This is valid syntax and it declares that it should reload the manifest with each new segment that it retrieves. However, most players set up an interval timer to reload the manifest and hard code this to the value of minimumUpdatePeriod, which would be pretty fatal in this case."

https://github.com/xbmc/inputstream.adaptive/blob/Matrix/src/common/AdaptiveTree.cpp#L471
`if (updateVar_.wait_for(updLck, std::chrono::milliseconds(updateInterval_)) == std::cv_status::timeout)`
With updateInterval of 0, that will complete straight away and refresh.
Now, this gets broken anyway after each segment is downloaded - so if we have 0s - we should just wait indefiently.
But I chose 30s for sanity sake