### PR TITLE
[fmp4] ensure streams are started when seeking into a new chapter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1057,6 +1057,7 @@ public:
   virtual void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid){};
   virtual void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid){};
   virtual bool RemoveStreamType(INPUTSTREAM_TYPE type) { return true; };
+  virtual bool IsStarted() const = 0;
 };
 
 /*******************************************************
@@ -1087,6 +1088,7 @@ public:
   void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override{};
   void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override{};
   bool RemoveStreamType(INPUTSTREAM_TYPE type) override { return true; };
+  bool IsStarted() const override { return true; }
 } DummyReader;
 
 /*******************************************************
@@ -1265,6 +1267,7 @@ public:
   }
 
   bool EOS() const override { return m_eos; };
+  bool IsStarted() const override { return m_started; };
   uint64_t DTS() const override { return m_dts; };
   uint64_t PTS() const override { return m_pts; };
   AP4_UI32 GetStreamId() const override { return m_streamId; };
@@ -1591,6 +1594,7 @@ public:
       m_codecHandler = new TTMLCodecHandler(nullptr);
   }
 
+  bool IsStarted() const override { return true; };
   bool EOS() const override { return m_eos; };
   uint64_t DTS() const override { return m_pts; };
   uint64_t PTS() const override { return m_pts; };
@@ -1708,6 +1712,7 @@ public:
     return m_typeMask == 0;
   };
 
+  bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_dts; }
   uint64_t PTS() const override { return m_pts; }
@@ -1805,6 +1810,7 @@ public:
   ADTSSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
     : ADTSReader(input), m_streamId(streamId), m_stream(dynamic_cast<AP4_DASHStream*>(input)){};
 
+  bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_pts; }
   uint64_t PTS() const override { return m_pts; }
@@ -1890,6 +1896,7 @@ public:
   WebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
     : WebmReader(input), m_streamId(streamId), m_stream(dynamic_cast<AP4_DASHStream*>(input)){};
 
+  bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_dts; }
   uint64_t PTS() const override { return m_pts; }
@@ -2862,6 +2869,25 @@ uint64_t Session::GetTimeshiftBufferStart()
     return 0ULL;
 }
 
+void Session::StartReader(
+    STREAM* stream, uint64_t seekTimeCorrected, int64_t ptsDiff, bool preceeding, bool timing)
+{
+  bool bReset = true;
+  if (timing)
+    seekTimeCorrected += stream->stream_.GetAbsolutePTSOffset();
+  else
+    seekTimeCorrected -= ptsDiff;
+  stream->stream_.seek_time(
+      static_cast<double>(seekTimeCorrected / STREAM_TIME_BASE),
+      preceeding, bReset);
+  if (bReset)
+    stream->reader_->Reset(false);
+  bool bStarted = false;
+  stream->reader_->Start(bStarted);
+  if (bStarted && (stream->reader_->GetInformation(stream->info_)))
+    changed_ = true;
+}
+
 SampleReader* Session::GetNextSample()
 {
   STREAM *res(0), *waiting(0);
@@ -2927,6 +2953,7 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
 
   seekTime -= chapterTime;
 
+  // don't try to seek past the end of the stream, leave a sensible amount so we can buffer properly
   if (adaptiveTree_->has_timeshift_buffer_)
   {
     uint64_t curTime, maxTime(0);
@@ -2940,11 +2967,19 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
     }
   }
 
+  // correct for starting segment pts value of chapter and chapter offset within program
   uint64_t seekTimeCorrected = static_cast<uint64_t>(seekTime * STREAM_TIME_BASE);
+  int64_t ptsDiff = 0;
   if (timing_stream_)
   {
+    // after seeking across chapters with fmp4 streams the reader will not have started
+    // so we start here to ensure that we have the required information to correctly
+    // seek with proper stream alignment
+    if (!timing_stream_->reader_->IsStarted())
+      StartReader(timing_stream_, seekTimeCorrected, ptsDiff, preceeding, true);
+
     seekTimeCorrected += timing_stream_->stream_.GetAbsolutePTSOffset();
-    int64_t ptsDiff = timing_stream_->reader_->GetPTSDiff();
+    ptsDiff = timing_stream_->reader_->GetPTSDiff();
     if (ptsDiff < 0 && seekTimeCorrected + ptsDiff > seekTimeCorrected)
       seekTimeCorrected = 0;
     else
@@ -2955,7 +2990,12 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
     if ((*b)->enabled && (*b)->reader_ &&
         (streamId == 0 || (*b)->info_.GetPhysicalIndex() == streamId))
     {
-      bool bReset;
+      bool bReset = true;
+      // all streams must be started before seeking to ensure cross chapter seeks
+      // will seek to the correct location/segment
+      if (!(*b)->reader_->IsStarted())
+        StartReader((*b), seekTimeCorrected, ptsDiff, preceeding, false);
+      // advance adaptiveStream to the correct segment (triggers segment download)
       if ((*b)->stream_.seek_time(
               static_cast<double>(seekTimeCorrected - (*b)->reader_->GetPTSDiff()) /
                   STREAM_TIME_BASE,
@@ -2963,6 +3003,7 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
       {
         if (bReset)
           (*b)->reader_->Reset(false);
+        // advance reader to requested time
         if (!(*b)->reader_->TimeSeek(seekTimeCorrected, preceeding))
           (*b)->reader_->Reset(true);
         else
@@ -2973,7 +3014,11 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
                     "seekTime(%0.1lf) for Stream:%d continues at %0.1lf (PTS: %llu)", seekTime,
                     (*b)->info_.GetPhysicalIndex(), destTime, (*b)->reader_->PTS());
           if ((*b)->info_.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
-            seekTime = destTime, seekTimeCorrected = (*b)->reader_->PTS(), preceeding = false;
+          {
+            seekTime = destTime;
+            seekTimeCorrected = (*b)->reader_->PTS();
+            preceeding = false;
+          }
           ret = true;
         }
       }

--- a/src/main.h
+++ b/src/main.h
@@ -144,6 +144,8 @@ public:
   uint64_t GetElapsedTimeMs()const { return elapsed_time_ / 1000; };
   uint64_t PTSToElapsed(uint64_t pts);
   uint64_t GetTimeshiftBufferStart();
+  void StartReader(
+      STREAM* stream, uint64_t seekTimeCorrected, int64_t ptsDiff, bool preceeding, bool timing);
   bool CheckChange(bool bSet = false){ bool ret = changed_; changed_ = bSet; return ret; };
   void SetVideoResolution(unsigned int w, unsigned int h) { width_ = w; height_ = h;};
   bool SeekTime(double seekTime, unsigned int streamId = 0, bool preceeding=true);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
As documented in #681 there is a current issue when seeking across chapter boundaries, this PR addresses that issue.
<!--- Describe your change in detail here. -->
fmp4 stream readers are not 'started' when a new chapter is loaded. This doesn't happen until either the first sample is read - called by DemuxRead() from Kodi, or through the SeekTime function itself during the seek process. The problem is that to function correctly, SeekTime needs to have accurate data from the stream reader, which is only populated once the stream reader has started, at this point in the function it is too late and the typical net effect is the audio stream advances to a segment far ahead of the video stream - playback then has no audio.

This change will check in SeekTime if the reader has started before the critical information is required and start it accordingly. Seeking can now take place in the same fashion whether seeking within a chapter or outside of.

I've also added some comments throughout SeekTime to help explain the inner workings for others benefit.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
This change is required in conjunction with #663 to solve #580 and similar issues that have been mentioned in #667
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #681

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
Tested on this stream:
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://proxy.uat.widevine.com/proxy||R{SSM}|
https://raw.githubusercontent.com/glennguy/wvtest/mp-live-clear-alt-2/h264_master.m3u8
```
* No DRM
* Internal PTS of start of stream (first segment) is not 0
* 2 chapters

Also tested on NBA add-on (in conjunction with changes in PR #663):
* Widevine
* Internal PTS of start of stream (first segment) is not 0
* 2 chapters
* Live

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows 10 Matrix 19.0

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users can seek without losing their audio stream
Users can use resume points (and add-on authors can use resume point workaround to make multi chapter live streams start in chapter > 1) and not lose audio stream

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
