### PR TITLE
New representation choosers: Fixed resolution / Ask quality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ADP_SOURCES
 	src/common/AdaptiveTree.cpp
 	src/common/RepresentationChooser.cpp
 	src/common/RepresentationChooserDefault.cpp
+	src/common/RepresentationChooserFixedRes.cpp
 	src/common/RepresentationChooserManualOSD.cpp
 	src/common/RepresentationSelector.cpp
 	src/parser/DASHTree.cpp
@@ -64,6 +65,7 @@ set(ADP_HEADERS
 	src/common/AdaptiveTree.h
 	src/common/RepresentationChooser.h
 	src/common/RepresentationChooserDefault.h
+	src/common/RepresentationChooserFixedRes.h
 	src/common/RepresentationChooserManualOSD.h
 	src/common/RepresentationSelector.h
 	src/parser/DASHTree.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ADP_SOURCES
 	src/common/AdaptiveStream.cpp
 	src/common/AdaptiveTree.cpp
 	src/common/RepresentationChooser.cpp
+	src/common/RepresentationChooserAskQuality.cpp
 	src/common/RepresentationChooserDefault.cpp
 	src/common/RepresentationChooserFixedRes.cpp
 	src/common/RepresentationChooserManualOSD.cpp
@@ -64,6 +65,7 @@ set(ADP_HEADERS
 	src/common/AdaptiveStream.h
 	src/common/AdaptiveTree.h
 	src/common/RepresentationChooser.h
+	src/common/RepresentationChooserAskQuality.h
 	src/common/RepresentationChooserDefault.h
 	src/common/RepresentationChooserFixedRes.h
 	src/common/RepresentationChooserManualOSD.h

--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -198,7 +198,12 @@ msgctxt "#30178"
 msgid "Fixed resolution"
 msgstr ""
 
-#empty strings reserved for "stream selection types" from id 30179 to 30190
+#. Item list value of setting with label #30174
+msgctxt "#30179"
+msgid "Ask quality"
+msgstr ""
+
+#empty strings reserved for "stream selection types" from id 30180 to 30190
 
 #. Assured buffer length duration (seconds)
 msgctxt "#30200"
@@ -268,3 +273,16 @@ msgid "4K"
 msgstr ""
 
 #empty strings reserved for resolution values of id #30110, #30113, from id 30217 to 30230
+
+#. Dialog window to select the video stream
+#: src/common/RepresentationChooserAskQuality.cpp
+msgctxt "#30231"
+msgid "Select video stream"
+msgstr ""
+
+#. Description of each list item in #30231 dialog window
+#. Do not translate placeholders: {codec} {quality}
+#: src/common/RepresentationChooserAskQuality.cpp
+msgctxt "#30232"
+msgid "Video stream {codec} {quality}"
+msgstr ""

--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -193,7 +193,12 @@ msgctxt "#30177"
 msgid "Manual OSD"
 msgstr ""
 
-#empty strings reserved for "stream selection types" from id 30177 to 30190
+#. Item list value of setting with label #30174
+msgctxt "#30178"
+msgid "Fixed resolution"
+msgstr ""
+
+#empty strings reserved for "stream selection types" from id 30179 to 30190
 
 #. Assured buffer length duration (seconds)
 msgctxt "#30200"

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -10,6 +10,7 @@
             <options>
               <option label="30176">default</option>
               <option label="30178">fixed-res</option>
+              <option label="30179">ask-quality</option>
               <option label="30177">manual-osd</option>
             </options>
           </constraints>

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -9,6 +9,7 @@
           <constraints>
             <options>
               <option label="30176">default</option>
+              <option label="30178">fixed-res</option>
               <option label="30177">manual-osd</option>
             </options>
           </constraints>
@@ -33,6 +34,7 @@
             <dependency type="visible">
               <or>
                 <condition setting="adaptivestream.type">default</condition>
+                <condition setting="adaptivestream.type">fixed-res</condition>
                 <condition setting="adaptivestream.type">manual-osd</condition>
               </or>
             </dependency>
@@ -58,6 +60,7 @@
             <dependency type="visible">
               <or>
                 <condition setting="adaptivestream.type">default</condition>
+                <condition setting="adaptivestream.type">fixed-res</condition>
                 <condition setting="adaptivestream.type">manual-osd</condition>
               </or>
             </dependency>

--- a/src/common/RepresentationChooser.cpp
+++ b/src/common/RepresentationChooser.cpp
@@ -9,6 +9,7 @@
 #include "RepresentationChooser.h"
 
 #include "../utils/log.h"
+#include "RepresentationChooserAskQuality.h"
 #include "RepresentationChooserDefault.h"
 #include "RepresentationChooserFixedRes.h"
 #include "RepresentationChooserManualOSD.h"
@@ -26,6 +27,8 @@ IRepresentationChooser* GetReprChooser(std::string_view type)
     return new CRepresentationChooserDefault();
   else if (type == "fixed-res")
     return new CRepresentationChooserFixedRes();
+  else if (type == "ask-quality")
+    return new CRepresentationChooserAskQuality();
   else if (type == "manual-osd")
     return new CRepresentationChooserManualOSD();
   else

--- a/src/common/RepresentationChooser.cpp
+++ b/src/common/RepresentationChooser.cpp
@@ -10,6 +10,7 @@
 
 #include "../utils/log.h"
 #include "RepresentationChooserDefault.h"
+#include "RepresentationChooserFixedRes.h"
 #include "RepresentationChooserManualOSD.h"
 
 #include <vector>
@@ -23,6 +24,8 @@ IRepresentationChooser* GetReprChooser(std::string_view type)
   // Chooser's names are used for add-on settings and Kodi properties
   if (type == "default" || type == "adaptive")
     return new CRepresentationChooserDefault();
+  else if (type == "fixed-res")
+    return new CRepresentationChooserFixedRes();
   else if (type == "manual-osd")
     return new CRepresentationChooserManualOSD();
   else

--- a/src/common/RepresentationChooserAskQuality.cpp
+++ b/src/common/RepresentationChooserAskQuality.cpp
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RepresentationChooserAskQuality.h"
+
+#include "../utils/StringUtils.h"
+#include "../utils/Utils.h"
+#include "../utils/log.h"
+#include "RepresentationSelector.h"
+#include "kodi/tools/StringUtils.h"
+
+#ifndef INPUTSTREAM_TEST_BUILD
+#include <kodi/gui/dialogs/Select.h>
+#endif
+
+#include <vector>
+
+using namespace adaptive;
+using namespace CHOOSER;
+using namespace UTILS;
+
+CRepresentationChooserAskQuality::CRepresentationChooserAskQuality()
+{
+  LOG::Log(LOGDEBUG, "[Repr. chooser] Type: Ask quality");
+}
+
+void CRepresentationChooserAskQuality::Initialize(const UTILS::PROPERTIES::ChooserProps& props)
+{
+}
+
+void CRepresentationChooserAskQuality::PostInit()
+{
+}
+
+AdaptiveTree::Representation* CRepresentationChooserAskQuality::ChooseRepresentation(
+    AdaptiveTree::AdaptationSet* adp)
+{
+  if (adp->type_ != AdaptiveTree::VIDEO)
+  {
+    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
+    return selector.HighestBw(adp);
+  }
+
+  //! @todo: m_isFirstVideoAdaptationSetChosen is a kind of workaround,
+  //! currently we dont handle in any way a codec priority and selection
+  //! that can happens when a manifest have multi-codec videos, therefore
+  //! we sent to Kodi the video stream of each codec, but only the
+  //! first one (in index order) will be choosen for the playback
+  //! with the potential to poorly manage a bandwidth optimisation.
+  //! So we ask to the user to select the quality only for the first video
+  //! AdaptationSet and we try to select the same quality (resolution)
+  //! on all other video AdaptationSet's (codecs)
+  if (!m_isFirstVideoAdaptationSetChosen)
+  {
+    // We find the best quality for the current resolution, to pre-select this entry
+    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
+    AdaptiveTree::Representation* bestRep{selector.Highest(adp)};
+
+    std::vector<std::string> entries;
+    int preselIndex{-1};
+
+    // Add available qualities
+    for (size_t i{0}; i < adp->representations_.size(); i++)
+    {
+      AdaptiveTree::Representation* rep{adp->representations_[i]};
+
+      std::string entryName{kodi::addon::GetLocalizedString(30232)};
+      STRING::ReplaceFirst(entryName, "{codec}", GetVideoCodecDesc(rep->codecs_));
+      STRING::ReplaceFirst(entryName, "{quality}",
+                           kodi::tools::StringUtils::Format("(%ix%i, %u Kbps)", rep->width_,
+                                                            rep->height_, rep->bandwidth_ / 1000));
+
+      if (rep == bestRep)
+        preselIndex = static_cast<int>(i);
+
+      entries.emplace_back(entryName);
+    }
+
+    int selIndex{kodi::gui::dialogs::Select::Show(kodi::addon::GetLocalizedString(30231), entries,
+                                                  preselIndex, 10000)};
+
+    AdaptiveTree::Representation* selRep{bestRep};
+
+    if (selIndex >= 0) // If was <0 has been cancelled by the user
+      selRep = adp->representations_[selIndex];
+
+    m_selectedResWidth = selRep->width_;
+    m_selectedResHeight = selRep->height_;
+    m_isFirstVideoAdaptationSetChosen = true;
+
+    return selRep;
+  }
+  else
+  {
+    // The user has already chosen the quality, we try select the same resolution
+    // in any case these are choosable only manually via Kodi OSD video settings.
+    CRepresentationSelector selector{m_selectedResWidth, m_selectedResHeight};
+    return selector.Highest(adp);
+  }
+}
+
+AdaptiveTree::Representation* CRepresentationChooserAskQuality::ChooseNextRepresentation(
+    AdaptiveTree::AdaptationSet* adp, AdaptiveTree::Representation* currentRep)
+{
+  return currentRep;
+}

--- a/src/common/RepresentationChooserAskQuality.h
+++ b/src/common/RepresentationChooserAskQuality.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RepresentationChooser.h"
+
+namespace CHOOSER
+{
+/*!
+ * \brief The quality of the stream is asked to the user by a dialog window
+ */
+class ATTR_DLL_LOCAL CRepresentationChooserAskQuality : public IRepresentationChooser
+{
+public:
+  CRepresentationChooserAskQuality();
+  ~CRepresentationChooserAskQuality() override {}
+
+  void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override;
+
+  void PostInit() override;
+
+  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp) override;
+
+  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp,
+      adaptive::AdaptiveTree::Representation* currentRep) override;
+
+private:
+  bool m_isFirstVideoAdaptationSetChosen{false};
+  int m_selectedResWidth{0};
+  int m_selectedResHeight{0};
+};
+
+} // namespace CHOOSER

