### PR TITLE
[Android] Use multiple WV sessions

### DIFF
--- a/wvdecrypter/wvdecrypter_android_jni.cpp
+++ b/wvdecrypter/wvdecrypter_android_jni.cpp
@@ -487,9 +487,9 @@ std::vector<char> WV_CencSingleSampleDecrypter::GetChallengeData()
 
 bool WV_CencSingleSampleDecrypter::HasLicenseKey(const uint8_t *keyid)
 {
-  // We work with one session for all streams.
-  // All license keys must be given in this key request
-  return true;
+  // true = one session for all streams, false = one sessions per stream
+  // false fixes pixaltion issues on some devices when manifest has multiple encrypted streams
+  return false;
 }
 
 void WV_CencSingleSampleDecrypter::GetCapabilities(const uint8_t *keyid, uint32_t media, SSD_DECRYPTER::SSD_CAPS &caps)


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/693


as per peaks comment here:
https://forum.kodi.tv/showthread.php?tid=350092&pid=2908844#pid2908844

This fixes pixalation issues on some streams mainly on Sony android tvs.
Seems the issue appears when both audio and video are encrypted

Test build (Android AARCH64)
https://jenkins.kodi.tv/job/xbmc/job/inputstream.adaptive/job/PR-734/5/artifact/cmake/addons/build/zips/inputstream.adaptive+android-aarch64/inputstream.adaptive-2.6.22.zip

Test build (Android ARMV7)
https://jenkins.kodi.tv/job/xbmc/job/inputstream.adaptive/job/PR-734/5/artifact/cmake/addons/build/zips/inputstream.adaptive+android-armv7/inputstream.adaptive-2.6.22.zip