### PR TITLE
Dont use filecache for subtitle download

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1530,7 +1530,7 @@ public:
 
     file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
     file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "gzip");
-    file.CURLOpen(0);
+    file.CURLOpen(ADDON_READ_CHUNKED | ADDON_READ_NO_CACHE);
 
     AP4_DataBuffer result;
 


### PR DESCRIPTION
update SubtitleSampleReader to use
file.CURLOpen(ADDON_READ_CHUNKED | ADDON_READ_NO_CACHE) instead of file.CURLOpen(0);

with the current Open(0) - kodi tries to fetch the result from filecache and you get weird EOF errors in the log.
Who knows what other issues that could be causing

stripped down version of: https://github.com/xbmc/inputstream.adaptive/pull/699