### PR TITLE
[Decrypter] undefine LOCLICENSE so .challenge, .init etc files are not written to disk

### DIFF
--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -33,7 +33,7 @@
 #error  "WIDEVINECDMFILENAME must be set"
 #endif
 
-#define LOCLICENSE 1
+//#define LOCLICENSE
 
 using namespace SSD;
 

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -36,7 +36,7 @@ using namespace SSD;
 
 SSD_HOST *host = 0;
 
-#define LOCLICENSE 1
+//#define LOCLICENSE
 
 void Log(unsigned int loglevel, const char *format, ...)
 {


### PR DESCRIPTION
not sure the need for these 4 files that are written.
probably for debugging back in the day.

IMO we shouldn't be writing to disc anymore than needed.
Devices like RPI SD cards have certain amount of writes blah.

It may also increase playback speed of WV content very slightly
More so on devices with slow write speeds (mechanical drive etc)

The "widevine" folder that is created I think is still needed for when persistent storage is enabled