### PR TITLE
[Matrix] Fix seek accuracy / Remove duplicate call to SeekTime

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3950,7 +3950,7 @@ bool CInputStreamAdaptive::PosTime(int ms)
   bool ret = m_session->SeekTime(static_cast<double>(ms) * 0.001f, 0, false);
   m_failedSeekTime = ret ? ~0 : ms;
 
-  return m_session->SeekTime(static_cast<double>(ms) * 0.001f, 0, false);
+  return ret;
 }
 
 int CInputStreamAdaptive::GetTotalTime()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
* In `PosTime` the call to `Session::SeekTime` is unnecessarily made twice, this change addresses that.
* Seeking made more accurate for audio/sub streams

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As can be observed in #785 seeking a stream in Kodi has the AdaptiveStreams and stream readers seek twice in a row - first to the requested location, then again 'on the spot'. ~~Undesired behaviour seems to stem from this on some platforms (Android in particular) possibly due to differences in how the data from the stream is consumed (suspect that inbetween calls some data is read and on second call one of the streams positions is then 'rounded up', causing misalignment).~~

ISA has a designated 'timing stream' (timing master) - this is normally the video stream if there is one and there will sometimes be a difference in pts between eg. audio and video streams. 
The current behavior when seeking is (has been documented in code comments previously and in this PR as best I can) that for each of the enables AdaptiveStreams, the AdaptiveStream will seek to the requested segment, then followed by stream's 'reader' to seek within the segment. The issues seen in #785 have been from this process running and arriving at different segments for audio/video. ~~While Windows seems to handle this fine, Android does not.~~ - not the cause of seeking issues

In part of this mechanism of seeking in `Session::SeekTime` here:
https://github.com/xbmc/inputstream.adaptive/blob/1d8877960ccf33f423b6d18ee6f9456fc9301fc8/src/main.cpp#L3099-L3104
the `seekTimeCorrected` variable is being changed to where the video stream actually ended up seeking to (i.e the start of a segment, rather than an arbitrary time that was selected on the timeline). What has been happening though on the next iterations of this function is the pts offset of the AdaptiveStream being iterated is used to calculate the next segment seek here:
https://github.com/xbmc/inputstream.adaptive/blob/1d8877960ccf33f423b6d18ee6f9456fc9301fc8/src/main.cpp#L3081-L3085 ~~which causes issues because this offset differs from the video stream offset.~~

Since Kodi only has one timeline for playback and not multiple for each component (video/audio/sub) it then follows that we should be using the same pts offset for each of these calculations in order to end up in the same place. Having the audio stream for example a couple of milliseconds forward of the video stream will cause the `AdaptiveStream::seek_time` function to advance a whole segment ahead, causing the misalignment.

The change therefore is to always use the timing stream pts offset when available for the seek_time operation.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime tested on Win 10 using YouTube live videos. Previously it could be observed that different segment numbers were seeked to on some videos at some times (although with no observable issue in playback on Windows), now the segments always align.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Attempt to resolve issues of #785 - update: does not.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
