### PR TITLE
Implement AV1 codec support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,9 @@ find_package(Kodi REQUIRED)
 set(ADP_SOURCES
     src/AdaptiveByteStream.cpp
 	src/main.cpp
-	src/codechandler/AVCCodecHandler.cpp
 	src/codechandler/CodecHandler.cpp
+	src/codechandler/AV1CodecHandler.cpp
+	src/codechandler/AVCCodecHandler.cpp
 	src/codechandler/HEVCCodecHandler.cpp
 	src/codechandler/MPEGCodecHandler.cpp
 	src/codechandler/TTMLCodecHandler.cpp
@@ -58,8 +59,9 @@ set(ADP_HEADERS
 	src/main.h
 	src/oscompat.h
 	src/SSD_dll.h
-	src/codechandler/AVCCodecHandler.h
 	src/codechandler/CodecHandler.h
+	src/codechandler/AV1CodecHandler.h
+	src/codechandler/AVCCodecHandler.h
 	src/codechandler/HEVCCodecHandler.h
 	src/codechandler/MPEGCodecHandler.h
 	src/codechandler/TTMLCodecHandler.h

--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -83,6 +83,7 @@ namespace SSD
     CodecVp8,
     CodecH264,
     CodecVp9,
+    CodecAv1,
   };
 
   enum CodecProfile // refer to STREAMCODEC_PROFILE
@@ -100,6 +101,9 @@ namespace SSD
     VP9CodecProfile1,
     VP9CodecProfile2,
     VP9CodecProfile3,
+    AV1CodecProfileMain,
+    AV1CodecProfileHigh,
+    AV1CodecProfileProfessional,
   };
 
   struct SSD_VIDEOINITDATA

--- a/src/codechandler/AV1CodecHandler.cpp
+++ b/src/codechandler/AV1CodecHandler.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AV1CodecHandler.h"
+
+AV1CodecHandler::AV1CodecHandler(AP4_SampleDescription* sd)
+  : CodecHandler(sd), m_codecProfile{STREAMCODEC_PROFILE::CodecProfileUnknown}
+{
+  if (AP4_Atom* atom = m_sampleDescription->GetDetails().GetChild(AP4_ATOM_TYPE_AV1C, 0))
+  {
+    AP4_Av1cAtom* av1c(AP4_DYNAMIC_CAST(AP4_Av1cAtom, atom));
+    if (av1c)
+    {
+      switch (av1c->GetSeqProfile())
+      {
+        case AP4_AV1_PROFILE_MAIN:
+          m_codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileMain;
+          break;
+        case AP4_AV1_PROFILE_HIGH:
+          m_codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileHigh;
+          break;
+        case AP4_AV1_PROFILE_PROFESSIONAL:
+          m_codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileProfessional;
+          break;
+        default:
+          m_codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileMain;
+      }
+
+      const AP4_DataBuffer& obus{av1c->GetConfigObus()};
+      m_extraData.SetData(obus.GetData(), obus.GetDataSize());
+    }
+  }
+}
+
+bool AV1CodecHandler::GetInformation(kodi::addon::InputstreamInfo& info)
+{
+  bool ret{CodecHandler::GetInformation(info)};
+  if (info.GetCodecProfile() != m_codecProfile)
+  {
+    info.SetCodecProfile(m_codecProfile);
+    return true;
+  }
+
+  return false;
+}

