### PR TITLE
Upstream Debian patches

### DIFF
--- a/wvdecrypter/cdm/build/build_config.h
+++ b/wvdecrypter/cdm/build/build_config.h
@@ -138,8 +138,18 @@
 #define ARCH_CPU_32_BITS 1
 #define ARCH_CPU_LITTLE_ENDIAN 1
 #endif
-#else
-#error Please add support for your architecture in build/build_config.h
+#elif (defined(__PPC64__) || defined(__PPC__)) && defined(__BIG_ENDIAN__)
+#define ARCH_CPU_PPC64_FAMILY 1
+#define ARCH_CPU_PPC64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
+#elif defined(__PPC64__)
+#define ARCH_CPU_PPC64_FAMILY 1
+#define ARCH_CPU_PPC64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+# else
+#error Please add support for your architecture in build/build_config.
 #endif
 
 // Type detection for wchar_t.

--- a/wvdecrypter/cdm/build/build_config.h
+++ b/wvdecrypter/cdm/build/build_config.h
@@ -148,6 +148,17 @@
 #define ARCH_CPU_PPC64 1
 #define ARCH_CPU_64_BITS 1
 #define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__riscv) || defined(__riscv__)
+#define ARCH_CPU_RISCV_FAMILY 1
+#define ARCH_CPU_RISCV 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#if defined(__riscv_xlen)
+# if (__riscv_xlen == 64)
+#  define ARCH_CPU_64_BITS 1
+# else
+#  define ARCH_CPU_32_BITS 1
+# endif
+#endif
 # else
 #error Please add support for your architecture in build/build_config.
 #endif


### PR DESCRIPTION
Enables building for `ppc64el` and `riscv64`