### PR TITLE
Representation chooser improvements and new settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,10 @@ set(ADP_SOURCES
 	src/codechandler/ttml/TTML.cpp
 	src/common/AdaptiveStream.cpp
 	src/common/AdaptiveTree.cpp
+	src/common/RepresentationChooser.cpp
 	src/common/RepresentationChooserDefault.cpp
+	src/common/RepresentationChooserManualOSD.cpp
+	src/common/RepresentationSelector.cpp
 	src/parser/DASHTree.cpp
 	src/parser/HLSTree.cpp
 	src/parser/SmoothTree.cpp
@@ -60,6 +63,8 @@ set(ADP_HEADERS
 	src/common/AdaptiveTree.h
 	src/common/RepresentationChooser.h
 	src/common/RepresentationChooserDefault.h
+	src/common/RepresentationChooserManualOSD.h
+	src/common/RepresentationSelector.h
 	src/parser/DASHTree.h
 	src/parser/HLSTree.h
 	src/parser/SmoothTree.h

--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -20,125 +20,246 @@ msgctxt "Addon Description"
 msgid "InputStream client for adaptive streams"
 msgstr ""
 
+#. Category title
 msgctxt "#30100"
 msgid "General"
 msgstr ""
 
-# The minimum bandwidth which should not be deceeded.
+#. The minimum bandwidth which should not be deceeded
 msgctxt "#30101"
-msgid "Min. Bandwidth (Bit/s)"
+msgid "Minimum bandwidth (Kbps)"
 msgstr ""
 
-# The maximum bandwidth which should not be exceeded. 0=unlimited
+#. The maximum bandwidth which should not be exceeded
 msgctxt "#30102"
-msgid "Max. Bandwidth (Bit/s)"
+msgid "Maximum bandwidth (Kbps)"
 msgstr ""
 
-# Assured buffer length duration (seconds)
-msgctxt "#30200"
-msgid "Assured Buffer Duration (sec)"
-msgstr ""
-
-# Max buffer length duration (seconds)
-msgctxt "#30201"
-msgid "Max Buffer Duration (sec)"
-msgstr ""
-
-# Ignore Window Display Resolution Change
-msgctxt "#30202"
-msgid "Ignore Window Change"
-msgstr ""
-
-# Absolute path to the folder containing the decrypters
+#. Description of setting with label #30101, 30102
 msgctxt "#30103"
-msgid "Decrypter path"
+msgid "Establishes the bandwidth limit not to be exceeded with the audio / video streams. Set to 0 to disable it."
 msgstr ""
 
-# Maximum Resolution
+#empty strings from id 30104 to 30109
+
+#. Maximum video resolution non-protected videos
 msgctxt "#30110"
-msgid "Max. Resolution general decoder"
+msgid "Maximum resolution"
 msgstr ""
 
-msgctxt "#30111"
-msgid "Stream Selection"
-msgstr ""
+#empty string with id 30111
 
+#. Type of media streams that will be handled for the playback
 msgctxt "#30112"
-msgid "Media"
+msgid "Type of media streams played"
 msgstr ""
 
-# Maximum allowed resolution if decoded through secure path
+#. Maximum video resolution for DRM-protected videos
 msgctxt "#30113"
-msgid "Max. Resolution secure decoder"
+msgid "Maximum resolution for DRM videos"
 msgstr ""
 
-# Select streams without respecting HDCP status
-msgctxt "#30114"
-msgid "Override HDCP status"
-msgstr ""
+#empty string with id 30114
 
 # Do not respect display resolution when selecting streams
 msgctxt "#30115"
-msgid "Ignore Display Resolution"
+msgid "Ignore screen resolution"
 msgstr ""
 
+#. Description of setting with label #30115
+msgctxt "#30116"
+msgid "If enabled, the screen resolution (or window size when in windowed mode) will no longer be considered when selecting the best video stream resolution when video starts and while in playback."
+msgstr ""
+
+msgctxt "#30117"
+msgid "Manual stream selection mode"
+msgstr ""
+
+#. Description of setting with label #30117
+msgctxt "#30118"
+msgid "Defines which type of streams to make available for manual selection on Kodi OSD settings during playback."
+msgstr ""
+
+#empty string with id 30119
+
+#. Category title
 msgctxt "#30120"
 msgid "Expert"
 msgstr ""
 
-msgctxt "#30121"
-msgid "Enable Pre-Release Features"
-msgstr ""
+#empty string with id 30121
 
 msgctxt "#30122"
-msgid "Don't use secure decoder if possible"
+msgid "Try avoiding the use of secure decoder"
 msgstr ""
 
-msgctxt "#30150"
-msgid "Max"
+#. Description of setting with label #30122
+msgctxt "#30123"
+msgid "Some Android devices defined as Widevine L1, may not work properly, which may result in a black screen during playback. In this case try to enable it."
 msgstr ""
 
-msgctxt "#30151"
-msgid "480p"
-msgstr ""
+#empty strings from id 30124 to 30155
 
-msgctxt "#30152"
-msgid "640p"
-msgstr ""
-
-msgctxt "#30153"
-msgid "720p"
-msgstr ""
-
-msgctxt "#30154"
-msgid "1080p"
-msgstr ""
-
-msgctxt "#30155"
-msgid "Automatically select streams"
-msgstr ""
-
+#. Item list value of setting with label #30117
 msgctxt "#30156"
-msgid "Manually select all streams"
+msgid "Audio / Video streams"
 msgstr ""
 
+#. Item list value of setting with label #30112
 msgctxt "#30157"
 msgid "All"
 msgstr ""
 
+#. Item list value of setting with label #30112
 msgctxt "#30158"
 msgid "Audio"
 msgstr ""
 
+#. Item list value of setting with label #30112
 msgctxt "#30159"
 msgid "Video"
 msgstr ""
 
-# Show all video streams
+#. Item list value of setting with label #30117
 msgctxt "#30160"
-msgid "Manually select video stream"
+msgid "Video streams"
 msgstr ""
 
+#. Item list value of setting with label #30112
 msgctxt "#30161"
-msgid "Video + Subtitles"
+msgid "Video / Subtitles"
 msgstr ""
+
+#. Category group title
+msgctxt "#30162"
+msgid "Adaptive stream"
+msgstr ""
+
+#empty strings from id 30163 to 30165
+
+#. Category group title
+msgctxt "#30166"
+msgid "DRM Widevine"
+msgstr ""
+
+msgctxt "#30167"
+msgid "WARNING: This is a TEST feature, may not work appropriately and may change on future versions."
+msgstr ""
+
+msgctxt "#30168"
+msgid "Auto determines initial bandwidth"
+msgstr ""
+
+#. Description of setting with label #30168
+msgctxt "#30169"
+msgid "If enabled, the bandwidth will be determined by the first download, however it may not be accurate. If the video quality at the start of playback is too low try disabling it."
+msgstr ""
+
+msgctxt "#30170"
+msgid "Initial bandwidth (Kbps)"
+msgstr ""
+
+#. Description of setting with label #30170
+msgctxt "#30171"
+msgid "Defines the initial bandwidth when it cannot be automatically determined. This value can be overridden by the minimum bandwidth setting."
+msgstr ""
+
+msgctxt "#30172"
+msgid "Ignore HDCP status"
+msgstr ""
+
+#. Description of setting with label #30172
+msgctxt "#30173"
+msgid "Some DRM-protected HD / UHD videos may only be played if the HDCP status is ignored."
+msgstr ""
+
+#. To set the stream selection type (refer to RepresentationChooser's)
+msgctxt "#30174"
+msgid "Stream selection type"
+msgstr ""
+
+#. Description of setting with label #30174
+msgctxt "#30175"
+msgid "Set how the audio / video streams quality will be chosen during playback. This setting may be overridden by the video add-on used. See Wiki for more information."
+msgstr ""
+
+#. Item list value of setting with label #30174
+msgctxt "#30176"
+msgid "Adaptive (default)"
+msgstr ""
+
+#. Item list value of setting with label #30174
+msgctxt "#30177"
+msgid "Manual OSD"
+msgstr ""
+
+#empty strings reserved for "stream selection types" from id 30177 to 30190
+
+#. Assured buffer length duration (seconds)
+msgctxt "#30200"
+msgid "Assured buffer duration (sec)"
+msgstr ""
+
+#. Max buffer length duration (seconds)
+msgctxt "#30201"
+msgid "Maximum buffer duration (sec)"
+msgstr ""
+
+#. Ignore screen resolution change e.g. window resize
+msgctxt "#30202"
+msgid "Ignore screen resolution change"
+msgstr ""
+
+#. Description of setting with label #30202
+msgctxt "#30203"
+msgid "If enabled, the screen resolution (or window size when in windowed mode) will no longer be considered when selecting the best video stream resolution while in playback."
+msgstr ""
+
+#. Absolute path to the folder containing the DRM binary files
+msgctxt "#30204"
+msgid "Decrypter path"
+msgstr ""
+
+#empty strings from id 30205 to 30209
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30210"
+msgid "Auto"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30211"
+msgid "480p"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30212"
+msgid "640p"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30213"
+msgid "720p"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30214"
+msgid "1080p"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30215"
+msgid "2K"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30216"
+msgid "1440p"
+msgstr ""
+
+#. Item list value of setting with label #30110, #30113
+msgctxt "#30217"
+msgid "4K"
+msgstr ""
+
+#empty strings reserved for resolution values of id #30110, #30113, from id 30217 to 30230

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -2,112 +2,174 @@
 <settings version="1">
   <section id="default">
     <category id="default" label="30100">
-      <group id="0">
-        <setting id="MINBANDWIDTH" type="integer" label="30101">
+      <group id="adaptivestream" label="30162">
+        <setting id="adaptivestream.type" type="string" label="30174" help="30175">
           <level>0</level>
-          <default>0</default>
-          <control type="edit" format="integer" />
+          <default>default</default>
+          <constraints>
+            <options>
+              <option label="30176">default</option>
+              <option label="30177">manual-osd</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
         </setting>
-        <setting id="MAXBANDWIDTH" type="integer" label="30102">
+        <setting parent="adaptivestream.type" id="adaptivestream.res.max" type="string" label="30110">
           <level>0</level>
-          <default>0</default>
-          <control type="edit" format="integer" />
+          <default>auto</default>
+          <constraints>
+            <options>
+              <option label="30210">auto</option>
+              <option label="30211">480p</option>
+              <option label="30212">640p</option>
+              <option label="30213">720p</option>
+              <option label="30214">1080p</option>
+              <option label="30215">2K</option>
+              <option label="30216">1440p</option>
+              <option label="30217">4K</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <or>
+                <condition setting="adaptivestream.type">default</condition>
+                <condition setting="adaptivestream.type">manual-osd</condition>
+              </or>
+			</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
-        <setting id="ASSUREDBUFFERDURATION" type="integer" label="30200">
-          <level>1</level>
-          <default>60</default>
-          <control type="edit" format="integer" />
-        </setting> 
-        <setting id="MAXBUFFERDURATION" type="integer" label="30201">
-          <level>1</level>
-          <default>120</default>
-          <control type="edit" format="integer" />
+        <setting parent="adaptivestream.type" id="adaptivestream.res.max.secure" type="string" label="30113">
+          <level>0</level>
+          <default>auto</default>
+          <constraints>
+            <options>
+              <option label="30210">auto</option>
+              <option label="30211">480p</option>
+              <option label="30212">640p</option>
+              <option label="30213">720p</option>
+              <option label="30214">1080p</option>
+              <option label="30215">2K</option>
+              <option label="30216">1440p</option>
+              <option label="30217">4K</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <or>
+                <condition setting="adaptivestream.type">default</condition>
+                <condition setting="adaptivestream.type">manual-osd</condition>
+              </or>
+			</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
-        <setting id="IGNOREWINDOWCHANGE" type="boolean" label="30202">
-          <level>1</level>
+        <setting parent="adaptivestream.type" id="adaptivestream.ignore.screen.res.change" type="boolean" label="30202" help="30203">
+          <level>0</level>
+          <default>false</default>
+          <visible>false</visible><!-- Not fully implemented yet -->
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting parent="adaptivestream.type" id="adaptivestream.ignore.screen.res" type="boolean" label="30115" help="30116">
+          <level>0</level>
+          <default>false</default>
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting parent="adaptivestream.type" id="adaptivestream.bandwidth.init.auto" type="boolean" label="30168" help="30169">
+          <level>0</level>
           <default>true</default>
-          <control type="toggle" />
-        </setting> 
-        <setting id="MAXRESOLUTION" type="integer" label="30110">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="30150">0</option> <!-- Max -->
-              <option label="30151">1</option>  <!-- 480p -->
-              <option label="30152">2</option>  <!-- 640p -->
-              <option label="30153">3</option>  <!-- 720p -->
-              <option label="30154">4</option> <!-- 1080p -->
-            </options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="MAXRESOLUTIONSECURE" type="integer" label="30113">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="30150">0</option> <!-- Max -->
-              <option label="30151">1</option>  <!-- 480p -->
-              <option label="30152">2</option>  <!-- 640p -->
-              <option label="30153">3</option>  <!-- 720p -->
-              <option label="30154">4</option> <!-- 1080p -->
-            </options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="STREAMSELECTION" type="integer" label="30111">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="30155">0</option> <!-- Auto -->
-              <option label="30156">1</option>  <!-- Manual -->
-              <option label="30160">2</option>  <!-- Manual video -->
-            </options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="MEDIATYPE" type="integer" label="30112">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="30157">0</option> <!-- All -->
-              <option label="30158">1</option>  <!-- Audio -->
-              <option label="30159">2</option>  <!-- Video -->
-              <option label="30161">3</option>  <!-- Video + Subs -->
-            </options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="HDCPOVERRIDE" type="boolean" label="30114">
-          <level>0</level>
-          <default>false</default>
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="IGNOREDISPLAY" type="boolean" label="30115">
+        <setting parent="adaptivestream.type" id="adaptivestream.bandwidth.init" type="integer" label="30170" help="30171">
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default>4000</default>
+          <constraints>
+            <minimum>500</minimum>
+            <step>1</step>
+            <maximum>1000000</maximum>
+          </constraints>
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="edit" format="integer"><heading>30170</heading></control>
+        </setting>
+        <setting parent="adaptivestream.type" id="adaptivestream.bandwidth.min" type="integer" label="30101" help="30103">
+          <level>0</level>
+          <default>0</default>
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="edit" format="integer"><heading>30101</heading></control>
+        </setting>
+        <setting parent="adaptivestream.type" id="adaptivestream.bandwidth.max" type="integer" label="30102" help="30103">
+          <level>0</level>
+          <default>0</default>
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="edit" format="integer"><heading>30102</heading></control>
+        </setting>
+        <setting parent="adaptivestream.type" id="adaptivestream.streamselection.mode" type="string" label="30117" help="30118">
+          <level>0</level>
+          <default>manual-v</default>
+          <constraints>
+            <options>
+              <option label="30160">manual-v</option>
+              <option label="30156">manual-av</option>
+            </options>
+          </constraints>
+          <dependencies>
+             <dependency type="visible" setting="adaptivestream.type">manual-osd</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
-      <group id="1">
-        <setting id="DECRYPTERPATH" type="string" label="30103">
-          <level>0</level>
-          <default>@DECRYPTERPATH@</default>
-          <control type="edit" format="string" />
-        </setting>
-        <setting id="WIDEVINE_API" type="integer">
-          <level>4</level>
-          <default>10</default>
+      <group id="misc">
+        <setting id="HDCPOVERRIDE" type="boolean" label="30172" help="30173">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
     <category id="expert" label="30120">
-      <group id="0">
-        <setting id="NOSECUREDECODER" type="boolean" label="30122">
-          <level>0</level>
+      <group id="misc">
+        <setting id="ASSUREDBUFFERDURATION" type="integer" label="30200" help="30167">
+          <level>1</level>
+          <default>60</default>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="MAXBUFFERDURATION" type="integer" label="30201" help="30167">
+          <level>1</level>
+          <default>120</default>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="MEDIATYPE" type="integer" label="30112">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30157">0</option><!-- All -->
+              <option label="30158">1</option><!-- Audio -->
+              <option label="30159">2</option><!-- Video -->
+              <option label="30161">3</option><!-- Video + Subs -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+      </group>
+      <group id="widevine" label="30166">
+        <setting id="NOSECUREDECODER" type="boolean" label="30122" help="30123">
+          <level>2</level>
           <default>false</default>
           <control type="toggle" />
           <dependencies>
@@ -115,6 +177,16 @@
               <condition on="property" name="InfoBool">system.platform.android</condition>
             </dependency>
           </dependencies>
+        </setting>
+        <setting id="DECRYPTERPATH" type="string" label="30204">
+          <level>2</level>
+          <default>@DECRYPTERPATH@</default>
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="InfoBool" operator="!is">system.platform.android</condition>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
         </setting>
       </group>
     </category>

--- a/src/AdaptiveByteStream.h
+++ b/src/AdaptiveByteStream.h
@@ -11,7 +11,12 @@
 #include "common/AdaptiveStream.h"
 
 #include <bento4/Ap4.h>
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
+#endif
 
 class ATTR_DLL_LOCAL CAdaptiveByteStream : public AP4_ByteStream
 {

--- a/src/aes_decrypter.h
+++ b/src/aes_decrypter.h
@@ -14,7 +14,11 @@
 
 #include <string>
 
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
+#endif
 
 class ATTR_DLL_LOCAL AESDecrypter : public IAESDecrypter
 {

--- a/src/codechandler/CodecHandler.h
+++ b/src/codechandler/CodecHandler.h
@@ -9,8 +9,13 @@
 #pragma once
 
 #include <bento4/Ap4.h>
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "../test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
 #include <kodi/addon-instance/Inputstream.h>
+#endif
 
 class ATTR_DLL_LOCAL CodecHandler
 {

--- a/src/codechandler/ttml/TTML.h
+++ b/src/codechandler/ttml/TTML.h
@@ -13,7 +13,11 @@
 #include <string>
 #include <vector>
 
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "../test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
+#endif
 
 class ATTR_DLL_LOCAL TTML2SRT
 {

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -16,8 +16,6 @@
 #include <string>
 #include <thread>
 
-#include <kodi/AddonBase.h>
-
 namespace adaptive
 {
   class AdaptiveStream;

--- a/src/common/RepresentationChooser.cpp
+++ b/src/common/RepresentationChooser.cpp
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RepresentationChooser.h"
+
+#include "../utils/log.h"
+#include "RepresentationChooserDefault.h"
+#include "RepresentationChooserManualOSD.h"
+
+#include <vector>
+
+using namespace CHOOSER;
+
+namespace
+{
+IRepresentationChooser* GetReprChooser(std::string_view type)
+{
+  if (type == "manual-osd")
+    return new CRepresentationChooserManualOSD();
+  else if (type == "default")
+    return new CRepresentationChooserDefault();
+  else
+    return nullptr;
+}
+} // unnamed namespace
+
+IRepresentationChooser* CHOOSER::CreateRepresentationChooser(
+    const UTILS::PROPERTIES::KodiProperties& kodiProps)
+{
+  IRepresentationChooser* reprChooser{nullptr};
+
+  // An add-on can override user settings
+  if (!kodiProps.m_streamSelectionType.empty())
+  {
+    reprChooser = GetReprChooser(kodiProps.m_streamSelectionType);
+    if (!reprChooser)
+      LOG::Log(LOGERROR, "Stream selection type \"%s\" not exist. Fallback to user settings");
+  }
+
+  if (!reprChooser)
+    reprChooser = GetReprChooser(kodi::addon::GetSettingString("adaptivestream.type"));
+
+  // Safe check for wrong settings, fallback to default
+  if (!reprChooser)
+    reprChooser = new CRepresentationChooserDefault();
+
+  reprChooser->Initialize(kodiProps);
+
+  return reprChooser;
+}
+
+void IRepresentationChooser::SetScreenResolution(const int width, const int height)
+{
+  m_screenCurrentWidth = width;
+  m_screenCurrentHeight = height;
+}

--- a/src/common/RepresentationChooserDefault.h
+++ b/src/common/RepresentationChooserDefault.h
@@ -11,72 +11,65 @@
 #include "RepresentationChooser.h"
 
 #include <chrono>
+#include <deque>
+#include <optional>
 
-namespace adaptive
+namespace CHOOSER
 {
 
 class ATTR_DLL_LOCAL CRepresentationChooserDefault : public IRepresentationChooser
 {
 public:
-  CRepresentationChooserDefault(std::string kodiProfilePath);
-  ~CRepresentationChooserDefault() override;
+  CRepresentationChooserDefault();
+  ~CRepresentationChooserDefault() override {}
 
   virtual void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) override;
   virtual void PostInit() override;
 
-  void SetScreenResolution(int width, int height) override;
+  void SetDownloadSpeed(const double speed) override;
 
-  void SetDownloadSpeed(double speed) override;
-  double GetDownloadSpeed() override { return m_downloadCurrentSpeed; }
-
-  void SetSecureSession(bool isSecureSession) override { m_isSecureSession = isSecureSession; }
   void AddDecrypterCaps(const SSD::SSD_DECRYPTER::SSD_CAPS& ssdCaps) override;
 
-  AdaptiveTree::Representation* ChooseRepresentation(AdaptiveTree::AdaptationSet* adp) override;
+  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp) override;
 
-  AdaptiveTree::Representation* ChooseNextRepresentation(AdaptiveTree::AdaptationSet* adp,
-                                                         AdaptiveTree::Representation* rep,
-                                                         size_t& validSegmentBuffers,
-                                                         size_t& availableSegmentBuffers,
-                                                         uint32_t& bufferLengthAssured,
-                                                         uint32_t& bufferLengthMax,
-                                                         uint32_t repCounter) override;
+  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp,
+      adaptive::AdaptiveTree::Representation* currentRep) override;
 
 protected:
-  int m_screenCurrentWidth{0};
-  int m_screenCurrentHeight{0};
-  int m_screenSelWidth{0};
-  int m_screenSelHeight{0};
-  int m_screenNextWidth{0};
-  int m_screenNextHeight{0};
+  /*!
+   * \brief Refresh screen resolution values from the current
+   */
+  void RefreshResolution();
 
-  bool m_isScreenResNeedUpdate{true};
-  std::chrono::steady_clock::time_point m_screenResLastUpdate{std::chrono::steady_clock::now()};
+  int m_screenWidth{0};
+  int m_screenHeight{0};
+  std::optional<std::chrono::steady_clock::time_point> m_screenResLastUpdate;
 
-  bool m_isSecureSession{false};
   bool m_isHdcpOverride{false};
 
-  int m_screenWidthMax{0}; // Max resolution for non-protected video content
-  int m_screenWidthMaxSecure{0}; // Max resolution for protected video content
+  std::string m_screenWidthMax; // Max resolution for non-protected video content
+  std::string m_screenWidthMaxSecure; // Max resolution for protected video content
 
   // Ignore screen resolution, from playback starts and when it changes while playing
   bool m_ignoreScreenRes{false};
   // Ignore resolution change, while it is playing only
   bool m_ignoreScreenResChange{false};
 
-  uint32_t m_bandwidthStored{0};
+  // The bandwidth (bit/s) calculated by the average download speed
   uint32_t m_bandwidthCurrent{0};
   uint32_t m_bandwidthMin{0};
   uint32_t m_bandwidthMax{0};
 
-  uint32_t m_bufferDurationAssured{0};
-  uint32_t m_bufferDurationMax{0};
+  // If true the initial bandwidth will be determined from the manifest download
+  bool m_bandwidthInitAuto{false};
+  // Default initial bandwidth
+  uint32_t m_bandwidthInit{0};
 
-  double m_downloadCurrentSpeed{0};
-  double m_downloadAverageSpeed{0};
+  std::deque<double> m_downloadSpeedChron;
 
   std::vector<SSD::SSD_DECRYPTER::SSD_CAPS> m_decrypterCaps;
-  std::string m_bandwidthFilePath;
 };
 
-} // namespace adaptive
+} // namespace CHOOSER

--- a/src/common/RepresentationChooserManualOSD.cpp
+++ b/src/common/RepresentationChooserManualOSD.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RepresentationChooserManualOSD.h"
+
+#include "../utils/log.h"
+#include "RepresentationSelector.h"
+
+using namespace CHOOSER;
+using namespace adaptive;
+using namespace UTILS;
+
+CRepresentationChooserManualOSD::CRepresentationChooserManualOSD()
+{
+  LOG::Log(LOGDEBUG, "[Repr. chooser] Type: Manual OSD");
+}
+
+void CRepresentationChooserManualOSD::Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps)
+{
+  std::string manualSelMode{kodi::addon::GetSettingString("adaptivestream.streamselection.mode")};
+
+  if (manualSelMode == "manual-v")
+    m_streamSelectionMode = SETTINGS::StreamSelection::MANUAL_VIDEO_ONLY;
+  else
+    m_streamSelectionMode = SETTINGS::StreamSelection::MANUAL;
+
+  m_screenWidthMax = kodi::addon::GetSettingString("adaptivestream.res.max");
+  m_screenWidthMaxSecure = kodi::addon::GetSettingString("adaptivestream.res.max.secure");
+
+  LOG::Log(LOGDEBUG,
+           "[Repr. chooser] Configuration\n"
+           "Stream manual selection mode: %s\n"
+           "Resolution max: %s\n"
+           "Resolution max for secure decoder: %s",
+           manualSelMode.c_str(), m_screenWidthMax.c_str(), m_screenWidthMaxSecure.c_str());
+}
+
+void CRepresentationChooserManualOSD::RefreshResolution()
+{
+  m_screenWidth = m_screenCurrentWidth;
+  m_screenHeight = m_screenCurrentHeight;
+
+  // If set, limit resolution to user choice
+  std::string_view userMaxRes{m_isSecureSession ? m_screenWidthMaxSecure : m_screenWidthMax};
+
+  auto mapIt{RESOLUTION_LIMITS.find(userMaxRes)};
+
+  if (mapIt != RESOLUTION_LIMITS.end())
+  {
+    const std::pair<int, int>& resLimit{mapIt->second};
+
+    if (m_screenWidth > resLimit.first)
+      m_screenWidth = resLimit.first;
+
+    if (m_screenHeight > resLimit.second)
+      m_screenHeight = resLimit.second;
+  }
+}
+
+void CRepresentationChooserManualOSD::PostInit()
+{
+  RefreshResolution();
+
+  LOG::Log(LOGDEBUG,
+           "[Repr. chooser] Stream selection conditions\n"
+           "Resolution: %ix%i",
+           m_screenWidth, m_screenHeight);
+}
+
+AdaptiveTree::Representation* CRepresentationChooserManualOSD::ChooseRepresentation(
+    AdaptiveTree::AdaptationSet* adp)
+{
+  CRepresentationSelector selector(m_screenWidth, m_screenHeight);
+
+  return selector.Highest(adp);
+}
+
+AdaptiveTree::Representation* CRepresentationChooserManualOSD::ChooseNextRepresentation(
+    AdaptiveTree::AdaptationSet* adp, AdaptiveTree::Representation* currentRep)
+{
+  return currentRep;
+}

--- a/src/common/RepresentationChooserManualOSD.h
+++ b/src/common/RepresentationChooserManualOSD.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2021 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RepresentationChooser.h"
+
+namespace CHOOSER
+{
+
+class ATTR_DLL_LOCAL CRepresentationChooserManualOSD : public IRepresentationChooser
+{
+public:
+  CRepresentationChooserManualOSD();
+  ~CRepresentationChooserManualOSD() override {}
+
+  virtual void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) override;
+
+  virtual void PostInit() override;
+
+  virtual UTILS::SETTINGS::StreamSelection GetStreamSelectionMode() override
+  {
+    return m_streamSelectionMode;
+  }
+
+  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp) override;
+
+  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp,
+      adaptive::AdaptiveTree::Representation* currentRep) override;
+
+protected:
+  void RefreshResolution();
+
+  UTILS::SETTINGS::StreamSelection m_streamSelectionMode{UTILS::SETTINGS::StreamSelection::AUTO};
+
+  int m_screenWidth{0};
+  int m_screenHeight{0};
+
+  std::string m_screenWidthMax; // Max resolution for non-protected video content
+  std::string m_screenWidthMaxSecure; // Max resolution for protected video content
+};
+
+} // namespace CHOOSER

