### PR TITLE
[Dash] Use representation BaseURL

### DIFF
--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -174,6 +174,7 @@ public:
     std::string codecs_;
     std::string codec_private_data_;
     std::string source_url_;
+    std::string base_url_;
     uint32_t bandwidth_;
     uint32_t samplingRate_;
     uint16_t width_, height_;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -483,7 +483,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
             dash->current_representation_->segtpl_ = dash->current_adaptationset_->segtpl_;
 
             dash->current_representation_->startNumber_ = ParseSegmentTemplate(
-                attr, dash->current_adaptationset_->base_url_, dash->base_domain_,
+                attr, dash->current_representation_->base_url_, dash->base_domain_,
                 dash->current_representation_->segtpl_, dash->current_adaptationset_->startNumber_);
             ReplacePlaceHolders(dash->current_representation_->segtpl_.media,
                                 dash->current_representation_->id,
@@ -658,13 +658,14 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           dash->current_representation_->timescale_ = dash->current_adaptationset_->timescale_;
           dash->current_representation_->duration_ = dash->current_adaptationset_->duration_;
           dash->current_representation_->startNumber_ = dash->current_adaptationset_->startNumber_;
-          dash->current_adaptationset_->representations_.push_back(dash->current_representation_);
           dash->current_representation_->width_ = dash->adpwidth_;
           dash->current_representation_->height_ = dash->adpheight_;
           dash->current_representation_->fpsRate_ = dash->adpfpsRate_;
           dash->current_representation_->fpsScale_ = dash->adpfpsScale_;
           dash->current_representation_->aspect_ = dash->adpaspect_;
           dash->current_representation_->containerType_ = dash->adpContainerType_;
+          dash->current_representation_->base_url_ = dash->current_adaptationset_->base_url_;
+          dash->current_adaptationset_->representations_.push_back(dash->current_representation_);
 
           dash->current_pssh_.clear();
           dash->current_hasRepURN_ = false;
@@ -1116,6 +1117,8 @@ static void XMLCALL end(void* data, const char* el)
                 url = dash->strXMLText_;
               else
                 url = dash->current_adaptationset_->base_url_ + dash->strXMLText_;
+
+              dash->current_representation_->base_url_ = url;
 
               if (dash->current_representation_->flags_ & AdaptiveTree::Representation::TEMPLATE)
               {

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -453,3 +453,20 @@ TEST_F(DASHTreeTest, CalculateRedirectSegTpl)
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/A48/init.mp4");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/A48/$Number$.m4s");
 }
+
+TEST_F(DASHTreeTest, CalculateReprensentationBaseURL)
+{
+  OpenTestFile("mpd/rep_base_url.mpd", "https://bit.ly/mpd/abcd.mpd", "");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.initialization, "https://foo.bar/mpd/slices/A_init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media, "https://foo.bar/mpd/slices/A$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.initialization, "https://bit.ly/mpd/B_init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.media, "https://bit.ly/mpd/B$Number%08d$.m4f");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/mpd/slices/A_init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/mpd/slices/A$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[1]->segtpl_.initialization, "https://foo.bar/mpd/slices2/B_init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[1]->segtpl_.media, "https://foo.bar/mpd/slices2/B$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[2]->segtpl_.initialization, "https://foo.bar/mpd/slices2/C_init.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[2]->segtpl_.media, "https://foo.bar/mpd/slices2/C$Number%08d$.m4f");
+}

--- a/src/test/manifests/mpd/rep_base_url.mpd
+++ b/src/test/manifests/mpd/rep_base_url.mpd
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2021-06-06T18:49:02Z" maxSegmentDuration="PT4.096S" minBufferTime="PT4.096S" minimumUpdatePeriod="PT8.000S" profiles="urn:mpeg:dash:profile:isoff-live:2011" publishTime="2021-06-06T19:38:20Z" suggestedPresentationDelay="PT12.288S" timeShiftBufferDepth="PT180.000S" type="dynamic">
+  <Period id="2924.544000" start="PT2924.544000S">
+    <AssetIdentifier schemeIdUri="urn:org:dashif:asset-id:2013" value="51aaf401283c45de9aa6d7369c0910d7"/>
+    <AdaptationSet contentType="video" id="1" maxFrameRate="30" maxHeight="504" maxWidth="896" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="2"/>
+      <InbandEventStream schemeIdUri="com.uplynk.asset.metadata"/>
+      <Representation bandwidth="41431" codecs="avc1.42000b" frameRate="22" height="54" id="A" scanType="progressive" width="96">
+        <BaseURL>https://foo.bar/mpd/slices/</BaseURL>
+        <SegmentTemplate initialization="$RepresentationID$_init.mp4" media="$RepresentationID$$Number%08d$.m4f" presentationTimeOffset="263208960" startNumber="714" timescale="90000">
+          <SegmentTimeline>
+            <S d="368640" r="7" t="263208960"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation bandwidth="41431" codecs="avc1.42000b" frameRate="22" height="54" id="B" scanType="progressive" width="96">
+        <SegmentTemplate initialization="$RepresentationID$_init.mp4" media="$RepresentationID$$Number%08d$.m4f" presentationTimeOffset="263208960" startNumber="714" timescale="90000">
+          <SegmentTimeline>
+            <S d="368640" r="7" t="263208960"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet contentType="video" id="2" maxFrameRate="30" maxHeight="504" maxWidth="896" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <BaseURL>https://foo.bar/mpd/slices2/</BaseURL>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="2"/>
+      <InbandEventStream schemeIdUri="com.uplynk.asset.metadata"/>
+      <Representation bandwidth="41431" codecs="avc1.42000b" frameRate="22" height="54" id="A" scanType="progressive" width="96">
+        <BaseURL>https://foo.bar/mpd/slices/</BaseURL>
+        <SegmentTemplate initialization="$RepresentationID$_init.mp4" media="$RepresentationID$$Number%08d$.m4f" presentationTimeOffset="263208960" startNumber="714" timescale="90000">
+          <SegmentTimeline>
+            <S d="368640" r="7" t="263208960"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation bandwidth="41431" codecs="avc1.42000b" frameRate="22" height="54" id="B" scanType="progressive" width="96">
+        <SegmentTemplate initialization="$RepresentationID$_init.mp4" media="$RepresentationID$$Number%08d$.m4f" presentationTimeOffset="263208960" startNumber="714" timescale="90000">
+          <SegmentTimeline>
+            <S d="368640" r="7" t="263208960"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation bandwidth="41431" codecs="avc1.42000b" frameRate="22" height="54" id="C" scanType="progressive" width="96">
+        <SegmentTemplate initialization="$RepresentationID$_init.mp4" media="$RepresentationID$$Number%08d$.m4f" presentationTimeOffset="263208960" startNumber="714" timescale="90000">
+          <SegmentTimeline>
+            <S d="368640" r="7" t="263208960"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-iso:2014" value="https://content-aeui1.uplynk.com/misc/utcservertime"/>
+</MPD>


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/707

PR: https://github.com/xbmc/inputstream.adaptive/pull/668 updated IA to calc media and init from the adaption sets base_url.
We should actually calculate it from the representations base url.