--- a/src/common/RepresentationChooserFixedRes.cpp
+++ b/src/common/RepresentationChooserFixedRes.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RepresentationChooserFixedRes.h"
+
+#include "../utils/SettingsUtils.h"
+#include "../utils/log.h"
+#include "RepresentationSelector.h"
+
+using namespace adaptive;
+using namespace CHOOSER;
+using namespace UTILS;
+
+CRepresentationChooserFixedRes::CRepresentationChooserFixedRes()
+{
+  LOG::Log(LOGDEBUG, "[Repr. chooser] Type: Fixed resolution");
+}
+
+void CRepresentationChooserFixedRes::Initialize(const UTILS::PROPERTIES::ChooserProps& props)
+{
+  std::pair<int, int> res;
+  if (SETTINGS::ParseResolutionLimit(kodi::addon::GetSettingString("adaptivestream.res.max"), res))
+  {
+    m_screenResMax = res;
+  }
+  if (SETTINGS::ParseResolutionLimit(kodi::addon::GetSettingString("adaptivestream.res.secure.max"),
+                                     res))
+  {
+    m_screenResSecureMax = res;
+  }
+
+  // Override settings with Kodi/video add-on properties
+
+  if (m_screenResMax.first == 0 ||
+      (props.m_resolutionMax.first > 0 && m_screenResMax > props.m_resolutionMax))
+  {
+    m_screenResMax = props.m_resolutionMax;
+  }
+
+  if (m_screenResSecureMax.first == 0 ||
+      (props.m_resolutionSecureMax.first > 0 && m_screenResSecureMax > props.m_resolutionSecureMax))
+  {
+    m_screenResSecureMax = props.m_resolutionSecureMax;
+  }
+
+  LOG::Log(LOGDEBUG,
+           "[Repr. chooser] Configuration\n"
+           "Resolution max: %ix%i\n"
+           "Resolution max for secure decoder: %ix%i",
+           m_screenResMax.first, m_screenResMax.second, m_screenResSecureMax.first,
+           m_screenResSecureMax.second);
+}
+
+void CRepresentationChooserFixedRes::PostInit()
+{
+  LOG::Log(LOGDEBUG,
+           "[Repr. chooser] Stream selection conditions\n"
+           "Screen resolution: %ix%i",
+           m_screenCurrentWidth, m_screenCurrentHeight);
+}
+
+AdaptiveTree::Representation* CRepresentationChooserFixedRes::ChooseRepresentation(
+    AdaptiveTree::AdaptationSet* adp)
+{
+  std::pair<int, int> resolution{m_isSecureSession ? m_screenResSecureMax : m_screenResMax};
+
+  if (resolution.first == 0) // Max limit set to "Auto"
+    resolution = {m_screenCurrentWidth, m_screenCurrentHeight};
+
+  CRepresentationSelector selector{resolution.first, resolution.second};
+
+  if (adp->type_ == AdaptiveTree::VIDEO)
+    return selector.Highest(adp);
+  else
+    return selector.HighestBw(adp);
+}
+
+AdaptiveTree::Representation* CRepresentationChooserFixedRes::ChooseNextRepresentation(
+    AdaptiveTree::AdaptationSet* adp, AdaptiveTree::Representation* currentRep)
+{
+  return currentRep;
+}

