### PR TITLE
Fixed estimate segments count method

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -154,12 +154,12 @@ namespace adaptive
     return false;
   }
 
-  uint32_t AdaptiveTree::estimate_segcount(uint64_t duration, uint32_t timescale)
+  size_t AdaptiveTree::EstimateSegmentsCount(uint64_t duration, uint32_t timescale)
   {
-    LOG::Log(LOGDEBUG,"estimate_segcount  duration=%llu , timescale=%u",duration , timescale);
-
-    duration /= timescale;
-    return static_cast<uint32_t>((overallSeconds_ / duration)*1.01);
+    double lengthSecs{static_cast<double>(duration) / timescale};
+    if (lengthSecs < 1)
+      lengthSecs = 1;
+    return static_cast<size_t>(overallSeconds_ / lengthSecs);
   }
 
   void AdaptiveTree::SetFragmentDuration(const AdaptationSet* adp, const Representation* rep, size_t pos, uint64_t timestamp, uint32_t fragmentDuration, uint32_t movie_timescale)

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -537,7 +537,11 @@ public:
    */
   void CheckHDCP();
 
-  uint32_t estimate_segcount(uint64_t duration, uint32_t timescale);
+  /*
+   * \brief Estimate the count of segments on overall period duration
+   */
+  size_t EstimateSegmentsCount(uint64_t duration, uint32_t timescale);
+
   void SetFragmentDuration(const AdaptationSet* adp, const Representation* rep, size_t pos, uint64_t timestamp, uint32_t fragmentDuration, uint32_t movie_timescale);
   uint16_t insert_psshset(StreamType type, Period* period = nullptr, AdaptationSet* adp = nullptr);
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -416,7 +416,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
               dash->current_representation_->duration_ = dur;
               dash->current_representation_->timescale_ = ts;
               dash->current_representation_->segments_.data.reserve(
-                  dash->estimate_segcount(dash->current_representation_->duration_,
+                  dash->EstimateSegmentsCount(dash->current_representation_->duration_,
                                           dash->current_representation_->timescale_));
             }
             else if (dash->current_adaptationset_->segment_durations_.data.size())
@@ -826,7 +826,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           {
             if (!dash->current_period_->duration_ && d)
               dash->current_period_->segment_durations_.data.reserve(
-                  dash->estimate_segcount(d, dash->current_period_->timescale_));
+                  dash->EstimateSegmentsCount(d, dash->current_period_->timescale_));
             dash->current_period_->startPTS_ = dash->pts_helper_ = t;
           }
           else if (t)
@@ -969,7 +969,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         if (dash->current_period_->timescale_)
         {
           if (dash->current_period_->duration_)
-            dash->current_period_->segment_durations_.data.reserve(dash->estimate_segcount(
+            dash->current_period_->segment_durations_.data.reserve(dash->EstimateSegmentsCount(
                 dash->current_period_->duration_, dash->current_period_->timescale_));
           dash->currentNode_ |= MPDNODE_SEGMENTLIST;
         }


### PR DESCRIPTION
This method is used only to optimize initial memory allocation of the vector not so important if we dont have an accurate value

but the calculation to get the lenght in seconds was done between two uint variables
then if a < b the result will be 0
and the following division will cause an exception

Fix #152

i will do the backport after approvation