### PR TITLE
[chooser] Merged ChooseRepresentation with ChooseNextRepresentation

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -451,8 +451,7 @@ bool AdaptiveStream::start_stream()
   if (choose_rep_)
   {
     choose_rep_ = false;
-    current_rep_ = tree_.GetRepChooser()->ChooseNextRepresentation(
-        current_adp_, segment_buffers_[valid_segment_buffers_].rep);
+    current_rep_ = tree_.GetRepChooser()->GetRepresentation(current_adp_);
   }
 
   if (!(current_rep_->flags_ & AdaptiveTree::Representation::INITIALIZED))
@@ -821,7 +820,7 @@ bool AdaptiveStream::ensureSegment()
       {
         // Defer until we have some free buffer
         if (available_segment_buffers_ < max_buffer_length_) {
-          newRep = tree_.GetRepChooser()->ChooseNextRepresentation(
+          newRep = tree_.GetRepChooser()->GetNextRepresentation(
               current_adp_, segment_buffers_[available_segment_buffers_ - 1].rep);
         }
         else

--- a/src/common/Chooser.cpp
+++ b/src/common/Chooser.cpp
@@ -64,8 +64,33 @@ IRepresentationChooser* CHOOSER::CreateRepresentationChooser(
   return reprChooser;
 }
 
-void IRepresentationChooser::SetScreenResolution(const int width, const int height)
+void CHOOSER::IRepresentationChooser::SetScreenResolution(const int width, const int height)
 {
   m_screenCurrentWidth = width;
   m_screenCurrentHeight = height;
+}
+
+void CHOOSER::IRepresentationChooser::LogDetails(adaptive::AdaptiveTree::Representation* currentRep,
+                                                 adaptive::AdaptiveTree::Representation* nextRep)
+{
+  if (!nextRep)
+    return;
+
+  if (!currentRep)
+  {
+    LOG::Log(LOGDEBUG,
+             "[Repr. chooser] Selected representation\n"
+             "ID %s (Bandwidth: %u bit/s, Resolution: %ix%i)",
+             nextRep->id.c_str(), nextRep->bandwidth_, nextRep->width_, nextRep->height_);
+  }
+  else if (currentRep != nextRep)
+  {
+    LOG::Log(LOGDEBUG,
+             "[Repr. chooser] Changed representation\n"
+             "Current ID %s (Bandwidth: %u bit/s, Resolution: %ix%i)\n"
+             "Next ID %s (Bandwidth: %u bit/s, Resolution: %ix%i)",
+             currentRep->id.c_str(), currentRep->bandwidth_, currentRep->width_,
+             currentRep->height_, nextRep->id.c_str(), nextRep->bandwidth_, nextRep->width_,
+             nextRep->height_);
+  }
 }

--- a/src/common/Chooser.h
+++ b/src/common/Chooser.h
@@ -71,14 +71,35 @@ public:
    */
   virtual void SetSecureSession(const bool isSecureSession) { m_isSecureSession = isSecureSession; }
 
-  virtual adaptive::AdaptiveTree::Representation* ChooseRepresentation(
-      adaptive::AdaptiveTree::AdaptationSet* adp) = 0;
+  /*!
+   * \brief Get the representation from an adaptation set
+   * \param adp The adaptation set where choose the representation
+   * \return The representation
+   */
+  adaptive::AdaptiveTree::Representation* GetRepresentation(
+      adaptive::AdaptiveTree::AdaptationSet* adp)
+  {
+    return GetNextRepresentation(adp, nullptr);
+  }
 
-  virtual adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+  /*!
+   * \brief Get the next representation from an adaptation set
+   * \param adp The adaptation set where choose the representation
+   * \param currentRep The current representation,
+   *        or nullptr for first start or changed to new period
+   * \return The next representation
+   */
+  virtual adaptive::AdaptiveTree::Representation* GetNextRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) = 0;
 
 protected:
+  /*!
+   * \brief Prints details of the selected or changed representation in the log
+   */
+  void LogDetails(adaptive::AdaptiveTree::Representation* currentRep,
+                  adaptive::AdaptiveTree::Representation* nextRep);
+
   bool m_isSecureSession{false};
 
   // Current screen width resolution (this value is auto-updated by Kodi)

--- a/src/common/ChooserAskQuality.h
+++ b/src/common/ChooserAskQuality.h
@@ -25,15 +25,12 @@ public:
 
   void PostInit() override;
 
-  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
-      adaptive::AdaptiveTree::AdaptationSet* adp) override;
-
-  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+  adaptive::AdaptiveTree::Representation* GetNextRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) override;
 
 private:
