### PR TITLE
Begin refactor of wvdecrypter, sample-aes-cbc support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(ADP_HEADERS
 	src/codechandler/VP9CodecHandler.h
 	src/codechandler/WebVTTCodecHandler.h
 	src/codechandler/ttml/TTML.h
+    src/common/AdaptiveDecrypter.h
 	src/common/AdaptiveStream.h
 	src/common/AdaptiveTree.h
 	src/common/RepresentationChooser.h

--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -12,7 +12,7 @@
 #include <string_view>
 
 //Functionality wich is supported by the Decrypter
-class AP4_CencSingleSampleDecrypter;
+class Adaptive_CencSingleSampleDecrypter;
 class AP4_DataBuffer;
 
 namespace SSD
@@ -42,7 +42,7 @@ namespace SSD
     {
       PROPERTY_HEADER
   };
-    static const uint32_t version = 14;
+    static const uint32_t version = 15;
 #if defined(ANDROID)
     virtual void* GetJNIEnv() = 0;
     virtual int GetSDKVersion() = 0;
@@ -196,15 +196,23 @@ namespace SSD
     // Return supported URN if type matches to capabilities, otherwise null
     virtual const char *SelectKeySytem(const char* keySystem) = 0;
     virtual bool OpenDRMSystem(const char *licenseURL, const AP4_DataBuffer &serverCertificate, const uint8_t config) = 0;
-    virtual AP4_CencSingleSampleDecrypter *CreateSingleSampleDecrypter(AP4_DataBuffer &pssh, const char *optionalKeyParameter, std::string_view defaultkeyid, bool skipSessionMessage) = 0;
-    virtual void DestroySingleSampleDecrypter(AP4_CencSingleSampleDecrypter* decrypter) = 0;
+    virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
+        AP4_DataBuffer& pssh,
+        const char* optionalKeyParameter,
+        std::string_view defaultkeyid,
+        bool skipSessionMessage) = 0;
+    virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) = 0;
 
-    virtual void GetCapabilities(AP4_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid, uint32_t media, SSD_DECRYPTER::SSD_CAPS &caps) = 0;
-    virtual bool HasLicenseKey(AP4_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid) = 0;
+    virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
+                                 const uint8_t* keyid,
+                                 uint32_t media,
+                                 SSD_DECRYPTER::SSD_CAPS& caps) = 0;
+    virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid) = 0;
     virtual bool HasCdmSession() = 0;
-    virtual std::string GetChallengeB64Data(AP4_CencSingleSampleDecrypter* decrypter) = 0;
+    virtual std::string GetChallengeB64Data(Adaptive_CencSingleSampleDecrypter* decrypter) = 0;
 
-    virtual bool OpenVideoDecoder(AP4_CencSingleSampleDecrypter* decrypter, const SSD_VIDEOINITDATA *initData) = 0;
+    virtual bool OpenVideoDecoder(Adaptive_CencSingleSampleDecrypter* decrypter,
+                                  const SSD_VIDEOINITDATA* initData) = 0;
     virtual SSD_DECODE_RETVAL DecodeVideo(void* instance, SSD_SAMPLE *sample, SSD_PICTURE *picture) = 0;
     virtual void ResetVideo() = 0;
   };

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include <bento4/Ap4.h>
+
+enum class ENCRYPTION_SCHEME
+{
+  NONE,
+  CENC,
+  CBCS
+};
+
+class Adaptive_CencSingleSampleDecrypter : public AP4_CencSingleSampleDecrypter
+{
+public:
+  Adaptive_CencSingleSampleDecrypter() : AP4_CencSingleSampleDecrypter(0){};
+
+  void SetCrypto(AP4_UI08 cryptBlocks, AP4_UI08 skipBlocks)
+  {
+    m_CryptBlocks = static_cast<uint32_t>(cryptBlocks);
+    m_SkipBlocks = static_cast<uint32_t>(skipBlocks);
+  };
+  virtual void SetEncryptionScheme(ENCRYPTION_SCHEME encryptionScheme){};
+
+protected:
+  uint32_t m_CryptBlocks{0};
+  uint32_t m_SkipBlocks{0};
+};

