### PR TITLE
Fix forced switch streams at video starts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1969,7 +1969,8 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
   }
 }
 
-// We call true if a reset is required, otherwise false.
+// If we change some Kodi stream property we must to return true
+// to allow Kodi demuxer to reset with our changes the stream properties.
 bool CInputStreamAdaptive::OpenStream(int streamid)
 {
   LOG::Log(LOGDEBUG, "OpenStream(%d)", streamid);
@@ -2033,7 +2034,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   {
     stream->SetReader(std::make_unique<CSubtitleSampleReader>(
         rep->url_, streamid, stream->info_.GetCodecInternalName()));
-    return false;
+    return stream->GetReader()->GetInformation(stream->info_);
   }
 
   AP4_Movie* movie(m_session->PrepareStream(stream, needRefetch));


### PR DESCRIPTION
After last changes i made on subtitles `GetInformation` was returning True to set the extradata to the subtitle stream,
but i havent realized that was needed add this info on `OpenStream` that was missing,
so `GetInformation` was called later causing the DEMUX_SPECIALID_STREAMCHANGE packet to be sent

I have also updated the comment above the method to make it more comprehensible what to do

tested Webvtt as ISO and Webvtt  as "file" mode
just video starts and after a video seek forward/backward and switched sub language from OSD settings
all ok