-  bool m_isFirstVideoAdaptationSetChosen{false};
+  bool m_isDialogShown{false};
   int m_selectedResWidth{0};
   int m_selectedResHeight{0};
 };

--- a/src/common/ChooserDefault.h
+++ b/src/common/ChooserDefault.h
@@ -32,10 +32,7 @@ public:
 
   void SetDownloadSpeed(const double speed) override;
 
-  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
-      adaptive::AdaptiveTree::AdaptationSet* adp) override;
-
-  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+  adaptive::AdaptiveTree::Representation* GetNextRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) override;
 

--- a/src/common/ChooserFixedRes.cpp
+++ b/src/common/ChooserFixedRes.cpp
@@ -64,9 +64,12 @@ void CRepresentationChooserFixedRes::PostInit()
            m_screenCurrentWidth, m_screenCurrentHeight);
 }
 
-AdaptiveTree::Representation* CRepresentationChooserFixedRes::ChooseRepresentation(
-    AdaptiveTree::AdaptationSet* adp)
+AdaptiveTree::Representation* CRepresentationChooserFixedRes::GetNextRepresentation(
+    AdaptiveTree::AdaptationSet* adp, AdaptiveTree::Representation* currentRep)
 {
+  if (currentRep)
+    return currentRep;
+
   std::pair<int, int> resolution{m_isSecureSession ? m_screenResSecureMax : m_screenResMax};
 
   if (resolution.first == 0) // Max limit set to "Auto"
@@ -75,13 +78,13 @@ AdaptiveTree::Representation* CRepresentationChooserFixedRes::ChooseRepresentati
   CRepresentationSelector selector{resolution.first, resolution.second};
 
   if (adp->type_ == AdaptiveTree::VIDEO)
-    return selector.Highest(adp);
+  {
+    AdaptiveTree::Representation* selRep{selector.Highest(adp)};
+    LogDetails(nullptr, selRep);
+    return selRep;
+  }
   else
+  {
     return selector.HighestBw(adp);
-}
-
-AdaptiveTree::Representation* CRepresentationChooserFixedRes::ChooseNextRepresentation(
-    AdaptiveTree::AdaptationSet* adp, AdaptiveTree::Representation* currentRep)
-{
-  return currentRep;
+  }
 }

--- a/src/common/ChooserFixedRes.h
+++ b/src/common/ChooserFixedRes.h
@@ -25,10 +25,7 @@ public:
 
   void PostInit() override;
 
-  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
-      adaptive::AdaptiveTree::AdaptationSet* adp) override;
-
-  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+  adaptive::AdaptiveTree::Representation* GetNextRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) override;
 

--- a/src/common/ChooserManualOSD.cpp
+++ b/src/common/ChooserManualOSD.cpp
@@ -78,16 +78,12 @@ void CRepresentationChooserManualOSD::PostInit()
            m_screenWidth, m_screenHeight);
 }
 
