### PR TITLE
[WebVTT] Fix sending segments packages

### DIFF
--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -63,7 +63,13 @@ namespace adaptive
     uint32_t read(void* buffer, uint32_t  bytesToRead);
     uint64_t tell(){ read(0, 0);  return absolute_position_; };
     bool seek(uint64_t const pos);
-    bool getSize(unsigned long long& sz);
+
+   /*!
+    * \brief Get the buffer size of the first segment in the buffer
+    * \param size The segment buffer size
+    * \return Return true if the size has been read, otherwise false
+    */
+    bool retrieveCurrentSegmentBufferSize(size_t& size);
     bool seek_time(double seek_seconds, bool preceeding, bool &needReset);
     AdaptiveTree::Period* getPeriod() { return current_period_; };
     AdaptiveTree::AdaptationSet* getAdaptationSet() { return current_adp_; };

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -140,6 +140,7 @@ public:
     uint64_t range_end_ = 0; //Either byterange end or sequence_id if range_begin is ~0
     const char *url = nullptr;
     uint64_t startPTS_ = 0;
+    uint64_t m_duration = 0; // If available gives the media duration of a segment (depends on type of stream e.g. HLS)
     uint16_t pssh_set_ = 0;
   };
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -458,7 +458,9 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         if (line.compare(0, 8, "#EXTINF:") == 0)
         {
           segment.startPTS_ = pts;
-          pts += static_cast<uint64_t>(atof(line.c_str() + 8) * rep->timescale_);
+          uint64_t duration = static_cast<uint64_t>(std::atof(line.c_str() + 8) * rep->timescale_);
+          segment.m_duration = duration;
+          pts += duration;
         }
         else if (line.compare(0, 17, "#EXT-X-BYTERANGE:") == 0)
         {


### PR DESCRIPTION
We are talking about segmented WebVTT on HLS streams,
until now all the packages (of each segment) were being sent in the kodi demuxer just before the playback starts,
in general this could be not a big problem perhaps that is why it has never been fixed,
but the problem will be raised when a stream have a lot of segments

A case is on issue #870 (see case 1) where the stream have more than 1000 segments,
this means download and processing more than 1000 files before the playback with a huge delay some minutes before the video can start, a clearly useless effort...

The purpose of this fix is set the right PTS on each segment in order to download and send to the demuxer the packets during playback and not before start the playback

This also revert the changes introduced with PR #841 no longer needed

This PR needs also a change on Kodi parser to handle better the flush of data PR https://github.com/xbmc/xbmc/pull/20858


#### HLS test streams used (the first link for the PR, the others to verify no regressions)
WebVTT Segmented (30min - 60 segments): https://s3.amazonaws.com/_bc_dml/example-content/bipbop-advanced/bipbop_16x9_variant.m3u8
WebVTT "as single file": http://dash.edgesuite.net/akamai/test/caption_test/ElephantsDream/elephants_dream_480p_heaac5_1.mpd
WebVTT fMP4 ISO/IEC: http://media.axprod.net/ExoPlayer/Captions2/Manifest.mpd

Sidenote in the segmented test stream, the subtitles are not displayed immediately this is due to X-TIMESTAMP-MAP i think that need some other change, that not concern this PR