### PR TITLE
[Nexus] Security fixes for embedded Bento4

### DIFF
--- a/depends/common/bento4/0991-Check-for-null-descriptor.patch
+++ b/depends/common/bento4/0991-Check-for-null-descriptor.patch
@@ -1,0 +1,25 @@
+From 71bac931b9a03a8c6c2580802ba2f99bb5a1cb6e Mon Sep 17 00:00:00 2001
+From: Dimitry Ishenko <dimitry.ishenko@gmail.com>
+Date: Wed, 12 May 2021 12:23:22 -0400
+Subject: [PATCH 01/13] Check for null descriptor
+
+---
+ Source/C++/Core/Ap4Descriptor.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/C++/Core/Ap4Descriptor.h b/Source/C++/Core/Ap4Descriptor.h
+index 7fe0717..4919bca 100644
+--- a/Source/C++/Core/Ap4Descriptor.h
++++ b/Source/C++/Core/Ap4Descriptor.h
+@@ -89,7 +89,7 @@ class AP4_DescriptorFinder : public AP4_List<AP4_Descriptor>::Item::Finder
+  public:
+     AP4_DescriptorFinder(AP4_UI08 tag) : m_Tag(tag) {}
+     AP4_Result Test(AP4_Descriptor* descriptor) const {
+-        return descriptor->GetTag() == m_Tag ? AP4_SUCCESS : AP4_FAILURE;
++        return (descriptor && descriptor->GetTag() == m_Tag) ? AP4_SUCCESS : AP4_FAILURE;
+     }
+     
+  private:
+-- 
+2.35.1
+

