### PR TITLE
[WV] More sensible defaults if | not in license url

### DIFF
--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -359,9 +359,9 @@ WV_DRM::WV_DRM(const char* licenseURL, const AP4_DataBuffer &serverCert, const u
   if (serverCert.GetDataSize())
     wv_adapter->SetServerCertificate(0, serverCert.GetData(), serverCert.GetDataSize());
 
-  // For backward compatibility: If no | is found in URL, make the amazon convention out of it
+  // For backward compatibility: If no | is found in URL, use the most common working config
   if (license_url_.find('|') == std::string::npos)
-    license_url_ += "|Content-Type=application%2Fx-www-form-urlencoded|widevine2Challenge=B{SSM}&includeHdcpTestKeyInLicense=true|JBlicense;hdcpEnforcementResolutionPixels";
+    license_url_ += "|Content-Type=application%2Foctet-stream|R{SSM}|";
 
   //wv_adapter->GetStatusForPolicy();
   //wv_adapter->QueryOutputProtectionStatus();

--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -181,7 +181,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
   if (license_url_.find('|') == std::string::npos)
   {
     if (key_system_ == WIDEVINE)
-      license_url_ += "|Content-Type=application%2Fx-www-form-urlencoded|widevine2Challenge=B{SSM}&includeHdcpTestKeyInLicense=false|JBlicense;hdcpEnforcementResolutionPixels";
+      license_url_ += "|Content-Type=application%2Foctet-stream|R{SSM}|";
     else if (key_system_ == PLAYREADY)
       license_url_ += "|Content-Type=text%2Fxml&SOAPAction=http%3A%2F%2Fschemas.microsoft.com%2FDRM%2F2007%2F03%2Fprotocols%2FAcquireLicense|R{SSM}|";
     else


### PR DESCRIPTION
Will fix issues like: https://github.com/xbmc/inputstream.adaptive/issues/713 and https://forum.kodi.tv/showthread.php?tid=363338&pid=3046463

Currently if no | is provided in the license url, IA defaults to some Amazon convention that I don't think I've actually seen ever used in production.

I assume it's some legacy value that used to be more common years ago.

Content-Type=application/octet-stream (binary file)
&
R{SSM} (Binary payload)

Are much much more common these days

This should help reduce issues :)

Eventually I think this default code needs updating.
eg. if the url is http://example.com/license_request|Myheaders
then I'm not sure what the payload type will be.... as the existing code here only runs if | not in url.
We would want to check when actually parsing the |. Thus letting us set defaults for headers and payload independently