### PR TITLE
[Dash] Override timeShiftBufferDepth with SegmentTimeline (if present)

### DIFF
--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -453,3 +453,10 @@ TEST_F(DASHTreeTest, CalculateRedirectSegTpl)
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/A48/init.mp4");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/A48/$Number$.m4s");
 }
+
+TEST_F(DASHTreeTest, OverrideTimeShiftBufferDepthWithSegmentTimeline)
+{
+  OpenTestFile("mpd/segmenttimeline_vs_tsbd.mpd", "http://foo.bar/stream.mpd", "");
+
+  EXPECT_EQ(tree->overallSeconds_, 43504);
+}

--- a/src/test/manifests/mpd/segmenttimeline_vs_tsbd.mpd
+++ b/src/test/manifests/mpd/segmenttimeline_vs_tsbd.mpd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:scte35="urn:scte:scte35:2013:xml" profiles="urn:mpeg:dash:profile:isoff-live:2011" availabilityStartTime="2016-05-04T00:00:00Z" maxSegmentDuration="PT6S" minBufferTime="PT12S" minimumUpdatePeriod="PT18S" publishTime="2021-06-09T14:20:31Z" suggestedPresentationDelay="PT32.12S" timeShiftBufferDepth="PT12H" type="dynamic">
+  <BaseURL>http://foo.bar</BaseURL>
+  <Period id="0" start="PT0S">
+    <AdaptationSet id="0" group="1" bitstreamSwitching="true" segmentAlignment="true" contentType="video" mimeType="video/mp4" startWithSAP="1" maxWidth="1920" maxHeight="1080" frameRate="50">
+      <SegmentTemplate timescale="90000" media="/$RepresentationID$/$Time$.mp4?t=dash-seg" initialization="/$RepresentationID$/init.mp4?t=dash-init" presentationTimeOffset="0">
+        <SegmentTimeline>
+          <S t="14479649308800" d="460800" r="8496"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="1080p" codecs="avc1.64002a" bandwidth="8000000" width="1920" height="1080"/>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
In attached mpd timeShiftBufferDepth is translated into 43200 seconds.
But the real length of the stream is 43504. Using the first value makes it
unable to seek in the last 5 minutes of the stream.

Fixes #278

I'm not sure at all whether it is a proper solution. Please see discussion in #278.