### PR TITLE
Fix webvtt/mp4 subtitles crash

### DIFF
--- a/src/parser/WebVTT.cpp
+++ b/src/parser/WebVTT.cpp
@@ -53,11 +53,8 @@ bool WebVTT::Parse(uint64_t pts, uint32_t duration, const void *buffer, size_t b
       uint32_t remainingVttcBoxSize = ReadNextUnsignedInt(cbuf);
       int pos = 8;
 
-      while (remainingVttcBoxSize > 0)
+      while (remainingVttcBoxSize > 8)
       {
-        if (remainingVttcBoxSize < 8)
-          break;
-
         uint32_t boxSize = ReadNextUnsignedInt(cbuf + pos);
         if (boxSize == 0)
           break;


### PR DESCRIPTION
When we hit the situation in this while loop where `remainingVttcBoxSize` is 8, `uint32_t boxSize = ReadNextUnsignedInt(cbuf + pos);` ends up reading whatever junk is in memory. In my testing case it was some text left over from the previous mp4 segment giving a very large boxSize!

I slightly simplified by removing the redundant condition check and just making part of the loop.

@CastagnaIT does this look alright to you?

fixes #946 

Many thanks to @Dis90 for spending so much time and effort getting me a test stream