### PR TITLE
On pre-init DRM still use the session opened

### DIFF
--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -42,7 +42,7 @@ namespace SSD
     {
       PROPERTY_HEADER
   };
-    static const uint32_t version = 15;
+    static const uint32_t version = 16;
 #if defined(ANDROID)
     virtual void* GetJNIEnv() = 0;
     virtual int GetSDKVersion() = 0;

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -8,6 +8,9 @@
 
 #include <bento4/Ap4.h>
 
+#include <stdexcept>
+#include <string_view>
+
 enum class ENCRYPTION_SCHEME
 {
   NONE,
@@ -26,6 +29,22 @@ public:
     m_SkipBlocks = static_cast<uint32_t>(skipBlocks);
   };
   virtual void SetEncryptionScheme(ENCRYPTION_SCHEME encryptionScheme){};
+
+  /*! \brief Add a Key ID to the current session
+   *  \param keyId The KID
+   */
+  virtual void AddKeyId(std::string_view keyId)
+  {
+    throw std::logic_error("AddKeyId method not implemented.");
+  };
+
+  /*! \brief Set a Key ID as default
+   *  \param keyId The KID
+   */
+  virtual void SetDefaultKeyId(std::string_view keyId)
+  {
+    throw std::logic_error("SetDefaultKeyId method not implemented.");
+  };
 
 protected:
   uint32_t m_CryptBlocks{0};

--- a/src/main.h
+++ b/src/main.h
@@ -79,9 +79,30 @@ public:
           const std::string& profilePath);
   virtual ~Session();
   bool Initialize(const std::uint8_t config, uint32_t max_user_bandwidth);
-  bool PreInitializeDRM(std::string& challengeB64, std::string& sessionId);
-  bool InitializeDRM();
-  bool InitializePeriod();
+
+  /*! \brief Pre-Initialize the DRM
+   *  \param challengeB64 [OUT] Provide the challenge data as base64
+   *  \param sessionId [OUT] Provide the session ID
+   *  \param isSessionOpened [OUT] Will be true if the DRM session has been opened
+   *  \return True if has success, false otherwise
+   */
+  bool PreInitializeDRM(std::string& challengeB64,
+                        std::string& sessionId,
+                        bool& isSessionOpened);
+
+  /*! \brief Initialize the DRM
+   *  \param addDefaultKID Set True to add the default KID to the first session
+   *  \return True if has success, false otherwise
+   */
+  bool InitializeDRM(bool addDefaultKID = false);
+
+  /*! \brief Initialize adaptive tree period
+   *  \param isSessionOpened Set True to kept and re-use the DRM session opened,
+   *         otherwise False to reinitialize the DRM session
+   *  \return True if has success, false otherwise
+   */
+  bool InitializePeriod(bool isSessionOpened = false);
+
   SampleReader *GetNextSample();
 
   struct STREAM

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -615,7 +615,6 @@ bool WV_CencSingleSampleDecrypter::KeyUpdateRequest(bool waitKeys, bool skipSess
       return false;
     }
   }
-  Log(SSDDEBUG, "License update successful");
 
   if (media_drm_.GetKeySystemType() != PLAYREADY)
   {
@@ -1016,6 +1015,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
   if (keyRequestData.size() == 2)
    media_drm_.SaveServiceCertificate();
 
+  Log(SSDDEBUG, "License update successful");
   return true;
 
 SSMFAIL:
@@ -1338,9 +1338,7 @@ public:
       return "";
 
     std::vector<char> challengeData = static_cast<WV_CencSingleSampleDecrypter*>(decrypter)->GetChallengeData();
-    std::string encChallengeData{BASE64::Encode(challengeData.data(), challengeData.size())};
-    // Keep data URL encoded otherwise will not be sent correctly in the HTTP header
-    return STRING::URLEncode(encChallengeData);
+    return BASE64::Encode(challengeData.data(), challengeData.size());
   }
 
   virtual bool HasCdmSession()


### PR DESCRIPTION
This change keep opened the drm session opened from the pre-init, and goes through the manifest request,
this will be applied to non-Android systems. Android mediadrm not allow to add KeyId to the session, therefore the session will continue to be closed and reopened a new one.

-Why
New changes to ntfx website reveals more info and new problems
now i can see that in the response data obtained from the "Licensed manifest" request, contains the manifest data, plus, the license data (all in one),
this is not a problem because i can split the response as two data and provide them to ISA without any problems via proxy

but the problem is that when i provide the license data to ISA, and the drm session is different (because previously closed), ISA fails to process license data, then playback of video is not possible

I initially suspected this, but I wasn't sure because it worked without problems
this because we used to make a separate request for the license, but now everything is included in the manifest.

I think, however, that website is still in the transition phase between old and new methods because there is a bit of a mix.

This needs a backport to Kodi 19

Currently tested on:
- Windows 10 64 bit with latest Kodi 20 nightly
- CoreElec Kodi 20 nightly (ARM)
