### PR TITLE
[Bento4] Add ism segfault patch

### DIFF
--- a/depends/common/bento4/0017-Fix-segfault-in-AP4_LinearReader-ProcessMoof.path
+++ b/depends/common/bento4/0017-Fix-segfault-in-AP4_LinearReader-ProcessMoof.path
@@ -1,0 +1,24 @@
+From e5b37c1e0a7a84fdc7b403c5e30a5e93706104b8 Mon Sep 17 00:00:00 2001
+From: Dobroslaw Kijowski <dobo90@gmail.com>
+Date: Tue, 19 Oct 2021 14:17:11 +0200
+Subject: [PATCH] Fix segfault in Ap4LinearReader ProcessMoof
+
+---
+ Source/C++/Core/Ap4LinearReader.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/C++/Core/Ap4LinearReader.cpp b/Source/C++/Core/Ap4LinearReader.cpp
+index 61c3a9d..2464865 100644
+--- a/Source/C++/Core/Ap4LinearReader.cpp
++++ b/Source/C++/Core/Ap4LinearReader.cpp
+@@ -329,7 +329,7 @@ AP4_LinearReader::ProcessMoof(AP4_ContainerAtom* moof,
+         tracker->m_SampleTable = NULL;
+         tracker->m_NextSampleIndex = 0;
+         for (unsigned int j=0; j<ids.ItemCount(); j++) {
+-            if (ids[j] == tracker->m_Track->GetId()) {
++            if (ids.ItemCount()==1 || ids[j] == tracker->m_Track->GetId()) {
+                 AP4_FragmentSampleTable* sample_table = NULL;
+                 result = m_Fragment->CreateSampleTable(&m_Movie, 
+                                                        ids[j], 
+-- 
+2.33.1


### PR DESCRIPTION
Fixes: https://github.com/xbmc/inputstream.adaptive/issues/853
Fixes: https://github.com/xbmc/inputstream.adaptive/issues/829

This change is in Matrix but wasnt migrated to new bento version / patches
https://github.com/xbmc/inputstream.adaptive/blob/Matrix/lib/libbento4/Core/Ap4LinearReader.cpp#L320

There was an attempt here to fix inside IA source:
https://github.com/xbmc/inputstream.adaptive/issues/829#issuecomment-947589808
But user reported it didnt fix the issue