### PR TITLE
[SUBTITLES PARSER] Remove added carriage return

### DIFF
--- a/src/parser/TTML.cpp
+++ b/src/parser/TTML.cpp
@@ -271,7 +271,7 @@ bool TTML2SRT::Prepare(uint64_t &pts, uint32_t &duration)
   m_SRT.clear();
   for (size_t i(0); i < sub.text.size(); ++i)
   {
-    if (i) m_SRT += "\r\n";
+    if (i) m_SRT += "\n";
     m_SRT += sub.text[i];
   }
   m_lastId = sub.id;

--- a/src/parser/WebVTT.cpp
+++ b/src/parser/WebVTT.cpp
@@ -192,7 +192,7 @@ bool WebVTT::Prepare(uint64_t &pts, uint32_t &duration)
   m_SRT.clear();
   for (size_t i(0); i < sub.text.size(); ++i)
   {
-    if (i) m_SRT += "\r\n";
+    if (i) m_SRT += "\n";
     m_SRT += sub.text[i];
   }
   m_lastId = sub.id;


### PR DESCRIPTION
I am working on a new text subtitles render for Kodi based on LibAss
currently subtitles parsers add a new line of Windows type on each line (`\r\n`) instead use unix like type,
this affect LibAss renderer to show tofu char at end of string.

Testing on Windows and CoreElec this change does not affect Kodi's current subtitles text render.

LibASS tofu:
![Clipboard01](https://user-images.githubusercontent.com/3257156/126891816-55dd9550-09a2-498d-ac05-67b7aea1212a.jpg)