--- a/src/main.h
+++ b/src/main.h
@@ -7,6 +7,7 @@
  */
 
 #include "SSD_dll.h"
+#include "common/AdaptiveDecrypter.h"
 #include "common/AdaptiveStream.h"
 #include "common/AdaptiveTree.h"
 #include "common/RepresentationChooser.h"
@@ -178,9 +179,12 @@ public:
   unsigned int GetStreamCount() const { return m_streams.size(); };
   const char *GetCDMSession(int nSet) { return cdm_sessions_[nSet].cdm_session_str_; };;
   uint8_t GetMediaTypeMask() const { return media_type_mask_; };
-  AP4_CencSingleSampleDecrypter * GetSingleSampleDecryptor(unsigned int nIndex)const{ return cdm_sessions_[nIndex].single_sample_decryptor_; };
+  Adaptive_CencSingleSampleDecrypter* GetSingleSampleDecryptor(unsigned int nIndex) const
+  {
+    return cdm_sessions_[nIndex].single_sample_decryptor_;
+  };
   SSD::SSD_DECRYPTER *GetDecrypter() { return decrypter_; };
-  AP4_CencSingleSampleDecrypter *GetSingleSampleDecrypter(std::string sessionId);
+  Adaptive_CencSingleSampleDecrypter* GetSingleSampleDecrypter(std::string sessionId);
   const SSD::SSD_DECRYPTER::SSD_CAPS &GetDecrypterCaps(unsigned int nIndex) const{ return cdm_sessions_[nIndex].decrypter_caps_; };
   uint64_t GetTotalTimeMs()const { return adaptiveTree_->overallSeconds_ * 1000; };
   uint64_t GetElapsedTimeMs()const { return elapsed_time_ / 1000; };
@@ -230,7 +234,7 @@ private:
   struct CDMSESSION
   {
     SSD::SSD_DECRYPTER::SSD_CAPS decrypter_caps_;
-    AP4_CencSingleSampleDecrypter *single_sample_decryptor_;
+    Adaptive_CencSingleSampleDecrypter* single_sample_decryptor_;
     const char* cdm_session_str_ = nullptr;
     bool shared_single_sample_decryptor_ = false;
   };

--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.h
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.h
@@ -121,10 +121,6 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>
 		const uint8_t* response,
 		uint32_t response_size);
 
-	void SetSessionActive(bool isActive);
-
-  bool IsSessionActive();
-
 	void CloseSession(uint32_t promise_id,
 		const char* session_id,
 		uint32_t session_id_size);
@@ -262,8 +258,6 @@ private:
   cdm::ContentDecryptionModule_9 *cdm9_;
   cdm::ContentDecryptionModule_10 *cdm10_;
   cdm::ContentDecryptionModule_11 *cdm11_;
-
-  std::atomic<bool> session_active_;
 
   DISALLOW_COPY_AND_ASSIGN(CdmAdapter);
 };

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -8,6 +8,7 @@
 
 #include "../src/SSD_dll.h"
 #include "../src/md5.h"
+#include "../src/common/AdaptiveDecrypter.h"
 #include "../src/utils/Base64Utils.h"
 #include "../src/utils/StringUtils.h"
 #include "../src/utils/Utils.h"
@@ -276,7 +277,7 @@ void WV_DRM::SaveServiceCertificate()
 /*----------------------------------------------------------------------
 |   WV_CencSingleSampleDecrypter
 +---------------------------------------------------------------------*/
-class WV_CencSingleSampleDecrypter : public AP4_CencSingleSampleDecrypter
+class WV_CencSingleSampleDecrypter : public Adaptive_CencSingleSampleDecrypter
 {
 public:
   // methods
@@ -354,8 +355,7 @@ WV_CencSingleSampleDecrypter::WV_CencSingleSampleDecrypter(WV_DRM& drm,
                                                            AP4_DataBuffer& pssh,
                                                            const char* optionalKeyParameter,
                                                            std::string_view defaultKeyId)
-  : AP4_CencSingleSampleDecrypter(0),
-    media_drm_(drm),
+  : media_drm_(drm),
     provisionRequested(false),
     keyUpdateRequested(false),
     hdcp_limit_(0),
@@ -1278,7 +1278,7 @@ public:
     return cdmsession_->GetMediaDrm();
   }
 