--- a/src/common/RepresentationSelector.cpp
+++ b/src/common/RepresentationSelector.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RepresentationSelector.h"
+
+#include <vector>
+
+using namespace CHOOSER;
+using namespace adaptive;
+
+CRepresentationSelector::CRepresentationSelector(const int& resWidth, const int& resHeight)
+{
+  m_screenWidth = resWidth;
+  m_screenHeight = resHeight;
+}
+
+AdaptiveTree::Representation* CRepresentationSelector::Lowest(
+    AdaptiveTree::AdaptationSet* adaptSet) const
+{
+  const std::vector<AdaptiveTree::Representation*>& reps = adaptSet->representations_;
+  return reps.empty() ? nullptr : *reps.begin();
+}
+
+AdaptiveTree::Representation* CRepresentationSelector::Highest(AdaptiveTree::AdaptationSet* adaptSet) const
+{
+  AdaptiveTree::Representation* highestRep{nullptr};
+
+  for (auto rep : adaptSet->representations_)
+  {
+    if (!rep)
+      continue;
+
+    if (rep->width_ <= m_screenWidth && rep->height_ <= m_screenHeight)
+    {
+      if (!highestRep || highestRep->width_ < rep->width_ && highestRep->height_ < rep->height_)
+      {
+        highestRep = rep;
+      }
+    }
+  }
+
+  if (!highestRep)
+    return Lowest(adaptSet);
+
+  return highestRep;
+}

