### PR TITLE
Moved HDCP check temporarily to AdaptiveTree

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -91,6 +91,44 @@ namespace adaptive
       delete *bp;
   }
 
+  //! @todo: CheckHDCP we will need to move this method in Session class to
+  //! avoid store the CAPS here, then call the Session method from AdaptiveTree
+  //! To be done after Session refactor
+  void AdaptiveTree::CheckHDCP()
+  {
+    //! @todo: is needed to implement an appropriate CP check to
+    //! remove HDCPOVERRIDE setting workaround
+
+    if (m_decrypterCaps.empty())
+      return;
+
+    uint32_t adpIndex{0};
+    adaptive::AdaptiveTree::AdaptationSet* adp{nullptr};
+    while (adp = GetAdaptationSet(adpIndex++))
+    {
+      if (adp->type_ != adaptive::AdaptiveTree::StreamType::VIDEO)
+        continue;
+
+      for (auto it = adp->representations_.begin(); it != adp->representations_.end();)
+      {
+        adaptive::AdaptiveTree::Representation* repr = *it;
+        uint16_t hdcpVersion = m_decrypterCaps[repr->pssh_set_].hdcpVersion;
+        int hdcpLimit = m_decrypterCaps[repr->pssh_set_].hdcpLimit;
+
+        if (repr->hdcpVersion_ > hdcpVersion ||
+            (hdcpLimit > 0 && repr->width_ * repr->height_ > hdcpLimit))
+        {
+          LOG::Log(LOGDEBUG, "Representation ID \"%s\" removed as not HDCP compliant",
+                   repr->id.c_str());
+          delete repr;
+          it = adp->representations_.erase(it);
+        }
+        else
+          it++;
+      }
+    }
+  }
+
   void AdaptiveTree::FreeSegments(Period* period, Representation* rep)
   {
     for (auto& segment : rep->segments_.data) {

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "expat.h"
-
+#include "../SSD_dll.h"
 #include "../utils/PropertiesUtils.h"
+#include "expat.h"
 
 #include <algorithm>
 #include <chrono>
@@ -531,6 +531,12 @@ public:
 
   bool has_type(StreamType t);
   void FreeSegments(Period* period, Representation* rep);
+
+  /*!
+   * \brief Check HDCP parameters to remove unplayable representations
+   */
+  void CheckHDCP();
+
   uint32_t estimate_segcount(uint64_t duration, uint32_t timescale);
   void SetFragmentDuration(const AdaptationSet* adp, const Representation* rep, size_t pos, uint64_t timestamp, uint32_t fragmentDuration, uint32_t movie_timescale);
   uint16_t insert_psshset(StreamType type, Period* period = nullptr, AdaptationSet* adp = nullptr);
@@ -562,6 +568,7 @@ public:
   virtual AdaptiveTree* Clone() const = 0;
 
   Settings m_settings;
+  std::vector<SSD::SSD_DECRYPTER::SSD_CAPS> m_decrypterCaps;
 
 protected:
   /*!

--- a/src/common/RepresentationChooser.h
+++ b/src/common/RepresentationChooser.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "../SSD_dll.h"
 #include "../utils/PropertiesUtils.h"
 #include "../utils/SettingsUtils.h"
 #include "AdaptiveTree.h"
@@ -71,13 +70,6 @@ public:
    * \param isSecureSession Set true if a secure session is in use
    */
   virtual void SetSecureSession(const bool isSecureSession) { m_isSecureSession = isSecureSession; }
-
-  /*!
-   * \brief Add the decrypter caps of a session. Can be used to determine the
-   *        HDCP version and limit of each stream representation.
-   * \param ssdCaps The SSD decripter caps of a session
-   */
-  virtual void AddDecrypterCaps(const SSD::SSD_DECRYPTER::SSD_CAPS& ssdCaps) {}
 
   virtual adaptive::AdaptiveTree::Representation* ChooseRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp) = 0;

--- a/src/common/RepresentationChooserDefault.h
+++ b/src/common/RepresentationChooserDefault.h
@@ -28,8 +28,6 @@ public:
 
   void SetDownloadSpeed(const double speed) override;
 
-  void AddDecrypterCaps(const SSD::SSD_DECRYPTER::SSD_CAPS& ssdCaps) override;
-
   adaptive::AdaptiveTree::Representation* ChooseRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp) override;
 
@@ -46,8 +44,6 @@ protected:
   int m_screenWidth{0};
   int m_screenHeight{0};
   std::optional<std::chrono::steady_clock::time_point> m_screenResLastUpdate;
-
-  bool m_isHdcpOverride{false};
 
   std::string m_screenWidthMax; // Max resolution for non-protected video content
   std::string m_screenWidthMaxSecure; // Max resolution for protected video content
@@ -68,8 +64,6 @@ protected:
   uint32_t m_bandwidthInit{0};
 
   std::deque<double> m_downloadSpeedChron;
-
-  std::vector<SSD::SSD_DECRYPTER::SSD_CAPS> m_decrypterCaps;
 };
 
 } // namespace CHOOSER

--- a/src/main.h
+++ b/src/main.h
@@ -166,6 +166,7 @@ public:
                  bool isDefaultRepr,
                  uint32_t uniqueId);
   void UpdateStream(STREAM& stream);
+
   AP4_Movie* PrepareStream(STREAM* stream, bool& needRefetch);
 
   STREAM* GetStream(unsigned int sid) const
@@ -251,5 +252,6 @@ private:
   uint8_t media_type_mask_{0};
   uint8_t drmConfig_{0};
   bool m_settingNoSecureDecoder{false};
+  bool m_settingIsHdcpOverride{false};
   bool first_period_initialized_{0};
 };

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1714,6 +1714,8 @@ void DASHTree::RefreshLiveSegments()
 
     if (updateTree->open(manifestUrlUpd, ""))
     {
+      CheckHDCP();
+
       m_manifestHeaders.m_etag = updateTree->m_manifestHeaders.m_etag;
       m_manifestHeaders.m_lastModified = updateTree->m_manifestHeaders.m_lastModified;
       location_ = updateTree->location_;

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -40,7 +40,6 @@ public:
 
   void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) override
   {
-    m_isHdcpOverride = true;
   }
 };
 

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -512,6 +512,8 @@ void WV_CencSingleSampleDecrypter::GetCapabilities(const uint8_t *keyid, uint32_
     caps.flags |= SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER;
   }
   LogF(SSDDEBUG, "hdcpLimit: %i", caps.hdcpLimit);
+
+  caps.hdcpVersion = 99;
 }
 
 bool WV_CencSingleSampleDecrypter::ProvisionRequest()


### PR DESCRIPTION
Check HDCP compliant is not a task of a representation chooser,
and this allows me to create new choosers without still keeping this in the interface

i have temporary moved this check in AdaptiveTree in awaiting for the future refactor of Session class, so a middle step

sidenote: `hdcpVersion` on android side was unset (not even in the structure) then i have add the value