### PR TITLE
[Matrix] Remove duplicate seektime call

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3950,7 +3950,7 @@ bool CInputStreamAdaptive::PosTime(int ms)
   bool ret = m_session->SeekTime(static_cast<double>(ms) * 0.001f, 0, false);
   m_failedSeekTime = ret ? ~0 : ms;
 
-  return m_session->SeekTime(static_cast<double>(ms) * 0.001f, 0, false);
+  return ret;
 }
 
 int CInputStreamAdaptive::GetTotalTime()


### PR DESCRIPTION
Already sorted in Nexus branch. Was a part of #848 