--- a/src/common/RepresentationSelector.h
+++ b/src/common/RepresentationSelector.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AdaptiveTree.h"
+
+namespace CHOOSER
+{
+
+class ATTR_DLL_LOCAL CRepresentationSelector
+{
+public:
+  CRepresentationSelector(const int& resWidth, const int& resHeight);
+  ~CRepresentationSelector() {}
+
+  /*!
+   * \brief Select the lowest representation (as index order)
+   * \param adaptSet The adaption set
+   * \return The lowest representation, otherwise nullptr if no available
+   */
+  adaptive::AdaptiveTree::Representation* Lowest(
+      adaptive::AdaptiveTree::AdaptationSet* adaptSet) const;
+
+  /*!
+   * \brief Select the highest representation quality closer to the screen resolution
+   * \param adaptSet The adaption set
+   * \return The highest representation, otherwise nullptr if no available
+   */
+  adaptive::AdaptiveTree::Representation* Highest(
+      adaptive::AdaptiveTree::AdaptationSet* adaptSet) const;
+
+private:
+  int m_screenWidth{0};
+  int m_screenHeight{0};
+};
+
+} // namespace adaptive

--- a/src/main.h
+++ b/src/main.h
@@ -14,7 +14,6 @@
 #include "common/AdaptiveTree.h"
 #include "common/RepresentationChooser.h"
 #include "samplereader/SampleReader.h"
