### PR TITLE
Set read position for byteranged TS streams to 0

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -84,9 +84,12 @@ void AdaptiveStream::ResetSegment(const AdaptiveTree::Segment* segment)
 {
   segment_read_pos_ = 0;
 
-  if (segment && !(current_rep_->flags_ & (AdaptiveTree::Representation::SEGMENTBASE |
-                                           AdaptiveTree::Representation::TEMPLATE |
-                                           AdaptiveTree::Representation::URLSEGMENTS)))
+  if (segment &&
+      !(current_rep_->flags_ &
+        (AdaptiveTree::Representation::SEGMENTBASE | 
+         AdaptiveTree::Representation::TEMPLATE |
+         AdaptiveTree::Representation::URLSEGMENTS)) &&
+      current_rep_->containerType_ != AdaptiveTree::ContainerType::CONTAINERTYPE_TS)
     absolute_position_ = segment->range_begin_;
 }
 


### PR DESCRIPTION
Fixes byteranged TS streams.

As documented in https://github.com/xbmc/inputstream.adaptive/issues/687

AFAIK there's no real difference between a TS file split into chunks or one that is retrieved with ranged requests. Each chunk has it's own init data bundled with it, this change will ensure that byteranged files are read the same as the chunks are.

Tested on several streams, no issue or regression found.