### PR TITLE
[cleanup] Moved kodi properties parser to utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(ADP_SOURCES
 	src/parser/SmoothTree.cpp
 	src/parser/PRProtectionParser.cpp
 	src/utils/Base64Utils.cpp
+	src/utils/PropertiesUtils.cpp
 	src/utils/StringUtils.cpp
 	src/utils/Utils.cpp
 	src/oscompat.cpp
@@ -55,6 +56,7 @@ set(ADP_HEADERS
 	src/parser/PRProtectionParser.h
 	src/utils/Base64Utils.h
 	src/utils/log.h
+	src/utils/PropertiesUtils.h
 	src/utils/StringUtils.h
 	src/utils/Utils.h
 	src/TSReader.h

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -41,23 +41,25 @@ namespace adaptive
     }
   }
 
-  AdaptiveTree::AdaptiveTree()
-    : current_period_(nullptr)
-    , next_period_(nullptr)
-    , parser_(0)
-    , currentNode_(0)
-    , segcount_(0)
-    , overallSeconds_(0)
-    , stream_start_(0)
-    , available_time_(0)
-    , base_time_(0)
-    , live_delay_(0)
-    , minPresentationOffset(0)
-    , has_timeshift_buffer_(false)
-    , has_overall_seconds_(false)
-    , updateInterval_(~0)
-    , updateThread_(nullptr)
-    , lastUpdated_(std::chrono::system_clock::now())
+  AdaptiveTree::AdaptiveTree(const UTILS::PROPERTIES::KodiProperties& kodiProps)
+    : m_kodiProps(kodiProps),
+      m_streamHeaders(kodiProps.m_streamHeaders),
+      current_period_(nullptr),
+      next_period_(nullptr),
+      parser_(0),
+      currentNode_(0),
+      segcount_(0),
+      overallSeconds_(0),
+      stream_start_(0),
+      available_time_(0),
+      base_time_(0),
+      live_delay_(0),
+      minPresentationOffset(0),
+      has_timeshift_buffer_(false),
+      has_overall_seconds_(false),
+      updateInterval_(~0),
+      updateThread_(nullptr),
+      lastUpdated_(std::chrono::system_clock::now())
   {
   }
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -10,6 +10,8 @@
 
 #include "expat.h"
 
+#include "../utils/PropertiesUtils.h"
+
 #include <chrono>
 #include <condition_variable>
 #include <inttypes.h>
@@ -463,8 +465,6 @@ public:
   uint64_t minPresentationOffset;
   bool has_timeshift_buffer_, has_overall_seconds_;
 
-  std::map<std::string, std::string> manifest_headers_;
-
   std::string supportedKeySystem_, location_;
 
   uint8_t adpChannelCount_, adp_pssh_set_;
@@ -480,7 +480,7 @@ public:
 
   std::string strXMLText_;
 
-  AdaptiveTree();
+  AdaptiveTree(const UTILS::PROPERTIES::KodiProperties& properties);
   virtual ~AdaptiveTree();
 
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) = 0;
@@ -563,6 +563,8 @@ protected:
   std::condition_variable updateVar_;
   std::thread *updateThread_;
   std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
+  std::map<std::string, std::string> m_streamHeaders;
+  const UTILS::PROPERTIES::KodiProperties m_kodiProps;
 
 private:
   void SegmentUpdateWorker();

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -48,10 +48,6 @@ enum
 
 static const char* CONTENTPROTECTION_TAG = "ContentProtection";
 