-  virtual AP4_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
+  virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
       AP4_DataBuffer& pssh,
       const char* optionalKeyParameter,
       std::string_view defaultkeyid,
@@ -1299,7 +1299,7 @@ public:
     return decrypter;
   }
 
-  virtual void DestroySingleSampleDecrypter(AP4_CencSingleSampleDecrypter* decrypter) override
+  virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override
   {
     if (decrypter)
     {
@@ -1313,7 +1313,10 @@ public:
     }
   }
 
-  virtual void GetCapabilities(AP4_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid, uint32_t media, SSD_DECRYPTER::SSD_CAPS &caps) override
+  virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
+                               const uint8_t* keyid,
+                               uint32_t media,
+                               SSD_DECRYPTER::SSD_CAPS& caps) override
   {
     if (decrypter)
       static_cast<WV_CencSingleSampleDecrypter*>(decrypter)->GetCapabilities(keyid,media,caps);
@@ -1321,14 +1324,15 @@ public:
       caps = { 0, 0, 0};
   }
 
-  virtual bool HasLicenseKey(AP4_CencSingleSampleDecrypter* decrypter, const uint8_t *keyid) override
+  virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
+                             const uint8_t* keyid) override
   {
     if (decrypter)
       return static_cast<WV_CencSingleSampleDecrypter*>(decrypter)->HasLicenseKey(keyid);
     return false;
   }
 
-  virtual std::string GetChallengeB64Data(AP4_CencSingleSampleDecrypter* decrypter) override
+  virtual std::string GetChallengeB64Data(Adaptive_CencSingleSampleDecrypter* decrypter) override
   {
     if (!decrypter)
       return "";
@@ -1339,12 +1343,13 @@ public:
     return STRING::URLEncode(encChallengeData);
   }
 
-  virtual bool HasCdmSession() 
+  virtual bool HasCdmSession()
   {
     return cdmsession_ != nullptr;
   }
 
-  virtual bool OpenVideoDecoder(AP4_CencSingleSampleDecrypter* decrypter, const SSD_VIDEOINITDATA *initData) override
+  virtual bool OpenVideoDecoder(Adaptive_CencSingleSampleDecrypter* decrypter,
+                                const SSD_VIDEOINITDATA* initData) override
   {
     return false;
   }


### PR DESCRIPTION
This is the result of looking into adding support for CBC encrypted streams. Not very common at the moment but I imagine it would be more popular with 'apple native' services - Fairplay uses this scheme. CBC uses a 'pattern' based encryption, where there is a pattern of clear vs encrypted samples. Typically (and in the case of the test video) there is 1 encrypted sample followed by 9 unencrypted or 'skipped' samples. An advantage of this method can be lower cpu utilization.

main.cpp doesn't want to know the concrete decrypter class, only the generic ap4 cencsinglesampledecrypter. This will provide the flexibility needed in future if there's a Playready or Fairplay decrypter module developed. Therefore for this AES-CBC feature in order to prevent yet more patches to bento4 or to cast into the concrete wv cenc ssd class we have now the 'Adaptive_CencSingleSampleDecrypter' base class which has this extended functionality.

If CBC encryption is found upon stream initialisation we set the decrypter up appropriately.

NOTE: This doesn't include support for the CBCS decoding feature on Android, changes and possibly API bump will be required in Kodi. Follow-up PR to come very soon.

Tested with
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://proxy.uat.widevine.com/proxy?provider=widevine_test||R{SSM}|
https://storage.googleapis.com/wvmedia/cbcs/h264/tears/tears_aes_cbcs.mpd
```
for CBC, and for regular CTR tested with:
```
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://cwip-shaka-proxy.appspot.com/no_auth|Content-Type=|R{SSM}|
https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/mpds/11331.mpd
```

on Windows 10.

edit: some additional background
