### PR TITLE
[Dash] Add suggestedPresentationDelay

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -284,10 +284,9 @@ bool AdaptiveStream::start_stream()
           if (!pos)
             pos = 1;
         }
-        //go at least 12 secs back
         uint64_t duration(current_rep_->get_segment(pos)->startPTS_ -
                           current_rep_->get_segment(pos - 1)->startPTS_);
-        pos -= static_cast<uint32_t>((12 * current_rep_->timescale_) / duration) + 1;
+        pos -= static_cast<uint32_t>((tree_.live_delay_ * current_rep_->timescale_) / duration);
         current_rep_->current_segment_ = current_rep_->get_segment(pos < 0 ? 0 : pos);
       }
       else // switching streams, align new stream segment no.

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -59,6 +59,7 @@ namespace adaptive
     , stream_start_(0)
     , available_time_(0)
     , base_time_(0)
+    , live_delay_(0)
     , minPresentationOffset(0)
     , has_timeshift_buffer_(false)
     , has_overall_seconds_(false)

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -466,7 +466,7 @@ public:
   uint32_t currentNode_;
   uint32_t segcount_;
   uint32_t initial_sequence_ = ~0UL;
-  uint64_t overallSeconds_, stream_start_, available_time_, base_time_;
+  uint64_t overallSeconds_, stream_start_, available_time_, base_time_, live_delay_;
   uint64_t minPresentationOffset;
   bool has_timeshift_buffer_, has_overall_seconds_;
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1068,6 +1068,8 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
       }
       else if (strcmp((const char*)*attr, "availabilityStartTime") == 0)
         dash->available_time_ = getTime((const char*)*(attr + 1));
+      else if (strcmp((const char*)*attr, "suggestedPresentationDelay") == 0)
+        AddDuration((const char*)*(attr + 1), dash->live_delay_, 1);
       else if (strcmp((const char*)*attr, "minimumUpdatePeriod") == 0)
       {
         uint64_t dur(0);

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -527,3 +527,9 @@ TEST_F(DASHTreeTest, AdaptionSetSwitching)
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[4]->representations_[0]->id, "8");
 }
+
+TEST_F(DASHTreeTest, SuggestedPresentationDelay)
+{
+  OpenTestFile("mpd/segtpl_spd.mpd", "https://foo.bar/segtpl_spd.mpd", "");
+  EXPECT_EQ(tree->live_delay_, 32);
+}

--- a/src/test/manifests/mpd/segtpl_spd.mpd
+++ b/src/test/manifests/mpd/segtpl_spd.mpd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" type="dynamic" minimumUpdatePeriod="PT4.000S" suggestedPresentationDelay="PT32S" minBufferTime="PT5.000S" maxSegmentDuration="PT4.500S" availabilityStartTime="2021-03-25T23:44:03Z" timeShiftBufferDepth="PT1800.000S" publishTime="2021-03-31T20:52:37Z" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="404187865" start="PT35652S">
+    <AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="25:14">
+      <SegmentTemplate timescale="90000" initialization="$RepresentationID$/segment-Header-init.m4s" media="$RepresentationID$/segment-$Number$.m4s" duration="360000" startNumber="404187866" presentationTimeOffset="7539818380345"/>
+      <Representation id="video1" width="400" height="224" frameRate="25" sar="1:1" scanType="progressive" bandwidth="450000" codecs="avc1.4D4015"/>
+      <Representation id="video2" width="640" height="360" frameRate="25" sar="1:1" scanType="progressive" bandwidth="600000" codecs="avc1.4D401E"/>
+      <Representation id="video3" width="960" height="540" frameRate="25" sar="1:1" scanType="progressive" bandwidth="1200000" codecs="avc1.4D401F"/>
+      <Representation id="video4" width="960" height="540" frameRate="25" sar="1:1" scanType="progressive" bandwidth="1800000" codecs="avc1.4D401F"/>
+      <Representation id="video5" width="1280" height="720" frameRate="25" sar="1:1" scanType="progressive" bandwidth="2600000" codecs="avc1.4D401F"/>
+      <Representation id="video6" width="1920" height="1080" frameRate="25" sar="1:1" scanType="progressive" bandwidth="3400000" codecs="avc1.4D4028"/>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" lang="ar" segmentAlignment="true" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate timescale="90000" initialization="$RepresentationID$/segment-Header-init.m4s" media="$RepresentationID$/segment-$Number$.m4s" duration="360000" startNumber="404187866" presentationTimeOffset="7539818380345"/>
+      <Representation id="audio1" audioSamplingRate="24000" bandwidth="96000" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="2021-03-31T20:53:07Z"/>
+</MPD>


### PR DESCRIPTION
fixes: https://github.com/xbmc/inputstream.adaptive/issues/647

This PR adds in a new live_delay_ manifest tree variable.
This tracks the delay / offset we want to keep from the live head.
I also updated the seeking code to use this value to stop seeking ahead of this point

With this PR, we will use suggestedPresentationDelay from a Dash manifest for this value.
Also we make sure this value is above ~~12s~~ 16s as anything lower breaks playback.

I've added a sanity check to the seek time.
If live_delay_ is greater than the total time of the stream, it stops us seeking a negative time.
start stream doesnt need such a check as that code already just grabs segment 0 if pos is < 0

removed the uint64_t overallsecs line as not actually used...

~~Oh, I found removing the preceeding = true in the seek code 
fixed a bug when seeking sometimes causing the stream to start pixelating.
Not sure why it is there. changing preceeding seems like a bad idea.
We are simply adjusting our seek amount.~~

TEST BUILDS:
https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-761/16/artifacts