-DASHTree::DASHTree()
-{
-}
-
 static uint8_t GetChannels(const char** attr)
 {
   const char *schemeIdUri(0), *value(0);
@@ -1592,7 +1588,7 @@ bool DASHTree::open(const std::string& url, const std::string& manifestUpdatePar
   strXMLText_.clear();
 
   PrepareManifestUrl(url, manifestUpdateParam);
-  additionalHeaders.insert(manifest_headers_.begin(), manifest_headers_.end());
+  additionalHeaders.insert(m_streamHeaders.begin(), m_streamHeaders.end());
   bool ret = download(manifest_url_.c_str(), additionalHeaders) && !periods_.empty();
 
   XML_ParserFree(parser_);
@@ -1675,8 +1671,7 @@ void DASHTree::RefreshLiveSegments()
       replaced.replace(update_parameter_pos, 14, buf);
     }
 
-    DASHTree updateTree;
-    updateTree.manifest_headers_ = manifest_headers_;
+    DASHTree updateTree(m_kodiProps);
     updateTree.base_time_ = base_time_;
     updateTree.supportedKeySystem_ = supportedKeySystem_;
     //Location element should be used on updates
@@ -1685,9 +1680,9 @@ void DASHTree::RefreshLiveSegments()
     if (!~update_parameter_pos)
     {
       if (!etag_.empty())
-        updateTree.manifest_headers_["If-None-Match"] = "\"" + etag_ + "\"";
+        updateTree.m_streamHeaders["If-None-Match"] = "\"" + etag_ + "\"";
       if (!last_modified_.empty())
-        updateTree.manifest_headers_["If-Modified-Since"] = last_modified_;
+        updateTree.m_streamHeaders["If-Modified-Since"] = last_modified_;
     }
 
     if (updateTree.open(manifest_url_ + replaced, ""))

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -18,7 +18,7 @@ namespace adaptive
 class ATTR_DLL_LOCAL DASHTree : public AdaptiveTree
 {
 public:
-  DASHTree();
+  DASHTree(const UTILS::PROPERTIES::KodiProperties& kodiProps) : AdaptiveTree(kodiProps){};
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
   virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -157,7 +157,7 @@ bool HLSTree::open(const std::string& url, const std::string& manifestUpdatePara
 bool HLSTree::open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders)
 {
   PrepareManifestUrl(url, manifestUpdateParam);
-  additionalHeaders.insert(manifest_headers_.begin(), manifest_headers_.end());
+  additionalHeaders.insert(m_streamHeaders.begin(), m_streamHeaders.end());
   if (download(manifest_url_.c_str(), additionalHeaders, &manifest_stream))
     return processManifest(manifest_stream);
   return false;
@@ -399,7 +399,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
 
     if (rep->flags_ & Representation::DOWNLOADED)
       ;
-    else if (download(rep->source_url_.c_str(), manifest_headers_, &stream, false))
+    else if (download(rep->source_url_.c_str(), m_streamHeaders, &stream, false))
     {
 #if FILEDEBUG
       FILE* f = fopen("inputstream_adaptive_sub.m3u8", "w");

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -31,7 +31,8 @@ public:
     ENCRYPTIONTYPE_WIDEVINE = 3,
     ENCRYPTIONTYPE_UNKNOWN = 4,
   };
-  HLSTree(IAESDecrypter* decrypter) : AdaptiveTree(), m_decrypter(decrypter){};
+  HLSTree(const UTILS::PROPERTIES::KodiProperties& kodiProps, IAESDecrypter* decrypter)
+    : AdaptiveTree(kodiProps), m_decrypter(decrypter){};
   virtual ~HLSTree();
 
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -21,7 +21,7 @@
 using namespace adaptive;
 using namespace UTILS;
 
-SmoothTree::SmoothTree()
+SmoothTree::SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps) : AdaptiveTree(kodiProps)
 {
   current_period_ = new AdaptiveTree::Period;
   periods_.push_back(current_period_);
@@ -355,7 +355,7 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
   strXMLText_.clear();
 
   PrepareManifestUrl(url, manifestUpdateParam);
-  additionalHeaders.insert(manifest_headers_.begin(), manifest_headers_.end());
+  additionalHeaders.insert(m_streamHeaders.begin(), m_streamHeaders.end());
   bool ret = download(manifest_url_.c_str(), additionalHeaders);
 
   XML_ParserFree(parser_);

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -18,7 +18,7 @@ namespace adaptive
 class ATTR_DLL_LOCAL SmoothTree : public AdaptiveTree
 {
 public:
-  SmoothTree();
+  SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps);
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
   virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${BINARY}
 	../common/RepresentationChooser.cpp
     ../oscompat.cpp
     ../utils/Base64Utils.cpp
+    ../utils/PropertiesUtils.cpp
     ../utils/StringUtils.cpp
     ../utils/Utils.cpp
     )

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -8,6 +8,8 @@
 
 #include "TestHelper.h"
 
+#include "../utils/PropertiesUtils.h"
+
 #include <gtest/gtest.h>
 
 
@@ -16,7 +18,8 @@ class DASHTreeTest : public ::testing::Test
 protected:
   void SetUp() override
   {
-    tree = new DASHTestTree;
+    UTILS::PROPERTIES::KodiProperties kodiProps;
+    tree = new DASHTestTree(kodiProps);
     tree->supportedKeySystem_ = "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
   }
 
@@ -209,7 +212,7 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTimeline)
 
 TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithPTO)
 {
-  tree->mock_time = 1617223929L;
+  tree->SetNowTime(1617223929L);
 
   OpenTestFile("mpd/segtpl_pto.mpd", "", "");
 
@@ -223,7 +226,7 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithPTO)
 
 TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithOldPublishTime)
 {
-  tree->mock_time = 1617229334L;
+  tree->SetNowTime(1617229334L);
 
   OpenTestFile("mpd/segtpl_old_publish_time.mpd", "", "");
 

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "TestHelper.h"
+
+#include "../utils/PropertiesUtils.h"
+
 #include <gtest/gtest.h>
 
 
@@ -15,7 +18,8 @@ class HLSTreeTest : public ::testing::Test
 protected:
   void SetUp() override
   {
-    tree = new adaptive::HLSTree(new AESDecrypter(std::string()));
+    UTILS::PROPERTIES::KodiProperties kodiProps;
+    tree = new adaptive::HLSTree(kodiProps, new AESDecrypter(std::string()));
     tree->supportedKeySystem_ = "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
   }
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -113,4 +113,6 @@ void AESDecrypter::ivFromSequence(uint8_t* buffer, uint64_t sid){}
 
 bool AESDecrypter::RenewLicense(const std::string& pluginUrl){return false;}
 
-DASHTestTree::DASHTestTree(){}
+DASHTestTree::DASHTestTree(UTILS::PROPERTIES::KodiProperties kodiProps) : DASHTree(kodiProps)
+{
+}

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -13,6 +13,7 @@
 #include "../common/RepresentationChooser.h"
 #include "../parser/DASHTree.h"
 #include "../parser/HLSTree.h"
+#include "../utils/PropertiesUtils.h"
 
 std::string GetEnv(const std::string& var);
 void SetFileName(std::string& file, const std::string name);
@@ -75,10 +76,13 @@ private:
 class DASHTestTree : public adaptive::DASHTree
 {
 public:
-  uint64_t mock_time = 10000000L;
-  std::chrono::system_clock::time_point mock_time_chrono = std::chrono::system_clock::now();
-  DASHTestTree();
-  uint64_t GetNowTime() override { return mock_time; }
-  std::chrono::system_clock::time_point GetNowTimeChrono() { return mock_time_chrono; };
+  DASHTestTree(UTILS::PROPERTIES::KodiProperties kodiProps);
+  uint64_t GetNowTime() override { return m_mockTime; }
+  void SetNowTime(uint64_t time) { m_mockTime = time; }
   void SetLastUpdated(std::chrono::system_clock::time_point tm) override { lastUpdated_ = tm; };
+  std::chrono::system_clock::time_point GetNowTimeChrono() { return m_mock_time_chrono; };
+
+private:
+  uint64_t m_mockTime = 10000000L;
+  std::chrono::system_clock::time_point m_mock_time_chrono = std::chrono::system_clock::now();
 };

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PropertiesUtils.h"
+
+#include "Utils.h"
+#include "kodi/tools/StringUtils.h"
+#include "log.h"
+
+#include <string_view>
+
+using namespace UTILS::PROPERTIES;
+using namespace kodi::tools;
+
+namespace
+{
+// clang-format off
+constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type";
+constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key";
+constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data";
+constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags";
+constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate";
+constexpr std::string_view PROP_MANIFEST_TYPE = "inputstream.adaptive.manifest_type";
+constexpr std::string_view PROP_MANIFEST_UPD_PARAM = "inputstream.adaptive.manifest_update_parameter";
+constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
+constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
+constexpr std::string_view PROP_BANDWIDTH_MAX = "inputstream.adaptive.max_bandwidth";
+constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
+constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
+// clang-format on
+} // unnamed namespace
+
+KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
+    const std::map<std::string, std::string> properties)
+{
+  KodiProperties props;
+
+  for (auto& prop : properties)
+  {
+    bool logPropValRedacted{false};
+
+    if (prop.first == PROP_LICENSE_TYPE)
+    {
+      props.m_licenseType = prop.second;
+    }
+    else if (prop.first == PROP_LICENSE_KEY)
+    {
+      props.m_licenseKey = prop.second;
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_LICENSE_DATA)
+    {
+      props.m_licenseData = prop.second;
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_LICENSE_FLAGS)
+    {
+      if (prop.second.find("persistent_storage") != std::string::npos)
+        props.m_isLicensePersistentStorage = true;
+      if (prop.second.find("force_secure_decoder") != std::string::npos)
+        props.m_isLicenseForceSecureDecoder = true;
+    }
+    else if (prop.first == PROP_SERVER_CERT)
+    {
+      props.m_serverCertificate = prop.second;
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_MANIFEST_TYPE)
+    {
+      if (StringUtils::CompareNoCase(prop.second, "MPD") == 0)
+        props.m_manifestType = ManifestType::MPD;
+      else if (StringUtils::CompareNoCase(prop.second, "ISM") == 0)
+        props.m_manifestType = ManifestType::ISM;
+      else if (StringUtils::CompareNoCase(prop.second, "HLS") == 0)
+        props.m_manifestType = ManifestType::HLS;
+      else
+        LOG::LogF(LOGERROR, "Manifest type \"%s\" is not supported", prop.second.c_str());
+    }
+    else if (prop.first == PROP_MANIFEST_UPD_PARAM)
+    {
+      props.m_manifestUpdateParam = prop.second;
+    }
+    else if (prop.first == PROP_STREAM_HEADERS)
+    {
+      ParseHeaderString(props.m_streamHeaders, prop.second);
+    }
+    else if (prop.first == PROP_AUDIO_LANG_ORIG)
+    {
+      props.m_audioLanguageOrig = prop.second;
+    }
+    else if (prop.first == PROP_BANDWIDTH_MAX)
+    {
+      props.m_bandwidthMax = std::stoul(prop.second);
+    }
+    else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
+    {
+      props.m_playTimeshiftBuffer = StringUtils::CompareNoCase(prop.second, "true") == 0;
+    }
+    else if (prop.first == PROP_PRE_INIT_DATA)
+    {
+      props.m_drmPreInitData = prop.second;
+      logPropValRedacted = true;
+    }
+    else
+    {
+      LOG::Log(LOGWARNING, "Property found \"%s\" is not supported", prop.first.c_str());
+      continue;
+    }
+
+    LOG::Log(LOGDEBUG, "Property found \"%s\" value: %s", prop.first.c_str(),
+             logPropValRedacted ? "[redacted]" : prop.second.c_str());
+  }
+
+  return props;
+}

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace UTILS
+{
+namespace PROPERTIES
+{
+
+enum class ManifestType
+{
+  UNKNOWN = 0,
+  MPD,
+  ISM,
+  HLS
+};
+
+struct KodiProperties
+{
+  std::string m_licenseType;
+  std::string m_licenseKey;
+  std::string m_licenseData;
+  bool m_isLicensePersistentStorage{false};
+  bool m_isLicenseForceSecureDecoder{false};
+  std::string m_serverCertificate;
+  ManifestType m_manifestType{ManifestType::UNKNOWN};
+  std::string m_manifestUpdateParam;
+  // HTTP headers used to download manifest and streams
+  std::map<std::string, std::string> m_streamHeaders;
+  std::string m_audioLanguageOrig;
+  uint32_t m_bandwidthMax{0};
+  bool m_playTimeshiftBuffer{false};
+  // PSSH/KID used to "pre-initialize" the DRM, the property value must be as
+  // "{PSSH as base64}|{KID as base64}". The challenge/session ID data generated
+  // by the initialisation of the DRM will be attached to the manifest request
+  // callback as HTTP headers with the names of "challengeB64" and "sessionId"
+  std::string m_drmPreInitData;
+};
+
+KodiProperties ParseKodiProperties(const std::map<std::string, std::string> properties);
+
+} // namespace PROPERTIES
+} // namespace UTILS


### PR DESCRIPTION
Cleanup to kodi properties parser and relative little cleanup to related code/contructors
to removes all incomprehensible variable names and make everything more uniform
to better understand where the data comes from,
the second thing is allow to get/propagate the properties easily with less variables