### PR TITLE
wvdecrypter: remove clearbytes even for 1 subsample

### DIFF
--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -1141,6 +1141,10 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
   bool useSingleDecrypt(false);
 
+  // CDM should get 1 block of encrypted data per sample, encrypted data
+  // from all subsamples should be formed into a contiguous block.
+  // Even if there is only 1 subsample, we should remove cleartext data
+  // from it before passing to CDM.
   if ((fragInfo.decrypter_flags_ & SSD_DECRYPTER::SSD_CAPS::SSD_SINGLE_DECRYPT) != 0)
   {
     decrypt_in_.Reserve(data_in.GetDataSize());

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -1141,7 +1141,7 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
   bool useSingleDecrypt(false);
 
-  if ((fragInfo.decrypter_flags_ & SSD_DECRYPTER::SSD_CAPS::SSD_SINGLE_DECRYPT) != 0 && subsample_count > 1)
+  if ((fragInfo.decrypter_flags_ & SSD_DECRYPTER::SSD_CAPS::SSD_SINGLE_DECRYPT) != 0)
   {
     decrypt_in_.Reserve(data_in.GetDataSize());
     decrypt_in_.SetDataSize(0);


### PR DESCRIPTION
When SINGLE_DECRYPT is used, CDM should not get any cleartext bytes, we should remove them even if there is only 1 subsample.

Else if CDM receives 1 subsample with some cleartext data, it cannot decrypt and we get `Decrypt Sample returns failure!` in the log.

Fixes https://github.com/xbmc/inputstream.adaptive/issues/393