### PR TITLE
Fix sub streams being unable to re-start

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -870,9 +870,13 @@ void AdaptiveStream::info(std::ostream& s)
 
 void AdaptiveStream::stop()
 {
-  if (current_rep_)
+  if (current_rep_) 
+  {
     const_cast<adaptive::AdaptiveTree::Representation*>(current_rep_)->flags_ &=
         ~adaptive::AdaptiveTree::Representation::ENABLED;
+    current_rep_->current_segment_ = 0;
+  }
+
   if (thread_data_)
   {
     StopWorker(STOPPED);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1967,6 +1967,7 @@ void Session::STREAM::disable()
   if (enabled)
   {
     stream_.stop();
+    stream_.Reset();
     reset();
     enabled = encrypted = false;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When we switch bandwidths for the video stream (send `DEMUX_SPECIALID_STREAMCHANGE` packet to Kodi) the video and audio streams are simply opened again, however with subtitles the current stream is closed/disabled first - see [here](https://github.com/xbmc/xbmc/blob/7478f983b67dc1e3b09e061acf2eaa675b0f0170/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L930).
In Matrix whenever streams are opened the segment number passed in always directs the AdaptiveStream to start from the beginning (first segment), Kodi then directs IA to seek the stream to the current location (calls `PosTime`).

For subtitles however PosTime isn't called, and we have the 'leftovers' from the last time the stream was running - `segment_read_pos_` and `current_segment_` in particular. This change will restore the Matrix behaviour by resetting these values when `stop()` is called on the AdaptiveStream (which only happens on `DEMUX_SPECIALID_STREAMCHANGE` for subtitle streams as per above)

I don't know if this is the correct solution, I think ideally VideoPlayer would ask the subtitle streams to seek as well as audio/video, but this may affect things outside of inputstream add-ons.... @CastagnaIT since you're much more familiar with subtitles within Kodi you may have an idea or opinion on this.

## Motivation and context
Fixes #836 

## How has this been tested?
Tested on https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8

## What is the effect on users?
Will (have not tested yet) fix D+ subtitles and other HLS/webvtt segmented subtitles 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
