### PR TITLE
[DigestMD5Utils] Moved operator in header to remove warning

### DIFF
--- a/src/utils/DigestMD5Utils.cpp
+++ b/src/utils/DigestMD5Utils.cpp
@@ -261,11 +261,6 @@ std::string UTILS::DIGEST::MD5::HexDigest() const
   return std::string(buf);
 }
 
-std::ostream& UTILS::DIGEST::operator<<(std::ostream& out, MD5 md5)
-{
-  return out << md5.HexDigest();
-}
-
 // F, G, H and I are basic MD5 functions.
 MD5::uint4 UTILS::DIGEST::MD5::F(uint4 x, uint4 y, uint4 z)
 {

--- a/src/utils/DigestMD5Utils.h
+++ b/src/utils/DigestMD5Utils.h
@@ -42,7 +42,7 @@ public:
   void Update(const char* buf, uint32_t length);
   MD5& Finalize();
   std::string HexDigest() const;
-  friend std::ostream& operator<<(std::ostream& out, MD5 md5);
+  friend std::ostream& operator<<(std::ostream& out, MD5& md5) { return out << md5.HexDigest(); }
 
 private:
   typedef unsigned char uint1; //  8bit


### PR DESCRIPTION
as title for warning

`warning: ‘std::ostream& UTILS::DIGEST::operator<<(std::ostream&, UTILS::DIGEST::MD5)’ has not been declared within UTILS::DIGEST`

forgot to check in previous pr
~i have to see jenkins as confirm~ its ok