### PR TITLE
Fix for huge media sequence numbers

### DIFF
--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -96,7 +96,7 @@ namespace adaptive
     {
       std::string buffer;
       AdaptiveTree::Segment segment;
-      unsigned int segment_number;
+      uint64_t segment_number;
       AdaptiveTree::Representation* rep;
     };
     std::vector<SEGMENTBUFFER> segment_buffers_;
@@ -118,7 +118,7 @@ namespace adaptive
     bool prepareNextDownload();
     bool prepareDownload(const AdaptiveTree::Representation* rep,
                          const AdaptiveTree::Segment* seg,
-                         unsigned int segNum);
+                         uint64_t segNum);
     int SecondsSinceUpdate() const;
     static void ReplacePlaceholder(std::string& url, const std::string placeholder, uint64_t value);
     bool ResolveSegmentBase(AdaptiveTree::Representation* rep, bool stopWorker);
@@ -173,7 +173,7 @@ namespace adaptive
     uint64_t currentPTSOffset_, absolutePTSOffset_;
 
     uint16_t download_pssh_set_;
-    unsigned int download_segNum_;
+    uint64_t download_segNum_;
     bool worker_processing_;
     uint8_t m_iv[16];
     bool m_fixateInitialization;

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -170,7 +170,7 @@ namespace adaptive
       (*b)->segments_.insert(seg);
   }
 
-  void AdaptiveTree::OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize)
+  void AdaptiveTree::OnDataArrived(uint64_t segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize)
   {
     memcpy(dst + dstOffset, src, dataSize);
   }

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -209,7 +209,7 @@ public:
     uint32_t expired_segments_;
     ContainerType containerType_;
     SegmentTemplate segtpl_;
-    unsigned int startNumber_;
+    uint64_t startNumber_;
     uint64_t nextPts_;
     //SegmentList
     uint64_t ptsOffset_;
@@ -251,14 +251,14 @@ public:
       return get_segment_pos(current_segment_);
     };
 
-    uint32_t getCurrentSegmentNumber() const
+    uint64_t getCurrentSegmentNumber() const
     {
-      return current_segment_ ? get_segment_pos(current_segment_) + startNumber_ : ~0U;
+      return current_segment_ ? static_cast<uint64_t>(get_segment_pos(current_segment_)) + startNumber_ : ~0ULL;
     };
 
-    uint32_t getSegmentNumber(const Segment *segment) const
+    uint64_t getSegmentNumber(const Segment *segment) const
     {
-      return segment ? get_segment_pos(segment) + startNumber_ : ~0U;
+      return segment ? static_cast<uint64_t>(get_segment_pos(segment)) + startNumber_ : ~0ULL;
     };
 
     void SetScaling()
@@ -293,7 +293,7 @@ public:
     uint32_t timescale_;
     uint64_t duration_;
     uint64_t startPTS_;
-    unsigned int startNumber_;
+    uint64_t startNumber_;
     bool impaired_, original_, default_, forced_;
     std::string language_;
     std::string mimeType_;
@@ -429,7 +429,9 @@ public:
 
     std::vector<AdaptationSet*> adaptationSets_;
     std::string base_url_, id_;
-    uint32_t timescale_ = 1000, startNumber_ = 1, sequence_ = 0;
+    uint32_t timescale_ = 1000;
+    uint32_t sequence_ = 0;
+    uint64_t startNumber_ = 1;
     uint64_t start_ = 0;
     uint64_t startPTS_ = 0;
     uint64_t duration_ = 0;
@@ -500,7 +502,7 @@ public:
     return PREPARE_RESULT_OK;
   };
   virtual std::chrono::time_point<std::chrono::system_clock> GetRepLastUpdated(const Representation* rep) { return std::chrono::system_clock::now(); }
-  virtual void OnDataArrived(unsigned int segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize);
+  virtual void OnDataArrived(uint64_t segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize);
   virtual void RefreshSegments(Period* period,
                                AdaptationSet* adp,
                                Representation* rep,

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -87,11 +87,11 @@ static uint8_t GetChannels(const char** attr)
   return 0;
 }
 
