### PR TITLE
Send mode and pattern with demux packets

### DIFF
--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -7,16 +7,10 @@
  */
 
 #include <bento4/Ap4.h>
+#include "../samplereader/SampleReader.h"
 
 #include <stdexcept>
 #include <string_view>
-
-enum class ENCRYPTION_SCHEME
-{
-  NONE,
-  CENC,
-  CBCS
-};
 
 class Adaptive_CencSingleSampleDecrypter : public AP4_CencSingleSampleDecrypter
 {
@@ -28,7 +22,7 @@ public:
     m_CryptBlocks = static_cast<uint32_t>(cryptBlocks);
     m_SkipBlocks = static_cast<uint32_t>(skipBlocks);
   };
-  virtual void SetEncryptionScheme(ENCRYPTION_SCHEME encryptionScheme){};
+  virtual void SetEncryptionScheme(CryptoMode encryptionScheme){};
 
   /*! \brief Add a Key ID to the current session
    *  \param keyId The KID

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2193,7 +2193,11 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
       memcpy(p->cryptoInfo->kid, pData, 16);
       pData += 16;
       iSize -= (pData - sr->GetSampleData());
+      ReaderCryptoInfo cryptoInfo = sr->GetReaderCryptoInfo();
       p->cryptoInfo->flags = 0;
+      p->cryptoInfo->cryptBlocks = cryptoInfo.m_cryptBlocks;
+      p->cryptoInfo->skipBlocks = cryptoInfo.m_skipBlocks;
+      p->cryptoInfo->mode = static_cast<uint16_t>(cryptoInfo.m_mode);
     }
     else
       p = AllocateDemuxPacket(iSize);

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -86,4 +86,5 @@ private:
   AP4_CencSampleDecrypter* m_decrypter{nullptr};
   uint64_t m_nextDuration{0};
   uint64_t m_nextTimestamp{0};
+  ReaderCryptoInfo m_readerCryptoInfo{ReaderCryptoInfo()};
 };

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -14,6 +14,22 @@
 #include <kodi/AddonBase.h>
 #include <kodi/addon-instance/Inputstream.h>
 
+// These values must match their respective constant values
+// defined in the Android MediaCodec class 
+enum class CryptoMode : uint16_t
+{
+  NONE = 0,
+  AES_CTR = 1,
+  AES_CBC = 2
+};
+
+struct ReaderCryptoInfo
+{
+  uint8_t m_cryptBlocks{0};
+  uint8_t m_skipBlocks{0};
+  CryptoMode m_mode{CryptoMode::NONE};
+};
+
 class ATTR_DLL_LOCAL ISampleReader
 {
 public:
@@ -41,4 +57,5 @@ public:
   virtual void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) {};
   virtual bool RemoveStreamType(INPUTSTREAM_TYPE type) { return true; };
   virtual bool IsStarted() const = 0;
+  virtual ReaderCryptoInfo GetReaderCryptoInfo() const { return ReaderCryptoInfo(); }
 };

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -217,7 +217,7 @@ public:
   SSD_DECODE_RETVAL DecodeVideo(void* hostInstance, SSD_SAMPLE *sample, SSD_PICTURE *picture);
   void ResetVideo();
 
-  void SetEncryptionScheme(ENCRYPTION_SCHEME encryptionScheme) override;
+  void SetEncryptionScheme(CryptoMode encryptionScheme) override;
   void SetDefaultKeyId(std::string_view keyId) override;
   void AddKeyId(std::string_view keyId) override;
 
@@ -1442,17 +1442,17 @@ void WV_CencSingleSampleDecrypter::ResetVideo()
   drained_ = true;
 }
 
-void WV_CencSingleSampleDecrypter::SetEncryptionScheme(ENCRYPTION_SCHEME encryptionScheme)
+void WV_CencSingleSampleDecrypter::SetEncryptionScheme(CryptoMode encryptionScheme)
 {
   switch (encryptionScheme)
   {
-    case ENCRYPTION_SCHEME::NONE:
+  case CryptoMode::NONE:
       m_EncryptionScheme = cdm::EncryptionScheme::kUnencrypted;
       break;
-    case ENCRYPTION_SCHEME::CENC:
+    case CryptoMode::AES_CTR:
       m_EncryptionScheme = cdm::EncryptionScheme::kCenc;
       break;
-    case ENCRYPTION_SCHEME::CBCS:
+    case CryptoMode::AES_CBC:
       m_EncryptionScheme = cdm::EncryptionScheme::kCbcs;
       break;
     default:


### PR DESCRIPTION
Dependent on https://github.com/xbmc/xbmc/pull/20915

Additional information required by inputstream interface is sent with these changes:
* Encryption mode
* Sample encryption pattern

This allows for decryption of CBCS streams on platforms receiving encrypted packets (Android)