--- a/src/common/RepresentationChooserFixedRes.h
+++ b/src/common/RepresentationChooserFixedRes.h
@@ -21,9 +21,9 @@ public:
   CRepresentationChooserFixedRes();
   ~CRepresentationChooserFixedRes() override {}
 
-  virtual void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override;
+  void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override;
 
-  virtual void PostInit() override;
+  void PostInit() override;
 
   adaptive::AdaptiveTree::Representation* ChooseRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp) override;
@@ -32,7 +32,7 @@ public:
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) override;
 
-protected:
+private:
   std::pair<int, int> m_screenResMax; // Max resolution for non-protected video content
   std::pair<int, int> m_screenResSecureMax; // Max resolution for protected video content
 };

--- a/src/common/RepresentationChooserFixedRes.h
+++ b/src/common/RepresentationChooserFixedRes.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RepresentationChooser.h"
+
+namespace CHOOSER
+{
+/*!
+ * \brief The stream quality is fixed to the max available resolution
+ */
+class ATTR_DLL_LOCAL CRepresentationChooserFixedRes : public IRepresentationChooser
+{
+public:
+  CRepresentationChooserFixedRes();
+  ~CRepresentationChooserFixedRes() override {}
+
+  virtual void Initialize(const UTILS::PROPERTIES::ChooserProps& props) override;
+
+  virtual void PostInit() override;
+
+  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp) override;
+
+  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp,
+      adaptive::AdaptiveTree::Representation* currentRep) override;
+
+protected:
+  std::pair<int, int> m_screenResMax; // Max resolution for non-protected video content
+  std::pair<int, int> m_screenResSecureMax; // Max resolution for protected video content
+};
+
+} // namespace CHOOSER