-static unsigned int ParseSegmentTemplate(const char** attr,
+static uint64_t ParseSegmentTemplate(const char** attr,
                                          std::string baseURL,
                                          std::string baseDomain,
                                          DASHTree::SegmentTemplate& tpl,
-                                         unsigned int startNumber)
+                                         uint64_t startNumber)
 {
   for (; *attr;)
   {
@@ -1656,7 +1656,7 @@ void DASHTree::RefreshLiveSegments()
   {
     std::string replaced;
     uint32_t numReplace = ~0U;
-    unsigned int nextStartNumber(~0);
+    uint64_t nextStartNumber(~0ULL);
     std::string::size_type update_parameter_pos = update_parameter_.find("$START_NUMBER$");
 
     if (~update_parameter_pos)
@@ -1686,7 +1686,7 @@ void DASHTree::RefreshLiveSegments()
 
       replaced = update_parameter_;
       char buf[32];
-      sprintf(buf, "%u", nextStartNumber);
+      sprintf(buf, "%llu", nextStartNumber);
       replaced.replace(update_parameter_pos, 14, buf);
     }
 
@@ -1786,7 +1786,7 @@ void DASHTree::RefreshLiveSegments()
                 else if ((*br)->startNumber_ <= 1) //Full update, be careful with startnumbers!
                 {
                   //TODO: check if first element or size differs
-                  unsigned int segmentId((*brd)->getCurrentSegmentNumber());
+                  uint64_t segmentId((*brd)->getCurrentSegmentNumber());
                   if ((*br)->flags_ & DASHTree::Representation::TIMELINE)
                   {
                     uint64_t search_pts = (*br)->segments_[0]->range_begin_;
@@ -1837,8 +1837,8 @@ void DASHTree::RefreshLiveSegments()
                   {
                     if (segmentId >= (*brd)->startNumber_ + (*brd)->segments_.size())
                       segmentId = (*brd)->startNumber_ + (*brd)->segments_.size() - 1;
-                    (*brd)->current_segment_ =
-                        (*brd)->get_segment(segmentId - (*brd)->startNumber_);
+                    (*brd)->current_segment_ = (*brd)->get_segment(
+                        static_cast<uint32_t>(segmentId - (*brd)->startNumber_));
                   }
 
                   if (((*brd)->flags_ & Representation::WAITFORSEGMENT) &&
@@ -1853,7 +1853,7 @@ void DASHTree::RefreshLiveSegments()
                          ((*br)->startNumber_ == (*brd)->startNumber_ &&
                           (*br)->segments_.size() > (*brd)->segments_.size()))
                 {
-                  unsigned int segmentId((*brd)->getCurrentSegmentNumber());
+                  uint64_t segmentId((*brd)->getCurrentSegmentNumber());
                   (*br)->segments_.swap((*brd)->segments_);
                   (*brd)->startNumber_ = (*br)->startNumber_;
                   if (!~segmentId || segmentId < (*brd)->startNumber_)
@@ -1862,8 +1862,8 @@ void DASHTree::RefreshLiveSegments()
                   {
                     if (segmentId >= (*brd)->startNumber_ + (*brd)->segments_.size())
                       segmentId = (*brd)->startNumber_ + (*brd)->segments_.size() - 1;
-                    (*brd)->current_segment_ =
-                        (*brd)->get_segment(segmentId - (*brd)->startNumber_);
+                    (*brd)->current_segment_ = (*brd)->get_segment(
+                        static_cast<uint32_t>(segmentId - (*brd)->startNumber_));
                   }
 
                   if (((*brd)->flags_ & Representation::WAITFORSEGMENT) &&

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -45,7 +45,7 @@ public:
   virtual void SetLastUpdated(std::chrono::system_clock::time_point tm){};
   void SetUpdateInterval(uint32_t interval) { updateInterval_ = interval; };
   uint64_t pts_helper_, timeline_time_;
-  uint32_t firstStartNumber_;
+  uint64_t firstStartNumber_;
   std::string current_playready_wrmheader_;
   std::string mpd_url_;
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -390,9 +390,9 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
   if (!rep->source_url_.empty())
   {
     SPINCACHE<Segment> newSegments;
-    unsigned int newStartNumber;
+    uint64_t newStartNumber;
     Segment newInitialization;
-    uint32_t segmentId(rep->getCurrentSegmentNumber());
+    uint64_t segmentId(rep->getCurrentSegmentNumber());
     std::stringstream stream;
     uint32_t adp_pos =
         std::find(period->adaptationSets_.begin(), period->adaptationSets_.end(), adp) -
@@ -527,7 +527,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         }
         else if (line.compare(0, 22, "#EXT-X-MEDIA-SEQUENCE:") == 0)
         {
-          newStartNumber = atol(line.c_str() + 22);
+          newStartNumber = std::stoull(line.substr(22));
         }
         else if (line.compare(0, 21, "#EXT-X-PLAYLIST-TYPE:") == 0)
         {
@@ -748,7 +748,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
       {
         if (segmentId >= rep->startNumber_ + rep->segments_.size())
           segmentId = rep->startNumber_ + rep->segments_.size() - 1;
-        rep->current_segment_ = rep->get_segment(segmentId - rep->startNumber_);
+        rep->current_segment_ = rep->get_segment(static_cast<uint32_t>(segmentId - rep->startNumber_));
       }
       if ((rep->flags_ & Representation::WAITFORSEGMENT) &&
           (rep->get_next_segment(rep->current_segment_) || current_period_ != periods_.back()))
@@ -774,7 +774,7 @@ bool HLSTree::write_data(void* buffer, size_t buffer_size, void* opaque)
   return true;
 }
 
-void HLSTree::OnDataArrived(unsigned int segNum,
+void HLSTree::OnDataArrived(uint64_t segNum,
                             uint16_t psshSet,
                             uint8_t iv[16],
                             const uint8_t* src,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -51,7 +51,7 @@ public:
                                                Representation* rep,
                                                bool update = false) override;
   virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;
-  virtual void OnDataArrived(unsigned int segNum,
+  virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
                              uint8_t iv[16],
                              const uint8_t* src,


### PR DESCRIPTION
In the case of a playlist that looks like this:
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-ALLOW-CACHE:NO
#EXT-X-TARGETDURATION:6
#EXT-X-MEDIA-SEQUENCE:20220118074255
#EXTINF:6,
#EXT-X-PROGRAM-DATE-TIME:2022-01-18T11:27:55.000+0100
...
```
The `atol` function is returning the max value for 32 bit integer when fed large values like this which prevents the correct media sequence from being used to align segments between old and new playlists. Net effect is that segments get skipped, creating discontinuities and eventually the AdaptiveStream is always looking for a segment that is off into the future.

This PR fixes by using `atoll`, and all references to the value once stored are now using 64 bit uint variables. Tested on tennix.it stream as referenced in this https://github.com/xbmc/inputstream.adaptive/issues/249#issuecomment-1014926605 (live event now ended) and other HLS and DASH live streams tested for regression.

Will backport to Matrix