### PR TITLE
Add support to pre-initialize the DRM

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer|pre_init_data"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">InputStream client for adaptive streams</summary>

--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -21,7 +21,7 @@ namespace SSD
     {
       PROPERTY_HEADER
   };
-    static const uint32_t version = 12;
+    static const uint32_t version = 13;
 #if defined(ANDROID)
     virtual void* GetJNIEnv() = 0;
     virtual int GetSDKVersion() = 0;
@@ -182,12 +182,13 @@ namespace SSD
     // Return supported URN if type matches to capabilities, otherwise null
     virtual const char *SelectKeySytem(const char* keySystem) = 0;
     virtual bool OpenDRMSystem(const char *licenseURL, const AP4_DataBuffer &serverCertificate, const uint8_t config) = 0;
-    virtual AP4_CencSingleSampleDecrypter *CreateSingleSampleDecrypter(AP4_DataBuffer &pssh, const char *optionalKeyParameter, const uint8_t *defaultkeyid) = 0;
+    virtual AP4_CencSingleSampleDecrypter *CreateSingleSampleDecrypter(AP4_DataBuffer &pssh, const char *optionalKeyParameter, const uint8_t *defaultkeyid, bool skipSessionMessage) = 0;
     virtual void DestroySingleSampleDecrypter(AP4_CencSingleSampleDecrypter* decrypter) = 0;
 
     virtual void GetCapabilities(AP4_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid, uint32_t media, SSD_DECRYPTER::SSD_CAPS &caps) = 0;
     virtual bool HasLicenseKey(AP4_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid) = 0;
     virtual bool HasCdmSession() = 0;
+    virtual std::string GetChallengeB64Data(AP4_CencSingleSampleDecrypter* decrypter) = 0;
 
     virtual bool OpenVideoDecoder(AP4_CencSingleSampleDecrypter* decrypter, const SSD_VIDEOINITDATA *initData) = 0;
     virtual SSD_DECODE_RETVAL DecodeVideo(void* instance, SSD_SAMPLE *sample, SSD_PICTURE *picture) = 0;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -454,7 +454,8 @@ public:
   AdaptiveTree();
   virtual ~AdaptiveTree();
 
-  virtual bool open(const std::string &url, const std::string &manifestUpdateParam) = 0;
+  virtual bool open(const std::string& url, const std::string& manifestUpdateParam) = 0;
+  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) = 0;
   virtual PREPARE_RESULT prepareRepresentation(Period* period,
                                                AdaptationSet* adp,
                                                Representation* rep,

--- a/src/main.h
+++ b/src/main.h
@@ -94,9 +94,11 @@ public:
           uint16_t display_height,
           const std::string& ov_audio,
           bool play_timeshift_buffer,
-          bool force_secure_decoder);
+          bool force_secure_decoder,
+          const std::string& drm_preinit_data);
   virtual ~Session();
   bool Initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
+  bool PreInitializeDRM(std::string& challengeB64, std::string& sessionId);
   bool InitializeDRM();
   bool InitializePeriod();
   SampleReader *GetNextSample();
@@ -177,6 +179,7 @@ private:
   MANIFEST_TYPE manifest_type_;
   std::string manifestURL_, manifestUpdateParam_;
   std::string license_key_, license_type_, license_data_;
+  std::string drmPreInitData_;
   std::map<std::string, std::string> media_headers_;
   AP4_DataBuffer server_certificate_;
   std::string profile_path_;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1558,6 +1558,11 @@ static void XMLCALL end(void* data, const char* el)
 +---------------------------------------------------------------------*/
 bool DASHTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