-#include "utils/SettingsUtils.h"
 #include "utils/PropertiesUtils.h"
 
 #include <float.h>
@@ -90,7 +89,7 @@ public:
            adaptive::AdaptiveTree::AdaptationSet* adp,
            adaptive::AdaptiveTree::Representation* initialRepr,
            const std::map<std::string, std::string>& media_headers,
-           adaptive::IRepresentationChooser* reprChooser,
+           CHOOSER::IRepresentationChooser* reprChooser,
            bool play_timeshift_buffer,
            bool choose_rep)
       : enabled(false),
@@ -239,14 +238,13 @@ private:
   std::vector<CDMSESSION> cdm_sessions_;
 
   adaptive::AdaptiveTree* adaptiveTree_{nullptr};
-  adaptive::IRepresentationChooser* m_reprChooser{nullptr};
+  CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
 
   std::vector<std::unique_ptr<STREAM>> m_streams;
   STREAM* timing_stream_{nullptr};
 
   uint32_t fixed_bandwidth_{0};
   bool changed_{false};
-  UTILS::SETTINGS::StreamSelection m_settingStreamSelection{UTILS::SETTINGS::StreamSelection::AUTO};
   uint64_t elapsed_time_{0};
   uint64_t chapter_start_time_{0}; // In STREAM_TIME_BASE
   double chapter_seek_time_{0.0}; // In seconds

