### PR TITLE
[HLS] Allow for AES-128 encrypted init segments

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -138,6 +138,7 @@ namespace adaptive
         (Representation::INITIALIZATION | Representation::URLSEGMENTS))
     {
       rep->initialization_.url.clear();
+      --period->psshSets_[rep->initialization_.pssh_set_].use_count_;
     }
     rep->segments_.clear();
     rep->current_segment_ = nullptr;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -706,6 +706,9 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
             rep->flags_ |= Representation::INITIALIZATION;
             rep->containerType_ = CONTAINERTYPE_MP4;
             hasMap = true;
+
+            if (currentEncryptionType == ENCRYPTIONTYPE_AES128)
+              newInitialization.pssh_set_ = insert_psshset(NOTYPE, period, adp);
           }
         }
       }
@@ -720,6 +723,9 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
         rep->initialization_.range_begin_ = 0;
         rep->initialization_.range_end_ = newSegments.data[0].range_begin_ - 1;
         rep->initialization_.pssh_set_ = 0;
+
+        if (currentEncryptionType == ENCRYPTIONTYPE_AES128)
+          rep->initialization_.pssh_set_ = insert_psshset(NOTYPE, period, adp);
       }
 
       FreeSegments(period, rep);


### PR DESCRIPTION
An oversight from earlier fmp4 implementation (at time of D+/HLS Widevine PR)
As fmp4 HLS streams have mainly come about with Widevine protection, having fmp4 with AES-128 encryption does not seem very common at all.

This PR allows for the situation where the initialization segment is encrypted as well as the main segments

Also corrected `FreeSegments` to also decrement the use count of the psshset in `rep->initialization_`

Should aid in fixing #963