### PR TITLE
Fix wrong condition in PTSToElapsed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2942,12 +2942,14 @@ uint64_t Session::PTSToElapsed(uint64_t pts)
 {
   if (timing_stream_)
   {
-    uint64_t manifest_time = (pts - timing_stream_->reader_->GetPTSDiff() > 0)
-                                 ? pts - timing_stream_->reader_->GetPTSDiff()
-                                 : 0;
-    return (manifest_time > timing_stream_->stream_.GetAbsolutePTSOffset())
-               ? manifest_time - timing_stream_->stream_.GetAbsolutePTSOffset()
-               : 0ULL;
+    int64_t manifest_time = static_cast<int64_t>(pts) - timing_stream_->reader_->GetPTSDiff();
+    if (manifest_time < 0)
+      manifest_time = 0;
+
+    if (static_cast<uint64_t>(manifest_time) > timing_stream_->stream_.GetAbsolutePTSOffset())
+      return static_cast<uint64_t>(manifest_time) - timing_stream_->stream_.GetAbsolutePTSOffset();
+
+    return 0ULL;
   }
   else
     return pts;


### PR DESCRIPTION
From what i know unsigned int cannot handle negative values
if that is the purpose of this condition it is wrong

these kinds of bugs are annoying because they are hidden and cause only bad works with conditions,
i have not checked all the code if unsigned int variables are handled correctly i hope there are no others