--- a/src/md5.h
+++ b/src/md5.h
@@ -14,8 +14,11 @@
 #include <cstring>
 #include <iostream>
 
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
-
+#endif
 
 // a small class for calculating MD5 hashes of strings or byte arrays
 // it is not meant to be fast or secure

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -10,19 +10,19 @@
 
 #include "../common/AdaptiveTree.h"
 
-#include <kodi/AddonBase.h>
-
 namespace adaptive
 {
 
 class ATTR_DLL_LOCAL DASHTree : public AdaptiveTree
 {
 public:
-  DASHTree(const UTILS::PROPERTIES::KodiProperties& kodiProps, IRepresentationChooser* reprChooser)
+  DASHTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
+           CHOOSER::IRepresentationChooser* reprChooser)
     : AdaptiveTree(kodiProps, reprChooser){};
+  DASHTree(const DASHTree& left);
+
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
-  virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;
   virtual void RefreshSegments(Period* period,
                                AdaptationSet* adp,
                                Representation* rep,
@@ -35,12 +35,16 @@ public:
   };
   virtual void SetLastUpdated(std::chrono::system_clock::time_point tm){};
   void SetUpdateInterval(uint32_t interval) { updateInterval_ = interval; };
+
   uint64_t pts_helper_, timeline_time_;
   uint64_t firstStartNumber_;
   std::string current_playready_wrmheader_;
   std::string mpd_url_;
 
 protected:
+  virtual bool ParseManifest(const std::string& data);
   virtual void RefreshLiveSegments() override;
-  };
-}
+
+  virtual DASHTree* Clone() const override { return new DASHTree{*this}; }
+};
+} // namespace adaptive

