### PR TITLE
[cleanup] Removed CheckHDCP from RefreshLiveSegments

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1653,6 +1653,7 @@ void DASHTree::RefreshSegments(Period* period,
 }
 
 //Can be called form update-thread!
+//! @todo: we are updating variables in non-thread safe way
 void DASHTree::RefreshLiveSegments()
 {
   if (has_timeshift_buffer_ && !update_parameter_.empty())

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1714,8 +1714,6 @@ void DASHTree::RefreshLiveSegments()
 
     if (updateTree->open(manifestUrlUpd, ""))
     {
-      CheckHDCP();
-
       m_manifestHeaders.m_etag = updateTree->m_manifestHeaders.m_etag;
       m_manifestHeaders.m_lastModified = updateTree->m_manifestHeaders.m_lastModified;
       location_ = updateTree->location_;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -885,6 +885,7 @@ void HLSTree::RefreshSegments(Period* period,
 }
 
 //Called form update-thread
+//! @todo: we are updating variables in non-thread safe way
 void HLSTree::RefreshLiveSegments()
 {
   if (m_refreshPlayList)


### PR DESCRIPTION
this part of code confuses me, this check is not necessary as we look for updates based on existing representations (already HDCP checked)

add two non-thread safe todo's, to keep in mind for future reworking