### PR TITLE
[Dash] Support urn:mpeg:dash:adaptation-set-switching:2016

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -384,12 +384,10 @@ namespace adaptive
   {
     for (std::vector<Period*>::const_iterator bp(periods_.begin()), ep(periods_.end()); bp != ep; ++bp)
     {
-      std::stable_sort((*bp)->adaptationSets_.begin(), (*bp)->adaptationSets_.end(), AdaptationSet::compare);
-
-      // Merge AUDIO streams, some provider pass everythng in own Audio sets
+      // Merge VIDEO & AUDIO adaption sets
       for (std::vector<AdaptationSet*>::iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea;)
       {
-        if ((*ba)->type_ == AUDIO && ba + 1 != ea && AdaptationSet::mergeable(*ba, *(ba + 1)))
+        if (((*ba)->type_ == AUDIO || (*ba)->type_ == VIDEO) && ba + 1 != ea && AdaptationSet::mergeable(*ba, *(ba + 1)))
         {
           for (size_t i(1); i < (*bp)->psshSets_.size(); ++i)
             if ((*bp)->psshSets_[i].adaptation_set_ == *ba)
@@ -403,6 +401,8 @@ namespace adaptive
         else
           ++ba;
       }
+
+      std::stable_sort((*bp)->adaptationSets_.begin(), (*bp)->adaptationSets_.end(), AdaptationSet::compare);
 
       for (std::vector<AdaptationSet*>::const_iterator ba((*bp)->adaptationSets_.begin()), ea((*bp)->adaptationSets_.end()); ba != ea; ++ba)
       {

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -599,6 +599,25 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
             attr += 2;
           }
         }
+        else if (strcmp(el, "SupplementalProperty") == 0)
+        {
+          const char *schemeIdUri(0), *value(0);
+
+          for (; *attr;)
+          {
+            if (strcmp((const char*)*attr, "schemeIdUri") == 0)
+              schemeIdUri = (const char*)*(attr + 1);
+            else if (strcmp((const char*)*attr, "value") == 0)
+              value = (const char*)*(attr + 1);
+            attr += 2;
+          }
+
+          if (schemeIdUri && value)
+          {
+            if (strcmp(schemeIdUri, "urn:mpeg:dash:adaptation-set-switching:2016") == 0)
+              dash->current_adaptationset_->switching_ids_ = split(value, ',');
+          }
+        }
         else if (dash->currentNode_ & MPDNODE_BASEURL)
         {
         }

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -136,7 +136,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithNoSlashes)
   OpenTestFile("mpd/segtpl_baseurl_noslashs.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
@@ -148,7 +148,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithMediaInitSlash)
   OpenTestFile("mpd/segtpl_slash_baseurl_noslash.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/media-video=66000-$Number$.m4s");
@@ -160,7 +160,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLSlash)
   OpenTestFile("mpd/segtpl_noslash_baseurl_slash.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
@@ -172,7 +172,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLAndMediaInitSlash)
   OpenTestFile("mpd/segtpl_slash_baseurl_slash.mpd", "https://foo.bar/initialpath/test.mpd", "");
 
   adaptive::AdaptiveTree::SegmentTemplate segtpl =
-      tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_;
+      tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/media-video=66000.dash");
   EXPECT_EQ(segtpl.media, "https://foo.bar/media-video=66000-$Number$.m4s");
@@ -182,7 +182,7 @@ TEST_F(DASHTreeTest, CalculateBaseURLInRepRangeBytes)
 {
   // Byteranged indexing
   OpenTestFile("mpd/segmentbase.mpd", "https://foo.bar/test.mpd", "");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->url_,
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->url_,
             "https://foo.bar/video/23.98p/r0/vid10.mp4");
 }
 
@@ -507,4 +507,23 @@ TEST_F(DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline)
   SetFileName(testHelper::testFile, "mpd/bad_segtimeline_4.mpd");
   ReadSegments(testStream, 16, 1);
   EXPECT_EQ(tree->current_period_->adaptationSets_[1]->representations_[0]->startNumber_, 5);