--- a/src/parser/PRProtectionParser.h
+++ b/src/parser/PRProtectionParser.h
@@ -10,7 +10,11 @@
 
 #include <string>
 
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "../test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
+#endif
 
 namespace adaptive
 {

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -11,6 +11,7 @@
 #include "../oscompat.h"
 #include "../utils/UrlUtils.h"
 #include "../utils/Utils.h"
+#include "../utils/log.h"
 #include "PRProtectionParser.h"
 
 #include <algorithm>
@@ -23,11 +24,16 @@ using namespace adaptive;
 using namespace UTILS;
 
 SmoothTree::SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-                       IRepresentationChooser* reprChooser)
+                       CHOOSER::IRepresentationChooser* reprChooser)
   : AdaptiveTree(kodiProps, reprChooser)
 {
   current_period_ = new AdaptiveTree::Period;
   periods_.push_back(current_period_);
+}
+
+adaptive::SmoothTree::SmoothTree(const SmoothTree& left)
+  : AdaptiveTree(left.m_kodiProps, left.m_reprChooser)
+{
 }
 
 /*----------------------------------------------------------------------
@@ -161,6 +167,9 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
 
         dash->current_representation_->segtpl_.media.replace(pos, 9, bw);
         dash->current_representation_->bandwidth_ = atoi(bw);
+        dash->current_representation_->assured_buffer_duration_ =
+            dash->m_settings.m_bufferAssuredDuration;
+        dash->current_representation_->max_buffer_duration_ = dash->m_settings.m_bufferMaxDuration;
         dash->current_adaptationset_->representations_.push_back(dash->current_representation_);
       }
       else if (strcmp(el, "c") == 0)
@@ -346,23 +355,23 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
 
 bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders)
 {
-  parser_ = XML_ParserCreate(NULL);
-  if (!parser_)
-    return false;
-  XML_SetUserData(parser_, (void*)this);
-  XML_SetElementHandler(parser_, start, end);
-  XML_SetCharacterDataHandler(parser_, text);
   currentNode_ = 0;
-  strXMLText_.clear();
 
   PrepareManifestUrl(url, manifestUpdateParam);
   additionalHeaders.insert(m_streamHeaders.begin(), m_streamHeaders.end());
-  bool ret = download(manifest_url_, additionalHeaders);
 
-  XML_ParserFree(parser_);
-  parser_ = 0;
+  std::stringstream data;
+  HTTPRespHeaders respHeaders;
+  if (!download(manifest_url_, additionalHeaders, data, respHeaders))
+    return false;
 
-  if (!ret)
+  effective_url_ = respHeaders.m_effectiveUrl;
+  m_manifestHeaders = respHeaders;
+
+  if (!PreparePaths(effective_url_))
+    return false;
+
+  if (!ParseManifest(data.str()))
     return false;
 
   uint8_t psshset(0);
@@ -400,12 +409,29 @@ bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateP
   return true;
 }
 
-bool SmoothTree::write_data(void* buffer, size_t buffer_size, void* opaque)
+bool SmoothTree::ParseManifest(const std::string& data)
 {
-  bool done(false);
-  XML_Status retval = XML_Parse(parser_, (const char*)buffer, buffer_size, done);
+  strXMLText_.clear();
 
-  if (retval == XML_STATUS_ERROR)
+  parser_ = XML_ParserCreate(nullptr);
+  if (!parser_)
     return false;
+
+  XML_SetUserData(parser_, (void*)this);
+  XML_SetElementHandler(parser_, start, end);
+  XML_SetCharacterDataHandler(parser_, text);
+
+  int isDone{0};
+  XML_Status status{XML_Parse(parser_, data.c_str(), static_cast<int>(data.size()), isDone)};
+
+  XML_ParserFree(parser_);
+  parser_ = nullptr;
+
+  if (status == XML_STATUS_ERROR)
+  {
+    LOG::LogF(LOGERROR, "Failed to parse the manifest file");
+    return false;
+  }
+
   return true;
 }

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -10,8 +10,6 @@
 
 #include "../common/AdaptiveTree.h"
 
-#include <kodi/AddonBase.h>
-
 namespace adaptive
 {
 
@@ -19,10 +17,15 @@ class ATTR_DLL_LOCAL SmoothTree : public AdaptiveTree
 {
 public:
   SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-             IRepresentationChooser* reprChooser);
+             CHOOSER::IRepresentationChooser* reprChooser);
+  SmoothTree(const SmoothTree& left);
+
   virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
-  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
-  virtual bool write_data(void* buffer, size_t buffer_size, void* opaque) override;
+  virtual bool open(const std::string& url,
+                    const std::string& manifestUpdateParam,
+                    std::map<std::string, std::string> additionalHeaders) override;
+
+  virtual SmoothTree* Clone() const override { return new SmoothTree{*this}; }
 
   enum
   {
@@ -34,6 +37,9 @@ public:
   };
 
   uint64_t pts_helper_;
-  };
 
-}
+protected:
+  virtual bool ParseManifest(const std::string& data);
+};
+
+} // namespace adaptive

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -11,8 +11,13 @@
 #include "../AdaptiveByteStream.h"
 
 #include <bento4/Ap4.h>
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "../test/KodiStubs.h"
+#else
 #include <kodi/AddonBase.h>
 #include <kodi/addon-instance/Inputstream.h>
+#endif
 
 class ATTR_DLL_LOCAL ISampleReader
 {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -14,7 +14,10 @@ add_executable(${BINARY}
     ../parser/PRProtectionParser.cpp
     ../common/AdaptiveStream.cpp
     ../common/AdaptiveTree.cpp
+    ../common/RepresentationChooser.cpp
     ../common/RepresentationChooserDefault.cpp
+    ../common/RepresentationChooserManualOSD.cpp
+    ../common/RepresentationSelector.cpp
     ../oscompat.cpp
     ../utils/Base64Utils.cpp
     ../utils/PropertiesUtils.cpp

--- a/src/test/KodiStubs.h
+++ b/src/test/KodiStubs.h
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+ // Kodi interface stubs
+
+#include <string>
+#include <vector>
+
+#ifdef _WIN32 // windows
+#if !defined(_SSIZE_T_DEFINED) && !defined(HAVE_SSIZE_T)
+typedef intptr_t ssize_t;
+#define _SSIZE_T_DEFINED
+#endif // !_SSIZE_T_DEFINED
+#ifndef SSIZE_MAX
+#define SSIZE_MAX INTPTR_MAX
+#endif // !SSIZE_MAX
+#else // Linux, Mac, FreeBSD
+#include <sys/types.h>
+#endif // TARGET_POSIX
+
+#define ATTR_DLL_LOCAL
+
+typedef enum CURLOptiontype
+{
+  ADDON_CURL_OPTION_OPTION,
+  ADDON_CURL_OPTION_PROTOCOL,
+  ADDON_CURL_OPTION_CREDENTIALS,
+  ADDON_CURL_OPTION_HEADER
+} CURLOptiontype;
+
+class CacheStatus;
+
+typedef enum FilePropertyTypes
+{
+  ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL,
+  ADDON_FILE_PROPERTY_RESPONSE_HEADER,
+  ADDON_FILE_PROPERTY_CONTENT_TYPE,
+  ADDON_FILE_PROPERTY_CONTENT_CHARSET,
+  ADDON_FILE_PROPERTY_MIME_TYPE,
+  ADDON_FILE_PROPERTY_EFFECTIVE_URL
+} FilePropertyTypes;
+
+typedef enum OpenFileFlags
+{
+  ADDON_READ_TRUNCATED = 0x01,
+  ADDON_READ_CHUNKED = 0x02,
+  ADDON_READ_CACHED = 0x04,
+  ADDON_READ_NO_CACHE = 0x08,
+  ADDON_READ_BITRATE = 0x10,
+  ADDON_READ_MULTI_STREAM = 0x20,
+  ADDON_READ_AUDIO_VIDEO = 0x40,
+  ADDON_READ_AFTER_WRITE = 0x80,
+  ADDON_READ_REOPEN = 0x100
+} OpenFileFlags;
+
+namespace kodi
+{
+namespace addon
+{
+
+inline std::string GetSettingString(const std::string& settingName,
+                                    const std::string& defaultValue = "")
+{
+  return defaultValue;
+}
+
+inline int GetSettingInt(const std::string& settingName, int defaultValue = 0)
+{
+  return defaultValue;
+}
+
+inline bool GetSettingBoolean(const std::string& settingName, bool defaultValue = false)
+{
+  return defaultValue;
+}
+
+} // namespace addon
+
+namespace vfs
+{
+class CFile
+{
+public:
+  CFile() = default;
+  virtual ~CFile() { Close(); }
+  bool OpenFile(const std::string& filename, unsigned int flags = 0) { return false; }
+
+  bool OpenFileForWrite(const std::string& filename, bool overwrite = false) { return false; }
+
+  bool IsOpen() const { return false; }
+  void Close() {}
+
+  bool CURLCreate(const std::string& url) { return false; }
+  bool CURLAddOption(CURLOptiontype type, const std::string& name, const std::string& value)
+  {
+    return false;
+  }
+
+  bool CURLOpen(unsigned int flags = 0) { return false; }
+
+  ssize_t Read(void* ptr, size_t size) { return 0; }
+
+  bool ReadLine(std::string& line) { return false; }
+
+  ssize_t Write(const void* ptr, size_t size) { return 0; }
+
+  void Flush() {}
+
+  int64_t Seek(int64_t position, int whence = SEEK_SET) { return 0; }
+
+  int Truncate(int64_t size) { return 0; }
+
+  int64_t GetPosition() const { return 0; }
+
+  int64_t GetLength() const { return 0; }
+
+  bool AtEnd() const { return true; }
+
+  int GetChunkSize() const { return 0; }
+
+  bool IoControlGetSeekPossible() const { return false; }
+
+  bool IoControlGetCacheStatus(CacheStatus& status) const { return false; }
+
+  bool IoControlSetCacheRate(uint32_t rate) { return false; }
+
+  bool IoControlSetRetry(bool retry) { return false; }
+
+  const std::string GetPropertyValue(FilePropertyTypes type, const std::string& name) const
+  {
+    return "";
+  }
+
+  const std::vector<std::string> GetPropertyValues(FilePropertyTypes type,
+                                                   const std::string& name) const
+  {
+    return std::vector<std::string>();
+  }
+
+  double GetFileDownloadSpeed() const { return 0.0; }
+};
+
+} // namespace vfs
+} // namespace kodi

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -52,7 +52,7 @@ protected:
   }
 
   DASHTestTree* tree;
-  adaptive::IRepresentationChooser* m_reprChooser{nullptr};
+  CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
 };
 
 class DASHTreeAdaptiveStreamTest : public DASHTreeTest

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -23,7 +23,7 @@ protected:
     m_reprChooser = new CTestRepresentationChooserDefault();
     m_reprChooser->Initialize(kodiProps);
 
-    tree = new adaptive::HLSTree(kodiProps, m_reprChooser, new AESDecrypter(std::string()));
+    tree = new HLSTestTree(kodiProps, m_reprChooser, new AESDecrypter(std::string()));
     tree->supportedKeySystem_ = "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
   }
 
@@ -62,7 +62,7 @@ protected:
   }
 
   adaptive::HLSTree* tree;
-  adaptive::IRepresentationChooser* m_reprChooser{nullptr};
+  CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
 };
 
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -26,40 +26,6 @@ void SetFileName(std::string& file, std::string name)
   file = GetEnv("DATADIR") + "/" + name;
 }
 
-bool adaptive::AdaptiveTree::download(const std::string& url,
-                                      const std::map<std::string, std::string>& manifestHeaders,
-                                      void* opaque,
-                                      bool isManifest)
-{
-  FILE* f = fopen(testHelper::testFile.c_str(), "rb");
-  if (!f)
-    return false;
-
-  if (!testHelper::effectiveUrl.empty())
-    effective_url_ = testHelper::effectiveUrl;
-  else
-    effective_url_ = url;
-
-  if (isManifest && !PreparePaths(effective_url_))
-  {
-    fclose(f);
-    return false;
-  }
-
-  // read the file
-  static const unsigned int CHUNKSIZE = 16384;
-  char buf[CHUNKSIZE];
-  size_t nbRead;
-
-  while ((nbRead = fread(buf, 1, CHUNKSIZE, f)) > 0 && ~nbRead && write_data(buf, nbRead, opaque))
-    ;
-
-  fclose(f);
-
-  SortTree();
-  return nbRead == 0;
-}
-
 bool TestAdaptiveStream::download_segment()
 {
   if (download_url_.empty())
@@ -112,3 +78,70 @@ std::string AESDecrypter::convertIV(const std::string& input)
 void AESDecrypter::ivFromSequence(uint8_t* buffer, uint64_t sid){}
 
 bool AESDecrypter::RenewLicense(const std::string& pluginUrl){return false;}
+
+bool DownloadFile(const std::string& url,
+                  const std::map<std::string, std::string>& reqHeaders,
+                  std::stringstream& data,
+                  adaptive::HTTPRespHeaders& respHeaders)
+{
+  FILE* f = fopen(testHelper::testFile.c_str(), "rb");
+  if (!f)
+    return false;
+
+  if (!testHelper::effectiveUrl.empty())
+    respHeaders.m_effectiveUrl = testHelper::effectiveUrl;
+  else
+    respHeaders.m_effectiveUrl = url;
+
+  // read the file
+  static const size_t bufferSize{16 * 1024}; // 16 byte
+  std::vector<char> bufferData(bufferSize);
+  bool isEOF{false};
+
+  while (!isEOF)
+  {
+    // Read the data in chunks
+    size_t byteRead{fread(bufferData.data(), sizeof(char), bufferSize, f)};
+    if (byteRead == 0) // EOF
+    {
+      isEOF = true;
+    }
+    else
+    {
+      data.write(bufferData.data(), byteRead);
+    }
+  }
+
+  fclose(f);
+  return true;
+}
+
+bool DASHTestTree::download(const std::string& url,
+                            const std::map<std::string, std::string>& reqHeaders,
+                            std::stringstream& data,
+                            adaptive::HTTPRespHeaders& respHeaders)
+{
+  if (DownloadFile(url, reqHeaders, data, respHeaders))
+  {
+    // We set the download speed to calculate the initial network bandwidth
+    m_reprChooser->SetDownloadSpeed(500000);
+
+    return true;
+  }
+  return false;
+}
+
+bool HLSTestTree::download(const std::string& url,
+                           const std::map<std::string, std::string>& reqHeaders,
+                           std::stringstream& data,
+                           adaptive::HTTPRespHeaders& respHeaders)
+{
+  if (DownloadFile(url, reqHeaders, data, respHeaders))
+  {
+    // We set the download speed to calculate the initial network bandwidth
+    m_reprChooser->SetDownloadSpeed(500000);
+
+    return true;
+  }
+  return false;
+}

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -32,6 +32,7 @@ constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original
 constexpr std::string_view PROP_BANDWIDTH_MAX = "inputstream.adaptive.max_bandwidth";
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
+constexpr std::string_view PROP_STREAM_SELECTION_TYPE = "inputstream.adaptive.stream_selection_type";
 // clang-format on
 } // unnamed namespace
 
@@ -95,7 +96,7 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     }
     else if (prop.first == PROP_BANDWIDTH_MAX)
     {
-      props.m_bandwidthMax = std::stoul(prop.second);
+      props.m_bandwidthMax = static_cast<uint32_t>(std::stoi(prop.second));
     }
     else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
     {
@@ -105,6 +106,10 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     {
       props.m_drmPreInitData = prop.second;
       logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_STREAM_SELECTION_TYPE)
+    {
+      props.m_drmPreInitData = prop.second;
     }
     else
     {

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -44,6 +44,8 @@ struct KodiProperties
   // by the initialisation of the DRM will be attached to the manifest request
   // callback as HTTP headers with the names of "challengeB64" and "sessionId"
   std::string m_drmPreInitData;
+  // Define the representation chooser type to be used, to override add-on user settings
+  std::string m_streamSelectionType;
 };
 
 KodiProperties ParseKodiProperties(const std::map<std::string, std::string> properties);


### PR DESCRIPTION
Another step to clean the representation chooser interface to prepare it for future new choosers

~This is full WIP is well on track but there are still a number of cases that i have not tested yet~

Main changes:

### Settings
has been reworked the add-on settings with the idea to be able to select the type of representation chooser, and change the available settings according to the type chosen.

Since there are a lot of changes in settings, i have added a first new representation chooser **Manual GUI**, to restore the manual stream selection mode, in separately way, which would otherwise conflict with the automatic selection of streams.

preview:
![immagine](https://user-images.githubusercontent.com/3257156/163567057-6ec4d7ea-fc1b-48ce-aaab-3e34254a1d09.png)
![immagine](https://user-images.githubusercontent.com/3257156/163567025-00f7a1f1-f83c-4c07-b3d9-12d383f4001a.png)

### Initial bandwidth change
Has been removed the bandwith value saved/restored to disk, that value not reflect the actual network condition.
We are at a disadvantage because with the web players, it is the browser that provides this information. Therefore, the only way to determine it is when we downloading the manifest files. 

As manifest files very small file, it is downloaded too quickly and the bandwidth is not determined properly, so I have proportioned the value, not so correct but i don't think you can do better (other ideas welcome).
Since is not perfect way, as you can see in the second screenshot, there is a settings that allow to disable the init. bandwidth autodetermination.

### Add new ISA Kodi properties "inputstream.adaptive.stream_selection_type"
This allow an addon to force choose a specific "Chooser type" so e.g. to have a fixed stream quality instead an adaptive stream

### Related cleanups
some bigger cleanup are:
- `AdaptiveTree::download` full reworked which was well messed up
- The assured_buffer_length_/max_buffer_duration_ has been moved out of repr. chooser
- In settings has been changed from bps to kbps, much more user-friendly
- Add a proper way to clone a tree `AdaptiveTree::Clone` to prevents override problems with derived classes (currently used only for DASH case)
- Introduced `test/KodiStubs.h`, this file have functions/classes mokups to replace Kodi API includes for the test build, then this we allow to remove all the if/endif build conditions in code.
It works as follow:
```
#ifdef INPUTSTREAM_TEST_BUILD
#include "../test/KodiStubs.h"
#else
#include <kodi/AddonBase.h>
#endif
```

fixes #528, i agreed to add only a few resolutions that fall within the common standards