### PR TITLE
[Matrix] fix build error about gtest if warning set to error 

### DIFF
--- a/depends/common/googletest/0001-FixWarningMaybe-uninitialized.patch
+++ b/depends/common/googletest/0001-FixWarningMaybe-uninitialized.patch
@@ -1,0 +1,20 @@
+--- a/googletest/src/gtest-death-test.cc
++++ b/googletest/src/gtest-death-test.cc
+@@ -1281,7 +1281,7 @@
+ GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
+ GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
+ static void StackLowerThanAddress(const void* ptr, bool* result) {
+-  int dummy;
++  int dummy = 0;
+   *result = (&dummy < ptr);
+ }
+ 
+@@ -1289,7 +1289,7 @@
+ GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
+ GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
+ static bool StackGrowsDown() {
+-  int dummy;
++  int dummy = 0;
+   bool result;
+   StackLowerThanAddress(&dummy, &result);
+   return result;

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.adaptive"
-  version="19.0.0"
+  version="19.0.1"
   name="InputStream Adaptive"
   provider-name="peak3d">
   <requires>@ADDON_DEPENDS@</requires>
@@ -15,6 +15,9 @@
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>
     <news>
+v19.0.1 (2021-12-10)
+- Fix compile error by GCC 11
+
 v19.0.0 (2021-09-14)
 - Change test builds to released 'Kodi 19 Matrix'
 - Increase version to 19.0.0


### PR DESCRIPTION
On my system comes it as compile error, as something sets the warning as error.

This the produced error message:
```
[ 12%] Building CXX object googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
In file included from inputstream.adaptive/build/build/googletest/src/googletest/googletest/src/gtest-all.cc:42:
inputstream.adaptive/build/build/googletest/src/googletest/googletest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
inputstream.adaptive/build/build/googletest/src/googletest/googletest/src/gtest-death-test.cc:1301:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
inputstream.adaptive/build/build/googletest/src/googletest/googletest/src/gtest-death-test.cc:1290:13: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerTh
 1290 | static void StackLowerThanAddress(const void* ptr, bool* result) {
      |             ^~~~~~~~~~~~~~~~~~~~~
inputstream.adaptive/build/build/googletest/src/googletest/googletest/src/gtest-death-test.cc:1299:7: note: ‘dummy’ declared here
 1299 |   int dummy;
      |       ^~~~~
cc1plus: all warnings being treated as errors
make[5]: *** [googletest/CMakeFiles/gtest.dir/build.make:82: googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o] Fehler 1
make[4]: *** [CMakeFiles/Makefile2:219: googletest/CMakeFiles/gtest.dir/all] Fehler 2
make[3]: *** [Makefile:160: all] Fehler 2
make[2]: *** [CMakeFiles/googletest.dir/build.make:133: build/googletest/src/googletest-stamp/googletest-build] Fehler 2
make[1]: *** [CMakeFiles/Makefile2:177: CMakeFiles/googletest.dir/all] Fehler 2
```

By change here becomes the dummy set to 0 and to prevent the warning/error

Within Nexus Version this fix already included, partial backport about https://github.com/xbmc/inputstream.adaptive/pull/850