### PR TITLE
Updated and fixed codecs in SSD interface

### DIFF
--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -42,7 +42,7 @@ namespace SSD
     {
       PROPERTY_HEADER
   };
-    static const uint32_t version = 17;
+    static const uint32_t version = 18;
 #if defined(ANDROID)
     virtual void* GetJNIEnv() = 0;
     virtual int GetSDKVersion() = 0;
@@ -63,11 +63,13 @@ namespace SSD
     virtual void LogVA(const SSDLogLevel level, const char* format, va_list args) = 0;
   };
 
-  /****************************************************************************************************/
-  // keep those values in track with xbmc\addons\kodi-addon-dev-kit\include\kodi\kodi_videocodec_types.h
-  /****************************************************************************************************/
+  /*
+   * Enums: SSD_VIDEOFORMAT, Codec, CodecProfile must be kept in sync with:
+   * xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_codec.h
+   * xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
+   */
 
-  enum SSD_VIDEOFORMAT
+  enum SSD_VIDEOFORMAT // refer to VIDEOCODEC_FORMAT
   {
     UnknownVideoFormat = 0,
     VideoFormatYV12,
@@ -75,27 +77,35 @@ namespace SSD
     MaxVideoFormats
   };
 
+  enum Codec // refer to VIDEOCODEC_TYPE
+  {
+    CodecUnknown = 0,
+    CodecVp8,
+    CodecH264,
+    CodecVp9,
+  };
+
+  enum CodecProfile // refer to STREAMCODEC_PROFILE
+  {
+    CodecProfileUnknown = 0,
+    CodecProfileNotNeeded,
+    H264CodecProfileBaseline,
+    H264CodecProfileMain,
+    H264CodecProfileExtended,
+    H264CodecProfileHigh,
+    H264CodecProfileHigh10,
+    H264CodecProfileHigh422,
+    H264CodecProfileHigh444Predictive,
+    VP9CodecProfile0 = 20,
+    VP9CodecProfile1,
+    VP9CodecProfile2,
+    VP9CodecProfile3,
+  };
+
   struct SSD_VIDEOINITDATA
   {
-    enum Codec {
-      CodecUnknown = 0,
-      CodecVp8,
-      CodecH264,
-      CodecVp9
-    } codec;
-
-    enum CodecProfile
-    {
-      CodecProfileUnknown = 0,
-      CodecProfileNotNeeded,
-      H264CodecProfileBaseline,
-      H264CodecProfileMain,
-      H264CodecProfileExtended,
-      H264CodecProfileHigh,
-      H264CodecProfileHigh10,
-      H264CodecProfileHigh422,
-      H264CodecProfileHigh444Predictive
-    } codecProfile;
+    Codec codec;
+    CodecProfile codecProfile;
 
     const SSD_VIDEOFORMAT *videoFormats;
 

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -1297,14 +1297,89 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 bool WV_CencSingleSampleDecrypter::OpenVideoDecoder(const SSD_VIDEOINITDATA *initData)
 {
   cdm::VideoDecoderConfig_3 vconfig;
-  vconfig.codec = static_cast<cdm::VideoCodec>(initData->codec);
-  vconfig.coded_size.width = initData->width;
-  vconfig.coded_size.height = initData->height;
+
   vconfig.extra_data = const_cast<uint8_t*>(initData->extraData);
   vconfig.extra_data_size = initData->extraDataSize;
-  vconfig.format = static_cast<cdm::VideoFormat> (initData->videoFormats[0]);
-  vconfig.profile = static_cast<cdm::VideoCodecProfile>(initData->codecProfile);
-  vconfig.color_space = { 2, 2, 2, cdm::ColorRange::kInvalid };
+
+  vconfig.coded_size.width = initData->width;
+  vconfig.coded_size.height = initData->height;
+
+  switch (initData->codec)
+  {
+    case SSD::Codec::CodecH264:
+      vconfig.codec = cdm::VideoCodec::kCodecH264;
+      break;
+    case SSD::Codec::CodecVp8:
+      vconfig.codec = cdm::VideoCodec::kCodecVp8;
+      break;
+    case SSD::Codec::CodecVp9:
+      vconfig.codec = cdm::VideoCodec::kCodecVp9;
+      break;
+    default:
+      vconfig.codec = cdm::VideoCodec::kUnknownVideoCodec;
+      LogF(SSDWARNING, "Unknown codec %i", initData->codec);
+      break;
+  }
+
+  switch (initData->codecProfile)
+  {
+    case SSD::CodecProfile::H264CodecProfileBaseline:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileBaseline;
+      break;
+    case SSD::CodecProfile::H264CodecProfileMain:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileMain;
+      break;
+    case SSD::CodecProfile::H264CodecProfileExtended:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileExtended;
+      break;
+    case SSD::CodecProfile::H264CodecProfileHigh:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh;
+      break;
+    case SSD::CodecProfile::H264CodecProfileHigh10:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh10;
+      break;
+    case SSD::CodecProfile::H264CodecProfileHigh422:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh422;
+      break;
+    case SSD::CodecProfile::H264CodecProfileHigh444Predictive:
+      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh444Predictive;
+      break;
+    case SSD::CodecProfile::VP9CodecProfile0:
+      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile0;
+      break;
+    case SSD::CodecProfile::VP9CodecProfile1:
+      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile1;
+      break;
+    case SSD::CodecProfile::VP9CodecProfile2:
+      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile2;
+      break;
+    case SSD::CodecProfile::VP9CodecProfile3:
+      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile3;
+      break;
+    case SSD::CodecProfile::CodecProfileNotNeeded:
+      vconfig.profile = cdm::VideoCodecProfile::kProfileNotNeeded;
+      break;
+    default:
+      LogF(SSDWARNING, "Unknown codec profile %i", initData->codecProfile);
+      vconfig.profile = cdm::VideoCodecProfile::kUnknownVideoCodecProfile;
+      break;
+  }
+
+  switch (initData->videoFormats[0])
+  {
+  case SSD::SSD_VIDEOFORMAT::VideoFormatYV12:
+    vconfig.format = cdm::VideoFormat::kYv12;
+    break;
+  case SSD::SSD_VIDEOFORMAT::VideoFormatI420:
+    vconfig.format = cdm::VideoFormat::kI420;
+    break;
+  default:
+    LogF(SSDWARNING, "Unknown video format %i", initData->videoFormats[0]);
+    vconfig.format = cdm::VideoFormat::kUnknownVideoFormat;
+    break;
+  }
+
+  vconfig.color_space = { 2, 2, 2, cdm::ColorRange::kInvalid }; // Unspecified
   vconfig.encryption_scheme = m_EncryptionScheme;
 
   cdm::Status ret = drm_.GetCdmAdapter()->InitializeVideoDecoder(vconfig);


### PR DESCRIPTION
The enums was not in-sync with the kodi interface and
the cast here
https://github.com/xbmc/inputstream.adaptive/blob/20.2.0-Nexus/src/main.cpp#L2321-L2322
was resulting in undefined behaviour because it is not safe cast an `enum` which does not contain the corresponding elements,
plus VP9 entries was missing resulting in the assignment of incorrect values

would be different if it were an `enum class` which supports casting with undefined values
but here we have a C interface (not C++) then we shoud use `enum`,
this double work to keep in sync our interface could be avoided if in future the wv project will be merged to the main one

I have also added a comparison with switches for each case, as they are different interfaces we cannot assume that the values are always exact with a simple static_cast...

i have not check you may need to backport