### PR TITLE
[DASH] Allow merging video adaption sets

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -383,12 +383,10 @@ namespace adaptive
   {
     for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep; ++bp)
     {
-      std::stable_sort((*bp)->adaptationSets_.begin(), (*bp)->adaptationSets_.end(), AdaptationSet::compare);
-
-      // Merge AUDIO streams, some provider pass everythng in own Audio sets
+      // Merge VIDEO & AUDIO adaption sets
       for (std::vector<AdaptationSet*>::iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea;)
       {
-        if ((*ba)->type_ == AUDIO && ba + 1 != ea && AdaptationSet::mergeable(*ba, *(ba + 1)))
+        if (((*ba)->type_ == VIDEO || (*ba)->type_ == AUDIO) && ba + 1 != ea && AdaptationSet::mergeable(*ba, *(ba + 1)))
         {
           for (size_t i(1); i < (*bp)->psshSets_.size(); ++i)
             if ((*bp)->psshSets_[i].adaptation_set_ == *ba)
@@ -402,6 +400,8 @@ namespace adaptive
         else
           ++ba;
       }
+
+      std::stable_sort((*bp)->adaptationSets_.begin(), (*bp)->adaptationSets_.end(), AdaptationSet::compare);
 
       for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea; ++ba)
       {

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -302,9 +302,7 @@ public:
     static bool compare(const AdaptationSet* a, const AdaptationSet *b)
     {
       if (a->type_ != b->type_)
-        return a->type_ < b->type_;
-      if (a->language_ != b->language_)
-        return a->language_ < b->language_;
+        return false;
       if (a->default_ != b->default_)
         return a->default_;
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -349,27 +349,26 @@ public:
 
     static bool mergeable(const AdaptationSet* a, const AdaptationSet *b)
     {
-      if (a->type_ == b->type_
-        && a->timescale_ == b->timescale_
-        && a->duration_ == b->duration_
-        && a->startPTS_ == b->startPTS_
-        && a->startNumber_ == b->startNumber_
-        && a->impaired_ == b->impaired_
-        && a->original_ == b->original_
-        && a->default_ == b->default_
-        && a->language_ == b->language_
-        && a->mimeType_ == b->mimeType_
-        && a->base_url_ == b->base_url_
-        && a->audio_track_id_ == b->audio_track_id_
-        && a->name_ == b->name_
-        && a->id_ == b->id_
-        && a->group_ == b->group_
-        && compareCodecs(a->codecs_, b->codecs_))
+      if (a->type_ == VIDEO && b->type_ == VIDEO && a->default_ == b->default_ &&
+          a->language_ == b->language_ && a->startPTS_ == b->startPTS_ && a->group_ == b->group_)
       {
-        return a->type_ == AUDIO
-          && a->representations_[0]->channelCount_ == b->representations_[0]->channelCount_
-          && compareCodecs(a->representations_[0]->codecs_, b->representations_[0]->codecs_);
+        return true;
       }
+
+      if (a->type_ == AUDIO && b->type_ == AUDIO && a->timescale_ == b->timescale_ &&
+          a->duration_ == b->duration_ && a->startPTS_ == b->startPTS_ &&
+          a->startNumber_ == b->startNumber_ && a->impaired_ == b->impaired_ &&
+          a->original_ == b->original_ && a->default_ == b->default_ &&
+          a->language_ == b->language_ && a->mimeType_ == b->mimeType_ &&
+          a->base_url_ == b->base_url_ && a->audio_track_id_ == b->audio_track_id_ &&
+          a->name_ == b->name_ && a->id_ == b->id_ && a->group_ == b->group_ &&
+          compareCodecs(a->codecs_, b->codecs_) &&
+          a->representations_[0]->channelCount_ == b->representations_[0]->channelCount_ &&
+          compareCodecs(a->representations_[0]->codecs_, b->representations_[0]->codecs_))
+      {
+        return true;
+      }
+
       return false;
     };
   }*current_adaptationset_;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -114,7 +114,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithNoSlashes)
   OpenTestFile("mpd/segtpl_baseurl_noslashs.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
@@ -126,7 +126,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithMediaInitSlash)
   OpenTestFile("mpd/segtpl_slash_baseurl_noslash.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/media-video=66000-$Number$.m4s");
@@ -138,7 +138,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLSlash)
   OpenTestFile("mpd/segtpl_noslash_baseurl_slash.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
@@ -150,7 +150,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLAndMediaInitSlash)
   OpenTestFile("mpd/segtpl_slash_baseurl_slash.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/media-video=66000-$Number$.m4s");
@@ -160,7 +160,7 @@ TEST_F(DASHTreeTest, CalculateBaseURLInRepRangeBytes)
 {
   // Byteranged indexing
   OpenTestFile("mpd/segmentbase.mpd", "https://foo.bar/test.mpd", "");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->url_,
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->url_,
             "https://foo.bar/video/23.98p/r0/vid10.mp4");
 }
 

--- a/src/test/manifests/mpd/fps_scale_adaptset.mpd
+++ b/src/test/manifests/mpd/fps_scale_adaptset.mpd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MPD _xmlns:ns2="http://www.w3.org/1999/xlink" mediaPresentationDuration="PT1H45M47.904S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_xmlns="xmlns">
 	<Period duration="PT1H45M47.904S">
-		<AdaptationSet contentType="video" frameRate="24000/1001">
+		<AdaptationSet group="0" contentType="video" frameRate="24000/1001">
 			<Representation bandwidth="3203000" codecs="avc1.4D401F" height="544" id="video=2492922" scanType="progressive" width="1280">
 				<BaseURL>video/23.98p/r0/vid01.mp4</BaseURL>
 				<SegmentBase indexRange="1796-20859" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -9,7 +9,7 @@
 				</SegmentBase>
 			</Representation>
 		</AdaptationSet>