--- a/depends/common/bento4/0992-Update-m_sampleCount-after-successfully-reading-in-m.patch
+++ b/depends/common/bento4/0992-Update-m_sampleCount-after-successfully-reading-in-m.patch
@@ -1,0 +1,52 @@
+From f69a9c7049300ef6b1bef1c874f1946fc53605fd Mon Sep 17 00:00:00 2001
+From: Dimitry Ishenko <dimitry.ishenko@gmail.com>
+Date: Wed, 12 May 2021 13:03:25 -0400
+Subject: [PATCH 02/13] Update m_sampleCount after successfully reading in
+ m_Entries
+
+This mostly reverts commit e6c7cda (except for the formatting).
+---
+ Source/C++/Core/Ap4StszAtom.cpp | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/Source/C++/Core/Ap4StszAtom.cpp b/Source/C++/Core/Ap4StszAtom.cpp
+index e3896e9..225dbbb 100644
+--- a/Source/C++/Core/Ap4StszAtom.cpp
++++ b/Source/C++/Core/Ap4StszAtom.cpp
+@@ -78,25 +78,27 @@ AP4_StszAtom::AP4_StszAtom(AP4_UI32        size,
+     }
+ 
+     stream.ReadUI32(m_SampleSize);
+-    stream.ReadUI32(m_SampleCount);
++    AP4_UI32 sampleCount;
++    stream.ReadUI32(sampleCount);
+     if (m_SampleSize == 0) { // means that the samples have different sizes
+         // check for overflow
+-        if (m_SampleCount > (size - AP4_FULL_ATOM_HEADER_SIZE - 8) / 4) {
++        if (sampleCount > (size - AP4_FULL_ATOM_HEADER_SIZE - 8) / 4) {
+             return;
+         }
+         
+         // read the entries
+-        unsigned char* buffer = new unsigned char[m_SampleCount * 4];
+-        AP4_Result result = stream.Read(buffer, m_SampleCount * 4);
++        unsigned char* buffer = new unsigned char[sampleCount * 4];
++        AP4_Result result = stream.Read(buffer, sampleCount * 4);
+         if (AP4_FAILED(result)) {
+             delete[] buffer;
+             return;
+         }
+-        m_Entries.SetItemCount((AP4_Cardinal)m_SampleCount);
+-        for (unsigned int i = 0; i < m_SampleCount; i++) {
++        m_Entries.SetItemCount((AP4_Cardinal)sampleCount);
++        for (unsigned int i = 0; i < sampleCount; i++) {
+             m_Entries[i] = AP4_BytesToUInt32BE(&buffer[i * 4]);
+         }
+         delete[] buffer;
++        m_SampleCount = sampleCount;
+     }
+ }
+ 
+-- 
+2.35.1
+

--- a/depends/common/bento4/0993-set-m_SampleCount-even-when-m_SampleSize-0.patch
+++ b/depends/common/bento4/0993-set-m_SampleCount-even-when-m_SampleSize-0.patch
@@ -1,0 +1,53 @@
+From 5922ba762af468c2066c02e7904a3d0d2ca648a9 Mon Sep 17 00:00:00 2001
+From: Gilles Boccon-Gibod <bok@bok.net>
+Date: Tue, 3 Aug 2021 18:13:22 -0700
+Subject: [PATCH 06/13] set m_SampleCount even when m_SampleSize != 0
+
+---
+ Source/C++/Core/Ap4StszAtom.cpp | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/Source/C++/Core/Ap4StszAtom.cpp b/Source/C++/Core/Ap4StszAtom.cpp
+index 225dbbb..bea1a47 100644
+--- a/Source/C++/Core/Ap4StszAtom.cpp
++++ b/Source/C++/Core/Ap4StszAtom.cpp
+@@ -78,28 +78,28 @@ AP4_StszAtom::AP4_StszAtom(AP4_UI32        size,
+     }
+ 
+     stream.ReadUI32(m_SampleSize);
+-    AP4_UI32 sampleCount;
+-    stream.ReadUI32(sampleCount);
++    AP4_UI32 sample_count;
++    stream.ReadUI32(sample_count);
+     if (m_SampleSize == 0) { // means that the samples have different sizes
+         // check for overflow
+-        if (sampleCount > (size - AP4_FULL_ATOM_HEADER_SIZE - 8) / 4) {
++        if (sample_count > (size - AP4_FULL_ATOM_HEADER_SIZE - 8) / 4) {
+             return;
+         }
+         
+         // read the entries
+-        unsigned char* buffer = new unsigned char[sampleCount * 4];
+-        AP4_Result result = stream.Read(buffer, sampleCount * 4);
++        unsigned char* buffer = new unsigned char[sample_count * 4];
++        AP4_Result result = stream.Read(buffer, sample_count * 4);
+         if (AP4_FAILED(result)) {
+             delete[] buffer;
+             return;
+         }
+-        m_Entries.SetItemCount((AP4_Cardinal)sampleCount);
+-        for (unsigned int i = 0; i < sampleCount; i++) {
++        m_Entries.SetItemCount((AP4_Cardinal)sample_count);
++        for (unsigned int i = 0; i < sample_count; i++) {
+             m_Entries[i] = AP4_BytesToUInt32BE(&buffer[i * 4]);
+         }
+         delete[] buffer;
+-        m_SampleCount = sampleCount;
+     }
++    m_SampleCount = sample_count;
+ }
+ 
+ /*----------------------------------------------------------------------
+-- 
+2.35.1
+

--- a/depends/common/bento4/0995-CVE-2019-17452.patch
+++ b/depends/common/bento4/0995-CVE-2019-17452.patch
@@ -1,0 +1,26 @@
+From ffea12e7055ba95b4b907cc140785cfb1c420c64 Mon Sep 17 00:00:00 2001
+From: Gilles Boccon-Gibod <bok@bok.net>
+Date: Sun, 27 Feb 2022 19:11:11 -0800
+Subject: [PATCH 10/13] fix #434
+
+---
+ Source/C++/Core/Ap4DescriptorFactory.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Source/C++/Core/Ap4DescriptorFactory.cpp b/Source/C++/Core/Ap4DescriptorFactory.cpp
+index 907277d..1db7986 100644
+--- a/Source/C++/Core/Ap4DescriptorFactory.cpp
++++ b/Source/C++/Core/Ap4DescriptorFactory.cpp
+@@ -127,6 +127,9 @@ AP4_DescriptorFactory::CreateDescriptorFromStream(AP4_ByteStream&  stream,
+             descriptor = new AP4_UnknownDescriptor(stream, tag, header_size, payload_size);
+             break;
+         }
++    } else {
++        stream.Seek(offset);
++        return AP4_ERROR_INVALID_FORMAT;
+     }
+     
+     // skip to the end of the descriptor
+-- 
+2.35.1
+

--- a/depends/common/bento4/0996-fix-663.patch
+++ b/depends/common/bento4/0996-fix-663.patch
@@ -1,0 +1,29 @@
+From 151c3ee9d07e2ecf0fbd42090deefa46866f4319 Mon Sep 17 00:00:00 2001
+From: Gilles Boccon-Gibod <bok@bok.net>
+Date: Sun, 20 Mar 2022 15:24:05 -0700
+Subject: [PATCH 12/13] fix #663
+
+---
+ Source/C++/Core/Ap4HdlrAtom.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Source/C++/Core/Ap4HdlrAtom.cpp b/Source/C++/Core/Ap4HdlrAtom.cpp
+index e31b3da..ea3d80a 100644
+--- a/Source/C++/Core/Ap4HdlrAtom.cpp
++++ b/Source/C++/Core/Ap4HdlrAtom.cpp
+@@ -144,8 +144,10 @@ AP4_HdlrAtom::WriteFields(AP4_ByteStream& stream)
+     }
+ 
+     // pad with zeros if necessary
+-    AP4_Size padding = m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size);
+-    while (padding--) stream.WriteUI08(0);
++    if (m_Size32 > AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size) {
++        AP4_Size padding = m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size);
++        while (padding--) stream.WriteUI08(0);
++    }
+ 
+     return AP4_SUCCESS;
+ }
+-- 
+2.35.1
+

--- a/depends/common/bento4/0997-fix-679.patch
+++ b/depends/common/bento4/0997-fix-679.patch
@@ -1,0 +1,145 @@
+From 4d8e1fc1b6fac465a85921e2c041fdb7cc3e0076 Mon Sep 17 00:00:00 2001
+From: Gilles Boccon-Gibod <bok@bok.net>
+Date: Sun, 20 Mar 2022 15:45:57 -0700
+Subject: [PATCH 13/13] fix #679
+
+---
+ Source/C++/Core/Ap4DvccAtom.cpp          | 22 +++++++++----------
+ Source/C++/Core/Ap4DvccAtom.h            |  4 +++-
+ Source/C++/Core/Ap4SampleDescription.cpp | 28 +++++++++++++-----------
+ 3 files changed, 29 insertions(+), 25 deletions(-)
+
+diff --git a/Source/C++/Core/Ap4DvccAtom.cpp b/Source/C++/Core/Ap4DvccAtom.cpp
+index 494036f..f5cc85c 100644
+--- a/Source/C++/Core/Ap4DvccAtom.cpp
++++ b/Source/C++/Core/Ap4DvccAtom.cpp
+@@ -127,18 +127,19 @@ AP4_DvccAtom::AP4_DvccAtom(AP4_UI08 dv_version_major,
+ |   AP4_DvccAtom::GetCodecString
+ +---------------------------------------------------------------------*/
+ AP4_Result
+-AP4_DvccAtom::GetCodecString(AP4_SampleDescription* parent, AP4_String& codec)
++AP4_DvccAtom::GetCodecString(const char* parent_codec_string,
++                             AP4_UI32    parent_format,
++                             AP4_String& codec)
+ {
+     char workspace[64];
+     
+-    AP4_UI32 format = parent->GetFormat();
+-    if (format == AP4_ATOM_TYPE_DVAV ||
+-        format == AP4_ATOM_TYPE_DVA1 ||
+-        format == AP4_ATOM_TYPE_DVHE ||
+-        format == AP4_ATOM_TYPE_DVH1) {
++    if (parent_format == AP4_ATOM_TYPE_DVAV ||
++        parent_format == AP4_ATOM_TYPE_DVA1 ||
++        parent_format == AP4_ATOM_TYPE_DVHE ||
++        parent_format == AP4_ATOM_TYPE_DVH1) {
+         /* Non backward-compatible */
+         char coding[5];
+-        AP4_FormatFourChars(coding, format);
++        AP4_FormatFourChars(coding, parent_format);
+         AP4_FormatString(workspace,
+                          sizeof(workspace),
+                          "%s.%02d.%02d",
+@@ -148,7 +149,8 @@ AP4_DvccAtom::GetCodecString(AP4_SampleDescription* parent, AP4_String& codec)
+         codec = workspace;
+     } else {
+         /* Backward-compatible */
+-        switch (format) {
++        AP4_UI32 format = parent_format;
++        switch (parent_format) {
+           case AP4_ATOM_TYPE_AVC1:
+             format = AP4_ATOM_TYPE_DVA1;
+             break;
+@@ -167,12 +169,10 @@ AP4_DvccAtom::GetCodecString(AP4_SampleDescription* parent, AP4_String& codec)
+         }
+         char coding[5];
+         AP4_FormatFourChars(coding, format);
+-        AP4_String parent_codec;
+-        parent->GetCodecString(parent_codec);
+         AP4_FormatString(workspace,
+                          sizeof(workspace),
+                          "%s,%s.%02d.%02d",
+-                         parent_codec.GetChars(),
++                         parent_codec_string,
+                          coding,
+                          GetDvProfile(),
+                          GetDvLevel());
+diff --git a/Source/C++/Core/Ap4DvccAtom.h b/Source/C++/Core/Ap4DvccAtom.h
+index 3329cac..f1d2e68 100644
+--- a/Source/C++/Core/Ap4DvccAtom.h
++++ b/Source/C++/Core/Ap4DvccAtom.h
+@@ -92,7 +92,9 @@ public:
+     AP4_UI08 GetDvBlSignalCompatibilityID() { return m_DvBlSignalCompatibilityID; }
+ 
+     // helpers
+-    AP4_Result GetCodecString(AP4_SampleDescription* parent, AP4_String& codec);
++    AP4_Result GetCodecString(const char* parent_codec_string,
++                              AP4_UI32    parent_format,
++                              AP4_String& codec);
+ 
+ private:
+     // members
+diff --git a/Source/C++/Core/Ap4SampleDescription.cpp b/Source/C++/Core/Ap4SampleDescription.cpp
+index ef5147c..247729f 100644
+--- a/Source/C++/Core/Ap4SampleDescription.cpp
++++ b/Source/C++/Core/Ap4SampleDescription.cpp
+@@ -399,12 +399,6 @@ AP4_AvcSampleDescription::AP4_AvcSampleDescription(AP4_UI32        format,
+ +---------------------------------------------------------------------*/
+ AP4_Result
+ AP4_AvcSampleDescription::GetCodecString(AP4_String& codec) {
+-    // Dolby Vision override
+-    AP4_DvccAtom* dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, m_Details.GetChild(AP4_ATOM_TYPE_DVCC));
+-    if (dvcc) {
+-        return dvcc->GetCodecString(this, codec);
+-    }
+-    
+     char coding[5];
+     AP4_FormatFourChars(coding, GetFormat());
+     char workspace[64];
+@@ -415,8 +409,15 @@ AP4_AvcSampleDescription::GetCodecString(AP4_String& codec) {
+                      GetProfile(),
+                      GetProfileCompatibility(),
+                      GetLevel());
+-    codec = workspace;
+     
++    // Dolby Vision override
++    AP4_DvccAtom* dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, m_Details.GetChild(AP4_ATOM_TYPE_DVCC));
++    if (dvcc) {
++        return dvcc->GetCodecString(workspace, GetFormat(), codec);
++    }
++
++    codec = workspace;
++
+     return AP4_SUCCESS;
+ }
+ 
+@@ -609,12 +610,6 @@ ReverseBits(AP4_UI32 bits)
+ +---------------------------------------------------------------------*/
+ AP4_Result
+ AP4_HevcSampleDescription::GetCodecString(AP4_String& codec) {
+-    // Dolby Vision override
+-    AP4_DvccAtom* dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, m_Details.GetChild(AP4_ATOM_TYPE_DVCC));
+-    if (dvcc) {
+-        return dvcc->GetCodecString(this, codec);
+-    }
+-
+     char coding[5];
+     AP4_FormatFourChars(coding, GetFormat());
+     char profile_space[2] = {0,0};
+@@ -636,6 +631,13 @@ AP4_HevcSampleDescription::GetCodecString(AP4_String& codec) {
+                      GetGeneralTierFlag()?'H':'L',
+                      GetGeneralLevel(),
+                      constraints);
++
++    // Dolby Vision override
++    AP4_DvccAtom* dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, m_Details.GetChild(AP4_ATOM_TYPE_DVCC));
++    if (dvcc) {
++        return dvcc->GetCodecString(workspace, GetFormat(), codec);
++    }
++
+     codec = workspace;
+     
+     return AP4_SUCCESS;
+-- 
+2.35.1
+

--- a/depends/common/bento4/0998-CVE-2021-32265.patch
+++ b/depends/common/bento4/0998-CVE-2021-32265.patch
@@ -1,0 +1,52 @@
+From 447bbfd4298676582de3e01e2b77d6f73dfb7aba Mon Sep 17 00:00:00 2001
+From: bwatson <bwatson@roblox.com>
+Date: Mon, 21 Mar 2022 14:17:44 -0700
+Subject: [PATCH] If there is no name, do not write any further data to the
+ atom. Fix for CVE-2021-32265;
+ https://github.com/axiomatic-systems/Bento4/issues/545 In an hdlr atom, where
+ the size of the source atom is too short to contain a name, an exception will
+ have occurred because it would try to recalculate the size of the name and
+ end up with an arithmetic overflow.
+
+---
+ Source/C++/Core/Ap4HdlrAtom.cpp | 21 ++++++++++-----------
+ 1 file changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/Source/C++/Core/Ap4HdlrAtom.cpp b/Source/C++/Core/Ap4HdlrAtom.cpp
+index ea3d80af..0ebfb951 100644
+--- a/Source/C++/Core/Ap4HdlrAtom.cpp
++++ b/Source/C++/Core/Ap4HdlrAtom.cpp
+@@ -121,23 +121,22 @@ AP4_HdlrAtom::WriteFields(AP4_ByteStream& stream)
+     result = stream.WriteUI32(m_Reserved[2]);
+     if (AP4_FAILED(result)) return result;
+     AP4_UI08 name_size = (AP4_UI08)m_HandlerName.GetLength();
+-    if (m_QuickTimeMode) {
+-        name_size += 1;
+-        if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
+-            name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
+-        }
+-        if (name_size) {
++    if (name_size) {
++        if (m_QuickTimeMode) {
++            name_size += 1;
++            if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
++                name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
++            }
+             result = stream.WriteUI08(name_size - 1);
+             if (AP4_FAILED(result)) return result;
+ 
+             result = stream.Write(m_HandlerName.GetChars(), name_size - 1);
+             if (AP4_FAILED(result)) return result;
+         }
+-    } else {
+-        if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
+-            name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
+-        }
+-        if (name_size) {
++        else {
++            if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
++                name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
++            }
+             result = stream.Write(m_HandlerName.GetChars(), name_size);
+             if (AP4_FAILED(result)) return result;
+         }


### PR DESCRIPTION
The following fixes have not yet been tagged in upstream Bento4:

 * CVE-2019-17452
 * CVE-2021-32265
 * 2 other issues with no CVE‌ ID assigned yet

Let's start with Nexus and proceed with Matrix which needs a bigger overhaul since the bundled version there is 1.4.3.