+}
+
+TEST_F(DASHTreeTest, AdaptionSetSwitching)
+{
+  OpenTestFile("mpd/adaptation_set_switching.mpd", "", "");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_.size(), 5);
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->id, "3");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->id, "1");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[2]->id, "2");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->id, "4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[1]->id, "5");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->id, "6");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[3]->representations_[0]->id, "7");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->representations_[0]->id, "8");
 }

--- a/src/test/manifests/mpd/adaptation_set_switching.mpd
+++ b/src/test/manifests/mpd/adaptation_set_switching.mpd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD _xmlns:ns2="http://www.w3.org/1999/xlink" mediaPresentationDuration="PT1H45M47.904S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_xmlns="xmlns">
+  <Period duration="PT1H45M47.904S">
+    <!-- 3 below should merge -->
+    <AdaptationSet id="0" group="0" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="1" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1,2"/>
+    </AdaptationSet>
+    <AdaptationSet id="1" group="0" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="2" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,2"/>
+    </AdaptationSet>
+    <AdaptationSet id="2" group="0" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="3" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1"/>
+    </AdaptationSet>
+
+    <!-- 2 below should merge -->
+    <AdaptationSet id="0" group="1" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="4" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1"/>
+    </AdaptationSet>
+    <AdaptationSet id="1" group="1" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="5" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0"/>
+    </AdaptationSet>
+
+    <!-- Wont merge as id 99 doesnt exist -->
+    <AdaptationSet id="2" group="1" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="6" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="99"/>
+    </AdaptationSet>
+
+    <!-- Wont merge as id 1 doesnt list my id -->
+    <AdaptationSet id="2" group="1" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="7" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1"/>
+    </AdaptationSet>
+
+    <!-- Wont merge as no adaptation-set-switching -->
+    <AdaptationSet id="3" group="1" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="8" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/555

**Note: This is not implementing adaptive bitrate switching....**

Currently IA will just pick whichever video set is at the top of the file. 
With this pr, it will merge whichever sets are allowed and therefore be able to access all the qualities either manually or automatically.

When adaptive switching is implemented, I'm pretty sure we will still need this PR so all representations are available for it to choose from

1st
Support urn:mpeg:dash:adaptation-set-switching:2016
Pretty straight-forward
1) store a list of ids (switching_ids_) pulled from urn:mpeg:dash:adaptation-set-switching:2016
   this can be a single id, or multiple with comma delimiter
2) update SortTree() to also merge VIDEO sets
3) add new check to mergeable for VIDEOs with same group and both contain each others id in switching_ids_
4) add tests

2nd
Move the sorting to after merging sets
if we had merged, then less sets to sort = slightly faster

3rd
I also made the sort ignore type and language 
it doesn't affect anything and makes the tests easier to view as they come in same order as the file.
Update the few tests that expected the order to change to the new ordered as in file
= less confusion

4th
:dash: looks like a fart

**TEST BUILDS HERE:
https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-694/7/artifacts**

**TEST STREAMS:**
https://raw.githubusercontent.com/matthuisman/ia_tests/master/mpd_multi_vid_sets/mpd_multi_vid_sets_highest_first.strm
https://raw.githubusercontent.com/matthuisman/ia_tests/master/mpd_multi_vid_sets/mpd_multi_vid_sets_lowest_first.strm
https://raw.githubusercontent.com/matthuisman/ia_tests/master/mpd_multi_vid_sets/mpd_multi_vid_sets_different.strm

Only thing I wasn't sure about is:
https://github.com/xbmc/inputstream.adaptive/pull/694/files#diff-f5e439696055d30c282716f0d0fc54ee6612edb6e4f29ef91b4c3a00cd426679R618
that split() helper functions returns a new vector array. 
is it ok to assign that directly to our std::vector<std::string> switching_ids_ ?