--- a/src/codechandler/AV1CodecHandler.h
+++ b/src/codechandler/AV1CodecHandler.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "CodecHandler.h"
+
+class ATTR_DLL_LOCAL AV1CodecHandler : public CodecHandler
+{
+public:
+  AV1CodecHandler(AP4_SampleDescription* sd);
+
+  bool GetInformation(kodi::addon::InputstreamInfo& info) override;
+  STREAMCODEC_PROFILE GetProfile() override { return m_codecProfile; }
+
+private:
+  STREAMCODEC_PROFILE m_codecProfile;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -622,8 +622,8 @@ bool CVideoCodecAdaptive::Open(const kodi::addon::VideoCodecInitdata& initData)
   if (!m_session || !m_session->GetDecrypter())
     return false;
 
-  if (initData.GetCodecType() == VIDEOCODEC_H264 && !initData.GetExtraDataSize() &&
-      !(m_state & STATE_WAIT_EXTRADATA))
+  if ((initData.GetCodecType() == VIDEOCODEC_H264 || initData.GetCodecType() == VIDEOCODEC_AV1) &&
+      !initData.GetExtraDataSize() && !(m_state & STATE_WAIT_EXTRADATA))
   {
     LOG::Log(LOGINFO, "VideoCodec::Open: Wait ExtraData");
     m_state |= STATE_WAIT_EXTRADATA;
@@ -644,6 +644,9 @@ bool CVideoCodecAdaptive::Open(const kodi::addon::VideoCodecInitdata& initData)
       break;
     case VIDEOCODEC_VP9:
       m_name += ".vp9";
+      break;
+    case VIDEOCODEC_AV1:
+      m_name += ".av1";
       break;
     default:
       break;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -70,6 +70,10 @@ static std::string getVideoCodec(const std::string& codecs)
     return "dvh1";
   else if (codecs.find("dvhe.") != std::string::npos)
     return "dvhe";
+  else if (codecs.find("av01") != std::string::npos)
+    return "av01";
+  else if (codecs.find("av1") != std::string::npos)
+    return "av1";
   else
     return "";
 }

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -7,6 +7,7 @@
  */
 
 #include "../ADTSReader.h"
+#include "../AdaptiveByteStream.h"
 #include "../TSReader.h"
 #include "SampleReader.h"
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -8,6 +8,14 @@
 
 #include "FragmentedSampleReader.h"
 
+#include "../AdaptiveByteStream.h"
+#include "../codechandler/AV1CodecHandler.h"
+#include "../codechandler/AVCCodecHandler.h"
+#include "../codechandler/HEVCCodecHandler.h"
+#include "../codechandler/MPEGCodecHandler.h"
+#include "../codechandler/TTMLCodecHandler.h"
+#include "../codechandler/VP9CodecHandler.h"
+#include "../codechandler/WebVTTCodecHandler.h"
 #include "../utils/log.h"
 
 namespace
@@ -473,6 +481,9 @@ void CFragmentedSampleReader::UpdateSampleDescription()
       break;
     case AP4_SAMPLE_FORMAT_VP9:
       m_codecHandler = new VP9CodecHandler(desc);
+      break;
+    case AP4_SAMPLE_FORMAT_AV01:
+      m_codecHandler = new AV1CodecHandler(desc);
       break;
     default:
       m_codecHandler = new CodecHandler(desc);

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -9,12 +9,7 @@
 #pragma once
 
 #include "../SSD_dll.h"
-#include "../codechandler/AVCCodecHandler.h"
-#include "../codechandler/HEVCCodecHandler.h"
-#include "../codechandler/MPEGCodecHandler.h"
-#include "../codechandler/TTMLCodecHandler.h"
-#include "../codechandler/VP9CodecHandler.h"
-#include "../codechandler/WebVTTCodecHandler.h"
+#include "../codechandler/CodecHandler.h"
 #include "../common/AdaptiveDecrypter.h"
 #include "../utils/log.h"
 #include "SampleReader.h"

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "../AdaptiveByteStream.h"
 #include "../common/AdaptiveDecrypter.h"
 
 #include <bento4/Ap4.h>

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "../AdaptiveByteStream.h"
 #include "../TSReader.h"
 #include "SampleReader.h"
 
@@ -13,9 +14,9 @@ class ATTR_DLL_LOCAL CTSSampleReader : public ISampleReader, public TSReader
 {
 public:
   CTSSampleReader(AP4_ByteStream* input,
-                 INPUTSTREAM_TYPE type,
-                 AP4_UI32 streamId,
-                 uint32_t requiredMask);
+                  INPUTSTREAM_TYPE type,
+                  AP4_UI32 streamId,
+                  uint32_t requiredMask);
 
   bool Initialize() override { return TSReader::Initialize(); }
   void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -320,12 +320,25 @@ void UTILS::ParseHeaderString(std::map<std::string, std::string>& headerMap,
 
 std::string UTILS::GetVideoCodecDesc(std::string_view codecName)
 {
-  if (codecName.find("avc") == 0 || codecName.find("h264") == 0)
+  if (codecName.find("avc") != std::string::npos || codecName.find("h264") != std::string::npos)
+  {
     return "H.264";
-  else if (codecName.find("hev") == 0 || codecName.find("hvc") == 0 || codecName.find("dvh") == 0)
+  }
+  else if (codecName.find("hev") != std::string::npos ||
+           codecName.find("hvc") != std::string::npos || codecName.find("dvh") != std::string::npos)
+  {
     return "H.265 / HEVC";
-  else if (codecName.find("vp9") == 0 || codecName.find("vp09") == 0)
+  }
+  else if (codecName.find("vp9") != std::string::npos ||
+           codecName.find("vp09") != std::string::npos)
+  {
     return "H.265 / VP9";
+  }
+  else if (codecName.find("av1") != std::string::npos ||
+           codecName.find("av01") != std::string::npos)
+  {
+    return "AV1";
+  }
   else
     return "";
 }

--- a/wvdecrypter/cdm/media/cdm/cdm_type_conversion.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_type_conversion.cc
@@ -59,6 +59,8 @@ cdm::VideoCodec media::ToCdmVideoCodec(const SSD::Codec codec)
       return cdm::VideoCodec::kCodecVp8;
     case SSD::Codec::CodecVp9:
       return cdm::VideoCodec::kCodecVp9;
+    case SSD::Codec::CodecAv1:
+      return cdm::VideoCodec::kCodecAv1;
     default:
       LOG::LogF(SSDWARNING, "Unknown video codec %i", codec);
       return cdm::VideoCodec::kUnknownVideoCodec;
@@ -91,6 +93,12 @@ cdm::VideoCodecProfile media::ToCdmVideoCodecProfile(const SSD::CodecProfile pro
       return cdm::VideoCodecProfile::kVP9Profile2;
     case SSD::CodecProfile::VP9CodecProfile3:
       return cdm::VideoCodecProfile::kVP9Profile3;
+    case SSD::CodecProfile::AV1CodecProfileMain:
+      return cdm::VideoCodecProfile::kAv1ProfileMain;
+    case SSD::CodecProfile::AV1CodecProfileHigh:
+      return cdm::VideoCodecProfile::kAv1ProfileHigh;
+    case SSD::CodecProfile::AV1CodecProfileProfessional:
+      return cdm::VideoCodecProfile::kAv1ProfilePro;
     case SSD::CodecProfile::CodecProfileNotNeeded:
       return cdm::VideoCodecProfile::kProfileNotNeeded;
     default:


### PR DESCRIPTION
This implement AV1 codec support

What is the current status, has been implemented for DASH and unofficially for HSL
the unencrypted streams are played with success, some examples:

https://storage.googleapis.com/bitmovin-demos/av1/stream.mpd
https://storage.googleapis.com/bitmovin-demos/av1/stream_chrome.mpd
http://ftp.itec.aau.at/datasets/mmsys18/testing/Beauty_4sec/multi-codec.mpd

For encrypted AV1 streams i havent found sample streams to test,
the only way that i found to test it is by using n@tflix, that provide MP4/CBCS.
Unfortunately, these encrypted streams are not being played in the right way,
~a possible cause is the use of CMAF~ (EDIT: the problem is wrong video format set), the image result as:
![immagine](https://user-images.githubusercontent.com/3257156/167647652-68d3450e-db19-47f3-8e05-9c401765aea8.png)
this problem looks similar to my old test with VP9.2 in Issue https://github.com/xbmc/inputstream.adaptive/issues/525 (still unresolved, not more tested over the time not knowing how to solve)

To do tests with N@tflix is possible to use this PR branch:
https://github.com/CastagnaIT/plugin.video.netflix/pull/1343
(clearly on browser Chrome N@tflix AV1 playback works fine)

I can suggest to add this support to allow to play at least AV1 unencrypted streams,
and when we will find an encrypted sample in future we will see how goes

**This depends from:** https://github.com/xbmc/xbmc/pull/21390