-		<AdaptationSet contentType="video" frameRate="30">
+		<AdaptationSet group="1" contentType="video" frameRate="30">
 			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416">
 				<BaseURL>video/23.98p/r0/vid02.mp4</BaseURL>
 				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -17,7 +17,7 @@
 				</SegmentBase>
 			</Representation>
 		</AdaptationSet>
-		<AdaptationSet contentType="video">
+		<AdaptationSet group="2" contentType="video">
 			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25">
 				<BaseURL>video/23.98p/r0/vid03.mp4</BaseURL>
 				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -25,7 +25,7 @@
 				</SegmentBase>
 			</Representation>
 		</AdaptationSet>
-		<AdaptationSet contentType="video">
+		<AdaptationSet group="3" contentType="video">
 			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25000/1000">
 				<BaseURL>video/23.98p/r0/vid04.mp4</BaseURL>
 				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -33,7 +33,7 @@
 				</SegmentBase>
 			</Representation>
 		</AdaptationSet>
-		<AdaptationSet contentType="video" frameRate="30">
+		<AdaptationSet group="4" contentType="video" frameRate="30">
 			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25">
 				<BaseURL>video/23.98p/r0/vid05.mp4</BaseURL>
 				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -41,7 +41,7 @@
 				</SegmentBase>
 			</Representation>
 		</AdaptationSet>
-		<AdaptationSet contentType="video" frameRate="24000/1001">
+		<AdaptationSet group="5" contentType="video" frameRate="24000/1001">
 			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="30">
 				<BaseURL>video/23.98p/r0/vid05.mp4</BaseURL>
 				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -49,7 +49,7 @@
 				</SegmentBase>
 			</Representation>
 		</AdaptationSet>
-		<AdaptationSet contentType="video" frameRate="24000/1001">
+		<AdaptationSet group="6" contentType="video" frameRate="24000/1001">
 			<Representation bandwidth="270000" codecs="avc1.4D400D" height="176" id="video=199197" scanType="progressive" width="416" frameRate="25000/1000">
 				<BaseURL>video/23.98p/r0/vid05.mp4</BaseURL>
 				<SegmentBase indexRange="1792-20855" indexRangeExact="true" timescale="24000" xmlns="urn:mpeg:dash:schema:mpd:2011">

--- a/src/test/manifests/mpd/placeholders.mpd
+++ b/src/test/manifests/mpd/placeholders.mpd
@@ -2,7 +2,7 @@
 <!-- Just In Time Delivered by Quortex Solution -->
 <MPD availabilityStartTime="1970-01-01T00:00:06Z" minBufferTime="PT6S" minimumUpdatePeriod="PT6S" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:hbbtv:dash:profile:isoff-live:2012" publishTime="2020-06-07T11:59:55Z" suggestedPresentationDelay="PT12S" timeShiftBufferDepth="PT1M18S" type="dynamic" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
 	<Period id="0" start="PT1588628086S">
-		<AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="0" group="0" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number$.m4s" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>
@@ -10,7 +10,7 @@
 			</SegmentTemplate>
 			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
 		</AdaptationSet>
-		<AdaptationSet id="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="1" group="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number%08d$.m4s" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>
@@ -18,7 +18,7 @@
 			</SegmentTemplate>
 			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
 		</AdaptationSet>
-		<AdaptationSet id="3" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="2" group="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Time$.m4s" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>
@@ -26,7 +26,7 @@
 			</SegmentTemplate>
 			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
 		</AdaptationSet>
-		<AdaptationSet id="4" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="3" group="3" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Time%014llu$" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>
@@ -34,7 +34,7 @@
 			</SegmentTemplate>
 			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
 		</AdaptationSet>
-		<AdaptationSet id="5" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="4" group="4" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number$.m4s?t=$Time$" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>
@@ -42,7 +42,7 @@
 			</SegmentTemplate>
 			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
 		</AdaptationSet>
-		<AdaptationSet id="6" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="5" group="5" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment_$Number%08d$.m4s?t=$Time%014llu$" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>
@@ -50,7 +50,7 @@
 			</SegmentTemplate>
 			<Representation bandwidth="300000" codecs="avc1.42001e" frameRate="25" height="224" id="videosd-400x224" sar="224:225" scanType="progressive" width="400"></Representation>
 		</AdaptationSet>
-		<AdaptationSet id="7" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+		<AdaptationSet id="6" group="6" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
 			<SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/segment.m4s" startNumber="487050" timescale="90000">
 				<SegmentTimeline>
 					<S d="540000" r="12" t="263007000000"/>


### PR DESCRIPTION

[Discussion around criteria required]

Current criteria is
```
if (a->type_ == VIDEO && b->type_ == VIDEO && a->default_ == b->default_ &&
 a->language_ == b->language_ && a->startPTS_ == b->startPTS_ && a->group_ == b->group_)
```
Both video adaption sets
Both have the same default value (role == main or no role)
Both are the same language
Both have the same startPTS
Both are in same group (not sure if we need this?)

I've tried, and IA and Kodi both seem capable of even switching between reps using different content encryption

I think our main concern is that they are the same "timing" so when IA switches - the video keeps going at the same position.

Other things to consider.
- Two reps in different sets with same width / height but different codec (eg. H264 and H265)
  (we may meed better rep sorting that picks based on codec + width + height vs just bandwidth currently)
  
The 2nd commit here makes the sorting of the sets a bit better.
For one - no need to sort Lang A above Lang Z... so just leave them in the order they come.
Also, no need to sort based on type (video, audio, subtitle). Again - just leave them in order they come.
Also makes tests [index] numbers match the manifest