### PR TITLE
Dont set preceeding when clamping seek

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3066,10 +3066,7 @@ bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
       maxSeek = 0;
 
     if (seekTime > maxSeek)
-    {
       seekTime = maxSeek;
-      preceeding = true;
-    }
   }
 
   // correct for starting segment pts value of chapter and chapter offset within program


### PR DESCRIPTION
If you play redbull stream in IPTV AU, and keep seeking fwd.
after a few tries, it will pause for a bit, and then come back pixelated

I found removing the preceeding = true in the seek code fixed the above issue.

To me, it just makes no sense why we are changing preceeding here?
All we are doing is reducing the seek time if its too far forward.
We aren't changing any other logic.
Why is what we are doing affecting preceeding?

eg.
user tries to seek to 30s, but we clamp to 20s. preceeding will be set to true
But if user had seeked to 20s, we would not need to adjust and be in the exact same position without preceeding being set to true.

This only affects live streams with timeshift buffer and only when seeking to the live head.


![screenshot00000](https://user-images.githubusercontent.com/6225961/136096160-17bce716-85ea-4285-b148-ab4bea487e3e.png)
