### PR TITLE
Handled limited GUI resolution with Adjust refresh rate and window resizing

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -306,3 +306,8 @@ msgstr ""
 msgctxt "#30235"
 msgid "Segments"
 msgstr ""
+
+#. Category group title
+msgctxt "#30236"
+msgid "Override settings"
+msgstr ""

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -69,23 +69,6 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting parent="adaptivestream.type" id="adaptivestream.ignore.screen.res.change" type="boolean" label="30202" help="30203">
-          <level>0</level>
-          <default>false</default>
-          <visible>false</visible><!-- Not fully implemented yet -->
-          <dependencies>
-             <dependency type="visible" setting="adaptivestream.type">default</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting parent="adaptivestream.type" id="adaptivestream.ignore.screen.res" type="boolean" label="30115" help="30116">
-          <level>0</level>
-          <default>false</default>
-          <dependencies>
-             <dependency type="visible" setting="adaptivestream.type">default</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
         <setting parent="adaptivestream.type" id="adaptivestream.bandwidth.init.auto" type="boolean" label="30168" help="30169">
           <level>0</level>
           <default>true</default>
@@ -232,6 +215,24 @@
             </dependency>
           </dependencies>
           <control type="edit" format="string" />
+        </setting>
+      </group>
+      <group id="overrides" label="30236">
+        <setting id="overrides.ignore.screen.res.change" type="boolean" label="30202" help="30203">
+          <level>0</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="overrides.ignore.screen.res" type="boolean" label="30115" help="30116">
+          <level>0</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="visible" setting="adaptivestream.type">default</dependency>
+          </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
     </category>

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1082,9 +1082,9 @@ void CSession::StartReader(
     m_changed = true;
 }
 
-void CSession::SetVideoResolution(int width, int height)
+void CSession::SetVideoResolution(int width, int height, int maxWidth, int maxHeight)
 {
-  m_reprChooser->SetScreenResolution(width, height);
+  m_reprChooser->SetScreenResolution(width, height, maxWidth, maxHeight);
 };
 
 bool CSession::GetNextSample(ISampleReader*& sampleReader)

--- a/src/Session.h
+++ b/src/Session.h
@@ -204,7 +204,7 @@ public:
    *  \param width The width in pixels
    *  \param height The height in pixels
    */
-  void SetVideoResolution(int width, int height);
+  void SetVideoResolution(int width, int height, int maxWidth, int maxHeight);
 
   /*! \brief Seek streams and readers to a specified time
    *  \param seekTime The seek time in seconds

--- a/src/common/Chooser.h
+++ b/src/common/Chooser.h
@@ -24,6 +24,7 @@ namespace CHOOSER
 class ATTR_DLL_LOCAL IRepresentationChooser
 {
 public:
+  IRepresentationChooser();
   virtual ~IRepresentationChooser() {}
 
   /*!
@@ -44,8 +45,13 @@ public:
    *        To be called every time the screen resolution change.
    * \param width Width resolution
    * \param height Height resolution
+   * \param maxWidth Max width resolution
+   * \param maxHeight Max height resolution
    */
-  void SetScreenResolution(const int width, const int height);
+  void SetScreenResolution(const int width,
+                           const int height,
+                           const int maxWidth,
+                           const int maxHeight);
 
   /*!
    * \brief Set the current download speed.
@@ -106,6 +112,13 @@ protected:
   int m_screenCurrentWidth{0};
   // Current screen height resolution (this value is auto-updated by Kodi)
   int m_screenCurrentHeight{0};
+  // Specifies when it is necessary to start playback with a stream having
+  // max allowed resolution to let Kodi auto-switching the screen resolution
+  // with "Adjust refresh rate" setting
+  bool m_isForceStartsMaxRes{false};
+
+private:
+  bool m_isAdjustRefreshRate{false};
 };
 
 IRepresentationChooser* CreateRepresentationChooser(

--- a/src/main.h
+++ b/src/main.h
@@ -34,7 +34,10 @@ public:
   bool OpenStream(int streamid) override;
   DEMUX_PACKET* DemuxRead() override;
   bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
-  void SetVideoResolution(int width, int height) override;
+  void SetVideoResolution(unsigned int width,
+                          unsigned int height,
+                          unsigned int maxWidth,
+                          unsigned int maxHeight);
   bool PosTime(int ms) override;
   int GetTotalTime() override;
   int GetTime() override;
@@ -53,8 +56,10 @@ public:
 private:
   std::shared_ptr<SESSION::CSession> m_session{nullptr};
   UTILS::PROPERTIES::KodiProperties m_kodiProps;
-  int m_currentVideoWidth{1280};
-  int m_currentVideoHeight{720};
+  int m_currentVideoWidth{0};
+  int m_currentVideoHeight{0};
+  int m_currentVideoMaxWidth{0};
+  int m_currentVideoMaxHeight{0};
   uint32_t m_IncludedStreams[16];
   bool m_checkChapterSeek = false;
   int m_failedSeekTime = ~0;

--- a/src/test/KodiStubs.h
+++ b/src/test/KodiStubs.h
@@ -60,6 +60,14 @@ typedef enum OpenFileFlags
   ADDON_READ_REOPEN = 0x100
 } OpenFileFlags;
 
+enum AdjustRefreshRateStatus
+{
+  ADJUST_REFRESHRATE_STATUS_OFF = 0,
+  ADJUST_REFRESHRATE_STATUS_ALWAYS,
+  ADJUST_REFRESHRATE_STATUS_ON_STARTSTOP,
+  ADJUST_REFRESHRATE_STATUS_ON_START,
+};
+
 namespace kodi
 {
 namespace addon
@@ -155,6 +163,11 @@ public:
 
 namespace gui
 {
+
+inline AdjustRefreshRateStatus GetAdjustRefreshRateStatus()
+{
+  return AdjustRefreshRateStatus::ADJUST_REFRESHRATE_STATUS_OFF;
+}
 
 namespace dialogs
 {


### PR DESCRIPTION
This handle two use cases
- when user limit Kodi GUI to 1080p to allow tv upscaling and use Adjust refresh rate to play until to 4k
- when Kodi is windowed mode we can have a callback from kodi of the updated resolution values after window resize

**It depends from:** https://github.com/xbmc/xbmc/pull/21319

Follow addon workaround settings are now not more needed and should not be used:
`Ignore screen resolution change`
`Ignore screen resolution`

they has been moved to `Expert` settings for a more likely future removal
also the id's of these settings are changed to make effective the new change on existing old addon installations

PS. i will do a cleanup to change all variables from `int` to `unsigned int` on another PR