### PR TITLE
parseIndexRange set first segment offset correctly

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,7 +505,7 @@ bool KodiAdaptiveStream::parseIndexRange(adaptive::AdaptiveTree::Representation*
       }
       AP4_Position pos;
       byteStream.Tell(pos);
-      seg.range_end_ = pos + getRepresentation()->indexRangeMin_ + sidx->GetFirstOffset() - 1;
+      seg.range_end_ = pos + rep->indexRangeMin_ + sidx->GetFirstOffset() - 1;
       rep->timescale_ = sidx->GetTimeScale();
       rep->SetScaling();
 


### PR DESCRIPTION
`parseIndexRange` is called on the next representation to be switched to, before it becomes the current representation. Therefore the existing code was getting the wrong offset to start filling segments from. This caused unexpected results, usually stream failure.

This behaviour applies to `SegmentBase`/index ranged streams

Example used for testing:
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
https://storage.googleapis.com/shaka-demo-assets/tos-ttml/dash.mpd
```

