### PR TITLE
[Matrix] final Matrix change to correct test builds and take as Version 19.0.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.GPL)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.inputstream.adaptive?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=79&branchName=Matrix)
+[![Build and run tests](https://github.com/xbmc/inputstream.adaptive/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/inputstream.adaptive/actions/workflows/build.yml)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/inputstream.adaptive/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.rtmp/branches/)
+
 # inputstream.adaptive
 
 This is an adaptive file addon for kodi's new InputStream Interface.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
 
 build_script:
   - cd ..
-  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
+  - git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git
   - cd %app_id%
   - mkdir build
   - cd build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,11 +43,11 @@ jobs:
           ARCHITECTURE: ARM
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
-        ARM64-UWP:
-          GENERATOR: "Visual Studio 15 2017"
-          ARCHITECTURE: ARM64
-          CONFIGURATION: Release
-          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+        #ARM64-UWP:
+        #  GENERATOR: "Visual Studio 15 2017"
+        #  ARCHITECTURE: ARM64
+        #  CONFIGURATION: Release
+        #  WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
 
     workspace:
       clean: all

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="2.6.23"
+  version="19.0.0"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -15,6 +15,12 @@
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>
     <news>
+v19.0.0 (2021-09-14)
+- Change test builds to released 'Kodi 19 Matrix'
+- Increase version to 19.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+
 v2.6.23 (2021-08-06)
 - Translations from weblate - de_de, ja_jp, ko_kr
  - [Android] use multiple drm sessions (solves stuttering)


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.

See also issue https://github.com/xbmc/inputstream.adaptive/issues/798