### PR TITLE
Refactor sample readers and AdaptiveByteStream into separate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 find_package(Kodi REQUIRED)
 
 set(ADP_SOURCES
+    src/AdaptiveByteStream.cpp
 	src/main.cpp
 	src/codechandler/AVCCodecHandler.cpp
 	src/codechandler/CodecHandler.cpp
@@ -23,6 +24,11 @@ set(ADP_SOURCES
 	src/parser/HLSTree.cpp
 	src/parser/SmoothTree.cpp
 	src/parser/PRProtectionParser.cpp
+	src/samplereader/ADTSSampleReader.cpp
+	src/samplereader/FragmentedSampleReader.cpp
+	src/samplereader/SubtitleSampleReader.cpp
+	src/samplereader/TSSampleReader.cpp
+	src/samplereader/WebmSampleReader.cpp
 	src/utils/Base64Utils.cpp
 	src/utils/PropertiesUtils.cpp
 	src/utils/StringUtils.cpp
@@ -37,6 +43,7 @@ set(ADP_SOURCES
 	)
 
 set(ADP_HEADERS
+    src/AdaptiveByteStream.h
 	src/main.h
 	src/oscompat.h
 	src/SSD_dll.h
@@ -57,6 +64,13 @@ set(ADP_HEADERS
 	src/parser/HLSTree.h
 	src/parser/SmoothTree.h
 	src/parser/PRProtectionParser.h
+	src/samplereader/ADTSSampleReader.h
+	src/samplereader/DummySampleReader.h
+	src/samplereader/FragmentedSampleReader.h
+	src/samplereader/SampleReader.h
+	src/samplereader/SubtitleSampleReader.h
+	src/samplereader/TSSampleReader.h
+	src/samplereader/WebmSampleReader.h
 	src/utils/Base64Utils.h
 	src/utils/log.h
 	src/utils/PropertiesUtils.h

--- a/src/AdaptiveByteStream.cpp
+++ b/src/AdaptiveByteStream.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AdaptiveByteStream.h"
+
+// AP4_ByteStream methods
+AP4_Result CAdaptiveByteStream::ReadPartial(void* buffer, AP4_Size bytesToRead, AP4_Size& bytesRead)
+{
+  bytesRead = m_adStream->read(buffer, bytesToRead);
+  return bytesRead > 0 ? AP4_SUCCESS : AP4_ERROR_READ_FAILED;
+}
+
+AP4_Result CAdaptiveByteStream::WritePartial(const void* buffer,
+                                            AP4_Size bytesToWrite,
+                                            AP4_Size& bytesWritten)
+{
+  /* unimplemented */
+  return AP4_ERROR_NOT_SUPPORTED;
+}
+
+AP4_Result CAdaptiveByteStream::Seek(AP4_Position position)
+{
+  return m_adStream->seek(position) ? AP4_SUCCESS : AP4_ERROR_NOT_SUPPORTED;
+}
+
+AP4_Result CAdaptiveByteStream::Tell(AP4_Position& position)
+{
+  position = m_adStream->tell();
+  return AP4_SUCCESS;
+}
+
+AP4_Result CAdaptiveByteStream::GetSize(AP4_LargeSize& size)
+{
+  return AP4_ERROR_NOT_SUPPORTED;
+}
+
+AP4_Result CAdaptiveByteStream::GetSegmentSize(size_t& size)
+{
+  if (m_adStream->ensureSegment() && m_adStream->retrieveCurrentSegmentBufferSize(size))
+  {
+    return AP4_SUCCESS;
+  }
+  return AP4_ERROR_EOS;
+}

--- a/src/AdaptiveByteStream.h
+++ b/src/AdaptiveByteStream.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "common/AdaptiveStream.h"
+
+#include <bento4/Ap4.h>
+#include <kodi/AddonBase.h>
+
+class ATTR_DLL_LOCAL CAdaptiveByteStream : public AP4_ByteStream
+{
+public:
+  CAdaptiveByteStream(adaptive::AdaptiveStream* adStream) : m_adStream(adStream){}
+  virtual ~CAdaptiveByteStream(){}
+
+  // AP4_ByteStream methods
+  AP4_Result ReadPartial(void* buffer, AP4_Size bytesToRead, AP4_Size& bytesRead) override;
+  AP4_Result WritePartial(const void* buffer,
+                          AP4_Size bytesToWrite,
+                          AP4_Size& bytesWritten) override;
+  AP4_Result Seek(AP4_Position position) override;
+  AP4_Result Tell(AP4_Position& position) override;
+  AP4_Result GetSize(AP4_LargeSize& size) override;
+  AP4_Result GetSegmentSize(size_t& size);
+
+  // AP4_Referenceable methods
+  void AddReference() override{};
+  void Release() override{};
+  bool waitingForSegment() const { return m_adStream->waitingForSegment(); }
+  void FixateInitialization(bool on) { m_adStream->FixateInitialization(on); }
+  void SetSegmentFileOffset(uint64_t offset) { m_adStream->SetSegmentFileOffset(offset); }
+
+protected:
+  adaptive::AdaptiveStream* m_adStream;
+};

--- a/src/codechandler/AVCCodecHandler.h
+++ b/src/codechandler/AVCCodecHandler.h
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include "CodecHandler.h"
 
 class ATTR_DLL_LOCAL AVCCodecHandler : public CodecHandler

--- a/src/codechandler/HEVCCodecHandler.h
+++ b/src/codechandler/HEVCCodecHandler.h
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include "CodecHandler.h"
 
 class ATTR_DLL_LOCAL HEVCCodecHandler : public CodecHandler

--- a/src/codechandler/MPEGCodecHandler.h
+++ b/src/codechandler/MPEGCodecHandler.h
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include "CodecHandler.h"
 
 class ATTR_DLL_LOCAL MPEGCodecHandler : public CodecHandler

--- a/src/codechandler/TTMLCodecHandler.h
+++ b/src/codechandler/TTMLCodecHandler.h
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include "CodecHandler.h"
 #include "ttml/TTML.h"
 

--- a/src/codechandler/VP9CodecHandler.h
+++ b/src/codechandler/VP9CodecHandler.h
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include "CodecHandler.h"
 
 class ATTR_DLL_LOCAL VP9CodecHandler : public CodecHandler

--- a/src/codechandler/WebVTTCodecHandler.h
+++ b/src/codechandler/WebVTTCodecHandler.h
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include "CodecHandler.h"
 
 class ATTR_DLL_LOCAL WebVTTCodecHandler : public CodecHandler

--- a/src/main.h
+++ b/src/main.h
@@ -6,11 +6,14 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
+#include "AdaptiveByteStream.h"
 #include "SSD_dll.h"
-#include "common/AdaptiveDecrypter.h"
 #include "common/AdaptiveStream.h"
 #include "common/AdaptiveTree.h"
 #include "common/RepresentationChooser.h"
+#include "samplereader/SampleReader.h"
 #include "utils/SettingsUtils.h"
 #include "utils/PropertiesUtils.h"
 
@@ -22,8 +25,7 @@
 #include <kodi/addon-instance/Inputstream.h>
 #include <kodi/tools/DllHelper.h>
 
-class AdaptiveByteStream;
-class SampleReader;
+class Adaptive_CencSingleSampleDecrypter;
 
 namespace XBMCFILE
 {
@@ -80,7 +82,7 @@ public:
    */
   bool InitializePeriod(bool isSessionOpened = false);
 
-  SampleReader *GetNextSample();
+  ISampleReader *GetNextSample();
 
   struct STREAM
   {
@@ -108,13 +110,13 @@ public:
      * \brief Get the stream sample reader pointer
      * \return The sample reader, otherwise nullptr if not set
      */
-    SampleReader* GetReader() const { return m_streamReader.get(); }
+    ISampleReader* GetReader() const { return m_streamReader.get(); }
 
     /*!
      * \brief Set the stream sample reader
      * \param reader The reader
      */
-    void SetReader(std::unique_ptr<SampleReader> reader) { m_streamReader = std::move(reader); }
+    void SetReader(std::unique_ptr<ISampleReader> reader) { m_streamReader = std::move(reader); }
 
     /*!
      * \brief Get the stream file handler pointer
@@ -135,13 +137,13 @@ public:
      * \brief Get the adaptive byte stream handler pointer
      * \return The adaptive byte stream handler, otherwise nullptr if not set
      */
-    AdaptiveByteStream* GetAdByteStream() const { return m_adByteStream.get(); }
+    CAdaptiveByteStream* GetAdByteStream() const { return m_adByteStream.get(); }
 
     /*!
      * \brief Set the adaptive byte stream handler
      * \param dataStream The adaptive byte stream handler
      */
-    void SetAdByteStream(std::unique_ptr<AdaptiveByteStream> adByteStream)
+    void SetAdByteStream(std::unique_ptr<CAdaptiveByteStream> adByteStream)
     {
       m_adByteStream = std::move(adByteStream);
     }
@@ -155,8 +157,8 @@ public:
     bool valid;
 
   private:
-    std::unique_ptr<SampleReader> m_streamReader;
-    std::unique_ptr<AdaptiveByteStream> m_adByteStream;
+    std::unique_ptr<ISampleReader> m_streamReader;
+    std::unique_ptr<CAdaptiveByteStream> m_adByteStream;
     std::unique_ptr<AP4_File> m_streamFile;
   };
 
@@ -225,6 +227,7 @@ private:
   AP4_DataBuffer server_certificate_;
   kodi::tools::CDllHelper* decrypterModule_{nullptr};
   SSD::SSD_DECRYPTER* decrypter_{nullptr};
+  std::unique_ptr<ISampleReader> m_dummySampleReader;
 
   struct CDMSESSION
   {

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ADTSSampleReader.h"
+
+CADTSSampleReader::CADTSSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
+  : ADTSReader{input},
+    m_streamId{streamId},
+    m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)}
+{
+}
+
+AP4_Result CADTSSampleReader::Start(bool& bStarted)
+{
+  bStarted = false;
+  if (m_started)
+    return AP4_SUCCESS;
+  bStarted = true;
+  m_started = true;
+  return ReadSample();
+}
+
+AP4_Result CADTSSampleReader::ReadSample()
+{
+  if (ReadPacket())
+  {
+    uint64_t pts{GetPts()};
+    if (pts == PTS_UNSET)
+      m_pts = STREAM_NOPTS_VALUE;
+    else
+      m_pts = (pts * 100) / 9;
+
+    if (~m_ptsOffs)
+    {
+      m_ptsDiff = m_pts - m_ptsOffs;
+      m_ptsOffs = ~0ULL;
+    }
+    return AP4_SUCCESS;
+  }
+  if (!m_adByteStream || !m_adByteStream->waitingForSegment())
+  {
+    m_eos = true;
+  }
+  return AP4_ERROR_EOS;
+}
+
+void CADTSSampleReader::Reset(bool bEOS)
+{
+  ADTSReader::Reset();
+  m_eos = bEOS;
+}
+
+bool CADTSSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+{
+  AP4_UI64 seekPos{(pts * 9) / 100};
+  if (ADTSReader::SeekTime(seekPos, preceeding))
+  {
+    m_started = true;
+    return AP4_SUCCEEDED(ReadSample());
+  }
+  return AP4_ERROR_EOS;
+}

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../ADTSReader.h"
+#include "../TSReader.h"
+#include "SampleReader.h"
+
+class ATTR_DLL_LOCAL CADTSSampleReader : public ISampleReader, public ADTSReader
+{
+public:
+  CADTSSampleReader(AP4_ByteStream* input, AP4_UI32 streamId);
+
+  bool IsStarted() const override { return m_started; }
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_pts; }
+  uint64_t PTS() const override { return m_pts; }
+  AP4_Result Start(bool& bStarted) override;
+  AP4_Result ReadSample() override;
+  void Reset(bool bEOS) override;
+  bool GetInformation(kodi::addon::InputstreamInfo& info) override
+  {
+    return ADTSReader::GetInformation(info);
+  }
+  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
+  int64_t GetPTSDiff() const override { return m_ptsDiff; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 90000; }
+  AP4_UI32 GetStreamId() const override { return m_streamId; }
+  AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
+  const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
+  uint64_t GetDuration() const override { return (ADTSReader::GetDuration() * 100) / 9; }
+  bool IsEncrypted() const override { return false; }
+
+private:
+  bool m_eos{false};
+  bool m_started{false};
+  AP4_UI32 m_streamId;
+  uint64_t m_pts{0};
+  int64_t m_ptsDiff{0};
+  uint64_t m_ptsOffs{~0ULL};
+  CAdaptiveByteStream* m_adByteStream;
+};

--- a/src/samplereader/DummySampleReader.h
+++ b/src/samplereader/DummySampleReader.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SampleReader.h"
+
+class ATTR_DLL_LOCAL CDummySampleReader : public ISampleReader
+{
+public:
+  virtual ~CDummySampleReader() = default;
+  bool EOS() const override { return false; }
+  uint64_t DTS() const override { return STREAM_NOPTS_VALUE; }
+  uint64_t PTS() const override { return STREAM_NOPTS_VALUE; }
+  AP4_Result Start(bool& bStarted) override { return AP4_SUCCESS; }
+  AP4_Result ReadSample() override { return AP4_SUCCESS; }
+  void Reset(bool bEOS) override {}
+  bool GetInformation(kodi::addon::InputstreamInfo& info) override { return false; }
+  bool TimeSeek(uint64_t pts, bool preceeding) override { return false; }
+  void SetPTSOffset(uint64_t offset) override {}
+  int64_t GetPTSDiff() const override { return 0; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 1; }
+  AP4_UI32 GetStreamId() const override { return 0; }
+  AP4_Size GetSampleDataSize() const override { return 0; }
+  const AP4_Byte* GetSampleData() const override { return nullptr; }
+  uint64_t GetDuration() const override { return 0; }
+  bool IsEncrypted() const override { return false; }
+  void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override {};
+  void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override {};
+  bool RemoveStreamType(INPUTSTREAM_TYPE type) override { return true; };
+  bool IsStarted() const override { return true; }
+};

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -1,0 +1,480 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FragmentedSampleReader.h"
+
+#include "../utils/log.h"
+
+namespace
+{
+constexpr uint8_t SMOOTHSTREAM_TFRFBOX_UUID[] = {0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46, 0x95,
+                                                 0x8e, 0x54, 0x26, 0xcb, 0x9e, 0x46, 0xa7, 0x9f};
+} // unnamed namespace
+
+
+CFragmentedSampleReader::CFragmentedSampleReader(AP4_ByteStream* input,
+                                                 AP4_Movie* movie,
+                                                 AP4_Track* track,
+                                                 AP4_UI32 streamId,
+                                                 Adaptive_CencSingleSampleDecrypter* ssd,
+                                                 const SSD::SSD_DECRYPTER::SSD_CAPS& dcaps)
+  : AP4_LinearReader{*movie, input},
+    m_track{track},
+    m_streamId{streamId},
+    m_decrypterCaps{dcaps},
+    m_singleSampleDecryptor{ssd}
+{
+  EnableTrack(m_track->GetId());
+
+  AP4_SampleDescription* desc{m_track->GetSampleDescription(0)};
+  if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
+  {
+    m_protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
+
+    AP4_ContainerAtom* schi;
+    if (m_protectedDesc->GetSchemeInfo() &&
+        (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
+    {
+      AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
+      if (tenc)
+        m_defaultKey = tenc->GetDefaultKid();
+      else
+      {
+        AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(
+            AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
+        if (piff)
+          m_defaultKey = piff->GetDefaultKid();
+      }
+    }
+  }
+
+  if (m_singleSampleDecryptor)
+    m_poolId = m_singleSampleDecryptor->AddPool();
+
+  m_timeBaseExt = STREAM_TIME_BASE;
+  m_timeBaseInt = m_track->GetMediaTimeScale();
+
+  // remove unneeded trailing zeroes
+  while (m_timeBaseExt > 1)
+  {
+    if ((m_timeBaseInt / 10) * 10 == m_timeBaseInt)
+    {
+      m_timeBaseExt /= 10;
+      m_timeBaseInt /= 10;
+    }
+    else
+      break;
+  }
+
+  //We need this to fill extradata
+  UpdateSampleDescription();
+}
+
+CFragmentedSampleReader::~CFragmentedSampleReader()
+{
+  if (m_singleSampleDecryptor)
+    m_singleSampleDecryptor->RemovePool(m_poolId);
+  delete m_decrypter;
+  delete m_codecHandler;
+}
+
+AP4_Result CFragmentedSampleReader::Start(bool& bStarted)
+{
+  bStarted = false;
+  if (m_started)
+    return AP4_SUCCESS;
+
+  m_started = true;
+  bStarted = true;
+  return ReadSample();
+}
+
+AP4_Result CFragmentedSampleReader::ReadSample()
+{
+  AP4_Result result;
+  if (!m_codecHandler || !m_codecHandler->ReadNextSample(m_sample, m_sampleData))
+  {
+    bool useDecryptingDecoder =
+        m_protectedDesc &&
+        (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0;
+    bool decrypterPresent{m_decrypter != nullptr};
+    if (AP4_FAILED(result = ReadNextSample(m_track->GetId(), m_sample,
+                                           (m_decrypter || useDecryptingDecoder) ? m_encrypted
+                                                                                 : m_sampleData)))
+    {
+      if (result == AP4_ERROR_EOS)
+      {
+        auto adByteStream = dynamic_cast<CAdaptiveByteStream*>(m_FragmentStream);
+        if (!adByteStream)
+        {
+          LOG::LogF(LOGERROR, "Fragment stream cannot be casted to AdaptiveByteStream");
+          m_eos = true;
+        }
+        else
+        {
+          if (adByteStream->waitingForSegment())
+          {
+            m_sampleData.SetDataSize(0);
+          }
+          else
+          {
+            m_eos = true;
+          }
+        }
+      }
+      return result;
+    }
+
+    //AP4_AvcSequenceParameterSet sps;
+    //AP4_AvcFrameParser::ParseFrameForSPS(m_sampleData.GetData(), m_sampleData.GetDataSize(), 4, sps);
+
+    //Protection could have changed in ProcessMoof
+    if (!decrypterPresent && m_decrypter != nullptr && !useDecryptingDecoder)
+      m_encrypted.SetData(m_sampleData.GetData(), m_sampleData.GetDataSize());
+    else if (decrypterPresent && m_decrypter == nullptr && !useDecryptingDecoder)
+      m_sampleData.SetData(m_encrypted.GetData(), m_encrypted.GetDataSize());
+
+    if (m_decrypter)
+    {
+      // Make sure that the decrypter is NOT allocating memory!
+      // If decrypter and addon are compiled with different DEBUG / RELEASE
+      // options freeing HEAP memory will fail.
+      m_sampleData.Reserve(m_encrypted.GetDataSize() + 4096);
+      if (AP4_FAILED(result =
+                         m_decrypter->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, NULL)))
+      {
+        LOG::Log(LOGERROR, "Decrypt Sample returns failure!");
+        if (++m_failCount > 50)
+        {
+          Reset(true);
+          return result;
+        }
+        else
+        {
+          m_sampleData.SetDataSize(0);
+        }
+      }
+      else
+      {
+        m_failCount = 0;
+      }
+    }
+    else if (useDecryptingDecoder)
+    {
+      m_sampleData.Reserve(m_encrypted.GetDataSize() + 1024);
+      m_singleSampleDecryptor->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, nullptr, 0,
+                                                 nullptr, nullptr);
+    }
+
+    if (m_codecHandler->Transform(m_sample.GetDts(), m_sample.GetDuration(), m_sampleData,
+                                  m_track->GetMediaTimeScale()))
+    {
+      m_codecHandler->ReadNextSample(m_sample, m_sampleData);
+    }
+  }
+
+  m_dts = (m_sample.GetDts() * m_timeBaseExt) / m_timeBaseInt;
+  m_pts = (m_sample.GetCts() * m_timeBaseExt) / m_timeBaseInt;
+
+  m_codecHandler->UpdatePPSId(m_sampleData);
+
+  return AP4_SUCCESS;
+}
+
+void CFragmentedSampleReader::Reset(bool bEOS)
+{
+  AP4_LinearReader::Reset();
+  m_eos = bEOS;
+  if (m_codecHandler)
+    m_codecHandler->Reset();
+}
+
+uint64_t CFragmentedSampleReader::GetDuration() const
+{
+  return (m_sample.GetDuration() * m_timeBaseExt) / m_timeBaseInt;
+}
+
+bool CFragmentedSampleReader::IsEncrypted() const
+{
+  return (m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH) != 0 &&
+         m_decrypter != nullptr;
+}
+
+bool CFragmentedSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
+{
+  if (!m_codecHandler)
+    return false;
+
+  bool edChanged(false);
+  if (m_bSampleDescChanged && m_codecHandler->m_extraData.GetDataSize() &&
+      !info.CompareExtraData(m_codecHandler->m_extraData.GetData(),
+                             m_codecHandler->m_extraData.GetDataSize()))
+  {
+    info.SetExtraData(m_codecHandler->m_extraData.GetData(),
+                      m_codecHandler->m_extraData.GetDataSize());
+    edChanged = true;
+  }
+
+  AP4_SampleDescription* desc(m_track->GetSampleDescription(0));
+  if (desc->GetType() == AP4_SampleDescription::TYPE_MPEG)
+  {
+    switch (static_cast<AP4_MpegSampleDescription*>(desc)->GetObjectTypeId())
+    {
+      case AP4_OTI_MPEG4_AUDIO:
+      case AP4_OTI_MPEG2_AAC_AUDIO_MAIN:
+      case AP4_OTI_MPEG2_AAC_AUDIO_LC:
+      case AP4_OTI_MPEG2_AAC_AUDIO_SSRP:
+        info.SetCodecName("aac");
+        break;
+      case AP4_OTI_DTS_AUDIO:
+      case AP4_OTI_DTS_HIRES_AUDIO:
+      case AP4_OTI_DTS_MASTER_AUDIO:
+      case AP4_OTI_DTS_EXPRESS_AUDIO:
+        info.SetCodecName("dca");
+        break;
+      case AP4_OTI_AC3_AUDIO:
+        info.SetCodecName("ac3");
+        break;
+      case AP4_OTI_EAC3_AUDIO:
+        info.SetCodecName("eac3");
+        break;
+    }
+  }
+
+  m_bSampleDescChanged = false;
+
+  if (m_codecHandler->GetInformation(info))
+    return true;
+
+  return edChanged;
+}
+
+bool CFragmentedSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+{
+  AP4_Ordinal sampleIndex;
+  AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));
+  if (AP4_SUCCEEDED(SeekSample(m_track->GetId(), seekPos, sampleIndex, preceeding)))
+  {
+    if (m_decrypter)
+      m_decrypter->SetSampleIndex(sampleIndex);
+
+    if (m_codecHandler)
+      m_codecHandler->TimeSeek(seekPos);
+
+    m_started = true;
+    return AP4_SUCCEEDED(ReadSample());
+  }
+  return false;
+}
+
+void CFragmentedSampleReader::SetPTSOffset(uint64_t offset)
+{
+  FindTracker(m_track->GetId())->m_NextDts = (offset * m_timeBaseInt) / m_timeBaseExt;
+  m_ptsOffs = offset;
+
+  if (m_codecHandler)
+    m_codecHandler->SetPTSOffset((offset * m_timeBaseInt) / m_timeBaseExt);
+}
+
+bool CFragmentedSampleReader::GetNextFragmentInfo(uint64_t& ts, uint64_t& dur)
+{
+  if (m_nextDuration)
+  {
+    dur = m_nextDuration;
+    ts = m_nextTimestamp;
+  }
+  else
+  {
+    auto fragSampleTable =
+        dynamic_cast<AP4_FragmentSampleTable*>(FindTracker(m_track->GetId())->m_SampleTable);
+    if (fragSampleTable)
+    {
+      dur = fragSampleTable->GetDuration();
+      ts = 0;
+    }
+    else
+    {
+      LOG::LogF(LOGERROR, "Can't get FragmentSampleTable from track %u", m_track->GetId());
+      return false;
+    }
+  }
+  return true;
+}
+
+AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
+                                                AP4_Position moof_offset,
+                                                AP4_Position mdat_payload_offset,
+                                                AP4_UI64 mdat_payload_size)
+{
+  // For prefixed initialization (usually ISM) we don't yet know the
+  // proper track id, let's find it now
+  if (m_track->GetId() == TRACKID_UNKNOWN)
+  {
+    auto fragment = std::make_unique<AP4_MovieFragment>(
+        AP4_MovieFragment(AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->Clone())));
+    AP4_Array<AP4_UI32> ids;
+    fragment->GetTrackIds(ids);
+
+    if (ids.ItemCount() == 1)
+      m_track->SetId(ids[0]);
+    else
+      return AP4_ERROR_NO_SUCH_ITEM;
+  }
+
+  AP4_Result result;
+
+  if (AP4_SUCCEEDED((result = AP4_LinearReader::ProcessMoof(moof, moof_offset, mdat_payload_offset,
+                                                            mdat_payload_size))))
+  {
+    AP4_ContainerAtom* traf =
+        AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
+
+    //For ISM Livestreams we have an UUID atom with one / more following fragment durations
+    m_nextDuration = 0;
+    m_nextTimestamp = 0;
+    AP4_Atom* atom{nullptr};
+    unsigned int atom_pos{0};
+
+    while ((atom = traf->GetChild(AP4_ATOM_TYPE_UUID, atom_pos++)) != nullptr)
+    {
+      AP4_UuidAtom* uuid_atom{AP4_DYNAMIC_CAST(AP4_UuidAtom, atom)};
+      if (memcmp(uuid_atom->GetUuid(), SMOOTHSTREAM_TFRFBOX_UUID, 16) == 0)
+      {
+        //verison(8) + flags(24) + numpairs(8) + pairs(ts(64)/dur(64))*numpairs
+        const AP4_DataBuffer& buf(AP4_DYNAMIC_CAST(AP4_UnknownUuidAtom, uuid_atom)->GetData());
+        if (buf.GetDataSize() >= 21)
+        {
+          const uint8_t* data(buf.GetData());
+          m_nextTimestamp = AP4_BytesToUInt64BE(data + 5);
+          m_nextDuration = AP4_BytesToUInt64BE(data + 13);
+        }
+        break;
+      }
+    }
+
+    //Check if the sample table description has changed
+    AP4_TfhdAtom* tfhd{AP4_DYNAMIC_CAST(AP4_TfhdAtom, traf->GetChild(AP4_ATOM_TYPE_TFHD, 0))};
+    if ((tfhd && tfhd->GetSampleDescriptionIndex() != m_sampleDescIndex) ||
+        (!tfhd && (m_sampleDescIndex = 1)))
+    {
+      m_sampleDescIndex = tfhd->GetSampleDescriptionIndex();
+      UpdateSampleDescription();
+    }
+
+    //Correct PTS
+    AP4_Sample sample;
+    if (~m_ptsOffs)
+    {
+      if (AP4_SUCCEEDED(GetSample(m_track->GetId(), sample, 0)))
+      {
+        m_pts = m_dts = (sample.GetCts() * m_timeBaseExt) / m_timeBaseInt;
+        m_ptsDiff = m_pts - m_ptsOffs;
+      }
+      m_ptsOffs = ~0ULL;
+    }
+
+    if (m_protectedDesc)
+    {
+      //Setup the decryption
+      AP4_CencSampleInfoTable* sample_table{nullptr};
+      AP4_UI32 algorithm_id = 0;
+
+      delete m_decrypter;
+      m_decrypter = 0;
+
+      AP4_ContainerAtom* traf =
+          AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
+
+      if (!m_protectedDesc || !traf)
+        return AP4_ERROR_INVALID_FORMAT;
+
+      bool reset_iv(false);
+      if (AP4_FAILED(result = AP4_CencSampleInfoTable::Create(m_protectedDesc, traf, algorithm_id,
+                                                              reset_iv, *m_FragmentStream,
+                                                              moof_offset, sample_table)))
+        // we assume unencrypted fragment here
+        goto SUCCESS;
+
+      if (AP4_FAILED(result = AP4_CencSampleDecrypter::Create(sample_table, algorithm_id, 0, 0, 0,
+                                                              reset_iv, m_singleSampleDecryptor,
+                                                              m_decrypter)))
+      {
+        return result;
+      }
+
+      // Inform decrypter of pattern decryption (CBCS)
+      if (m_protectedDesc->GetSchemeType() == AP4_PROTECTION_SCHEME_TYPE_CENC)
+      {
+        m_singleSampleDecryptor->SetEncryptionScheme(ENCRYPTION_SCHEME::CENC);
+        m_singleSampleDecryptor->SetCrypto(0, 0);
+      }
+      else if (m_protectedDesc->GetSchemeType() == AP4_PROTECTION_SCHEME_TYPE_CBCS)
+      {
+        m_singleSampleDecryptor->SetEncryptionScheme(ENCRYPTION_SCHEME::CBCS);
+        m_singleSampleDecryptor->SetCrypto(sample_table->GetCryptByteBlock(),
+                                           sample_table->GetSkipByteBlock());
+      }
+    }
+  }
+SUCCESS:
+  if (m_singleSampleDecryptor && m_codecHandler)
+    m_singleSampleDecryptor->SetFragmentInfo(m_poolId, m_defaultKey,
+                                             m_codecHandler->m_naluLengthSize,
+                                             m_codecHandler->m_extraData, m_decrypterCaps.flags);
+
+  return AP4_SUCCESS;
+}
+
+void CFragmentedSampleReader::UpdateSampleDescription()
+{
+  if (m_codecHandler)
+    delete m_codecHandler;
+  m_codecHandler = 0;
+  m_bSampleDescChanged = true;
+
+  AP4_SampleDescription* desc(m_track->GetSampleDescription(m_sampleDescIndex - 1));
+  if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
+  {
+    m_protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
+    desc = m_protectedDesc->GetOriginalSampleDescription();
+  }
+  LOG::Log(LOGDEBUG, "UpdateSampleDescription: codec %d", desc->GetFormat());
+  switch (desc->GetFormat())
+  {
+    case AP4_SAMPLE_FORMAT_AVC1:
+    case AP4_SAMPLE_FORMAT_AVC2:
+    case AP4_SAMPLE_FORMAT_AVC3:
+    case AP4_SAMPLE_FORMAT_AVC4:
+      m_codecHandler = new AVCCodecHandler(desc);
+      break;
+    case AP4_SAMPLE_FORMAT_HEV1:
+    case AP4_SAMPLE_FORMAT_HVC1:
+    case AP4_SAMPLE_FORMAT_DVHE:
+    case AP4_SAMPLE_FORMAT_DVH1:
+      m_codecHandler = new HEVCCodecHandler(desc);
+      break;
+    case AP4_SAMPLE_FORMAT_MP4A:
+      m_codecHandler = new MPEGCodecHandler(desc);
+      break;
+    case AP4_SAMPLE_FORMAT_STPP:
+      m_codecHandler = new TTMLCodecHandler(desc);
+      break;
+    case AP4_SAMPLE_FORMAT_WVTT:
+      m_codecHandler = new WebVTTCodecHandler(desc, false);
+      break;
+    case AP4_SAMPLE_FORMAT_VP9:
+      m_codecHandler = new VP9CodecHandler(desc);
+      break;
+    default:
+      m_codecHandler = new CodecHandler(desc);
+      break;
+  }
+
+  if ((m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED) != 0)
+    m_codecHandler->ExtraDataToAnnexB();
+}

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../SSD_dll.h"
+#include "../codechandler/AVCCodecHandler.h"
+#include "../codechandler/HEVCCodecHandler.h"
+#include "../codechandler/MPEGCodecHandler.h"
+#include "../codechandler/TTMLCodecHandler.h"
+#include "../codechandler/VP9CodecHandler.h"
+#include "../codechandler/WebVTTCodecHandler.h"
+#include "../common/AdaptiveDecrypter.h"
+#include "../utils/log.h"
+#include "SampleReader.h"
+
+class ATTR_DLL_LOCAL CFragmentedSampleReader : public ISampleReader, public AP4_LinearReader
+{
+public:
+  CFragmentedSampleReader(AP4_ByteStream* input,
+                         AP4_Movie* movie,
+                         AP4_Track* track,
+                         AP4_UI32 streamId,
+                         Adaptive_CencSingleSampleDecrypter* ssd,
+                         const SSD::SSD_DECRYPTER::SSD_CAPS& dcaps);
+
+  ~CFragmentedSampleReader();
+
+  AP4_Result Start(bool& bStarted) override;
+  AP4_Result ReadSample() override;
+  void Reset(bool bEOS);
+  bool EOS() const override { return m_eos; }
+  bool IsStarted() const override { return m_started; }
+  uint64_t DTS() const override { return m_dts; }
+  uint64_t PTS() const override { return m_pts; }
+  AP4_UI32 GetStreamId() const override { return m_streamId; }
+  AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); }
+  const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); }
+  uint64_t GetDuration() const override;
+  bool IsEncrypted() const override;
+  bool GetInformation(kodi::addon::InputstreamInfo& info);
+  bool TimeSeek(uint64_t pts, bool preceeding);
+  void SetPTSOffset(uint64_t offset);
+  int64_t GetPTSDiff() const override { return m_ptsDiff; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur);
+  uint32_t GetTimeScale() const override { return m_track->GetMediaTimeScale(); }
+
+  static const AP4_UI32 TRACKID_UNKNOWN = -1;
+
+protected:
+  AP4_Result ProcessMoof(AP4_ContainerAtom* moof,
+                         AP4_Position moof_offset,
+                         AP4_Position mdat_payload_offset,
+                         AP4_UI64 mdat_payload_size);
+
+private:
+  void UpdateSampleDescription();
+
+  AP4_Track* m_track;
+  AP4_UI32 m_poolId{0};
+  AP4_UI32 m_streamId;
+  AP4_UI32 m_sampleDescIndex{1};
+  SSD::SSD_DECRYPTER::SSD_CAPS m_decrypterCaps;
+  unsigned int m_failCount{0};
+  bool m_bSampleDescChanged{false};
+  bool m_eos{false};
+  bool m_started{false};
+  int64_t m_dts{0};
+  int64_t m_pts{0};
+  int64_t m_ptsDiff{0};
+  AP4_UI64 m_ptsOffs{~0ULL};
+  uint64_t m_timeBaseExt;
+  uint64_t m_timeBaseInt;
+  AP4_Sample m_sample;
+  AP4_DataBuffer m_encrypted;
+  AP4_DataBuffer m_sampleData;
+  CodecHandler* m_codecHandler{nullptr};
+  const AP4_UI08* m_defaultKey{nullptr};
+  AP4_ProtectedSampleDescription* m_protectedDesc{nullptr};
+  Adaptive_CencSingleSampleDecrypter* m_singleSampleDecryptor;
+  AP4_CencSampleDecrypter* m_decrypter{nullptr};
+  uint64_t m_nextDuration{0};
+  uint64_t m_nextTimestamp{0};
+};

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../AdaptiveByteStream.h"
+
+#include <bento4/Ap4.h>
+#include <kodi/AddonBase.h>
+#include <kodi/addon-instance/Inputstream.h>
+
+class ATTR_DLL_LOCAL ISampleReader
+{
+public:
+  virtual ~ISampleReader() = default;
+  virtual bool Initialize() { return true; };
+  virtual bool EOS() const = 0;
+  virtual uint64_t DTS() const = 0;
+  virtual uint64_t PTS() const = 0;
+  virtual uint64_t DTSorPTS() const { return DTS() < PTS() ? DTS() : PTS(); };
+  virtual AP4_Result Start(bool& bStarted) = 0;
+  virtual AP4_Result ReadSample() = 0;
+  virtual void Reset(bool bEOS) = 0;
+  virtual bool GetInformation(kodi::addon::InputstreamInfo& info) = 0;
+  virtual bool TimeSeek(uint64_t pts, bool preceeding) = 0;
+  virtual void SetPTSOffset(uint64_t offset) = 0;
+  virtual int64_t GetPTSDiff() const = 0;
+  virtual bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) = 0;
+  virtual uint32_t GetTimeScale() const = 0;
+  virtual AP4_UI32 GetStreamId() const = 0;
+  virtual AP4_Size GetSampleDataSize() const = 0;
+  virtual const AP4_Byte* GetSampleData() const = 0;
+  virtual uint64_t GetDuration() const = 0;
+  virtual bool IsEncrypted() const = 0;
+  virtual void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) {};
+  virtual void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) {};
+  virtual bool RemoveStreamType(INPUTSTREAM_TYPE type) { return true; };
+  virtual bool IsStarted() const = 0;
+};

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SubtitleSampleReader.h"
+
+#include "../utils/log.h"
+
+CSubtitleSampleReader::CSubtitleSampleReader(const std::string& url,
+                                           AP4_UI32 streamId,
+                                           const std::string& codecInternalName)
+  : m_streamId{streamId}
+{
+  // open the file
+  kodi::vfs::CFile file;
+  if (!file.CURLCreate(url))
+    return;
+
+  file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
+  file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "gzip");
+  file.CURLOpen(ADDON_READ_CHUNKED | ADDON_READ_NO_CACHE);
+
+  AP4_DataBuffer result;
+
+  // read the file
+  static const unsigned int CHUNKSIZE = 16384;
+  AP4_Byte buf[CHUNKSIZE];
+  size_t nbRead;
+  while ((nbRead = file.Read(buf, CHUNKSIZE)) > 0 && ~nbRead)
+    result.AppendData(buf, nbRead);
+  file.Close();
+
+  if (codecInternalName == "wvtt")
+    m_codecHandler = new WebVTTCodecHandler(nullptr, true);
+  else
+    m_codecHandler = new TTMLCodecHandler(nullptr);
+
+  m_codecHandler->Transform(0, 0, result, 1000);
+}
+
+CSubtitleSampleReader::CSubtitleSampleReader(Session::STREAM* stream,
+                                           AP4_UI32 streamId,
+                                           const std::string& codecInternalName)
+  : m_streamId{streamId}, m_adByteStream{stream->GetAdByteStream()}, m_adStream{&stream->m_adStream}
+{
+  if (codecInternalName == "wvtt")
+    m_codecHandler = new WebVTTCodecHandler(nullptr, false);
+  else
+    m_codecHandler = new TTMLCodecHandler(nullptr);
+}
+
+AP4_Result CSubtitleSampleReader::Start(bool& bStarted)
+{
+  m_eos = false;
+  return AP4_SUCCESS;
+}
+
+AP4_Result CSubtitleSampleReader::ReadSample()
+{
+  if (m_codecHandler->ReadNextSample(m_sample,
+                                     m_sampleData)) // Read the sample data from a file url
+  {
+    m_pts = m_sample.GetCts() * 1000;
+    return AP4_SUCCESS;
+  }
+  else if (m_adByteStream) // Read the sample data from a segment file stream (e.g. HLS)
+  {
+    // Get the next segment
+    if (m_adStream && m_adStream->ensureSegment())
+    {
+      size_t segSize;
+      if (m_adStream->retrieveCurrentSegmentBufferSize(segSize))
+      {
+        AP4_DataBuffer segData;
+        while (segSize > 0)
+        {
+          AP4_Size readSize = m_segmentChunkSize;
+          if (segSize < static_cast<size_t>(m_segmentChunkSize))
+            readSize = static_cast<AP4_Size>(segSize);
+
+          AP4_Byte* buf = new AP4_Byte[readSize];
+          segSize -= readSize;
+          if (AP4_SUCCEEDED(m_adByteStream->Read(buf, readSize)))
+          {
+            segData.AppendData(buf, readSize);
+            delete[] buf;
+          }
+          else
+          {
+            delete[] buf;
+            break;
+          }
+        }
+        auto rep = m_adStream->getRepresentation();
+        if (rep)
+        {
+          auto currentSegment = rep->current_segment_;
+          if (currentSegment)
+          {
+            m_codecHandler->Transform(currentSegment->startPTS_, currentSegment->m_duration,
+                                      segData, 1000);
+            if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))
+            {
+              m_pts = m_sample.GetCts();
+              m_ptsDiff = m_pts - m_ptsOffset;
+              return AP4_SUCCESS;
+            }
+          }
+          else
+            LOG::LogF(LOGERROR, "Failed to get current segment of subtitle stream");
+        }
+        else
+          LOG::LogF(LOGERROR, "Failed to get Representation of subtitle stream");
+      }
+      else
+      {
+        LOG::LogF(LOGERROR, "Failed to get subtitle segment buffer size");
+      }
+    }
+  }
+  m_eos = true;
+  return AP4_ERROR_EOS;
+}
+
+void CSubtitleSampleReader::Reset(bool bEOS)
+{
+  if (m_adByteStream || bEOS)
+    m_codecHandler->Reset();
+}
+
+bool CSubtitleSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
+{
+  if (m_codecHandler->m_extraData.GetDataSize() &&
+      !info.CompareExtraData(m_codecHandler->m_extraData.GetData(),
+                             m_codecHandler->m_extraData.GetDataSize()))
+  {
+    info.SetExtraData(m_codecHandler->m_extraData.GetData(),
+                      m_codecHandler->m_extraData.GetDataSize());
+    return true;
+  }
+  return false;
+}
+
+bool CSubtitleSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+{
+  if (dynamic_cast<WebVTTCodecHandler*>(m_codecHandler))
+  {
+    m_pts = pts;
+    return true;
+  }
+  else
+  {
+    if (m_codecHandler->TimeSeek(pts / 1000))
+      return AP4_SUCCEEDED(ReadSample());
+    return false;
+  }
+}

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../codechandler/TTMLCodecHandler.h"
+#include "../codechandler/WebVTTCodecHandler.h"
+#include "../common/AdaptiveStream.h"
+#include "../main.h" //! @todo: Relying on for STREAM objects, to be removed in a future cleanup
+#include "SampleReader.h"
+
+class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
+{
+public:
+  CSubtitleSampleReader(const std::string& url,
+                       AP4_UI32 streamId,
+                       const std::string& codecInternalName);
+
+  CSubtitleSampleReader(Session::STREAM* stream,
+                       AP4_UI32 streamId,
+                       const std::string& codecInternalName);
+
+  bool IsStarted() const override { return true; }
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_pts; }
+  uint64_t PTS() const override { return m_pts; }
+  AP4_Result Start(bool& bStarted) override;
+  AP4_Result ReadSample() override;
+  void Reset(bool bEOS) override;
+  bool GetInformation(kodi::addon::InputstreamInfo& info) override;
+  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffset = offset; }
+  int64_t GetPTSDiff() const override { return m_ptsDiff; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 1000; }
+  AP4_UI32 GetStreamId() const override { return m_streamId; }
+  AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); }
+  const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); }
+  uint64_t GetDuration() const override { return m_sample.GetDuration() * 1000; }
+  bool IsEncrypted() const override { return false; }
+
+private:
+  uint64_t m_pts{0};
+  uint64_t m_ptsOffset{0};
+  uint64_t m_ptsDiff{0};
+  AP4_UI32 m_streamId;
+  bool m_eos{false};
+  CodecHandler* m_codecHandler;
+  AP4_Sample m_sample;
+  AP4_DataBuffer m_sampleData;
+  CAdaptiveByteStream* m_adByteStream{nullptr};
+  adaptive::AdaptiveStream* m_adStream{nullptr};
+  const AP4_Size m_segmentChunkSize = 16384; // 16kb
+};

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TSSampleReader.h"
+
+CTSSampleReader::CTSSampleReader(AP4_ByteStream* input,
+                               INPUTSTREAM_TYPE type,
+                               AP4_UI32 streamId,
+                               uint32_t requiredMask)
+  : TSReader{input, requiredMask},
+    m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)},
+    m_typeMask{1U << type}
+{
+  m_typeMap[INPUTSTREAM_TYPE_NONE] = streamId;
+  m_typeMap[type] = streamId;
+}
+
+void CTSSampleReader::AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid)
+{
+  m_typeMap[type] = sid;
+  m_typeMask |= (1 << type);
+  if (m_started)
+    StartStreaming(m_typeMask);
+}
+
+void CTSSampleReader::SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid)
+{
+  m_typeMap[type] = sid;
+  m_typeMask = (1 << type);
+}
+
+bool CTSSampleReader::RemoveStreamType(INPUTSTREAM_TYPE type)
+{
+  m_typeMask &= ~(1 << type);
+  StartStreaming(m_typeMask);
+  return m_typeMask == 0;
+}
+
+AP4_Result CTSSampleReader::Start(bool& bStarted)
+{
+  bStarted = false;
+  if (m_started)
+    return AP4_SUCCESS;
+
+  if (!StartStreaming(m_typeMask))
+  {
+    m_eos = true;
+    return AP4_ERROR_CANNOT_OPEN_FILE;
+  }
+
+  m_started = true;
+  bStarted = true;
+  return ReadSample();
+}
+
+AP4_Result CTSSampleReader::ReadSample()
+{
+  if (ReadPacket())
+  {
+    m_dts = (GetDts() == PTS_UNSET) ? STREAM_NOPTS_VALUE : (GetDts() * 100) / 9;
+    m_pts = (GetPts() == PTS_UNSET) ? STREAM_NOPTS_VALUE : (GetPts() * 100) / 9;
+
+    if (~m_ptsOffs)
+    {
+      m_ptsDiff = m_pts - m_ptsOffs;
+      m_ptsOffs = ~0ULL;
+    }
+    return AP4_SUCCESS;
+  }
+  if (!m_adByteStream || !m_adByteStream->waitingForSegment())
+    m_eos = true;
+  return AP4_ERROR_EOS;
+}
+
+void CTSSampleReader::Reset(bool bEOS)
+{
+  TSReader::Reset();
+  m_eos = bEOS;
+}
+
+bool CTSSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+{
+  if (!StartStreaming(m_typeMask))
+    return false;
+
+  AP4_UI64 seekPos((pts * 9) / 100);
+  if (TSReader::SeekTime(seekPos, preceeding))
+  {
+    m_started = true;
+    return AP4_SUCCEEDED(ReadSample());
+  }
+  return AP4_ERROR_EOS;
+}

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../TSReader.h"
+#include "SampleReader.h"
+
+class ATTR_DLL_LOCAL CTSSampleReader : public ISampleReader, public TSReader
+{
+public:
+  CTSSampleReader(AP4_ByteStream* input,
+                 INPUTSTREAM_TYPE type,
+                 AP4_UI32 streamId,
+                 uint32_t requiredMask);
+
+  bool Initialize() override { return TSReader::Initialize(); }
+  void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
+  void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
+  bool RemoveStreamType(INPUTSTREAM_TYPE type) override;
+  bool IsStarted() const override { return m_started; }
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_dts; }
+  uint64_t PTS() const override { return m_pts; }
+  AP4_Result Start(bool& bStarted) override;
+  AP4_Result ReadSample() override;
+  void Reset(bool bEOS) override;
+  bool GetInformation(kodi::addon::InputstreamInfo& info) override
+  {
+    return TSReader::GetInformation(info);
+  }
+  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
+  int64_t GetPTSDiff() const override { return m_ptsDiff; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 90000; }
+  AP4_UI32 GetStreamId() const override { return m_typeMap[GetStreamType()]; }
+  AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
+  const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
+  uint64_t GetDuration() const override { return (TSReader::GetDuration() * 100) / 9; }
+  bool IsEncrypted() const override { return false; }
+
+private:
+  uint32_t m_typeMask; //Bit representation of INPUTSTREAM_TYPES
+  uint32_t m_typeMap[16];
+  uint64_t m_pts{0};
+  uint64_t m_dts{0};
+  uint64_t m_ptsOffs{~0ULL};
+  int64_t m_ptsDiff{0};
+  bool m_eos{false};
+  bool m_started{false};
+  CAdaptiveByteStream* m_adByteStream;
+};

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WebmSampleReader.h"
+
+CWebmSampleReader::CWebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
+  : WebmReader{input},
+    m_streamId{streamId},
+    m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)} {};
+
+bool CWebmSampleReader::Initialize()
+{
+  m_adByteStream->FixateInitialization(true);
+  bool ret = WebmReader::Initialize();
+  WebmReader::Reset();
+  m_adByteStream->FixateInitialization(false);
+  m_adByteStream->SetSegmentFileOffset(GetCueOffset());
+  return ret;
+}
+
+AP4_Result CWebmSampleReader::Start(bool& bStarted)
+{
+  bStarted = false;
+  if (m_started)
+    return AP4_SUCCESS;
+  m_started = bStarted = true;
+  return ReadSample();
+}
+
+AP4_Result CWebmSampleReader::ReadSample()
+{
+  if (ReadPacket())
+  {
+    m_dts = GetDts() * 1000;
+    m_pts = GetPts() * 1000;
+
+    if (~m_ptsOffs)
+    {
+      m_ptsDiff = m_pts - m_ptsOffs;
+      m_ptsOffs = ~0ULL;
+    }
+    return AP4_SUCCESS;
+  }
+  if (!m_adByteStream || !m_adByteStream->waitingForSegment())
+    m_eos = true;
+  return AP4_ERROR_EOS;
+}
+
+void CWebmSampleReader::Reset(bool bEOS)
+{
+  WebmReader::Reset();
+  m_eos = bEOS;
+}
+
+bool CWebmSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+{
+  AP4_UI64 seekPos((pts * 9) / 100);
+  if (WebmReader::SeekTime(seekPos, preceeding))
+  {
+    m_started = true;
+    return AP4_SUCCEEDED(ReadSample());
+  }
+  return AP4_ERROR_EOS;
+}

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "../AdaptiveByteStream.h"
+#include "../WebmReader.h"
+#include "SampleReader.h"
+
+class ATTR_DLL_LOCAL CWebmSampleReader : public ISampleReader, public WebmReader
+{
+public:
+  CWebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId);
+
+  bool IsStarted() const override { return m_started; }
+  bool EOS() const override { return m_eos; }
+  uint64_t DTS() const override { return m_dts; }
+  uint64_t PTS() const override { return m_pts; }
+  bool Initialize() override;
+  AP4_Result Start(bool& bStarted) override;
+  AP4_Result ReadSample() override;
+  void Reset(bool bEOS) override;
+  bool GetInformation(kodi::addon::InputstreamInfo& info) override
+  {
+    return WebmReader::GetInformation(info);
+  }
+  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
+  int64_t GetPTSDiff() const override { return m_ptsDiff; }
+  bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
+  uint32_t GetTimeScale() const override { return 1000; }
+  AP4_UI32 GetStreamId() const override { return m_streamId; }
+  AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
+  const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
+  uint64_t GetDuration() const override { return WebmReader::GetDuration() * 1000; }
+  bool IsEncrypted() const override { return false; }
+
+private:
+  AP4_UI32 m_streamId;
+  uint64_t m_pts{0};
+  uint64_t m_dts{0};
+  uint64_t m_ptsOffs{~0ULL};
+  int64_t m_ptsDiff{0};
+  bool m_eos{false};
+  bool m_started{false};
+  CAdaptiveByteStream* m_adByteStream;
+};


### PR DESCRIPTION
Moved the AdaptiveByteStream and SampleReader classes into their own units, cleaned up the code as well. Main.cpp is almost half our original size at start of refactoring :)