### PR TITLE
[Settings] Only show securedecoder on android. Remove prerelease 

### DIFF
--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -91,15 +91,15 @@
     </category>
     <category id="expert" label="30120">
       <group id="0">
-        <setting id="PRERELEASEFEATURES" type="boolean" label="30121">
-          <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="NOSECUREDECODER" type="boolean" label="30122">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="InfoBool">system.platform.android</condition>
+            </dependency>
+          </dependencies>
         </setting>
       </group>
     </category>

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -49,6 +49,4 @@ bool create_ism_license(std::string key, std::string license_data, std::vector<u
 void parseheader(std::map<std::string, std::string>& headerMap, const std::string& headerString);
 int endswith(const char* in, const char* suffix);
 
-extern bool preReleaseFeatures;
-
 #define MKTAG(a,b,c,d) ((a) | ((b) << 8) | ((c) << 16) | ((unsigned)(d) << 24))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,6 @@
     (p) = NULL; \
   } while (0)
 
-//extern definition in helpers.h
-bool preReleaseFeatures = false;
-
 void Log(const LogLevel loglevel, const char* format, ...)
 {
   char buffer[16384];
@@ -2042,10 +2039,6 @@ Session::Session(MANIFEST_TYPE manifestType,
 
   manual_streams_ = kodi::GetSettingInt("STREAMSELECTION");
   kodi::Log(ADDON_LOG_DEBUG, "STREAMSELECTION selected: %d ", manual_streams_);
-
-  preReleaseFeatures = kodi::GetSettingBoolean("PRERELEASEFEATURES");
-  if (preReleaseFeatures)
-    kodi::Log(ADDON_LOG_INFO, "PRERELEASEFEATURES enabled!");
 
   allow_no_secure_decoder_ = kodi::GetSettingBoolean("NOSECUREDECODER");
   kodi::Log(ADDON_LOG_DEBUG, "FORCENONSECUREDECODER selected: %d ", allow_no_secure_decoder_);


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/691

only show securedecoder on Android.
remove prerelease setting as not used and not likely to be used as now an official add-on
(left the language strings)

Tested:
Windows - setting not shown
Android - setting is shown