### PR TITLE
Adaptive chooser improvements and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(ADP_SOURCES
 	src/utils/Base64Utils.cpp
 	src/utils/PropertiesUtils.cpp
 	src/utils/StringUtils.cpp
+	src/utils/SettingsUtils.cpp
 	src/utils/UrlUtils.cpp
 	src/utils/Utils.cpp
 	src/oscompat.cpp

--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer|pre_init_data|stream_selection_type"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -35,11 +35,11 @@
                 <condition setting="adaptivestream.type">default</condition>
                 <condition setting="adaptivestream.type">manual-osd</condition>
               </or>
-			</dependency>
+            </dependency>
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting parent="adaptivestream.type" id="adaptivestream.res.max.secure" type="string" label="30113">
+        <setting parent="adaptivestream.type" id="adaptivestream.res.secure.max" type="string" label="30113">
           <level>0</level>
           <default>auto</default>
           <constraints>
@@ -60,7 +60,7 @@
                 <condition setting="adaptivestream.type">default</condition>
                 <condition setting="adaptivestream.type">manual-osd</condition>
               </or>
-			</dependency>
+            </dependency>
           </dependencies>
           <control type="spinner" format="string" />
         </setting>

--- a/src/common/RepresentationChooser.cpp
+++ b/src/common/RepresentationChooser.cpp
@@ -20,10 +20,11 @@ namespace
 {
 IRepresentationChooser* GetReprChooser(std::string_view type)
 {
-  if (type == "manual-osd")
-    return new CRepresentationChooserManualOSD();
-  else if (type == "default")
+  // Chooser's names are used for add-on settings and Kodi properties
+  if (type == "default" || type == "adaptive")
     return new CRepresentationChooserDefault();
+  else if (type == "manual-osd")
+    return new CRepresentationChooserManualOSD();
   else
     return nullptr;
 }
@@ -49,7 +50,7 @@ IRepresentationChooser* CHOOSER::CreateRepresentationChooser(
   if (!reprChooser)
     reprChooser = new CRepresentationChooserDefault();
 
-  reprChooser->Initialize(kodiProps);
+  reprChooser->Initialize(kodiProps.m_chooserProps);
 
   return reprChooser;
 }

--- a/src/common/RepresentationChooser.h
+++ b/src/common/RepresentationChooser.h
@@ -18,7 +18,9 @@
 
 namespace CHOOSER
 {
-
+/*!
+ * \brief Defines the behaviours on which the quality of streams is chosen
+ */
 class ATTR_DLL_LOCAL IRepresentationChooser
 {
 public:

--- a/src/common/RepresentationChooser.h
+++ b/src/common/RepresentationChooser.h
@@ -12,14 +12,12 @@
 #include "../utils/SettingsUtils.h"
 #include "AdaptiveTree.h"
 
+#include <map>
 #include <string_view>
+#include <utility>
 
 namespace CHOOSER
 {
-
-const std::map<std::string_view, std::pair<int, int>> RESOLUTION_LIMITS{
-    {"480p", {640, 480}}, {"640p", {960, 640}},    {"720p", {1280, 720}}, {"1080p", {1920, 1080}},
-    {"2K", {2048, 1080}}, {"1440p", {2560, 1440}}, {"4K", {3840, 2160}}};
 
 class ATTR_DLL_LOCAL IRepresentationChooser
 {
@@ -32,7 +30,7 @@ public:
    *        DRM data can be read only with PostInit callback)
    * \param m_kodiProps The Kodi properties
    */
-  virtual void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) {}
+  virtual void Initialize(const UTILS::PROPERTIES::ChooserProps& props) {}
 
   /*!
    * \brief Post initialization, will be called just after DRM initialization

--- a/src/common/RepresentationChooserDefault.h
+++ b/src/common/RepresentationChooserDefault.h
@@ -17,7 +17,10 @@
 
 namespace CHOOSER
 {
-
+/*!
+ * \brief Adaptive stream, the quality of the stream is changed according
+ *        to the bandwidth and screen resolution
+ */
 class ATTR_DLL_LOCAL CRepresentationChooserDefault : public IRepresentationChooser
 {
 public:

--- a/src/common/RepresentationChooserDefault.h
+++ b/src/common/RepresentationChooserDefault.h
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <deque>
 #include <optional>
+#include <utility>
 
 namespace CHOOSER
 {
@@ -23,7 +24,7 @@ public:
   CRepresentationChooserDefault();
   ~CRepresentationChooserDefault() override {}
 
-  virtual void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) override;
+  virtual void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override;
   virtual void PostInit() override;
 
   void SetDownloadSpeed(const double speed) override;
@@ -45,8 +46,8 @@ protected:
   int m_screenHeight{0};
   std::optional<std::chrono::steady_clock::time_point> m_screenResLastUpdate;
 
-  std::string m_screenWidthMax; // Max resolution for non-protected video content
-  std::string m_screenWidthMaxSecure; // Max resolution for protected video content
+  std::pair<int, int> m_screenResMax; // Max resolution for non-protected video content
+  std::pair<int, int> m_screenResSecureMax; // Max resolution for protected video content
 
   // Ignore screen resolution, from playback starts and when it changes while playing
   bool m_ignoreScreenRes{false};
@@ -55,6 +56,8 @@ protected:
 
   // The bandwidth (bit/s) calculated by the average download speed
   uint32_t m_bandwidthCurrent{0};
+  // The average bandwidth (bit/s) that could be limited by user settings or add-on
+  uint32_t m_bandwidthCurrentLimited{0};
   uint32_t m_bandwidthMin{0};
   uint32_t m_bandwidthMax{0};
 

--- a/src/common/RepresentationChooserManualOSD.h
+++ b/src/common/RepresentationChooserManualOSD.h
@@ -19,7 +19,7 @@ public:
   CRepresentationChooserManualOSD();
   ~CRepresentationChooserManualOSD() override {}
 
-  virtual void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) override;
+  virtual void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override;
 
   virtual void PostInit() override;
 
@@ -43,8 +43,8 @@ protected:
   int m_screenWidth{0};
   int m_screenHeight{0};
 
-  std::string m_screenWidthMax; // Max resolution for non-protected video content
-  std::string m_screenWidthMaxSecure; // Max resolution for protected video content
+  std::pair<int, int> m_screenResMax; // Max resolution for non-protected video content
+  std::pair<int, int> m_screenResSecureMax; // Max resolution for protected video content
 };
 
 } // namespace CHOOSER

--- a/src/common/RepresentationChooserManualOSD.h
+++ b/src/common/RepresentationChooserManualOSD.h
@@ -12,7 +12,10 @@
 
 namespace CHOOSER
 {
-
+/*!
+ * \brief The quality of the streams is fixed and can be changed
+ *        through Kodi OSD settings.
+ */
 class ATTR_DLL_LOCAL CRepresentationChooserManualOSD : public IRepresentationChooser
 {
 public:

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(${BINARY}
     ../oscompat.cpp
     ../utils/Base64Utils.cpp
     ../utils/PropertiesUtils.cpp
+    ../utils/SettingsUtils.cpp
     ../utils/StringUtils.cpp
     ../utils/UrlUtils.cpp
     ../utils/Utils.cpp

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -22,7 +22,7 @@ protected:
     UTILS::PROPERTIES::KodiProperties kodiProps;
 
     m_reprChooser = new CTestRepresentationChooserDefault();
-    m_reprChooser->Initialize(kodiProps);
+    m_reprChooser->Initialize(kodiProps.m_chooserProps);
 
     tree = new DASHTestTree(kodiProps, m_reprChooser);
 

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -21,7 +21,7 @@ protected:
     UTILS::PROPERTIES::KodiProperties kodiProps;
 
     m_reprChooser = new CTestRepresentationChooserDefault();
-    m_reprChooser->Initialize(kodiProps);
+    m_reprChooser->Initialize(kodiProps.m_chooserProps);
 
     tree = new HLSTestTree(kodiProps, m_reprChooser, new AESDecrypter(std::string()));
     tree->supportedKeySystem_ = "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -38,7 +38,7 @@ public:
   CTestRepresentationChooserDefault() : CHOOSER::CRepresentationChooserDefault() {}
   ~CTestRepresentationChooserDefault() override {}
 
-  void Initialize(const UTILS::PROPERTIES::KodiProperties& kodiProps) override
+  void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override
   {
   }
 };

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "PropertiesUtils.h"
 
+#include "SettingsUtils.h"
 #include "Utils.h"
 #include "kodi/tools/StringUtils.h"
 #include "log.h"
@@ -29,10 +30,15 @@ constexpr std::string_view PROP_MANIFEST_TYPE = "inputstream.adaptive.manifest_t
 constexpr std::string_view PROP_MANIFEST_UPD_PARAM = "inputstream.adaptive.manifest_update_parameter";
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
-constexpr std::string_view PROP_BANDWIDTH_MAX = "inputstream.adaptive.max_bandwidth";
+constexpr std::string_view PROP_BANDWIDTH_MAX = "inputstream.adaptive.max_bandwidth"; //! @todo: deprecated, to be removed on next Kodi release
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
+
+// Chooser's properties
 constexpr std::string_view PROP_STREAM_SELECTION_TYPE = "inputstream.adaptive.stream_selection_type";
+constexpr std::string_view PROP_CHOOSER_BANDWIDTH_MAX = "inputstream.adaptive.chooser_bandwidth_max";
+constexpr std::string_view PROP_CHOOSER_RES_MAX = "inputstream.adaptive.chooser_resolution_max";
+constexpr std::string_view PROP_CHOOSER_RES_SECURE_MAX = "inputstream.adaptive.chooser_resolution_secure_max";
 // clang-format on
 } // unnamed namespace
 
@@ -94,9 +100,12 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     {
       props.m_audioLanguageOrig = prop.second;
     }
-    else if (prop.first == PROP_BANDWIDTH_MAX)
+    else if (prop.first == PROP_BANDWIDTH_MAX) //! @todo: deprecated, to be removed on next Kodi release
     {
-      props.m_bandwidthMax = static_cast<uint32_t>(std::stoi(prop.second));
+      LOG::Log(LOGWARNING, "Warning \"inputstream.adaptive.max_bandwidth\" property is deprecated "
+                           "and may not works. Please read \"Integration\" and \"Stream selection types\" "
+                           "pages on the Wiki to learn more about the new properties.");
+      props.m_chooserProps.m_bandwidthMax = static_cast<uint32_t>(std::stoi(prop.second));
     }
     else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
     {
@@ -110,6 +119,26 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     else if (prop.first == PROP_STREAM_SELECTION_TYPE)
     {
       props.m_drmPreInitData = prop.second;
+    }
+    else if (prop.first == PROP_CHOOSER_BANDWIDTH_MAX)
+    {
+      props.m_chooserProps.m_bandwidthMax = static_cast<uint32_t>(std::stoi(prop.second));
+    }
+    else if (prop.first == PROP_CHOOSER_RES_MAX)
+    {
+      std::pair<int, int> res;
+      if (SETTINGS::ParseResolutionLimit(prop.second, res))
+        props.m_chooserProps.m_resolutionMax = res;
+      else
+        LOG::Log(LOGERROR, "Resolution not valid on \"%s\" property.", prop.first.c_str());
+    }
+    else if (prop.first == PROP_CHOOSER_RES_SECURE_MAX)
+    {
+      std::pair<int, int> res;
+      if (SETTINGS::ParseResolutionLimit(prop.second, res))
+        props.m_chooserProps.m_resolutionSecureMax = res;
+      else
+        LOG::Log(LOGERROR, "Resolution not valid on \"%s\" property.", prop.first.c_str());
     }
     else
     {

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -10,6 +10,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 namespace UTILS
 {
@@ -22,6 +23,13 @@ enum class ManifestType
   MPD,
   ISM,
   HLS
+};
+
+struct ChooserProps
+{
+  uint32_t m_bandwidthMax{0};
+  std::pair<int, int> m_resolutionMax; // Res. limit for non-protected videos
+  std::pair<int, int> m_resolutionSecureMax; // Res. limit for DRM protected videos
 };
 
 struct KodiProperties
@@ -37,7 +45,6 @@ struct KodiProperties
   // HTTP headers used to download manifest and streams
   std::map<std::string, std::string> m_streamHeaders;
   std::string m_audioLanguageOrig;
-  uint32_t m_bandwidthMax{0};
   bool m_playTimeshiftBuffer{false};
   // PSSH/KID used to "pre-initialize" the DRM, the property value must be as
   // "{PSSH as base64}|{KID as base64}". The challenge/session ID data generated
@@ -46,6 +53,8 @@ struct KodiProperties
   std::string m_drmPreInitData;
   // Define the representation chooser type to be used, to override add-on user settings
   std::string m_streamSelectionType;
+  // Representation chooser properties, to override add-on user settings
+  ChooserProps m_chooserProps;
 };
 
 KodiProperties ParseKodiProperties(const std::map<std::string, std::string> properties);

--- a/src/utils/SettingsUtils.cpp
+++ b/src/utils/SettingsUtils.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SettingsUtils.h"
+
+using namespace UTILS::SETTINGS;
+
+bool UTILS::SETTINGS::ParseResolutionLimit(std::string_view resStr, std::pair<int, int>& res)
+{
+  auto mapIt{RESOLUTION_LIMITS.find(resStr)};
+
+  if (mapIt != RESOLUTION_LIMITS.end())
+  {
+    res = mapIt->second;
+    return true;
+  }
+
+  return false;
+}

--- a/src/utils/SettingsUtils.h
+++ b/src/utils/SettingsUtils.h
@@ -8,10 +8,18 @@
 
 #pragma once
 
+#include <map>
+#include <string_view>
+#include <utility>
+
 namespace UTILS
 {
 namespace SETTINGS
 {
+
+const std::map<std::string_view, std::pair<int, int>> RESOLUTION_LIMITS{
+    {"480p", {640, 480}}, {"640p", {960, 640}},    {"720p", {1280, 720}}, {"1080p", {1920, 1080}},
+    {"2K", {2048, 1080}}, {"1440p", {2560, 1440}}, {"4K", {3840, 2160}}};
 
 enum class StreamSelection
 {
@@ -19,6 +27,14 @@ enum class StreamSelection
   MANUAL,
   MANUAL_VIDEO_ONLY
 };
+
+/*!
+ * \brief Parse resolution limit as string to Width / Height pair
+ * \param resStr The resolution string
+ * \param res [OUT] The resolution parsed
+ * \return True if has success, otherwise false
+ */
+bool ParseResolutionLimit(std::string_view resStr, std::pair<int, int>& res);
 
 } // namespace SETTINGS
 } // namespace UTILS


### PR DESCRIPTION
Another round of improvements and cleanup to make all more structured for new future chooser's properties

Has been add 2 new properties for Adaptive chooser:
- `inputstream.adaptive.chooser_resolution_max` -> overwrites the respective setting only if the user has not set it, or if it exceeds the value
- `inputstream.adaptive.chooser_resolution_secure_max` -> overwrites the respective setting only if the user has not set it, or if it exceeds the value

and deprecated the old one:
- `inputstream.adaptive.max_bandwidth` -> for now still working, but will raise a log warning to notice future its removal. Now replaced by `inputstream.adaptive.chooser_bandwidth_max`

Has been fixed in adaptive chooser the user bandwidth limit setting, that was respected in `ChooseRepresentation` method but not in `ChooseNextRepresentation` method

fix #596
