### PR TITLE
[Curl] Improvements

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -21,6 +21,7 @@
 #include "oscompat.h"
 #include <stdlib.h>
 #include <sstream>
+#include <algorithm>
 
 #ifndef BYTE
 typedef unsigned char BYTE;
@@ -526,7 +527,11 @@ void parseheader(std::map<std::string, std::string>& headerMap, const std::strin
   {
     std::string::size_type pos(b->find('='));
     if(pos != std::string::npos)
-      headerMap[trimcp(b->substr(0, pos))] = url_decode(trimcp(b->substr(pos+1)));
+    {
+      std::string name = trimcp(b->substr(0, pos));
+      std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+      headerMap[name] = url_decode(trimcp(b->substr(pos+1)));
+    }
   }
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -149,6 +149,7 @@ public:
   bool SeekTime(double seekTime, unsigned int streamId = 0, bool preceeding=true);
   bool IsLive() const { return adaptiveTree_->has_timeshift_buffer_; };
   MANIFEST_TYPE GetManifestType() const { return manifest_type_; };
+  std::map<std::string, std::string> GetMediaHeaders() const { return media_headers_; };
   const AP4_UI08 *GetDefaultKeyId(const uint16_t index) const;
   uint32_t GetIncludedStreamMask() const;
   STREAM_CRYPTO_KEY_SYSTEM GetCryptoKeySystem() const;


### PR DESCRIPTION
**Test builds:
https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-699/2/artifacts**

**first:**
make parseheader store the header names in lower-case.
This will make user provided header names lowercase. 
This allows user to override any headers set in IA 
(as long as IA uses lowercase as well - which it does)

**second:**
n need to check if headers contain 'connection' before setting connection 
if the user has provided it, it will be overridden with their value when it loops the media headers

**third:**
add a new method to session to get the media headers so we can use them in SubtitleSampleReader
and anywhere else needed in future.

**fourth:**
remove file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
this does nothing. The default value of failonerror is 0 = off.
https://curl.se/libcurl/c/CURLOPT_FAILONERROR.html

**fifth:**
update SubtitleSampleReader to use 
file.CURLOpen(ADDON_READ_CHUNKED | ADDON_READ_NO_CACHE) instead of file.CURLOpen(0);
with the current Open(0) - kodi tries to fetch the result from filecache and you get weird EOF errors in the log. 
Who knows what other issues that could be causing

**sixth:**
update SubtitleSampleReader to also use the same mediaheaders that Video & Audio already use

**seventh:**
noticed an issue if SubtitleSampleReader returns without setting a codec_handler - Kodi will segfault and crash.
Until now - it wasn't really an issue as there was no check for the failed url download.
So I used @glennguy's new m_started to detect if the reader actually downloaded the subs. 
If it failed, then we disable the stream.

**eighth:**
added keep-alive to Mainfest download and Subtitle download.
This may help speed up manifest refreshes as the socket may stay open.
If they aren't needed - the server can always respond with "close"

**ninth:**
remove setting accept-encoding so IA will just use curls default (deflate, gzip, br)