--- a/src/common/RepresentationSelector.cpp
+++ b/src/common/RepresentationSelector.cpp
@@ -49,3 +49,22 @@ AdaptiveTree::Representation* CRepresentationSelector::Highest(AdaptiveTree::Ada
 
   return highestRep;
 }
+
+AdaptiveTree::Representation* CRepresentationSelector::HighestBw(
+    AdaptiveTree::AdaptationSet* adaptSet) const
+{
+  AdaptiveTree::Representation* repHigherBw{nullptr};
+
+  for (auto rep : adaptSet->representations_)
+  {
+    if (!rep)
+      continue;
+
+    if (!repHigherBw || rep->bandwidth_ > repHigherBw->bandwidth_)
+    {
+      repHigherBw = rep;
+    }
+  }
+
+  return repHigherBw;
+}

--- a/src/common/RepresentationSelector.h
+++ b/src/common/RepresentationSelector.h
@@ -35,6 +35,14 @@ public:
   adaptive::AdaptiveTree::Representation* Highest(
       adaptive::AdaptiveTree::AdaptationSet* adaptSet) const;
 
+  /*!
+   * \brief Select the representation with the higher bandwidth
+   * \param adaptSet The adaption set
+   * \return The representation with higher bandwidth, otherwise nullptr if no available
+   */
+  adaptive::AdaptiveTree::Representation* HighestBw(
+      adaptive::AdaptiveTree::AdaptationSet* adaptSet) const;
+
 private:
   int m_screenWidth{0};
   int m_screenHeight{0};

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${BINARY}
     ../common/AdaptiveTree.cpp
     ../common/RepresentationChooser.cpp
     ../common/RepresentationChooserDefault.cpp
