### PR TITLE
[cleanup] Removed KodiAdaptiveStream class

### DIFF
--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -71,17 +71,12 @@ namespace adaptive
     void FixateInitialization(bool on);
     void SetSegmentFileOffset(uint64_t offset) { m_segmentFileOffset = offset; };
     bool StreamChanged() { return stream_changed_; }
+
   protected:
     virtual bool download(const std::string& url,
                           const std::map<std::string, std::string>& mediaHeaders,
-                          std::string* lockfreeBuffer)
-    {
-      return false;
-    };
-    virtual bool parseIndexRange(AdaptiveTree::Representation* rep, const std::string& buffer)
-    {
-      return false;
-    };
+                          std::string* lockfreeBuffer);
+    virtual bool parseIndexRange(AdaptiveTree::Representation* rep, const std::string& buffer);
     bool write_data(const void* buffer, size_t buffer_size, std::string* lockfreeBuffer);
     virtual void SetLastUpdated(std::chrono::system_clock::time_point tm) {};
     std::chrono::time_point<std::chrono::system_clock> lastUpdated_;

--- a/src/main.h
+++ b/src/main.h
@@ -47,30 +47,6 @@ namespace XBMCFILE
 Kodi Streams implementation
 ********************************************************/
 
-class ATTR_DLL_LOCAL KodiAdaptiveStream : public adaptive::AdaptiveStream
-{
-public:
-  KodiAdaptiveStream(adaptive::AdaptiveTree& tree,
-                     adaptive::AdaptiveTree::AdaptationSet* adp,
-                     adaptive::AdaptiveTree::Representation* initialRepr,
-                     const std::map<std::string, std::string>& media_headers,
-                     adaptive::IRepresentationChooser* reprChooser,
-                     bool play_timeshift_buffer,
-                     bool choose_rep)
-    : adaptive::AdaptiveStream(tree, adp, initialRepr, media_headers, play_timeshift_buffer, choose_rep),
-      m_reprChooser(reprChooser){};
-
-protected:
-  bool download(const std::string& url,
-                const std::map<std::string, std::string>& mediaHeaders,
-                std::string* lockfreeBuffer) override;
-  bool parseIndexRange(adaptive::AdaptiveTree::Representation* rep,
-                       const std::string& buffer) override;
-
-private:
-  adaptive::IRepresentationChooser* m_reprChooser{nullptr};
-};
-
 class ATTR_DLL_LOCAL Session : public adaptive::AdaptiveStreamObserver
 {
 public:
@@ -119,8 +95,7 @@ public:
         encrypted(false),
         mainId_(0),
         current_segment_(0),
-        m_kodiAdStream(
-            t, adp, initialRepr, media_headers, reprChooser, play_timeshift_buffer, choose_rep),
+        m_adStream(t, adp, initialRepr, media_headers, play_timeshift_buffer, choose_rep),
         segmentChanged(false),
         valid(true){};
 
@@ -174,7 +149,7 @@ public:
     bool enabled, encrypted;
     uint16_t mainId_;
     uint32_t current_segment_;
-    KodiAdaptiveStream m_kodiAdStream;
+    adaptive::AdaptiveStream m_adStream;
     kodi::addon::InputstreamInfo info_;
     bool segmentChanged;
     bool valid;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -79,8 +79,7 @@ protected:
   TestAdaptiveStream* NewStream(adaptive::AdaptiveTree::AdaptationSet* adp, bool playTsb=true)
   {
     auto initialRepr{tree->GetRepChooser()->ChooseRepresentation(adp)};
-    return new TestAdaptiveStream(*tree, adp, initialRepr, mediaHeaders, tree->GetRepChooser(),
-                                  playTsb, false);
+    return new TestAdaptiveStream(*tree, adp, initialRepr, mediaHeaders, playTsb, false);
   }
 
   void ReadSegments(TestAdaptiveStream* stream,

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -48,12 +48,10 @@ public:
                      adaptive::AdaptiveTree::AdaptationSet* adp,
                      adaptive::AdaptiveTree::Representation* initialRepr,
                      const std::map<std::string, std::string>& media_headers,
-                     adaptive::IRepresentationChooser* reprChooser,
                      bool play_timeshift_buffer,
                      bool choose_rep)
     : adaptive::AdaptiveStream(
-          tree, adp, initialRepr, media_headers, play_timeshift_buffer, choose_rep),
-      m_reprChooser(reprChooser){};
+          tree, adp, initialRepr, media_headers, play_timeshift_buffer, choose_rep){};
 
   std::chrono::system_clock::time_point mock_time_stream = std::chrono::system_clock::now();
   void SetLastUpdated(std::chrono::system_clock::time_point tm) override { lastUpdated_ = tm; };
@@ -63,9 +61,6 @@ protected:
   virtual bool download(const std::string& url,
                         const std::map<std::string, std::string>& mediaHeaders,
                         std::string* lockfreeBuffer) override;
-
-private:
-  adaptive::IRepresentationChooser* m_reprChooser{nullptr};
 };
 
 class AESDecrypter : public IAESDecrypter


### PR DESCRIPTION
As discussed in the past i have removed not needed `KodiAdaptiveStream` class
and merged the code to the parent class, no functional change

i do not like too much add `INPUTSTREAM_TEST_BUILD` conditions
but i don't know of any better way to avoid breaking the test build
due to references to objects of Kodi interface includes