### PR TITLE
GetNextSample: Avoid spam log when no sample reader exists

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2605,10 +2605,8 @@ SampleReader* Session::GetNextSample()
     bool isStarted{false};
     SampleReader* streamReader = stream->GetReader();
     if (!streamReader)
-    {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
       continue;
-    }
+
     if (stream->enabled && !streamReader->EOS() && AP4_SUCCEEDED(streamReader->Start(isStarted)))
     {
       if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())


### PR DESCRIPTION
Avoid spam log when no sample reader exists

forgot to remove log print from GetNextSample that cause tons of log output like this:
`2022-02-26 18:23:21.950 T:5252    ERROR <general>: AddOnLog: inputstream.adaptive: Session::GetNextSample: Cannot get the stream sample reader`