+  return open(url, manifestUpdateParam, std::map<std::string, std::string>());
+}
+
+bool DASHTree::open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders)
+{
   parser_ = XML_ParserCreate(NULL);
   if (!parser_)
     return false;
@@ -1569,7 +1574,8 @@ bool DASHTree::open(const std::string& url, const std::string& manifestUpdatePar
   strXMLText_.clear();
 
   PrepareManifestUrl(url, manifestUpdateParam);
-  bool ret = download(manifest_url_.c_str(), manifest_headers_) && !periods_.empty();
+  additionalHeaders.insert(manifest_headers_.begin(), manifest_headers_.end());
+  bool ret = download(manifest_url_.c_str(), additionalHeaders) && !periods_.empty();
 
   XML_ParserFree(parser_);
   parser_ = 0;

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -30,6 +30,7 @@ class ATTRIBUTE_HIDDEN DASHTree : public AdaptiveTree
 public:
   DASHTree();
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
+  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
   virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;
   virtual void RefreshSegments(Period* period,
                                AdaptationSet* adp,

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -158,8 +158,14 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
 
 bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
+  return open(url, manifestUpdateParam, std::map<std::string, std::string>());
+}
+
+bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders)
+{
   PrepareManifestUrl(url, manifestUpdateParam);
-  if (download(manifest_url_.c_str(), manifest_headers_, &manifest_stream))
+  additionalHeaders.insert(manifest_headers_.begin(), manifest_headers_.end());
+  if (download(manifest_url_.c_str(), additionalHeaders, &manifest_stream))
     return processManifest(manifest_stream);
   return false;
 }

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -45,6 +45,7 @@ public:
   virtual ~HLSTree();
 
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
+  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
   virtual PREPARE_RESULT prepareRepresentation(Period* period,
                                                AdaptationSet* adp,
                                                Representation* rep,

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -349,6 +349,11 @@ static void XMLCALL end(void* data, const char* el)
 
 bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam)
 {
+  return open(url, manifestUpdateParam, std::map<std::string, std::string>());
+}
+
+bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders)
+{
   parser_ = XML_ParserCreate(NULL);
   if (!parser_)
     return false;
@@ -359,7 +364,8 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
   strXMLText_.clear();
 
   PrepareManifestUrl(url, manifestUpdateParam);
-  bool ret = download(manifest_url_.c_str(), manifest_headers_);
+  additionalHeaders.insert(manifest_headers_.begin(), manifest_headers_.end());
+  bool ret = download(manifest_url_.c_str(), additionalHeaders);
 
   XML_ParserFree(parser_);
   parser_ = 0;

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -30,6 +30,7 @@ class ATTRIBUTE_HIDDEN SmoothTree : public AdaptiveTree
 public:
   SmoothTree();
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
+  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
   virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;
 
   enum

--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
@@ -328,9 +328,14 @@ void CdmAdapter::UpdateSession(uint32_t promise_id,
       response, response_size);
 }
 
-void CdmAdapter::SetSessionActive()
+void CdmAdapter::SetSessionActive(bool isActive)
 {
-  session_active_ = true;
+  session_active_ = isActive;
+}
+
+bool CdmAdapter::IsSessionActive()
+{
+  return session_active_;
 }
 
 void CdmAdapter::CloseSession(uint32_t promise_id,

--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.h
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.h
@@ -101,7 +101,9 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>
 		const uint8_t* response,
 		uint32_t response_size);
 
-	void SetSessionActive();
+	void SetSessionActive(bool isActive);
+
+  bool IsSessionActive();
 
 	void CloseSession(uint32_t promise_id,
 		const char* session_id,


### PR DESCRIPTION
This PR add the support to pre-initialize the DRM with a PSSH+KID provided by an add-on via ListItem property.

The purpose is to allow add-ons to make licensed manifest requests via ISA manifest proxy callback.
In order to do licensed manifest requests is needed two data:
- The challenge
- The session id

As discussed previously on #666 and https://github.com/CastagnaIT/plugin.video.netflix/pull/1129#issuecomment-830779762 i have implemented all the things.

In brief:
- The add-on add in the play callback this property (to the list item passed to xbmcplugin.setResolvedUrl) :
`setProperty('inputstream.adaptive.pre_init_data', 'pssh|kid')`
by providing the PSSH and the KID values both encoded as base64 and splitted by a `|`
- When ISA see the `pre_init_data` property data, pre initialize the DRM with the PSSH+KID provided
At this point we have the DRM challenge and the session id generated
- When ISA do the manifest proxy callback to the add-on, attach to the request these two headers:
`challengeB64` (encoded as base64) and `sessionId`
- The add-on when receive the manifest proxy callback can read the challenge and the session id from the headers

NOTE: This not change in any way the current use of the manifest request

The tests were conducted with ntfx add-on, where if the challenge/sid were wrong, video playback would not take place,
and on ARM devices it is the only way to achieve 1080P resolution.

Tested on:
- ARM device with last CoreELEC nightly with Kodi 19 ✅
- Windows 10 64 bit with latest Kodi 19 release ✅
- Android Widevine L3 with latest Kodi 19 release ✅
- Android Widevine L1 with latest Kodi 19 release ✅
- Linux Mint with latest Kodi 19 release ✅
