### PR TITLE
Fix kodi freeze by session close

### DIFF
--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
@@ -5,7 +5,6 @@
 #include "cdm_adapter.h"
 #include <chrono>
 #include <thread>
-#include <atomic>
 
 #define DCHECK(condition) assert(condition)
 
@@ -135,6 +134,7 @@ CdmAdapter::CdmAdapter(
 , cdm_config_(cdm_config)
 , active_buffer_(0)
 , cdm9_(0), cdm10_(0), cdm11_(0)
+, session_active_(false)
 {
   //DCHECK(!key_system_.empty());
   Initialize();
@@ -328,10 +328,16 @@ void CdmAdapter::UpdateSession(uint32_t promise_id,
       response, response_size);
 }
 
+void CdmAdapter::SetSessionActive()
+{
+  session_active_ = true;
+}
+
 void CdmAdapter::CloseSession(uint32_t promise_id,
   const char* session_id,
   uint32_t session_id_size)
 {
+  session_active_ = false;
   exit_thread_flag = true;
   while (timer_thread_running) 
   {
@@ -506,8 +512,11 @@ cdm::Buffer* CdmAdapter::Allocate(uint32_t capacity)
 void CdmAdapter::SetTimer(int64_t delay_ms, void* context)
 {
   //LICENSERENEWAL
-  exit_thread_flag = false;
-  std::thread(timerfunc, shared_from_this(), delay_ms, context).detach();
+  if (session_active_)
+  {
+    exit_thread_flag = false;
+    std::thread(timerfunc, shared_from_this(), delay_ms, context).detach();
+  }
 }
 
 cdm::Time CdmAdapter::GetCurrentWallTime()

--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.h
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.h
@@ -6,6 +6,7 @@
 #include <inttypes.h>
 #include <memory>
 #include <mutex>
+#include <atomic>
 
 #include "../../base/native_library.h"
 #include "../../base/compiler_specific.h"
@@ -99,6 +100,8 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>
 		uint32_t session_id_size,
 		const uint8_t* response,
 		uint32_t response_size);
+
+	void SetSessionActive();
 
 	void CloseSession(uint32_t promise_id,
 		const char* session_id,
@@ -237,6 +240,8 @@ private:
   cdm::ContentDecryptionModule_9 *cdm9_;
   cdm::ContentDecryptionModule_10 *cdm10_;
   cdm::ContentDecryptionModule_11 *cdm11_;
+
+  std::atomic<bool> session_active_;
 
   DISALLOW_COPY_AND_ASSIGN(CdmAdapter);
 };

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -174,6 +174,7 @@ public:
 
   void GetCapabilities(const uint8_t* key, uint32_t media, SSD_DECRYPTER::SSD_CAPS &caps);
   virtual const char *GetSessionId() override;
+  void SetSessionActive();
   void CloseSessionId();
   void SetSession(const char* session, uint32_t session_size, const uint8_t *data, size_t data_size)
   {
@@ -390,7 +391,10 @@ void WV_DRM::OnCDMMessage(const char* session, uint32_t session_size, CDMADPMSG 
     return;
 
   if (msg == CDMADPMSG::kSessionMessage)
+  {
     (*b)->SetSession(session, session_size, data, data_size);
+    (*b)->SetSessionActive();
+  }
   else if (msg == CDMADPMSG::kSessionKeysChange)
     (*b)->AddSessionKey(data, data_size, status);
 };
@@ -570,6 +574,11 @@ void WV_CencSingleSampleDecrypter::GetCapabilities(const uint8_t* key, uint32_t 
 const char *WV_CencSingleSampleDecrypter::GetSessionId()
 {
   return session_.empty()? nullptr : session_.c_str();
+}
+
+void WV_CencSingleSampleDecrypter::SetSessionActive()
+{
+  drm_.GetCdmAdapter()->SetSessionActive();
 }
 
 void WV_CencSingleSampleDecrypter::CloseSessionId()


### PR DESCRIPTION
Two points do cause Kodi to freeze randomly on session end:

* CloseSession should not be called in dispose function
* SetTimer callback did reset `exit_thread_flag` status to `false` while being in CloseSession function cause waiting endless that `timer_thread_running` become false

More than 150 start/stop cycles (30s cycle time) where successful done with this modification. Tested with CoreELEC 19.2-Matrix_nightly and last Amazon VOD. Before these changes Kodi got randomly frozen between 1-30 cycles.

This should solve issue #728 