### PR TITLE
Set DEMUX_SPECIALID_STREAMCHANGE_AV to switch stream callback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3465,7 +3465,7 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
   {
     DEMUX_PACKET* p = AllocateDemuxPacket(0);
     p->iStreamId = DEMUX_SPECIALID_STREAMCHANGE;
-    LOG::Log(LOGDEBUG, "DEMUX_SPECIALID_STREAMCHANGE");
+    LOG::Log(LOGDEBUG, "DEMUX_SPECIALID_STREAMCHANGE_AV");
     return p;
   }
 
@@ -3520,7 +3520,7 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
     m_session->InitializePeriod();
     DEMUX_PACKET* p = AllocateDemuxPacket(0);
     p->iStreamId = DEMUX_SPECIALID_STREAMCHANGE;
-    LOG::Log(LOGDEBUG, "DEMUX_SPECIALID_STREAMCHANGE");
+    LOG::Log(LOGDEBUG, "DEMUX_SPECIALID_STREAMCHANGE_AV");
     return p;
   }
   return NULL;


### PR DESCRIPTION
As reference to https://github.com/xbmc/xbmc/pull/20579

This is a solution for the problems with subtitles that happens every time that ISA switch the streams while in playback (adaptive streams)

Currently the `DEMUX_SPECIALID_STREAMCHANGE` cause the reset of subtitle codec handler in kodi core and (depends on type of subtitle) also the subsequent request to download again the subtitle data from ISA

This cause a lot of differents side effects, that depends also on the type of subtitle used (due to different codec behaviours) from my tests:
- Double/triple/... subtitles displayed
- Kodi language subtitle setting will be resetted then changed (if user has selected another track or set external subtitle)
- Kodi subtitle disabled at every packet callback, no way to kept subtitle enabled

This new `DEMUX_SPECIALID_STREAMCHANGE_AV` want achieve the goal of reset audio/video streams only, that is called for adaptive stream, and keep subtitle stream that no need to be resetted.

**Is required https://github.com/xbmc/xbmc/pull/20579 before the merge**