### PR TITLE
Fix crashing on 2nd period start

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -451,8 +451,7 @@ bool AdaptiveStream::start_stream()
   if (choose_rep_)
   {
     choose_rep_ = false;
-    current_rep_ = tree_.GetRepChooser()->ChooseNextRepresentation(
-        current_adp_, segment_buffers_[valid_segment_buffers_].rep);
+    current_rep_ = tree_.GetRepChooser()->ChooseRepresentation(current_adp_);
   }
 
   if (!(current_rep_->flags_ & AdaptiveTree::Representation::INITIALIZED))


### PR DESCRIPTION
In start stream we're sending a null rep over to ChooseNextRepresentation which becomes defereneced

Calling ChooserRepresentation instead will do the usual, but now we already have some decent data for the current bandwidth (compared to very weak data on playback start which is just from downloading the manifest).
All things being equal with the adaptive chooser we should expect to select the same representation as the previous period if the adaptationsets/reps are 1:1 with the new period, otherwise the rep which best suits the current conditions.