### PR TITLE
[Dash] Always use timeShiftBufferDepth for live

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1065,12 +1065,14 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
     if (!mpt)
       mpt = tsbd;
 
-    AddDuration(mpt, dash->overallSeconds_, 1);
+    // Always use timeShiftBufferDepth for live manifest
+    if (dash->has_timeshift_buffer_)
+      AddDuration(tsbd, dash->overallSeconds_, 1);
+    else
+      AddDuration(mpt, dash->overallSeconds_, 1);
+
     dash->has_overall_seconds_ = dash->overallSeconds_ > 0;
-
-    uint64_t overallsecs(dash->overallSeconds_ ? dash->overallSeconds_ + 60 : 86400);
     dash->minPresentationOffset = ~0ULL;
-
     dash->currentNode_ |= MPDNODE_MPD;
   }
 }

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -217,12 +217,14 @@ TEST_F(DASHTreeTest, CalculateLiveWithPresentationDuration)
 {
   OpenTestFile("mpd/segtimeline_live_pd.mpd", "", "");
   EXPECT_EQ(tree->has_timeshift_buffer_, true);
+  EXPECT_EQ(tree->overallSeconds_, 78);
 }
 
 TEST_F(DASHTreeTest, CalculateStaticWithPresentationDuration)
 {
   OpenTestFile("mpd/segtpl_slash_baseurl_slash.mpd", "", "");
   EXPECT_EQ(tree->has_timeshift_buffer_, false);
+  EXPECT_EQ(tree->overallSeconds_, 6472);
 }
 
 TEST_F(DASHTreeTest, CalculateCorrectFpsScaleFromAdaptionSet)


### PR DESCRIPTION
currently if a live manifest has both timeShiftBufferDepth  and mediaPresentationDuration, IA will set the overalseconds to mediaPresentationDuration.

For live, we should always use timeShiftBufferDepth  as mediaPresentationDuration is only telling the total time not the time available to timeshift

also removed the overallsecs line as thats not actually used