### PR TITLE
Allow date in changelog optionally and add delay before release step

### DIFF
--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -15,6 +15,10 @@ on:
         description: 'Update news in addon.xml.in? [true|false]'
         required: true
         default: 'true'
+      add_date:
+        description: 'Add date to version number in changelog and news. ie. "v1.0.1 (2021-7-17)" [true|false]'
+        required: true
+        default: 'false'
 
 jobs:
   default:
@@ -47,15 +51,16 @@ jobs:
 
       - name: Increment version and update changelogs
         run: |
+          arguments=
           if [[ ${{ github.event.inputs.update_news }} == true ]] ;
           then
-            python3 ../scripts/changelog_and_release.py ${{ github.event.inputs.version_type }} ${{ github.event.inputs.changelog_text }} --update-news
-          elif [[ ${{ github.event.inputs.update_news }} == false ]] ;
-          then
-            python3 ../scripts/changelog_and_release.py ${{ github.event.inputs.version_type }} ${{ github.event.inputs.changelog_text }}
-          else
-            exit 1
+            arguments=$(echo $arguments && echo --update-news)
           fi
+          if [[ ${{ github.event.inputs.add_date }} == true ]] ;
+          then
+            arguments=$(echo $arguments && echo --add-date)
+          fi
+          python3 ../scripts/changelog_and_release.py ${{ github.event.inputs.version_type }} ${{ github.event.inputs.changelog_text }} $arguments
         working-directory: ${{ github.event.repository.name }}
 
       - name: Get required variables
@@ -72,13 +77,19 @@ jobs:
           echo ::set-output name=version::$version
           branch=$(echo ${GITHUB_REF#refs/heads/})
           echo ::set-output name=branch::$branch
+          echo ::set-output name=today::$(date +'%Y-%m-%d')
         working-directory: ${{ github.event.repository.name }}
 
       - name: Commit changes
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git commit -m "changelog and version v${{ steps.required-variables.outputs.version }}" -a
+          commit_message="changelog and version v${{ steps.required-variables.outputs.version }}"
+          if [[ ${{ github.event.inputs.add_date }} == true ]] ;
+          then
+            commit_message="$commit_message (${{ steps.required-variables.outputs.today }})"
+          fi
+          git commit -m "$commit_message" -a
         working-directory: ${{ github.event.repository.name }}
 
       - name: Push changes
@@ -86,6 +97,10 @@ jobs:
         with:
           branch: ${{ github.ref }}
           directory: ${{ github.event.repository.name }}
+
+      - name: Sleep for 60 seconds
+        run: sleep 60s
+        shell: bash
 
       - name: Create Release
         id: create-release

--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -18,7 +18,7 @@ on:
       add_date:
         description: 'Add date to version number in changelog and news. ie. "v1.0.1 (2021-7-17)" [true|false]'
         required: true
-        default: 'false'
+        default: 'true'
 
 jobs:
   default:


### PR DESCRIPTION
Release workflow did not previously allow date to be included in the changelog. Also a delay is introduced before the release step to ensure the commits are in before the release happens.