+    ../common/RepresentationChooserFixedRes.cpp
     ../common/RepresentationChooserManualOSD.cpp
     ../common/RepresentationSelector.cpp
     ../oscompat.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${BINARY}
     ../common/AdaptiveStream.cpp
     ../common/AdaptiveTree.cpp
     ../common/RepresentationChooser.cpp
+    ../common/RepresentationChooserAskQuality.cpp
     ../common/RepresentationChooserDefault.cpp
     ../common/RepresentationChooserFixedRes.cpp
     ../common/RepresentationChooserManualOSD.cpp

--- a/src/test/KodiStubs.h
+++ b/src/test/KodiStubs.h
@@ -64,6 +64,10 @@ namespace kodi
 {
 namespace addon
 {
+inline std::string GetLocalizedString(uint32_t labelId, const std::string& defaultStr = "")
+{
+  return defaultStr;
+}
 
 inline std::string GetSettingString(const std::string& settingName,
                                     const std::string& defaultValue = "")
@@ -148,4 +152,28 @@ public:
 };
 
 } // namespace vfs
+
+namespace gui
+{
+
+namespace dialogs
+{
+
+namespace Select
+{
+
+inline int Show(const std::string& heading,
+                const std::vector<std::string>& entries,
+                int selected = -1,
+                unsigned int autoclose = 0)
+{
+  return selected;
+}
+
+} // namespace Select
+
+} // namespace dialogs
+
+} // namespace gui
+
 } // namespace kodi

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -317,3 +317,15 @@ void UTILS::ParseHeaderString(std::map<std::string, std::string>& headerMap,
     }
   }
 }
+
+std::string UTILS::GetVideoCodecDesc(std::string_view codecName)
+{
+  if (codecName.find("avc") == 0 || codecName.find("h264") == 0)
+    return "H.264";
+  else if (codecName.find("hev") == 0 || codecName.find("hvc") == 0 || codecName.find("dvh") == 0)
+    return "H.265 / HEVC";
+  else if (codecName.find("vp9") == 0 || codecName.find("vp09") == 0)
+    return "H.265 / VP9";
+  else
+    return "";
+}

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -27,6 +27,13 @@ bool CreateISMlicense(std::string_view key,
 void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std::string& header);
 
 /*!
+ * \brief Get video codec description from a codec name
+ * \param codecName The codec name
+ * \return The codec description, otherwise empty if unsupported
+ */
+std::string GetVideoCodecDesc(std::string_view codecName);
+
+/*!
  * \brief Make a FourCC code as unsigned integer value
  * \param c1 The first FourCC char
  * \param c2 The second FourCC char


### PR DESCRIPTION
This PR add two new choosers a lot requested over the time that will make happy a lot of users

### Fixed resolution
The stream is fixed for the full duration of the video, when playback starts will be chosen the best video resolution that fit the screen resolution, an user can also limit to a max resolution (e.g. for not powerful CPUs),
of course network bandwidth is not considered.

### Ask quality
Just before playing a video, the user will be asked to choose the preferred video quality from a dialog window,
which will remain fixed for the full duration of the video (network bandwidth is not considered).

![immagine](https://user-images.githubusercontent.com/3257156/164219746-fa57b03a-228d-446a-be74-544a62b99acc.png)

here i have left a "todo" in sourcecode for cases of multi-codec manifests which may be discussed and improved in some way in the future

As always a video add-on can force the choice of one of the available choosers despite the user setting