### PR TITLE
Allow local paths again (until 20)

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -323,7 +323,6 @@ namespace adaptive
     paramPos = base_url_.find_last_of('/', base_url_.length());
     if (paramPos == std::string::npos)
     {
-      Log(LOGLEVEL_ERROR, "Invalid url: / expected (%s)", url.c_str());
       return false;
     }
     base_url_.resize(paramPos + 1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,8 +287,16 @@ bool adaptive::AdaptiveTree::download(const char* url,
 
   effective_url_ = file.GetPropertyValue(ADDON_FILE_PROPERTY_EFFECTIVE_URL, "");
 
+  // effective url is empty for local paths
+  if (effective_url_.empty())
+  {
+    kodi::Log(ADDON_LOG_WARNING, "Local file support will be removed in Kodi 20");
+    effective_url_ = url;
+  }
+
   if (isManifest && !PreparePaths(effective_url_))
   {
+    kodi::Log(ADDON_LOG_ERROR, "Invalid url: %s", effective_url_.c_str());
     file.Close();
     return false;
   }

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -275,3 +275,13 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
   EXPECT_EQ(pts, 20993000);
 }
+
+TEST_F(HLSTreeTest, TestLocalFilePath)
+{
+  OpenTestFileMaster("hls/redirect_absolute_1v_master.m3u8", "C:/temp/redirect_absolute_1v_master.m3u8", "");
+
+  std::string rep_url = tree->BuildDownloadUrl(
+      tree->current_period_->adaptationSets_[0]->representations_[0]->source_url_);
+
+  EXPECT_EQ(rep_url, "https://bit.ly/abcd");
+}

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -34,11 +34,8 @@ bool adaptive::AdaptiveTree::download(const char* url,
   else
     effective_url_ = url;
 
-  if (isManifest && !PreparePaths(effective_url_))
-  {
-    fclose(f);
-    return false;
-  }
+  if (isManifest)
+    PreparePaths(effective_url_);
 
   // read the file
   static const unsigned int CHUNKSIZE = 16384;


### PR DESCRIPTION
Fixes: https://github.com/xbmc/inputstream.adaptive/issues/701

In my last PR here:
https://github.com/xbmc/inputstream.adaptive/pull/675/files#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R290

I added a check for if PreparePaths failed.
If it failed, we would stop processing and return.

However, this breaks using local files.
(Which aren't really supported anyway)

This replaces the hard-exit with a warning in the log and continues to try to play the file.
As long as it's using full urls - it should work OK.
Anything that relies on base_url or base_domain would not work.

as discussed with @glennguy , local paths aren't really supported and them working until now is more a lucky coincidence / hack.

this PR gets them working again - but as per the log warning - **support for them will be removed in 20**

Add-ons relying on them should use a small HTTP API / Proxy to do any required modifications to the manifest.