-AdaptiveTree::Representation* CRepresentationChooserManualOSD::ChooseRepresentation(
-    AdaptiveTree::AdaptationSet* adp)
-{
-  CRepresentationSelector selector(m_screenWidth, m_screenHeight);
-
-  return selector.Highest(adp);
-}
-
-AdaptiveTree::Representation* CRepresentationChooserManualOSD::ChooseNextRepresentation(
+AdaptiveTree::Representation* CRepresentationChooserManualOSD::GetNextRepresentation(
     AdaptiveTree::AdaptationSet* adp, AdaptiveTree::Representation* currentRep)
 {
-  return currentRep;
+  if (currentRep)
+    return currentRep;
+
+  CRepresentationSelector selector(m_screenWidth, m_screenHeight);
+  return selector.Highest(adp);
 }

--- a/src/common/ChooserManualOSD.h
+++ b/src/common/ChooserManualOSD.h
@@ -31,10 +31,7 @@ public:
     return m_streamSelectionMode;
   }
 
-  adaptive::AdaptiveTree::Representation* ChooseRepresentation(
-      adaptive::AdaptiveTree::AdaptationSet* adp) override;
-
-  adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+  adaptive::AdaptiveTree::Representation* GetNextRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) override;
 

--- a/src/common/ChooserTest.h
+++ b/src/common/ChooserTest.h
@@ -30,10 +30,7 @@ namespace CHOOSER
       return m_streamSelectionMode;
     }
 
-    adaptive::AdaptiveTree::Representation* ChooseRepresentation(
-      adaptive::AdaptiveTree::AdaptationSet* adp) override;
-
-    adaptive::AdaptiveTree::Representation* ChooseNextRepresentation(
+    adaptive::AdaptiveTree::Representation* GetNextRepresentation(
       adaptive::AdaptiveTree::AdaptationSet* adp,
       adaptive::AdaptiveTree::Representation* currentRep) override;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -643,7 +643,7 @@ bool Session::InitializeDRM(bool addDefaultKID /* = false */)
         if (m_kodiProps.m_licenseData.empty())
         {
           adaptive::AdaptiveTree::Representation* initialRepr{
-              m_reprChooser->ChooseRepresentation(sessionPsshset.adaptation_set_)};
+              m_reprChooser->GetRepresentation(sessionPsshset.adaptation_set_)};
 
           Session::STREAM stream(*adaptiveTree_, sessionPsshset.adaptation_set_, initialRepr,
                                  media_headers_, m_reprChooser, m_kodiProps.m_playTimeshiftBuffer,
@@ -911,7 +911,7 @@ bool Session::InitializePeriod(bool isSessionOpened /* = false */)
       isManualStreamSelection = streamSelectionMode == SETTINGS::StreamSelection::MANUAL;
 
     // Get the default initial stream repr. based on "adaptive repr. chooser"
-    adaptive::AdaptiveTree::Representation* defaultRepr{m_reprChooser->ChooseRepresentation(adp)};
+    adaptive::AdaptiveTree::Representation* defaultRepr{m_reprChooser->GetRepresentation(adp)};
 
     if (isManualStreamSelection)
     {

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -78,7 +78,7 @@ protected:
 
   TestAdaptiveStream* NewStream(adaptive::AdaptiveTree::AdaptationSet* adp, bool playTsb=true)
   {
-    auto initialRepr{tree->GetRepChooser()->ChooseRepresentation(adp)};
+    auto initialRepr{tree->GetRepChooser()->GetRepresentation(adp)};
     return new TestAdaptiveStream(*tree, adp, initialRepr, mediaHeaders, playTsb, false);
   }
 


### PR DESCRIPTION
Merged ChooseRepresentation with ChooseNextRepresentation
both methods do more or less the same things with small differences
implicitly this contains the fix mentioned in #958 then superseed PR #958
i preferred doing another cleaning step

Log has been improved, now you can understand when chooser select the representation for the first start or for period change by:
`[Repr. chooser] Selected representation`
vs
`[Repr. chooser] Changed representation`
that happens when stream is changed for a chooser specified behaviour

you can see by testing multiperiod mpd that when a period is switched, there are two sequentials `Selected representation` that sound a bit weird, that could be need to investigate in future