### PR TITLE
[cleanup] Implemented UrlUtils and relative code cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(ADP_SOURCES
 	src/utils/Base64Utils.cpp
 	src/utils/PropertiesUtils.cpp
 	src/utils/StringUtils.cpp
+	src/utils/UrlUtils.cpp
 	src/utils/Utils.cpp
 	src/oscompat.cpp
 	src/TSReader.cpp
@@ -58,6 +59,7 @@ set(ADP_HEADERS
 	src/utils/log.h
 	src/utils/PropertiesUtils.h
 	src/utils/StringUtils.h
+	src/utils/UrlUtils.h
 	src/utils/Utils.h
 	src/TSReader.h
 	src/aes_decrypter.h

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -72,7 +72,7 @@ namespace adaptive
     void SetSegmentFileOffset(uint64_t offset) { m_segmentFileOffset = offset; };
     bool StreamChanged() { return stream_changed_; }
   protected:
-    virtual bool download(const char* url,
+    virtual bool download(const std::string& url,
                           const std::map<std::string, std::string>& mediaHeaders,
                           std::string* lockfreeBuffer)
     {

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -451,7 +451,6 @@ public:
   std::string manifest_url_;
   std::string base_url_;
   std::string effective_url_;
-  std::string base_domain_;
   std::string update_parameter_;
   std::string etag_;
   std::string last_modified_;
@@ -545,7 +544,7 @@ public:
   }
 
 protected:
-  virtual bool download(const char* url,
+  virtual bool download(const std::string& url,
                         const std::map<std::string, std::string>& manifestHeaders,
                         void* opaque = nullptr,
                         bool isManifest = true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,7 +259,7 @@ protected:
 Kodi Streams implementation
 ********************************************************/
 
-bool adaptive::AdaptiveTree::download(const char* url,
+bool adaptive::AdaptiveTree::download(const std::string& url,
                                       const std::map<std::string, std::string>& manifestHeaders,
                                       void* opaque,
                                       bool isManifest)
@@ -279,7 +279,7 @@ bool adaptive::AdaptiveTree::download(const char* url,
 
   if (!file.CURLOpen(ADDON_READ_CHUNKED | ADDON_READ_NO_CACHE))
   {
-    LOG::Log(LOGERROR, "Download failed: %s", url);
+    LOG::Log(LOGERROR, "Download failed: %s", url.c_str());
     return false;
   }
 
@@ -311,7 +311,7 @@ bool adaptive::AdaptiveTree::download(const char* url,
   return nbRead == 0;
 }
 
-bool KodiAdaptiveStream::download(const char* url,
+bool KodiAdaptiveStream::download(const std::string& url,
                                   const std::map<std::string, std::string>& mediaHeaders,
                                   std::string* lockfreeBuffer)
 {
@@ -343,7 +343,7 @@ bool KodiAdaptiveStream::download(const char* url,
 
     if (returnCode >= 400)
     {
-      LOG::Log(LOGERROR, "Download failed with error %d: %s", returnCode, url);
+      LOG::Log(LOGERROR, "Download failed with error %d: %s", returnCode, url.c_str());
     }
     else
     {
@@ -360,7 +360,7 @@ bool KodiAdaptiveStream::download(const char* url,
       {
         if (!nbReadOverall)
         {
-          LOG::Log(LOGERROR, "Download doesn't provide any data: %s", url);
+          LOG::Log(LOGERROR, "Download doesn't provide any data: %s", url.c_str());
           return false;
         }
 
@@ -376,12 +376,12 @@ bool KodiAdaptiveStream::download(const char* url,
                                        current_download_speed_ * ratio);
         }
         LOG::Log(LOGDEBUG,
-                 "Download %s finished, avg speed: %0.2lfbyte/s, current speed: %0.2lfbyte/s", url,
-                 chooser_->get_download_speed(), current_download_speed_);
+                 "Download %s finished, avg speed: %0.2lfbyte/s, current speed: %0.2lfbyte/s",
+                 url.c_str(), chooser_->get_download_speed(), current_download_speed_);
         //pass download speed to
       }
       else
-        LOG::Log(LOGDEBUG, "Download %s cancelled", url);
+        LOG::Log(LOGDEBUG, "Download %s cancelled", url.c_str());
     }
     file.Close();
     return nbRead == 0;

--- a/src/main.h
+++ b/src/main.h
@@ -45,12 +45,6 @@ namespace XBMCFILE
 Kodi Streams implementation
 ********************************************************/
 
-class ATTR_DLL_LOCAL KodiAdaptiveTree : public adaptive::AdaptiveTree
-{
-protected:
-  virtual bool download(const char* url);
-};
-
 class ATTR_DLL_LOCAL KodiAdaptiveStream : public adaptive::AdaptiveStream
 {
 public:
@@ -65,7 +59,7 @@ public:
       chooser_(chooser){};
 
 protected:
-  bool download(const char* url,
+  bool download(const std::string& url,
                 const std::map<std::string, std::string>& mediaHeaders,
                 std::string* lockfreeBuffer) override;
   bool parseIndexRange(adaptive::AdaptiveTree::Representation* rep,

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -9,6 +9,7 @@
 #include "SmoothTree.h"
 
 #include "../oscompat.h"
+#include "../utils/UrlUtils.h"
 #include "../utils/Utils.h"
 #include "PRProtectionParser.h"
 
@@ -226,7 +227,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           dash->current_adaptationset_->segment_durations_.data.reserve(
               atoi((const char*)*(attr + 1)));
         else if (strcmp((const char*)*attr, "Url") == 0)
-          dash->current_adaptationset_->base_url_ = dash->base_url_ + (const char*)*(attr + 1);
+          dash->current_adaptationset_->base_url_ = URL::Join(dash->base_url_, *(attr + 1));
         attr += 2;
       }
       dash->segcount_ = 0;
@@ -356,7 +357,7 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
 
   PrepareManifestUrl(url, manifestUpdateParam);
   additionalHeaders.insert(m_streamHeaders.begin(), m_streamHeaders.end());
-  bool ret = download(manifest_url_.c_str(), additionalHeaders);
+  bool ret = download(manifest_url_, additionalHeaders);
 
   XML_ParserFree(parser_);
   parser_ = 0;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${BINARY}
     ../utils/Base64Utils.cpp
     ../utils/PropertiesUtils.cpp
     ../utils/StringUtils.cpp
+    ../utils/UrlUtils.cpp
     ../utils/Utils.cpp
     )
 

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -9,6 +9,7 @@
 #include "TestHelper.h"
 
 #include "../utils/PropertiesUtils.h"
+#include "../utils/UrlUtils.h"
 
 #include <gtest/gtest.h>
 
@@ -122,9 +123,9 @@ TEST_F(DASHTreeTest, CalculateBaseURL)
 
 TEST_F(DASHTreeTest, CalculateBaseDomain)
 {
-  OpenTestFile("mpd/segtpl.mpd", "https://foo.bar/mpd/test.mpd", "");
-
-  EXPECT_EQ(tree->base_domain_, "https://foo.bar");
+  std::string url{"https://foo.bar/mpd/test.mpd"};
+  std::string domainUrl{UTILS::URL::GetDomainUrl(url)};
+  EXPECT_EQ(domainUrl, "https://foo.bar");
 }
 
 TEST_F(DASHTreeTest, CalculateBaseUrlFromRedirect)

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -233,8 +233,7 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
 
   std::string pssh_url = tree->BuildDownloadUrl(tree->current_period_->psshSets_[1].pssh_);
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(pssh_url,
-            "https://foo.bar/hls/video/stream_name/../../key/key.php?stream=stream_name");
+  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
@@ -256,8 +255,7 @@ TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
 
   std::string pssh_url = tree->BuildDownloadUrl(tree->current_period_->psshSets_[1].pssh_);
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(pssh_url,
-            "https://foo.bar/hls/video/stream_name/../../key/key.php?stream=stream_name");
+  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, PtsSetInMultiPeriod)

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -26,7 +26,7 @@ void SetFileName(std::string& file, std::string name)
   file = GetEnv("DATADIR") + "/" + name;
 }
 
-bool adaptive::AdaptiveTree::download(const char* url,
+bool adaptive::AdaptiveTree::download(const std::string& url,
                                       const std::map<std::string, std::string>& manifestHeaders,
                                       void* opaque,
                                       bool isManifest)
@@ -66,12 +66,12 @@ bool TestAdaptiveStream::download_segment()
     return false;
   testHelper::downloadList.push_back(download_url_);
 
-  return download(download_url_.c_str(), download_headers_, nullptr);
+  return download(download_url_, download_headers_, nullptr);
 }
 
-bool TestAdaptiveStream::download(const char* url,
-  const std::map<std::string, std::string>& mediaHeaders,
-  std::string* lockfreeBuffer)
+bool TestAdaptiveStream::download(const std::string& url,
+                                  const std::map<std::string, std::string>& mediaHeaders,
+                                  std::string* lockfreeBuffer)
 {
   size_t nbRead = ~0UL;
   std::stringstream ss("Sixteen bytes!!!");

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -45,9 +45,9 @@ public:
   virtual bool download_segment() override;
 
 protected:
-  virtual bool download(const char* url,
-    const std::map<std::string, std::string>& mediaHeaders,
-    std::string* lockfreeBuffer) override;
+  virtual bool download(const std::string& url,
+                        const std::map<std::string, std::string>& mediaHeaders,
+                        std::string* lockfreeBuffer) override;
 
 private:
   DefaultRepresentationChooser* chooser_ = nullptr;

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -1,0 +1,211 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "UrlUtils.h"
+
+#include "StringUtils.h"
+
+using namespace UTILS::URL;
+
+namespace
+{
+bool isUrl(std::string url,
+           bool allowFragments,
+           bool allowQueryParams,
+           bool validateLenght,
+           bool validateProtocol,
+           bool requireProtocol,
+           bool allowRelativeUrls)
+{
+  if (url.empty())
+    return false;
+
+  if (validateLenght && url.size() >= 2083)
+    return false;
+
+  if (!allowFragments && url.find('#') != std::string::npos)
+    return false;
+
+  if (!allowQueryParams &&
+      (url.find('?') != std::string::npos || url.find('&') != std::string::npos))
+    return false;
+
+  size_t paramPos = url.find('#');
+  if (paramPos != std::string::npos)
+    url.resize(paramPos);
+
+  paramPos = url.find('?');
+  if (paramPos != std::string::npos)
+    url.resize(paramPos);
+
+  paramPos = url.find("://");
+  if (paramPos != std::string::npos)
+  {
+    if (validateProtocol)
+    {
+      std::string protocol{url.substr(0, paramPos)};
+      if (protocol != "http" && protocol != "https")
+        return false;
+    }
+    url = url.substr(paramPos + 3);
+  }
+  else if (requireProtocol)
+  {
+    return false;
+  }
+  else if (url.compare(0, 1, "/") == 0)
+  {
+    if (!allowRelativeUrls)
+      return false;
+
+    url = url.substr(1);
+  }
+
+  if (url.empty())
+    return false;
+
+  return true;
+}
+} // unnamed namespace
+
+bool UTILS::URL::IsValidUrl(const std::string& url)
+{
+  return isUrl(url, false, true, true, true, true, false);
+}
+
+bool UTILS::URL::IsUrlAbsolute(std::string_view url)
+{
+  return (url.compare(0, 7, "http://") == 0 || url.compare(0, 8, "https://") == 0);
+}
+
+bool UTILS::URL::IsUrlRelative(std::string_view url)
+{
+  return (url.compare(0, 1, "/") == 0);
+}
+
+bool UTILS::URL::IsUrlRelativeLevel(std::string_view url)
+{
+  return (url.compare(0, 3, "../") == 0);
+}
+
+std::string UTILS::URL::GetParametersFromPlaceholder(std::string& url, std::string_view placeholder)
+{
+  std::string::size_type phPos = url.find(placeholder);
+  if (phPos != std::string::npos)
+  {
+    while (phPos && url[phPos] != '&' && url[phPos] != '?')
+    {
+      --phPos;
+    }
+    if (phPos > 0)
+      return url.substr(phPos);
+  }
+  return "";
+}
+
+std::string UTILS::URL::GetParameters(std::string& url) {
+  size_t paramsPos = url.find('?');
+  if (paramsPos != std::string::npos)
+    return url.substr(paramsPos + 1);
+
+  return "";
+}
+
+std::string UTILS::URL::RemoveParameters(std::string url, bool removeFilenameParam /* = true */)
+{
+  size_t paramsPos = url.find('?');
+  if (paramsPos != std::string::npos)
+    url.resize(paramsPos);
+
+  if (removeFilenameParam)
+  {
+    size_t slashPos = url.find_last_of('/');
+    if (slashPos != std::string::npos && slashPos != (url.find("://") + 2))
+    {
+      if (url.substr(slashPos).find(".") != std::string::npos)
+        url.resize(slashPos + 1);
+    }
+  }
+  return url;
+}
+
+void UTILS::URL::AppendParameters(std::string& url, std::string params)
+{
+  if (params.empty())
+    return;
+
+  if (url.find_first_of('?') == std::string::npos)
+    url += "?";
+  else
+    url += "&";
+
+  if (params.front() == '&' || params.front() == '?')
+    params.pop_back();
+
+  url += params;
+}
+
+std::string UTILS::URL::GetDomainUrl(std::string url)
+{
+  if (IsUrlAbsolute(url))
+  {
+    size_t paramsPos = url.find('?');
+    if (paramsPos != std::string::npos)
+      url = url.substr(0, paramsPos);
+
+    size_t slashPos = url.find_first_of('/', url.find("://") + 3);
+    if (slashPos != std::string::npos)
+      url = url.substr(0, slashPos);
+  }
+  if (url.back() == '/')
+    url.pop_back();
+
+  return url;
+}
+
+std::string UTILS::URL::Join(std::string baseUrl, std::string otherUrl)
+{
+  if (baseUrl.empty())
+    return otherUrl;
+
+  if (baseUrl.back() == '/')
+    baseUrl.pop_back();
+
+  if (IsUrlRelativeLevel(otherUrl))
+  {
+    // Join the otherUrl to the relative level path of the baseUrl,
+    // if the baseUrl do not have directory levels available will be appended
+    static const std::string_view relativeChars{"../"};
+    size_t pos{0};
+    std::string parentBaseUrl{baseUrl};
+
+    size_t addrsStartPos{1};
+    if (IsUrlAbsolute(baseUrl))
+      addrsStartPos = baseUrl.find("://") + 3;
+    else if (IsUrlRelativeLevel(baseUrl))
+      addrsStartPos = 3;
+
+    // Loop to go back in to each base URL directory level
+    while ((pos = otherUrl.find(relativeChars, pos)) != std::string::npos)
+    {
+      std::size_t lastSlashPos = parentBaseUrl.find_last_of('/');
+      if ((lastSlashPos + 1) == addrsStartPos)
+        break;
+      parentBaseUrl = parentBaseUrl.substr(0, lastSlashPos);
+      pos += relativeChars.size();
+    }
+    STRING::ReplaceAll(otherUrl, relativeChars, "");
+    return parentBaseUrl + "/" + otherUrl;
+  }
+  if (IsUrlRelative(otherUrl))
+  {
+    // Join the otherUrl to the domain of the baseUrl
+    return GetDomainUrl(baseUrl) + otherUrl;
+  }
+  return baseUrl + "/" + otherUrl;
+}

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace UTILS
+{
+namespace URL
+{
+/*! \brief Check if it is a valid URL
+ *  \return True if it is a valid URL, false otherwise
+ */
+bool IsValidUrl(const std::string& url);
+
+/*! \brief Check if it is an absolute URL
+ *  \return True if it is an absolute URL, false otherwise
+ */
+bool IsUrlAbsolute(std::string_view url);
+
+/*! \brief Check if it is a relative URL e.g. "/something/"
+ *  \param url An URL
+ *  \return True if it is a relative URL, false otherwise
+ */
+bool IsUrlRelative(std::string_view url);
+
+/*! \brief Check if it is a relative URL to a level e.g. "../something/"
+ *  \param url An URL
+ *  \return True if it is a relative URL to a level, false otherwise
+ */
+bool IsUrlRelativeLevel(std::string_view url);
+
+/*! \brief Get URL parameters starting from the parameter referred to the value
+ *   placeholder until the end. E.g. with placeholder "$START_NUMBER$"
+ *   from "https://foo.bar/dash.mpd?start_seq=$START_NUMBER$"
+ *   will return "?start_seq=$START_NUMBER$"
+ *  \param url An URL with parameteres
+ *  \param placeholder The value placeholder name of a parameter
+ *  \return The parameters referred to the placeholder until the end of url
+ */
+std::string GetParametersFromPlaceholder(std::string& url, std::string_view placeholder);
+
+/*! \brief Get URL parameters e.g. "?q=something"
+ *  \param url An URL
+ *  \return The URL parameters
+ */
+std::string GetParameters(std::string& url);
+
+/*! \brief Remove URL parameters e.g. "?q=something"
+ *  \param url An URL
+ *  \param removeFilenameParam If true remove the last URL level if it
+ *   contains a filename with extension
+ *  \return The URL without parameters
+ */
+std::string RemoveParameters(std::string url, bool removeFilenameParam = true);
+
+/*! \brief Append a string of parameters to an URL with/without pre-existents params
+ *  \param url URL where append the parameters
+ *  \param params Params to be appended
+ */
+void AppendParameters(std::string& url, std::string params);
+
+/*! \brief Get the domain URL from an URL
+ *  \param url An URL
+ *  \return The domain URL
+ */
+std::string GetDomainUrl(std::string url);
+
+/*! \brief Join two URLS. The URL values could be absolute and/or relative.
+ *   NOTE: If baseUrl is not a domain URL, and otherUrl is a relative URL,
+ *   the domain URL will be automatically determined from the baseUrl.
+ *  \param baseUrl The base URL (without parameters)
+ *  \param otherUrl The other URL to be joined.
+ *   Can be partial/relative/relative to a level
+ *  \return The final URL
+ */
+std::string Join(std::string baseUrl, std::string otherUrl);
+
+} // namespace URL
+} // namespace UTILS


### PR DESCRIPTION
Moved all common URL operations in utils
and to make URLS operations more safe

This PR also add the support to handle Relative URLS with parent levels, so example:
`../../this/sun`

when will be joined with another base URL will be automatically adjusted, e.g.
base URL: `http://www.example.com/cat/dog/birds/`

After the join operation will be:
`http://www.example.com/cat/this/sun`

before this PR instead result as:
`http://www.example.com/cat/dog/birds/../../this/sun`
cause of wrong url stream download with Facebook live videos ref. #544

For the url validation `URL::IsValidUrl` i have implemented partially the isURL method from https://github.com/validatorjs/validator.js i think it is enough for our purposes, should be a task of the developer who integrates ISAdaptive into his add-on that should take care of providing valid links
