### PR TITLE
Refactor of Session class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,10 @@ set(ADP_SOURCES
 	src/utils/SettingsUtils.cpp
 	src/utils/UrlUtils.cpp
 	src/utils/Utils.cpp
+	src/KodiHost.cpp
 	src/oscompat.cpp
+	src/Session.cpp
+	src/Stream.cpp
 	src/TSReader.cpp
 	src/aes_decrypter.cpp
 	src/ADTSReader.cpp
@@ -91,6 +94,9 @@ set(ADP_HEADERS
 	src/utils/StringUtils.h
 	src/utils/UrlUtils.h
 	src/utils/Utils.h
+	src/KodiHost.h
+	src/Session.h
+	src/Stream.h
 	src/TSReader.h
 	src/aes_decrypter.h
 	src/ADTSReader.h

--- a/src/KodiHost.cpp
+++ b/src/KodiHost.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "KodiHost.h"
+
+#include "utils/log.h"
+
+void* CKodiHost::CURLCreate(const char* strURL)
+{
+  kodi::vfs::CFile* file{new kodi::vfs::CFile};
+  if (!file->CURLCreate(strURL))
+  {
+    delete file;
+    return nullptr;
+  }
+  return file;
+}
+
+bool CKodiHost::CURLAddOption(void* file, CURLOPTIONS opt, const char* name, const char* value)
+{
+  const CURLOptiontype xbmcmap[]{ADDON_CURL_OPTION_PROTOCOL, ADDON_CURL_OPTION_HEADER};
+  return static_cast<kodi::vfs::CFile*>(file)->CURLAddOption(xbmcmap[opt], name, value);
+}
+
+const char* CKodiHost::CURLGetProperty(void* file, CURLPROPERTY prop, const char* name)
+{
+  const FilePropertyTypes xbmcmap[]{ADDON_FILE_PROPERTY_RESPONSE_HEADER};
+  m_strPropertyValue = static_cast<kodi::vfs::CFile*>(file)->GetPropertyValue(xbmcmap[prop], name);
+  return m_strPropertyValue.c_str();
+}
+
+bool CKodiHost::CURLOpen(void* file)
+{
+  return static_cast<kodi::vfs::CFile*>(file)->CURLOpen(ADDON_READ_NO_CACHE);
+}
+
+size_t CKodiHost::ReadFile(void* file, void* lpBuf, size_t uiBufSize)
+{
+  return static_cast<kodi::vfs::CFile*>(file)->Read(lpBuf, uiBufSize);
+}
+
+void CKodiHost::CloseFile(void* file)
+{
+  return static_cast<kodi::vfs::CFile*>(file)->Close();
+}
+
+bool CKodiHost::CreateDir(const char* dir)
+{
+  return kodi::vfs::CreateDirectory(dir);
+}
+
+void CKodiHost::LogVA(const SSD::SSDLogLevel level, const char* format, va_list args)
+{
+  std::vector<char> data;
+  data.resize(256);
+
+  va_list argsStart;
+  va_copy(argsStart, args);
+
+  int ret;
+  while (static_cast<size_t>(ret = vsnprintf(data.data(), data.size(), format, args)) > data.size())
+  {
+    data.resize(data.size() * 2);
+    args = argsStart;
+  }
+  LOG::Log(static_cast<LogLevel>(level), data.data());
+  va_end(argsStart);
+}
+
+void CKodiHost::SetLibraryPath(const char* libraryPath)
+{
+  m_strLibraryPath = libraryPath;
+
+  const char* pathSep{libraryPath[0] && libraryPath[1] == ':' && isalpha(libraryPath[0]) ? "\\"
+                                                                                         : "/"};
+
+  if (m_strLibraryPath.size() && m_strLibraryPath.back() != pathSep[0])
+    m_strLibraryPath += pathSep;
+}
+
+void CKodiHost::SetProfilePath(const std::string& profilePath)
+{
+  m_strProfilePath = profilePath;
+
+  const char* pathSep{profilePath[0] && profilePath[1] == ':' && isalpha(profilePath[0]) ? "\\"
+                                                                                         : "/"};
+
+  if (m_strProfilePath.size() && m_strProfilePath.back() != pathSep[0])
+    m_strProfilePath += pathSep;
+
+  //let us make cdm userdata out of the addonpath and share them between addons
+  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 2));
+  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1));
+  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1) +
+                          1);
+
+  kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
+  m_strProfilePath += "cdm";
+  m_strProfilePath += pathSep;
+  kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
+}
+
+bool CKodiHost::GetBuffer(void* instance, SSD::SSD_PICTURE& picture)
+{
+  return instance ? static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->GetFrameBuffer(
+                        *reinterpret_cast<VIDEOCODEC_PICTURE*>(&picture))
+                  : false;
+}
+
+void CKodiHost::ReleaseBuffer(void* instance, void* buffer)
+{
+  if (instance)
+    static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->ReleaseFrameBuffer(buffer);
+}

--- a/src/KodiHost.h
+++ b/src/KodiHost.h
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "SSD_dll.h"
+
+#include <kodi/Filesystem.h>
+#include <kodi/General.h>
+#include <kodi/addon-instance/VideoCodec.h>
+
+#if defined(ANDROID)
+#include <kodi/platform/android/System.h>
+#endif
+
+class ATTR_DLL_LOCAL CKodiHost : public SSD::SSD_HOST
+{
+public:
+#if defined(ANDROID)
+  virtual void* GetJNIEnv() override { return m_androidSystem.GetJNIEnv(); };
+
+  virtual int GetSDKVersion() override { return m_androidSystem.GetSDKVersion(); };
+
+  virtual const char* GetClassName() override
+  {
+    m_retvalHelper = m_androidSystem.GetClassName();
+    return m_retvalHelper.c_str();
+  };
+
+#endif
+  virtual const char* GetLibraryPath() const override { return m_strLibraryPath.c_str(); };
+
+  virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); };
+
+  virtual void* CURLCreate(const char* strURL) override;
+
+  virtual bool CURLAddOption(void* file,
+                             CURLOPTIONS opt,
+                             const char* name,
+                             const char* value) override;
+
+  virtual const char* CURLGetProperty(void* file, CURLPROPERTY prop, const char* name) override;
+
+  virtual bool CURLOpen(void* file) override;
+
+  virtual size_t ReadFile(void* file, void* lpBuf, size_t uiBufSize) override;
+
+  virtual void CloseFile(void* file) override;
+
+  virtual bool CreateDir(const char* dir) override;
+
+  void LogVA(const SSD::SSDLogLevel level, const char* format, va_list args) override;
+
+  void SetLibraryPath(const char* libraryPath);
+
+  void SetProfilePath(const std::string& profilePath);
+
+  virtual bool GetBuffer(void* instance, SSD::SSD_PICTURE& picture) override;
+
+  virtual void ReleaseBuffer(void* instance, void* buffer) override;
+
+private:
+  std::string m_strProfilePath;
+  std::string m_strLibraryPath;
+  std::string m_strPropertyValue;
+
+#if defined(ANDROID)
+  kodi::platform::CInterfaceAndroidSystem m_androidSystem;
+  std::string m_retvalHelper;
+#endif
+};

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1,0 +1,1458 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Session.h"
+
+#include "aes_decrypter.h"
+#include "parser/DASHTree.h"
+#include "parser/HLSTree.h"
+#include "parser/SmoothTree.h"
+#include "samplereader/ADTSSampleReader.h"
+#include "samplereader/DummySampleReader.h"
+#include "samplereader/FragmentedSampleReader.h"
+#include "samplereader/SubtitleSampleReader.h"
+#include "samplereader/TSSampleReader.h"
+#include "samplereader/WebmSampleReader.h"
+#include "utils/Base64Utils.h"
+#include "utils/SettingsUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/Utils.h"
+#include "utils/log.h"
+
+#include <kodi/addon-instance/Inputstream.h>
+
+using namespace UTILS;
+using namespace kodi::tools;
+using namespace SESSION;
+
+static const AP4_Track::Type TIDC[adaptive::AdaptiveTree::STREAM_TYPE_COUNT] = {
+    AP4_Track::TYPE_UNKNOWN, AP4_Track::TYPE_VIDEO, AP4_Track::TYPE_AUDIO,
+    AP4_Track::TYPE_SUBTITLES};
+
+
+CSession::CSession(const PROPERTIES::KodiProperties& kodiProps,
+                   const std::string& manifestUrl,
+                   const std::map<std::string, std::string>& mediaHeaders,
+                   const std::string& profilePath)
+  : m_kodiProps(kodiProps),
+    m_manifestUrl(manifestUrl),
+    m_mediaHeaders(mediaHeaders),
+    m_dummySampleReader(std::make_unique<CDummySampleReader>()),
+    m_KodiHost(std::make_unique<CKodiHost>()),
+    m_reprChooser(CHOOSER::CreateRepresentationChooser(kodiProps))
+
+{
+  m_KodiHost->SetProfilePath(profilePath);
+
+  switch (kodiProps.m_manifestType)
+  {
+    case PROPERTIES::ManifestType::MPD:
+      m_adaptiveTree = new adaptive::DASHTree(kodiProps, m_reprChooser);
+      break;
+    case PROPERTIES::ManifestType::ISM:
+      m_adaptiveTree = new adaptive::SmoothTree(kodiProps, m_reprChooser);
+      break;
+    case PROPERTIES::ManifestType::HLS:
+      m_adaptiveTree = new adaptive::HLSTree(kodiProps, m_reprChooser);
+      break;
+    default:
+      LOG::LogF(LOGFATAL, "Manifest type not handled");
+      return;
+  };
+
+  m_settingNoSecureDecoder = kodi::addon::GetSettingBoolean("NOSECUREDECODER");
+  LOG::Log(LOGDEBUG, "Setting NOSECUREDECODER value: %d", m_settingNoSecureDecoder);
+
+  m_settingIsHdcpOverride = kodi::addon::GetSettingBoolean("HDCPOVERRIDE");
+  LOG::Log(LOGDEBUG, "Ignore HDCP status setting value: %i", m_settingIsHdcpOverride);
+
+  switch (kodi::addon::GetSettingInt("MEDIATYPE"))
+  {
+    case 1:
+      m_mediaTypeMask = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::AUDIO;
+      break;
+    case 2:
+      m_mediaTypeMask = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO;
+      break;
+    case 3:
+      m_mediaTypeMask = (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO) |
+                        (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::SUBTITLE);
+      break;
+    default:
+      m_mediaTypeMask = static_cast<uint8_t>(~0);
+  }
+
+  if (!kodiProps.m_serverCertificate.empty())
+  {
+    std::string decCert{BASE64::Decode(kodiProps.m_serverCertificate)};
+    m_serverCertificate.SetData(reinterpret_cast<const AP4_Byte*>(decCert.data()), decCert.size());
+  }
+}
+
+CSession::~CSession()
+{
+  LOG::Log(LOGDEBUG, "CSession::~CSession()");
+  m_streams.clear();
+  DisposeDecrypter();
+
+  delete m_adaptiveTree;
+  m_adaptiveTree = nullptr;
+
+  delete m_reprChooser;
+  m_reprChooser = nullptr;
+}
+
+void CSession::SetSupportedDecrypterURN(std::string& key_system)
+{
+  typedef SSD::SSD_DECRYPTER* (*CreateDecryptorInstanceFunc)(SSD::SSD_HOST * host,
+                                                             uint32_t version);
+
+  std::string specialpath = kodi::addon::GetSettingString("DECRYPTERPATH");
+  if (specialpath.empty())
+  {
+    LOG::Log(LOGDEBUG, "DECRYPTERPATH not specified in settings.xml");
+    return;
+  }
+  m_KodiHost->SetLibraryPath(kodi::vfs::TranslateSpecialProtocol(specialpath).c_str());
+
+  std::vector<std::string> searchPaths{2};
+  searchPaths[0] =
+      kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/");
+  searchPaths[1] = kodi::addon::GetAddonInfo("path");
+
+  std::vector<kodi::vfs::CDirEntry> items;
+
+  for (auto searchPath : searchPaths)
+  {
+    LOG::Log(LOGDEBUG, "Searching for decrypters in: %s", searchPath.c_str());
+
+    if (!kodi::vfs::GetDirectory(searchPath, "", items))
+      continue;
+
+    for (auto item : items)
+    {
+      if (item.Label().compare(0, 4, "ssd_") && item.Label().compare(0, 7, "libssd_"))
+        continue;
+
+      bool success = false;
+      m_dllHelper = std::make_unique<kodi::tools::CDllHelper>();
+      if (m_dllHelper->LoadDll(item.Path()))
+      {
+        CreateDecryptorInstanceFunc startup;
+        if (m_dllHelper->RegisterSymbol(startup, "CreateDecryptorInstance"))
+        {
+          SSD::SSD_DECRYPTER* decrypter = startup(m_KodiHost.get(), SSD::SSD_HOST::version);
+          const char* suppUrn(0);
+
+          if (decrypter && (suppUrn = decrypter->SelectKeySytem(m_kodiProps.m_licenseType.c_str())))
+          {
+            LOG::Log(LOGDEBUG, "Found decrypter: %s", item.Path().c_str());
+            success = true;
+            m_decrypter = decrypter;
+            key_system = suppUrn;
+            break;
+          }
+        }
+      }
+      else
+      {
+        LOG::Log(LOGDEBUG, "%s", dlerror());
+      }
+      if (!success)
+      {
+        m_dllHelper.reset();
+      }
+    }
+  }
+}
+
+void CSession::DisposeSampleDecrypter()
+{
+  if (m_decrypter)
+  {
+    for (auto& cdmSession : m_cdmSessions)
+    {
+      cdmSession.m_cdmSessionStr = nullptr;
+      if (!cdmSession.m_sharedCencSsd)
+      {
+        m_decrypter->DestroySingleSampleDecrypter(cdmSession.m_cencSingleSampleDecrypter);
+        cdmSession.m_cencSingleSampleDecrypter = nullptr;
+      }
+      else
+      {
+        cdmSession.m_cencSingleSampleDecrypter = nullptr;
+        cdmSession.m_sharedCencSsd = false;
+      }
+    }
+  }
+}
+
+void CSession::DisposeDecrypter()
+{
+  if (!m_dllHelper)
+    return;
+
+  DisposeSampleDecrypter();
+
+  typedef void (*DeleteDecryptorInstanceFunc)(SSD::SSD_DECRYPTER*);
+  DeleteDecryptorInstanceFunc disposefn;
+
+  if (m_dllHelper->RegisterSymbol(disposefn, "DeleteDecryptorInstance"))
+    disposefn(m_decrypter);
+
+  m_decrypter = nullptr;
+}
+
+/*----------------------------------------------------------------------
+|   initialize
++---------------------------------------------------------------------*/
+
+bool CSession::Initialize()
+{
+  if (!m_adaptiveTree)
+    return false;
+
+  // Get URN's wich are supported by this addon
+  if (!m_kodiProps.m_licenseType.empty())
+  {
+    SetSupportedDecrypterURN(m_adaptiveTree->supportedKeySystem_);
+    LOG::Log(LOGDEBUG, "Supported URN: %s", m_adaptiveTree->supportedKeySystem_.c_str());
+  }
+
+  // Preinitialize the DRM, if pre-initialisation data are provided
+  std::map<std::string, std::string> additionalHeaders = std::map<std::string, std::string>();
+  bool isSessionOpened{false};
+
+  if (!m_kodiProps.m_drmPreInitData.empty())
+  {
+    std::string challengeB64;
+    std::string sessionId;
+    // Pre-initialize the DRM allow to generate the challenge and session ID data
+    // used to make licensed manifest requests (via proxy callback)
+    if (PreInitializeDRM(challengeB64, sessionId, isSessionOpened))
+    {
+      additionalHeaders["challengeB64"] = STRING::URLEncode(challengeB64);
+      additionalHeaders["sessionId"] = sessionId;
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  // Open manifest file with location redirect support  bool mpdSuccess;
+  std::string manifestUrl =
+      m_adaptiveTree->location_.empty() ? m_manifestUrl : m_adaptiveTree->location_;
+  if (!m_adaptiveTree->open(manifestUrl, m_kodiProps.m_manifestUpdateParam, additionalHeaders) ||
+      m_adaptiveTree->empty())
+  {
+    LOG::Log(LOGERROR, "Could not open / parse manifest (%s)", manifestUrl.c_str());
+    return false;
+  }
+  LOG::Log(
+      LOGINFO,
+      "Successfully parsed manifest file (Periods: %ld, Streams in first period: %ld, Type: %s)",
+      m_adaptiveTree->periods_.size(), m_adaptiveTree->current_period_->adaptationSets_.size(),
+      m_adaptiveTree->has_timeshift_buffer_ ? "live" : "VOD");
+
+  // Always need at least 16s delay from live
+  if (m_adaptiveTree->live_delay_ < 16)
+    m_adaptiveTree->live_delay_ = 16;
+
+  return InitializePeriod(isSessionOpened);
+}
+
+bool CSession::PreInitializeDRM(std::string& challengeB64,
+                                std::string& sessionId,
+                                bool& isSessionOpened)
+{
+  std::string psshData;
+  std::string kidData;
+  // Parse the PSSH/KID data
+  std::string::size_type posSplitter(m_kodiProps.m_drmPreInitData.find("|"));
+  if (posSplitter != std::string::npos)
+  {
+    psshData = m_kodiProps.m_drmPreInitData.substr(0, posSplitter);
+    kidData = m_kodiProps.m_drmPreInitData.substr(posSplitter + 1);
+  }
+
+  if (psshData.empty() || kidData.empty())
+  {
+    LOG::LogF(LOGERROR, "Invalid DRM pre-init data, must be as: {PSSH as base64}|{KID as base64}");
+    return false;
+  }
+
+  m_cdmSessions.resize(2);
+  memset(&m_cdmSessions.front(), 0, sizeof(CCdmSession));
+  // Try to initialize an SingleSampleDecryptor
+  LOG::LogF(LOGDEBUG, "Entering encryption section");
+
+  if (m_kodiProps.m_licenseKey.empty())
+  {
+    LOG::LogF(LOGERROR, "Invalid license_key");
+    return false;
+  }
+
+  if (!m_decrypter)
+  {
+    LOG::LogF(LOGERROR, "No decrypter found for encrypted stream");
+    return false;
+  }
+
+  if (!m_decrypter->HasCdmSession())
+  {
+    if (!m_decrypter->OpenDRMSystem(m_kodiProps.m_licenseKey.c_str(), m_serverCertificate,
+                                    m_drmConfig))
+    {
+      LOG::LogF(LOGERROR, "OpenDRMSystem failed");
+      return false;
+    }
+  }
+
+  AP4_DataBuffer init_data;
+  init_data.SetBufferSize(1024);
+  const char* optionalKeyParameter{nullptr};
+
+  // Set the provided PSSH
+  std::string decPssh{BASE64::Decode(psshData)};
+  init_data.SetData(reinterpret_cast<const AP4_Byte*>(decPssh.data()), decPssh.size());
+
+  // Decode the provided KID
+  std::string decKid{BASE64::Decode(kidData)};
+
+  CCdmSession& session(m_cdmSessions[1]);
+
+  std::string hexKid{StringUtils::ToHexadecimal(decKid)};
+  LOG::LogF(LOGDEBUG, "Initializing session with KID: %s", hexKid.c_str());
+
+  if (m_decrypter && init_data.GetDataSize() >= 4 &&
+      (session.m_cencSingleSampleDecrypter = m_decrypter->CreateSingleSampleDecrypter(
+           init_data, optionalKeyParameter, decKid, true)) != 0)
+  {
+    session.m_cdmSessionStr = session.m_cencSingleSampleDecrypter->GetSessionId();
+    sessionId = session.m_cdmSessionStr;
+    challengeB64 = m_decrypter->GetChallengeB64Data(session.m_cencSingleSampleDecrypter);
+  }
+  else
+  {
+    LOG::LogF(LOGERROR, "Initialize failed (SingleSampleDecrypter)");
+    session.m_cencSingleSampleDecrypter = nullptr;
+    return false;
+  }
+#if defined(ANDROID)
+  // On android is not possible add the default KID key
+  // then we cannot re-use same session
+  DisposeSampleDecrypter();
+#else
+  isSessionOpened = true;
+#endif
+  return true;
+}
+
+bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
+{
+  bool isSecureVideoSession{false};
+  m_cdmSessions.resize(m_adaptiveTree->current_period_->psshSets_.size());
+  memset(&m_cdmSessions.front(), 0, sizeof(CCdmSession));
+
+  // Try to initialize an SingleSampleDecryptor
+  if (m_adaptiveTree->current_period_->encryptionState_)
+  {
+    std::string licenseKey{m_kodiProps.m_licenseKey};
+
+    if (licenseKey.empty())
+      licenseKey = m_adaptiveTree->license_url_;
+
+    LOG::Log(LOGDEBUG, "Entering encryption section");
+
+    if (licenseKey.empty())
+    {
+      LOG::Log(LOGERROR, "Invalid license_key");
+      return false;
+    }
+
+    if (!m_decrypter)
+    {
+      LOG::Log(LOGERROR, "No decrypter found for encrypted stream");
+      return false;
+    }
+
+    if (!m_decrypter->HasCdmSession())
+    {
+      if (!m_decrypter->OpenDRMSystem(licenseKey.c_str(), m_serverCertificate, m_drmConfig))
+      {
+        LOG::Log(LOGERROR, "OpenDRMSystem failed");
+        return false;
+      }
+    }
+    std::string strkey(m_adaptiveTree->supportedKeySystem_.substr(9));
+    size_t pos;
+    while ((pos = strkey.find('-')) != std::string::npos)
+      strkey.erase(pos, 1);
+    if (strkey.size() != 32)
+    {
+      LOG::Log(LOGERROR, "Key system mismatch (%s)!", m_adaptiveTree->supportedKeySystem_.c_str());
+      return false;
+    }
+
+    unsigned char key_system[16];
+    AP4_ParseHex(strkey.c_str(), key_system, 16);
+    uint32_t currentSessionTypes = 0;
+
+    // cdmSession 0 is reserved for unencrypted streams
+    for (size_t ses{1}; ses < m_cdmSessions.size(); ++ses)
+    {
+      AP4_DataBuffer init_data;
+      const char* optionalKeyParameter{nullptr};
+      auto sessionPsshset{m_adaptiveTree->current_period_->psshSets_[ses]};
+      uint32_t sessionType = 0;
+
+      if (sessionPsshset.media_ > 0)
+      {
+        sessionType = sessionPsshset.media_;
+      }
+      else
+      {
+        switch (sessionPsshset.adaptation_set_->type_)
+        {
+          case adaptive::AdaptiveTree::VIDEO:
+            sessionType = adaptive::AdaptiveTree::Period::PSSH::MEDIA_VIDEO;
+            break;
+          case adaptive::AdaptiveTree::AUDIO:
+            sessionType = adaptive::AdaptiveTree::Period::PSSH::MEDIA_AUDIO;
+            break;
+          default:
+            break;
+        }
+      }
+
+      if (sessionPsshset.pssh_ == "FILE")
+      {
+        LOG::Log(LOGDEBUG, "Searching PSSH data in FILE");
+
+        if (m_kodiProps.m_licenseData.empty())
+        {
+          auto initialRepr{m_reprChooser->GetRepresentation(sessionPsshset.adaptation_set_)};
+
+          CStream stream{
+              *m_adaptiveTree, sessionPsshset.adaptation_set_,    initialRepr, m_mediaHeaders,
+              m_reprChooser,   m_kodiProps.m_playTimeshiftBuffer, false};
+
+          stream.m_isEnabled = true;
+          stream.m_adStream.start_stream();
+          stream.SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream.m_adStream));
+          stream.SetStreamFile(std::make_unique<AP4_File>(*stream.GetAdByteStream(),
+                                                          AP4_DefaultAtomFactory::Instance_, true));
+          AP4_Movie* movie{stream.GetStreamFile()->GetMovie()};
+          if (movie == NULL)
+          {
+            LOG::Log(LOGERROR, "No MOOV in stream!");
+            stream.Disable();
+            return false;
+          }
+          AP4_Array<AP4_PsshAtom>& pssh{movie->GetPsshAtoms()};
+
+          for (size_t i{0}; !init_data.GetDataSize() && i < pssh.ItemCount(); i++)
+          {
+            if (memcmp(pssh[i].GetSystemId(), key_system, 16) == 0)
+            {
+              init_data.AppendData(pssh[i].GetData().GetData(), pssh[i].GetData().GetDataSize());
+              if (sessionPsshset.defaultKID_.empty())
+              {
+                if (pssh[i].GetKid(0))
+                {
+                  sessionPsshset.defaultKID_ = std::string((const char*)pssh[i].GetKid(0), 16);
+                }
+                else if (AP4_Track* track = movie->GetTrack(TIDC[stream.m_adStream.get_type()]))
+                {
+                  AP4_ProtectedSampleDescription* m_protectedDesc =
+                      static_cast<AP4_ProtectedSampleDescription*>(track->GetSampleDescription(0));
+                  AP4_ContainerAtom* schi;
+                  if (m_protectedDesc->GetSchemeInfo() &&
+                      (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
+                  {
+                    AP4_TencAtom* tenc{
+                        AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0))};
+                    if (tenc)
+                    {
+                      sessionPsshset.defaultKID_ =
+                          std::string(reinterpret_cast<const char*>(tenc->GetDefaultKid()), 16);
+                    }
+                    else
+                    {
+                      AP4_PiffTrackEncryptionAtom* piff{
+                          AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom,
+                                           schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0))};
+                      if (piff)
+                      {
+                        sessionPsshset.defaultKID_ =
+                            std::string(reinterpret_cast<const char*>(piff->GetDefaultKid()), 16);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          if (!init_data.GetDataSize())
+          {
+            LOG::Log(LOGERROR, "Could not extract license from video stream (PSSH not found)");
+            stream.Disable();
+            return false;
+          }
+          stream.Disable();
+        }
+        else if (!sessionPsshset.defaultKID_.empty())
+        {
+          init_data.SetData(reinterpret_cast<AP4_Byte*>(sessionPsshset.defaultKID_.data()), 16);
+
+          std::string decLicenseData{BASE64::Decode(m_kodiProps.m_licenseData)};
+          uint8_t* decLicDataUInt{reinterpret_cast<uint8_t*>(decLicenseData.data())};
+
+          uint8_t* uuid{reinterpret_cast<uint8_t*>(strstr(decLicenseData.data(), "{KID}"))};
+          if (uuid)
+          {
+            memmove(uuid + 11, uuid, m_kodiProps.m_licenseData.size() - (uuid - decLicDataUInt));
+            memcpy(uuid, init_data.GetData(), init_data.GetDataSize());
+            init_data.SetData(decLicDataUInt, m_kodiProps.m_licenseData.size() + 11);
+          }
+          else
+          {
+            init_data.SetData(decLicDataUInt, m_kodiProps.m_licenseData.size());
+          }
+        }
+        else
+          return false;
+      }
+      else
+      {
+        if (m_kodiProps.m_manifestType == PROPERTIES::ManifestType::ISM)
+        {
+          if (m_kodiProps.m_licenseType == "com.widevine.alpha")
+          {
+            std::string licenseData{m_kodiProps.m_licenseData};
+            if (licenseData.empty())
+              licenseData = "e0tJRH0="; // {KID}
+            std::vector<uint8_t> init_data_v;
+            CreateISMlicense(sessionPsshset.defaultKID_, licenseData, init_data_v);
+            init_data.SetData(init_data_v.data(), init_data_v.size());
+          }
+          else
+          {
+            init_data.SetData(reinterpret_cast<const uint8_t*>(sessionPsshset.pssh_.data()),
+                              sessionPsshset.pssh_.size());
+            optionalKeyParameter =
+                m_kodiProps.m_licenseData.empty() ? nullptr : m_kodiProps.m_licenseData.c_str();
+          }
+        }
+        else
+        {
+          std::string decPssh{BASE64::Decode(sessionPsshset.pssh_)};
+          init_data.SetBufferSize(1024);
+          init_data.SetData(reinterpret_cast<const AP4_Byte*>(decPssh.data()), decPssh.size());
+        }
+      }
+
+      CCdmSession& session{m_cdmSessions[ses]};
+      std::string defaultKid{sessionPsshset.defaultKID_};
+
+      const char* defkid{sessionPsshset.defaultKID_.empty() ? nullptr
+                                                            : sessionPsshset.defaultKID_.data()};
+
+      if (addDefaultKID && ses == 1 && session.m_cencSingleSampleDecrypter)
+      {
+        // If the CDM has been pre-initialized, on non-android systems
+        // we use the same session opened then we have to add the current KID
+        // because the session has been opened with a different PSSH/KID
+        session.m_cencSingleSampleDecrypter->AddKeyId(defaultKid);
+        session.m_cencSingleSampleDecrypter->SetDefaultKeyId(defaultKid);
+      }
+
+      if (m_decrypter && !defaultKid.empty())
+      {
+        std::string hexKid{StringUtils::ToHexadecimal(defaultKid)};
+        LOG::Log(LOGDEBUG, "Initializing stream with KID: %s", hexKid.c_str());
+
+        // use shared ssd session if we already have 1 of the same stream type
+        if (currentSessionTypes & sessionType)
+        {
+          for (size_t i{1}; i < ses; ++i)
+          {
+            if (m_decrypter->HasLicenseKey(m_cdmSessions[i].m_cencSingleSampleDecrypter,
+                                           reinterpret_cast<const uint8_t*>(defkid)))
+            {
+              session.m_cencSingleSampleDecrypter = m_cdmSessions[i].m_cencSingleSampleDecrypter;
+              session.m_sharedCencSsd = true;
+              break;
+            }
+          }
+        }
+      }
+      else if (!defkid && !session.m_cencSingleSampleDecrypter)
+      {
+        LOG::Log(LOGWARNING, "Initializing stream with unknown KID!");
+      }
+
+      currentSessionTypes |= sessionType;
+
+      if (m_decrypter && init_data.GetDataSize() >= 4 &&
+          (session.m_cencSingleSampleDecrypter ||
+           (session.m_cencSingleSampleDecrypter = m_decrypter->CreateSingleSampleDecrypter(
+                init_data, optionalKeyParameter, defaultKid, false)) != 0))
+      {
+        m_decrypter->GetCapabilities(session.m_cencSingleSampleDecrypter,
+                                     reinterpret_cast<const uint8_t*>(defaultKid.c_str()),
+                                     sessionPsshset.media_, session.m_decrypterCaps);
+
+        if (session.m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_INVALID)
+        {
+          m_adaptiveTree->current_period_->RemovePSSHSet(static_cast<std::uint16_t>(ses));
+        }
+        else if (session.m_decrypterCaps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH)
+        {
+          session.m_cdmSessionStr = session.m_cencSingleSampleDecrypter->GetSessionId();
+          isSecureVideoSession = true;
+
+          if (m_settingNoSecureDecoder && !m_kodiProps.m_isLicenseForceSecureDecoder &&
+              !m_adaptiveTree->current_period_->need_secure_decoder_)
+            session.m_decrypterCaps.flags &= ~SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER;
+        }
+      }
+      else
+      {
+        LOG::Log(LOGERROR, "Initialize failed (SingleSampleDecrypter)");
+        for (size_t i(ses); i < m_cdmSessions.size(); ++i)
+          m_cdmSessions[i].m_cencSingleSampleDecrypter = nullptr;
+
+        return false;
+      }
+    }
+  }
+
+  m_adaptiveTree->m_decrypterCaps.clear();
+  if (!m_settingIsHdcpOverride)
+  {
+    for (const auto& cdmsession : m_cdmSessions)
+    {
+      m_adaptiveTree->m_decrypterCaps.emplace_back(cdmsession.m_decrypterCaps);
+    }
+    m_adaptiveTree->CheckHDCP();
+  }
+
+  m_reprChooser->SetSecureSession(isSecureVideoSession);
+  m_reprChooser->PostInit();
+
+  return true;
+}
+
+bool CSession::InitializePeriod(bool isSessionOpened /* = false */)
+{
+  bool psshChanged{true};
+  if (m_adaptiveTree->next_period_)
+  {
+    psshChanged =
+        !(m_adaptiveTree->current_period_->psshSets_ == m_adaptiveTree->next_period_->psshSets_);
+    m_adaptiveTree->current_period_ = m_adaptiveTree->next_period_;
+    m_adaptiveTree->next_period_ = nullptr;
+  }
+
+  m_chapterStartTime = GetChapterStartTime();
+
+  if (m_adaptiveTree->current_period_->encryptionState_ ==
+      adaptive::AdaptiveTree::ENCRYTIONSTATE_ENCRYPTED)
+  {
+    LOG::Log(LOGERROR, "Unable to handle decryption. Unsupported!");
+    return false;
+  }
+
+  // create SESSION::STREAM objects. One for each AdaptationSet
+  m_streams.clear();
+
+  if (!psshChanged)
+    LOG::Log(LOGDEBUG, "Reusing DRM psshSets for new period!");
+  else
+  {
+    if (isSessionOpened)
+    {
+      LOG::Log(LOGDEBUG, "New period, reinitialize by using same session");
+    }
+    else
+    {
+      LOG::Log(LOGDEBUG, "New period, dispose sample decrypter and reinitialize");
+      DisposeSampleDecrypter();
+    }
+
+    if (!InitializeDRM(isSessionOpened))
+      return false;
+  }
+
+  uint32_t adpIndex{0};
+  adaptive::AdaptiveTree::AdaptationSet* adp{nullptr};
+  SETTINGS::StreamSelection streamSelectionMode{m_reprChooser->GetStreamSelectionMode()};
+
+  while ((adp = m_adaptiveTree->GetAdaptationSet(adpIndex++)))
+  {
+    if (adp->representations_.empty())
+      continue;
+
+    bool isManualStreamSelection;
+    if (adp->type_ == adaptive::AdaptiveTree::StreamType::VIDEO)
+      isManualStreamSelection = streamSelectionMode != SETTINGS::StreamSelection::AUTO;
+    else
+      isManualStreamSelection = streamSelectionMode == SETTINGS::StreamSelection::MANUAL;
+
+    // Get the default initial stream repr. based on "adaptive repr. chooser"
+    auto defaultRepr{m_reprChooser->GetRepresentation(adp)};
+
+    if (isManualStreamSelection)
+    {
+      // Add all stream representations
+      for (size_t i{0}; i < adp->representations_.size(); i++)
+      {
+        size_t reprIndex{adp->representations_.size() - i};
+        uint32_t uniqueId{adpIndex};
+        uniqueId |= reprIndex << 16;
+
+        adaptive::AdaptiveTree::Representation* currentRepr{adp->representations_[i]};
+        bool isDefaultRepr{currentRepr == defaultRepr};
+
+        AddStream(adp, currentRepr, isDefaultRepr, uniqueId);
+      }
+    }
+    else
+    {
+      // Add the default stream representation only
+      size_t reprIndex{adp->representations_.size()};
+      uint32_t uniqueId{adpIndex};
+      uniqueId |= reprIndex << 16;
+
+      AddStream(adp, defaultRepr, true, uniqueId);
+    }
+  }
+
+  m_firstPeriodInitialized = true;
+  return true;
+}
+
+void CSession::AddStream(adaptive::AdaptiveTree::AdaptationSet* adp,
+                         adaptive::AdaptiveTree::Representation* initialRepr,
+                         bool isDefaultRepr,
+                         uint32_t uniqueId)
+{
+  m_streams.push_back(std::make_unique<CStream>(*m_adaptiveTree, adp, initialRepr, m_mediaHeaders,
+                                                m_reprChooser, m_kodiProps.m_playTimeshiftBuffer,
+                                                m_firstPeriodInitialized));
+
+  CStream& stream{*m_streams.back()};
+
+  uint32_t flags{INPUTSTREAM_FLAG_NONE};
+  size_t copySize{adp->name_.size() > 255 ? 255 : adp->name_.size()};
+  stream.m_info.SetName(adp->name_);
+
+  switch (adp->type_)
+  {
+    case adaptive::AdaptiveTree::VIDEO:
+    {
+      stream.m_info.SetStreamType(INPUTSTREAM_TYPE_VIDEO);
+      if (isDefaultRepr)
+        flags |= INPUTSTREAM_FLAG_DEFAULT;
+      break;
+    }
+    case adaptive::AdaptiveTree::AUDIO:
+    {
+      stream.m_info.SetStreamType(INPUTSTREAM_TYPE_AUDIO);
+      if (adp->impaired_)
+        flags |= INPUTSTREAM_FLAG_VISUAL_IMPAIRED;
+      if (adp->default_)
+        flags |= INPUTSTREAM_FLAG_DEFAULT;
+      if (adp->original_ || (!m_kodiProps.m_audioLanguageOrig.empty() &&
+                             adp->language_ == m_kodiProps.m_audioLanguageOrig))
+      {
+        flags |= INPUTSTREAM_FLAG_ORIGINAL;
+      }
+      break;
+    }
+    case adaptive::AdaptiveTree::SUBTITLE:
+    {
+      stream.m_info.SetStreamType(INPUTSTREAM_TYPE_SUBTITLE);
+      if (adp->impaired_)
+        flags |= INPUTSTREAM_FLAG_HEARING_IMPAIRED;
+      if (adp->forced_)
+        flags |= INPUTSTREAM_FLAG_FORCED;
+      if (adp->default_)
+        flags |= INPUTSTREAM_FLAG_DEFAULT;
+      break;
+    }
+    default:
+      break;
+  }
+
+  stream.m_info.SetFlags(flags);
+  stream.m_info.SetPhysicalIndex(uniqueId);
+  stream.m_info.SetLanguage(adp->language_);
+  stream.m_info.ClearExtraData();
+  stream.m_info.SetFeatures(0);
+
+  stream.m_adStream.set_observer(dynamic_cast<adaptive::AdaptiveStreamObserver*>(this));
+
+  UpdateStream(stream);
+}
+
+void CSession::UpdateStream(CStream& stream)
+{
+  const adaptive::AdaptiveTree::Representation* rep{stream.m_adStream.getRepresentation()};
+  const SSD::SSD_DECRYPTER::SSD_CAPS& caps{GetDecrypterCaps(rep->pssh_set_)};
+
+  stream.m_info.SetWidth(static_cast<uint32_t>(rep->width_));
+  stream.m_info.SetHeight(static_cast<uint32_t>(rep->height_));
+  stream.m_info.SetAspect(rep->aspect_);
+
+  if (stream.m_info.GetAspect() == 0.0f && stream.m_info.GetHeight())
+    stream.m_info.SetAspect((float)stream.m_info.GetWidth() / stream.m_info.GetHeight());
+  stream.m_isEncrypted = rep->get_psshset() > 0;
+
+  stream.m_info.SetExtraData(nullptr, 0);
+  if (rep->codec_private_data_.size())
+  {
+    std::string annexb;
+    const std::string* res(&annexb);
+
+    if ((caps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED) &&
+        stream.m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
+    {
+      LOG::Log(LOGDEBUG, "UpdateStream: Convert avc -> annexb");
+      annexb = AvcToAnnexb(rep->codec_private_data_);
+    }
+    else
+    {
+      res = &rep->codec_private_data_;
+    }
+    stream.m_info.SetExtraData(reinterpret_cast<const uint8_t*>(res->data()), res->size());
+  }
+
+  // we currently use only the first track!
+  size_t pos{rep->codecs_.find(",")};
+  if (pos == std::string::npos)
+    pos = rep->codecs_.size();
+
+  stream.m_info.SetCodecInternalName(rep->codecs_);
+  stream.m_info.SetCodecFourCC(0);
+
+#if INPUTSTREAM_VERSION_LEVEL > 0
+  stream.m_info.SetColorSpace(INPUTSTREAM_COLORSPACE_UNSPECIFIED);
+  stream.m_info.SetColorRange(INPUTSTREAM_COLORRANGE_UNKNOWN);
+  stream.m_info.SetColorPrimaries(INPUTSTREAM_COLORPRIMARY_UNSPECIFIED);
+  stream.m_info.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_UNSPECIFIED);
+#else
+  stream.m_info.SetColorSpace(INPUTSTREAM_COLORSPACE_UNKNOWN);
+  stream.m_info.SetColorRange(INPUTSTREAM_COLORRANGE_UNKNOWN);
+#endif
+  if (rep->codecs_.find("mp4a") == 0 || rep->codecs_.find("aac") == 0)
+    stream.m_info.SetCodecName("aac");
+  else if (rep->codecs_.find("dts") == 0)
+    stream.m_info.SetCodecName("dca");
+  else if (rep->codecs_.find("ac-3") == 0)
+    stream.m_info.SetCodecName("ac3");
+  else if (rep->codecs_.find("ec-3") == 0)
+    stream.m_info.SetCodecName("eac3");
+  else if (rep->codecs_.find("avc") == 0 || rep->codecs_.find("h264") == 0)
+    stream.m_info.SetCodecName("h264");
+  else if (rep->codecs_.find("hev") == 0)
+    stream.m_info.SetCodecName("hevc");
+  else if (rep->codecs_.find("hvc") == 0 || rep->codecs_.find("dvh") == 0)
+  {
+    stream.m_info.SetCodecFourCC(
+        MakeFourCC(rep->codecs_[0], rep->codecs_[1], rep->codecs_[2], rep->codecs_[3]));
+    stream.m_info.SetCodecName("hevc");
+  }
+  else if (rep->codecs_.find("vp9") == 0 || rep->codecs_.find("vp09") == 0)
+  {
+    stream.m_info.SetCodecName("vp9");
+#if INPUTSTREAM_VERSION_LEVEL > 0
+    if ((pos = rep->codecs_.find(".")) != std::string::npos)
+      stream.m_info.SetCodecProfile(static_cast<STREAMCODEC_PROFILE>(
+          VP9CodecProfile0 + atoi(rep->codecs_.c_str() + (pos + 1))));
+#endif
+  }
+  else if (rep->codecs_.find("opus") == 0)
+    stream.m_info.SetCodecName("opus");
+  else if (rep->codecs_.find("vorbis") == 0)
+    stream.m_info.SetCodecName("vorbis");
+  else if (rep->codecs_.find("stpp") == 0 || rep->codecs_.find("ttml") == 0)
+    stream.m_info.SetCodecName("srt");
+  else if (rep->codecs_.find("wvtt") == 0)
+    stream.m_info.SetCodecName("webvtt");
+  else
+  {
+    LOG::Log(LOGWARNING, "Unsupported codec %s in stream ID: %s", rep->codecs_.c_str(),
+             rep->id.c_str());
+    stream.m_isValid = false;
+  }
+
+  // We support currently only mp4 / ts / adts
+  if (rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_NOTYPE &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_MP4 &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TS &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_ADTS &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_WEBM &&
+      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TEXT)
+  {
+    LOG::Log(LOGWARNING, "Unsupported container in stream ID: %s", rep->id.c_str());
+    stream.m_isValid = false;
+  }
+
+  stream.m_info.SetFpsRate(rep->fpsRate_);
+  stream.m_info.SetFpsScale(rep->fpsScale_);
+  stream.m_info.SetSampleRate(rep->samplingRate_);
+  stream.m_info.SetChannels(rep->channelCount_);
+  stream.m_info.SetBitRate(rep->bandwidth_);
+}
+
+AP4_Movie* CSession::PrepareStream(CStream* stream, bool& needRefetch)
+{
+  needRefetch = false;
+  switch (m_adaptiveTree->prepareRepresentation(stream->m_adStream.getPeriod(),
+                                                stream->m_adStream.getAdaptationSet(),
+                                                stream->m_adStream.getRepresentation()))
+  {
+    case adaptive::AdaptiveTree::PREPARE_RESULT_FAILURE:
+      return nullptr;
+    case adaptive::AdaptiveTree::PREPARE_RESULT_DRMCHANGED:
+      if (!InitializeDRM())
+        return nullptr;
+    case adaptive::AdaptiveTree::PREPARE_RESULT_DRMUNCHANGED:
+      stream->m_isEncrypted = stream->m_adStream.getRepresentation()->pssh_set_ > 0;
+      needRefetch = true;
+      break;
+    default:;
+  }
+
+  if (stream->m_adStream.getRepresentation()->containerType_ ==
+          adaptive::AdaptiveTree::CONTAINERTYPE_MP4 &&
+      (stream->m_adStream.getRepresentation()->flags_ &
+       adaptive::AdaptiveTree::Representation::INITIALIZATION_PREFIXED) == 0 &&
+      stream->m_adStream.getRepresentation()->get_initialization() == nullptr)
+  {
+    //We'll create a Movie out of the things we got from manifest file
+    //note: movie will be deleted in destructor of stream->input_file_
+    AP4_Movie* movie{new AP4_Movie()};
+
+    AP4_SyntheticSampleTable* sample_table{new AP4_SyntheticSampleTable()};
+
+    AP4_SampleDescription* sample_descryption;
+    if (stream->m_info.GetCodecName() == "h264")
+    {
+      const std::string& extradata{stream->m_adStream.getRepresentation()->codec_private_data_};
+      AP4_MemoryByteStream ms{reinterpret_cast<const uint8_t*>(extradata.data()),
+                              static_cast<const AP4_Size>(extradata.size())};
+      AP4_AvccAtom* atom{AP4_AvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms)};
+      sample_descryption =
+          new AP4_AvcSampleDescription(AP4_SAMPLE_FORMAT_AVC1, stream->m_info.GetWidth(),
+                                       stream->m_info.GetHeight(), 0, nullptr, atom);
+    }
+    else if (stream->m_info.GetCodecName() == "hevc")
+    {
+      const std::string& extradata{(stream->m_adStream.getRepresentation()->codec_private_data_)};
+      AP4_MemoryByteStream ms{reinterpret_cast<const AP4_UI08*>(extradata.data()),
+                              static_cast<const AP4_Size>(extradata.size())};
+      AP4_HvccAtom* atom{AP4_HvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms)};
+      sample_descryption =
+          new AP4_HevcSampleDescription(AP4_SAMPLE_FORMAT_HEV1, stream->m_info.GetWidth(),
+                                        stream->m_info.GetHeight(), 0, nullptr, atom);
+    }
+    else if (stream->m_info.GetCodecName() == "srt")
+      sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_SUBTITLES,
+                                                     AP4_SAMPLE_FORMAT_STPP, 0);
+    else
+      sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_UNKNOWN, 0, 0);
+
+    if (stream->m_adStream.getRepresentation()->get_psshset() > 0)
+    {
+      AP4_ContainerAtom schi{AP4_ATOM_TYPE_SCHI};
+      schi.AddChild(
+          new AP4_TencAtom(AP4_CENC_CIPHER_AES_128_CTR, 8,
+                           GetDefaultKeyId(stream->m_adStream.getRepresentation()->get_psshset())));
+      sample_descryption = new AP4_ProtectedSampleDescription(
+          0, sample_descryption, 0, AP4_PROTECTION_SCHEME_TYPE_PIFF, 0, "", &schi);
+    }
+    sample_table->AddSampleDescription(sample_descryption);
+
+    movie->AddTrack(new AP4_Track(TIDC[stream->m_adStream.get_type()], sample_table,
+                                  CFragmentedSampleReader::TRACKID_UNKNOWN,
+                                  stream->m_adStream.getRepresentation()->timescale_, 0,
+                                  stream->m_adStream.getRepresentation()->timescale_, 0, "", 0, 0));
+    //Create a dumy MOOV Atom to tell Bento4 its a fragmented stream
+    AP4_MoovAtom* moov{new AP4_MoovAtom()};
+    moov->AddChild(new AP4_ContainerAtom(AP4_ATOM_TYPE_MVEX));
+    movie->SetMoovAtom(moov);
+    return movie;
+  }
+  return nullptr;
+}
+
+void CSession::EnableStream(CStream* stream, bool enable)
+{
+  if (enable)
+  {
+    if (!m_timingStream)
+      m_timingStream = stream;
+
+    stream->m_isEnabled = true;
+  }
+  else
+  {
+    if (stream == m_timingStream)
+      m_timingStream = nullptr;
+
+    stream->Disable();
+  }
+}
+
+uint64_t CSession::PTSToElapsed(uint64_t pts)
+{
+  if (m_timingStream)
+  {
+    ISampleReader* timingReader{m_timingStream->GetReader()};
+    if (!timingReader)
+    {
+      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
+      return 0;
+    }
+
+    // adjusted pts value taking the difference between segment's pts and reader pts
+    int64_t manifest_time{static_cast<int64_t>(pts) - timingReader->GetPTSDiff()};
+    if (manifest_time < 0)
+      manifest_time = 0;
+
+    if (static_cast<uint64_t>(manifest_time) > m_timingStream->m_adStream.GetAbsolutePTSOffset())
+      return static_cast<uint64_t>(manifest_time) -
+             m_timingStream->m_adStream.GetAbsolutePTSOffset();
+
+    return 0ULL;
+  }
+  else
+    return pts;
+}
+
+uint64_t CSession::GetTimeshiftBufferStart()
+{
+  if (m_timingStream)
+  {
+    ISampleReader* timingReader{m_timingStream->GetReader()};
+    if (!timingReader)
+    {
+      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
+      return 0ULL;
+    }
+    return m_timingStream->m_adStream.GetAbsolutePTSOffset() + timingReader->GetPTSDiff();
+  }
+  else
+    return 0ULL;
+}
+
+// TODO: clean this up along with seektime
+void CSession::StartReader(
+    CStream* stream, uint64_t seekTime, int64_t ptsDiff, bool preceeding, bool timing)
+{
+  bool bReset = true;
+  if (timing)
+    seekTime += stream->m_adStream.GetAbsolutePTSOffset();
+  else
+    seekTime -= ptsDiff;
+
+  stream->m_adStream.seek_time(static_cast<double>(seekTime / STREAM_TIME_BASE), preceeding,
+                               bReset);
+
+  ISampleReader* streamReader = stream->GetReader();
+  if (!streamReader)
+  {
+    LOG::LogF(LOGERROR, "Cannot get the stream reader");
+    return;
+  }
+
+  if (bReset)
+    streamReader->Reset(false);
+
+  bool bStarted = false;
+  streamReader->Start(bStarted);
+  if (bStarted && (streamReader->GetInformation(stream->m_info)))
+    m_changed = true;
+}
+
+void CSession::SetVideoResolution(int width, int height)
+{
+  m_reprChooser->SetScreenResolution(width, height);
+};
+
+ISampleReader* CSession::GetNextSample()
+{
+  CStream* res{nullptr};
+  CStream* waiting{nullptr};
+
+  for (auto& stream : m_streams)
+  {
+    bool isStarted{false};
+    ISampleReader* streamReader{stream->GetReader()};
+    if (!streamReader)
+      continue;
+
+    if (stream->m_isEnabled && !streamReader->EOS() &&
+        AP4_SUCCEEDED(streamReader->Start(isStarted)))
+    {
+      if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())
+      {
+        if (stream->m_adStream.waitingForSegment(true))
+          waiting = stream.get();
+        else
+          res = stream.get();
+      }
+    }
+
+    if (isStarted && streamReader->GetInformation(stream->m_info))
+      m_changed = true;
+  }
+
+  if (res)
+  {
+    CheckFragmentDuration(*res);
+    if (res->GetReader()->GetInformation(res->m_info))
+      m_changed = true;
+    if (res->GetReader()->PTS() != STREAM_NOPTS_VALUE)
+      m_elapsedTime = PTSToElapsed(res->GetReader()->PTS()) + GetChapterStartTime();
+    return res->GetReader();
+  }
+  else if (waiting)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    return m_dummySampleReader.get();
+  }
+  return nullptr;
+}
+
+bool CSession::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
+{
+  bool ret{false};
+
+  //we don't have pts < 0 here and work internally with uint64
+  if (seekTime < 0)
+    seekTime = 0;
+
+  // Check if we leave our current period
+  double chapterTime{0};
+  std::vector<adaptive::AdaptiveTree::Period*>::const_iterator pi;
+  for (pi = m_adaptiveTree->periods_.cbegin(); pi != m_adaptiveTree->periods_.cend(); ++pi)
+  {
+    chapterTime += double((*pi)->duration_) / (*pi)->timescale_;
+    if (chapterTime > seekTime)
+      break;
+  }
+
+  if (pi == m_adaptiveTree->periods_.end())
+    --pi;
+  chapterTime -= double((*pi)->duration_) / (*pi)->timescale_;
+
+  if ((*pi) != m_adaptiveTree->current_period_)
+  {
+    LOG::Log(LOGDEBUG, "SeekTime: seeking into new chapter: %d",
+             static_cast<int>((pi - m_adaptiveTree->periods_.begin()) + 1));
+    SeekChapter((pi - m_adaptiveTree->periods_.begin()) + 1);
+    m_chapterSeekTime = seekTime;
+    return true;
+  }
+
+  seekTime -= chapterTime;
+
+  // don't try to seek past the end of the stream, leave a sensible amount so we can buffer properly
+  if (m_adaptiveTree->has_timeshift_buffer_)
+  {
+    double maxSeek{0};
+    uint64_t curTime;
+    uint64_t maxTime{0};
+    for (auto& stream : m_streams)
+    {
+      if (stream->m_isEnabled && (curTime = stream->m_adStream.getMaxTimeMs()) && curTime > maxTime)
+      {
+        maxTime = curTime;
+      }
+    }
+
+    maxSeek = (static_cast<double>(maxTime) / 1000) - m_adaptiveTree->live_delay_;
+    if (maxSeek < 0)
+      maxSeek = 0;
+
+    if (seekTime > maxSeek)
+      seekTime = maxSeek;
+  }
+
+  // correct for starting segment pts value of chapter and chapter offset within program
+  uint64_t seekTimeCorrected{static_cast<uint64_t>(seekTime * STREAM_TIME_BASE)};
+  int64_t ptsDiff{0};
+  if (m_timingStream)
+  {
+    // after seeking across chapters with fmp4 streams the reader will not have started
+    // so we start here to ensure that we have the required information to correctly
+    // seek with proper stream alignment
+    ISampleReader* timingReader{m_timingStream->GetReader()};
+    if (!timingReader)
+    {
+      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
+      return false;
+    }
+    if (!timingReader->IsStarted())
+      StartReader(m_timingStream, seekTimeCorrected, ptsDiff, preceeding, true);
+
+    seekTimeCorrected += m_timingStream->m_adStream.GetAbsolutePTSOffset();
+    ptsDiff = timingReader->GetPTSDiff();
+    if (ptsDiff < 0 && seekTimeCorrected + ptsDiff > seekTimeCorrected)
+      seekTimeCorrected = 0;
+    else
+      seekTimeCorrected += ptsDiff;
+  }
+
+  for (auto& stream : m_streams)
+  {
+    ISampleReader* streamReader{stream->GetReader()};
+    if (!streamReader)
+    {
+      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
+      continue;
+    }
+    if (stream->m_isEnabled && (streamId == 0 || stream->m_info.GetPhysicalIndex() == streamId))
+    {
+      bool reset{true};
+      // all streams must be started before seeking to ensure cross chapter seeks
+      // will seek to the correct location/segment
+      if (!streamReader->IsStarted())
+        StartReader(stream.get(), seekTimeCorrected, ptsDiff, preceeding, false);
+
+      double seekSecs{static_cast<double>(seekTimeCorrected - streamReader->GetPTSDiff()) /
+                      STREAM_TIME_BASE};
+      if (stream->m_adStream.seek_time(seekSecs, preceeding, reset))
+      {
+        if (reset)
+          streamReader->Reset(false);
+        // advance reader to requested time
+        if (!streamReader->TimeSeek(seekTimeCorrected, preceeding))
+        {
+          streamReader->Reset(true);
+        }
+        else
+        {
+          double destTime{static_cast<double>(PTSToElapsed(streamReader->PTS())) /
+                          STREAM_TIME_BASE};
+          LOG::Log(LOGINFO, "Seek time (%0.1lf) for stream: %d continues at %0.1lf (PTS: %llu)",
+                   seekTime, stream->m_info.GetPhysicalIndex(), destTime, streamReader->PTS());
+          if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
+          {
+            seekTime = destTime;
+            seekTimeCorrected = streamReader->PTS();
+            preceeding = false;
+          }
+          ret = true;
+        }
+      }
+      else
+        streamReader->Reset(true);
+    }
+  }
+
+  return ret;
+}
+
+void CSession::OnSegmentChanged(adaptive::AdaptiveStream* adStream)
+{
+  for (auto& stream : m_streams)
+  {
+    if (&stream->m_adStream == adStream)
+    {
+      ISampleReader* streamReader{stream->GetReader()};
+      if (!streamReader)
+        LOG::LogF(LOGWARNING, "Cannot get the stream sample reader");
+      else
+        streamReader->SetPTSOffset(stream->m_adStream.GetCurrentPTSOffset());
+
+      stream->m_hasSegmentChanged = true;
+      break;
+    }
+  }
+}
+
+void CSession::OnStreamChange(adaptive::AdaptiveStream* adStream)
+{
+  for (auto& stream : m_streams)
+  {
+    if (stream->m_isEnabled && &stream->m_adStream == adStream)
+    {
+      UpdateStream(*stream);
+      m_changed = true;
+    }
+  }
+}
+
+void CSession::CheckFragmentDuration(CStream& stream)
+{
+  uint64_t nextTs;
+  uint64_t nextDur;
+  ISampleReader* streamReader{stream.GetReader()};
+  if (!streamReader)
+  {
+    LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
+    return;
+  }
+
+  if (stream.m_hasSegmentChanged && streamReader->GetNextFragmentInfo(nextTs, nextDur))
+  {
+    m_adaptiveTree->SetFragmentDuration(
+        stream.m_adStream.getAdaptationSet(), stream.m_adStream.getRepresentation(),
+        stream.m_adStream.getSegmentPos(), nextTs, static_cast<uint32_t>(nextDur),
+        streamReader->GetTimeScale());
+  }
+  stream.m_hasSegmentChanged = false;
+}
+
+const AP4_UI08* CSession::GetDefaultKeyId(const uint16_t index) const
+{
+  static const AP4_UI08 default_key[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  if (m_adaptiveTree->current_period_->psshSets_[index].defaultKID_.size() == 16)
+    return reinterpret_cast<const AP4_UI08*>(
+        m_adaptiveTree->current_period_->psshSets_[index].defaultKID_.data());
+
+  return default_key;
+}
+
+Adaptive_CencSingleSampleDecrypter* CSession::GetSingleSampleDecrypter(std::string sessionId)
+{
+  for (std::vector<CCdmSession>::iterator b(m_cdmSessions.begin() + 1), e(m_cdmSessions.end());
+       b != e; ++b)
+  {
+    if (b->m_cdmSessionStr && sessionId == b->m_cdmSessionStr)
+      return b->m_cencSingleSampleDecrypter;
+  }
+  return nullptr;
+}
+
+uint32_t CSession::GetIncludedStreamMask() const
+{
+  const INPUTSTREAM_TYPE adp2ips[] = {INPUTSTREAM_TYPE_NONE, INPUTSTREAM_TYPE_VIDEO,
+                                      INPUTSTREAM_TYPE_AUDIO, INPUTSTREAM_TYPE_SUBTITLE};
+  uint32_t res{0};
+  for (unsigned int i(0); i < 4; ++i)
+  {
+    if (m_adaptiveTree->current_period_->included_types_ & (1U << i))
+      res |= (1U << adp2ips[i]);
+  }
+  return res;
+}
+
+STREAM_CRYPTO_KEY_SYSTEM CSession::GetCryptoKeySystem() const
+{
+  if (m_kodiProps.m_licenseType == "com.widevine.alpha")
+    return STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE;
+#if STREAMCRYPTO_VERSION_LEVEL >= 1
+  else if (m_kodiProps.m_licenseType == "com.huawei.wiseplay")
+    return STREAM_CRYPTO_KEY_SYSTEM_WISEPLAY;
+#endif
+  else if (m_kodiProps.m_licenseType == "com.microsoft.playready")
+    return STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY;
+  else
+    return STREAM_CRYPTO_KEY_SYSTEM_NONE;
+}
+
+int CSession::GetChapter() const
+{
+  if (m_adaptiveTree)
+  {
+    std::vector<adaptive::AdaptiveTree::Period*>::const_iterator res =
+        std::find(m_adaptiveTree->periods_.cbegin(), m_adaptiveTree->periods_.cend(),
+                  m_adaptiveTree->current_period_);
+    if (res != m_adaptiveTree->periods_.cend())
+      return (res - m_adaptiveTree->periods_.cbegin()) + 1;
+  }
+  return -1;
+}
+
+int CSession::GetChapterCount() const
+{
+  if (m_adaptiveTree)
+    return m_adaptiveTree->periods_.size() > 1 ? m_adaptiveTree->periods_.size() : 0;
+
+  return 0;
+}
+
+const char* CSession::GetChapterName(int ch) const
+{
+  --ch;
+  if (ch >= 0 && ch < static_cast<int>(m_adaptiveTree->periods_.size()))
+    return m_adaptiveTree->periods_[ch]->id_.c_str();
+
+  return "[Unknown]";
+}
+
+int64_t CSession::GetChapterPos(int ch) const
+{
+  int64_t sum{0};
+  --ch;
+
+  for (; ch; --ch)
+  {
+    sum += (m_adaptiveTree->periods_[ch - 1]->duration_ * STREAM_TIME_BASE) /
+           m_adaptiveTree->periods_[ch - 1]->timescale_;
+  }
+
+  return sum / STREAM_TIME_BASE;
+}
+
+uint64_t CSession::GetChapterStartTime() const
+{
+  uint64_t start_time = 0;
+  for (adaptive::AdaptiveTree::Period* p : m_adaptiveTree->periods_)
+  {
+    if (p == m_adaptiveTree->current_period_)
+      break;
+    else
+      start_time += (p->duration_ * STREAM_TIME_BASE) / p->timescale_;
+  }
+  return start_time;
+}
+
+int CSession::GetPeriodId() const
+{
+  if (m_adaptiveTree)
+  {
+    if (IsLive())
+    {
+      return m_adaptiveTree->current_period_->sequence_ == m_adaptiveTree->initial_sequence_
+                 ? 1
+                 : m_adaptiveTree->current_period_->sequence_ + 1;
+    }
+    else
+      return GetChapter();
+  }
+  return -1;
+}
+
+bool CSession::SeekChapter(int ch)
+{
+  if (m_adaptiveTree->next_period_)
+    return true;
+
+  --ch;
+  if (ch >= 0 && ch < static_cast<int>(m_adaptiveTree->periods_.size()) &&
+      m_adaptiveTree->periods_[ch] != m_adaptiveTree->current_period_)
+  {
+    m_adaptiveTree->next_period_ = m_adaptiveTree->periods_[ch];
+    for (auto& stream : m_streams)
+    {
+      if (stream->GetReader())
+        stream->GetReader()->Reset(true);
+    }
+    return true;
+  }
+  return false;
+}

--- a/src/Session.h
+++ b/src/Session.h
@@ -1,0 +1,367 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "KodiHost.h"
+#include "Stream.h"
+#include "common/AdaptiveStream.h"
+#include "common/AdaptiveTree.h"
+#include "common/Chooser.h"
+#include "samplereader/SampleReader.h"
+#include "utils/PropertiesUtils.h"
+
+#include <bento4/Ap4.h>
+#include <kodi/tools/DllHelper.h>
+
+class Adaptive_CencSingleSampleDecrypter;
+
+namespace SESSION
+{
+class ATTR_DLL_LOCAL CSession : public adaptive::AdaptiveStreamObserver
+{
+public:
+  CSession(const UTILS::PROPERTIES::KodiProperties& properties,
+           const std::string& manifestUrl,
+           const std::map<std::string, std::string>& mediaHeaders,
+           const std::string& profilePath);
+  virtual ~CSession();
+
+  /*! \brief Set the DRM configuration flags
+   *  \param config Flags to be passed to the decrypter
+   */
+  void SetDrmConfig(const std::uint8_t config) { m_drmConfig = config; }
+
+  /*! \brief Initialize the session
+   *  \return True if has success, false otherwise
+   */
+  bool Initialize();
+
+  /*! \brief Pre-Initialize the DRM
+   *  \param challengeB64 [OUT] Provide the challenge data as base64
+   *  \param sessionId [OUT] Provide the session ID
+   *  \param isSessionOpened [OUT] Will be true if the DRM session has been opened
+   *  \return True if has success, false otherwise
+   */
+  bool PreInitializeDRM(std::string& challengeB64, std::string& sessionId, bool& isSessionOpened);
+
+  /*! \brief Initialize the DRM
+   *  \param addDefaultKID Set True to add the default KID to the first session
+   *  \return True if has success, false otherwise
+   */
+  bool InitializeDRM(bool addDefaultKID = false);
+
+  /*! \brief Initialize adaptive tree period
+   *  \param isSessionOpened Set True to kept and re-use the DRM session opened,
+   *         otherwise False to reinitialize the DRM session
+   *  \return True if has success, false otherwise
+   */
+  bool InitializePeriod(bool isSessionOpened = false);
+
+  /*! \brief Get the next sample's reader, set flags if the stream has changed
+   *  \return The SampleReader for the next chronological sample
+   *         if found otherwise nullptr
+   */
+  ISampleReader* GetNextSample();
+
+  /*! \brief Create and push back a new Stream object
+   *  \param adp The AdaptationSet of the stream
+   *  \param repr The Representation of the stream
+   *  \param isDefaultRepr Whether this Representation is the default
+   *  \param uniqueId A unique identifier for the Representation
+   */
+  void AddStream(adaptive::AdaptiveTree::AdaptationSet* adp,
+                 adaptive::AdaptiveTree::Representation* repr,
+                 bool isDefaultRepr,
+                 uint32_t uniqueId);
+
+  /*! \brief Update stream's InputstreamInfo
+   *  \param stream The stream to update
+   */
+  void UpdateStream(CStream& stream);
+
+  /*! \brief Update stream's InputstreamInfo
+   *  \param stream The stream to prepare
+   *  \param needRefetch [OUT] Set to true if stream info has changed
+   *  \return The Movie box if the stream container is MP4 and a valid MOOV
+   *        box is found, otherwise nullptr
+   */
+  AP4_Movie* PrepareStream(CStream* stream, bool& needRefetch);
+
+
+  /*! \brief Get a stream by index (starting at 1)
+   *  \param sid The one-indexed stream id
+   *  \return The stream object if the index exists
+   */
+  CStream* GetStream(unsigned int sid) const
+  {
+    return sid - 1 < m_streams.size() ? m_streams[sid - 1].get() : nullptr;
+  }
+
+  /*! \brief Enable or disable a stream
+   *  \param stream The stream object to act on
+   *  \param enable Whether to enable or disable the stream
+   */
+  void EnableStream(CStream* stream, bool enable);
+
+  /*! \brief Get the number of streams in the session
+   *  \return The number of streams in the session
+   */
+  unsigned int GetStreamCount() const { return m_streams.size(); }
+
+  /*! \brief Get a session string (session id) by index from the cdm sessions
+   *  \param index The index (psshSet number) of the cdm session
+   *  \return The session string
+   */
+  const char* GetCDMSession(unsigned int index) { return m_cdmSessions[index].m_cdmSessionStr; }
+
+  /*! \brief Get the media type mask
+   *  \return The media type mask
+   */
+  uint8_t GetMediaTypeMask() const { return m_mediaTypeMask; }
+
+  /*! \brief Get a single sample decrypter by index from the cdm sessions
+   *  \param index The index (psshSet number) of the cdm session
+   *  \return The single sample decrypter
+   */
+  Adaptive_CencSingleSampleDecrypter* GetSingleSampleDecryptor(unsigned int index) const
+  {
+    return m_cdmSessions[index].m_cencSingleSampleDecrypter;
+  }
+
+  /*! \brief Get the decrypter (SSD lib)
+   *  \return The decrypter
+   */
+  SSD::SSD_DECRYPTER* GetDecrypter() { return m_decrypter; }
+
+  /*! \brief Get a single sample decrypter matching the session id provided
+   *  \param sessionId The session id string to match
+   *  \return The single sample decrypter
+   */
+  Adaptive_CencSingleSampleDecrypter* GetSingleSampleDecrypter(std::string sessionId);
+
+  /*! \brief Get decrypter capabilities for a single sample decrypter
+   *  \param index The index (psshSet number) of the cdm session
+   *  \return The single sample decrypter capabilities
+   */
+  const SSD::SSD_DECRYPTER::SSD_CAPS& GetDecrypterCaps(unsigned int index) const
+  {
+    return m_cdmSessions[index].m_decrypterCaps;
+  };
+
+  /*! \brief Get the total time in ms of the stream
+   *  \return The total time in ms of the stream
+   */
+  uint64_t GetTotalTimeMs() const { return m_adaptiveTree->overallSeconds_ * 1000; };
+
+  /*! \brief Get the elapsed time in ms of the stream including all chapters
+   *  \return The elapsed time in ms of the stream including all chapters
+   */
+  uint64_t GetElapsedTimeMs() const { return m_elapsedTime / 1000; };
+
+  /*! \brief Provide a pts value that represents the time elapsed from current stream window
+   *  \param pts The pts value coming from the stream reader
+   *  \return The adjusted pts value
+   */
+  uint64_t PTSToElapsed(uint64_t pts);
+
+  /*! \brief Get the start pts of the first segment in the timing stream
+   *       with the difference in manifest time and reader time added
+   *  \return The reader's timeshift buffer starting pts
+   */
+  uint64_t GetTimeshiftBufferStart();
+
+  /*! \brief Align adaptiveStream and start stream reader
+   *  \param stream The stream to start
+   *  \param seekTime The pts value to start the stream at
+   *  \param ptsDiff The pts difference to adjust seekTime by
+   *  \param preceeding True to ask reader to seek to preceeding sync point
+   *  \param timing True if this is the initial starting stream
+   */
+  void StartReader(
+      CStream* stream, uint64_t seekTime, int64_t ptsDiff, bool preceeding, bool timing);
+
+  /*! \brief Check if the stream has changed, reset changed status
+   *  \param bSet True to keep m_changed value true
+   *  \return True if stream has changed
+   */
+  bool CheckChange(bool bSet = false)
+  {
+    bool ret = m_changed;
+    m_changed = bSet;
+    return ret;
+  };
+
+  /*! \brief To inform of Kodi's current screen resolution
+   *  \param width The width in pixels
+   *  \param height The height in pixels
+   */
+  void SetVideoResolution(int width, int height);
+
+  /*! \brief Seek streams and readers to a specified time
+   *  \param seekTime The seek time in seconds
+   *  \param streamId ID of stream to seek, 0 seeks all
+   *  \param preceeding True to seek to keyframe preceeding seektime,
+   *         false to clamp to the start of the next segment
+   *  \return True if seeking to another chapter or 1+ streams successfully
+   *          seeked, false on error or no streams seeked
+   */
+  bool SeekTime(double seekTime, unsigned int streamId = 0, bool preceeding = true);
+
+  /*! \brief Report if the current content is dynamic/live
+   *  \return True if live, false if VOD
+   */
+  bool IsLive() const { return m_adaptiveTree->has_timeshift_buffer_; };
+
+  /*! \brief Get the type of manifest being played
+   *  \return ManifestType - MPD/ISM/HLS
+   */
+  UTILS::PROPERTIES::ManifestType GetManifestType() const { return m_kodiProps.m_manifestType; }
+
+  /*! \brief Get the default keyid for a pssh
+   *  \param index The psshset number to retrieve from
+   *  \return The default keyid
+   */
+  const AP4_UI08* GetDefaultKeyId(const uint16_t index) const;
+
+
+  /*! \brief Get the mask of included streams
+   *  \return A 32 uint with bits set of 'included' streams
+   */
+  uint32_t GetIncludedStreamMask() const;
+
+
+  /*! \brief Get the type crypto key system in use
+   *  \return enum of crypto key system
+   */
+  STREAM_CRYPTO_KEY_SYSTEM GetCryptoKeySystem() const;
+
+  /*! \brief Get the initial discontinuity sequence number
+   *  \return The sequence number of the first discontinuity sequence
+   *          encountered when playback started
+   */
+  uint32_t GetInitialSequence() const { return m_adaptiveTree->initial_sequence_; }
+
+  /*! \brief Get the chapter number currently being played
+   *  \return 1 indexed vlaue of the current period
+   */
+  int GetChapter() const;
+
+  /*! \brief Get the total amount of chapters
+   *  \return The chapter count
+   */
+  int GetChapterCount() const;
+
+  /*! \brief Get the type crypto key system in use
+   *  \param ch The index of chapter/period
+   *  \return The id of the period
+   */
+  const char* GetChapterName(int ch) const;
+
+  /*! \brief Get the chapter position in milliseconds
+   *  \param ch The index (1 indexed) of chapter/period
+   *  \return The position in milliseconds of the chapter/period
+   */
+  int64_t GetChapterPos(int ch) const;
+
+  /*! \brief Get the id or sequence of the current period
+   *  \return The id/sequence of the current chapter/period
+   */
+  int GetPeriodId() const;
+
+  /*! \brief Seek to the chapter/period specified
+   *  \param ch The index (1 indexed) of chapter/period
+   *  \return True if successful, false if invalid
+   */
+  bool SeekChapter(int ch);
+
+  /*! \brief Get start time of current chapter/period
+   *  \return Time in us at start of current chapter/period
+   */
+  uint64_t GetChapterStartTime() const;
+
+  /*! \brief Get value of m_chapterSeekTime
+   *  \return Time stored in m_chapterSeekTime
+   */
+  double GetChapterSeekTime() { return m_chapterSeekTime; };
+
+  /*! \brief Set m_chapterSeekTime back to 0
+   */
+  void ResetChapterSeekTime() { m_chapterSeekTime = 0; };
+
+  //Observer Section
+
+  /*! \brief Sets the current pts offset.
+   *         To be called when the current segment of an adaptive stream changes.
+   *  \param adStream The adaptive stream on which the segment has changed
+   */
+  void OnSegmentChanged(adaptive::AdaptiveStream* adStream) override;
+
+  /*! \brief Sets the changed flag.
+   *         To be called when the stream has changed/switched.
+   *  \param adStream The adaptive stream on which the stream has changed
+   */
+  void OnStreamChange(adaptive::AdaptiveStream* adStream) override;
+
+protected:
+  /*! \brief If available, read the duration and timestamp of the next fragment and
+   *         set the related members
+   *  \param adStream [OUT] The adaptive stream to check
+   */
+  void CheckFragmentDuration(CStream& stream);
+
+  /*! \brief Check for and load decrypter module matching the supplied key system
+   *  \param key_system [OUT] Will be assigned to if a decrypter is found matching
+   *                    the set license type
+   */
+  void SetSupportedDecrypterURN(std::string& key_system);
+
+  /*! \brief Destroy all CencSingleSampleDecrypter instances
+   */
+  void DisposeSampleDecrypter();
+
+  /*! \brief Destroy the decrypter module instance
+   */
+  void DisposeDecrypter();
+
+private:
+  const UTILS::PROPERTIES::KodiProperties m_kodiProps;
+  std::string m_manifestUrl;
+  std::map<std::string, std::string> m_mediaHeaders;
+  AP4_DataBuffer m_serverCertificate;
+  std::unique_ptr<kodi::tools::CDllHelper> m_dllHelper;
+  SSD::SSD_DECRYPTER* m_decrypter{nullptr};
+  std::unique_ptr<ISampleReader> m_dummySampleReader;
+
+  struct CCdmSession
+  {
+    SSD::SSD_DECRYPTER::SSD_CAPS m_decrypterCaps;
+    Adaptive_CencSingleSampleDecrypter* m_cencSingleSampleDecrypter;
+    const char* m_cdmSessionStr = nullptr;
+    bool m_sharedCencSsd{false};
+  };
+  std::vector<CCdmSession> m_cdmSessions;
+
+  adaptive::AdaptiveTree* m_adaptiveTree;
+  CHOOSER::IRepresentationChooser* m_reprChooser;
+
+  std::vector<std::unique_ptr<CStream>> m_streams;
+  CStream* m_timingStream{nullptr};
+
+  bool m_changed{false};
+  uint64_t m_elapsedTime{0};
+  uint64_t m_chapterStartTime{0}; // In STREAM_TIME_BASE
+  double m_chapterSeekTime{0.0}; // In seconds
+  uint8_t m_mediaTypeMask{0};
+  uint8_t m_drmConfig{0};
+  bool m_settingNoSecureDecoder{false};
+  bool m_settingIsHdcpOverride{false};
+  bool m_firstPeriodInitialized{false};
+  std::unique_ptr<CKodiHost> m_KodiHost;
+};
+} // namespace SESSION

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Stream.h"
+
+using namespace SESSION;
+
+void CStream::Disable()
+{
+  if (m_isEnabled)
+  {
+    m_adStream.stop();
+    Reset();
+    m_isEnabled = false;
+    m_isEncrypted = false;
+  }
+}
+
+void CStream::Reset()
+{
+  if (m_isEnabled)
+  {
+    m_streamReader.reset();
+    m_streamFile.reset();
+    m_adByteStream.reset();
+    m_mainId = 0;
+  }
+}

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AdaptiveByteStream.h"
+#include "common/AdaptiveStream.h"
+#include "samplereader/SampleReader.h"
+
+#include <bento4/Ap4.h>
+#include <kodi/addon-instance/Inputstream.h>
+
+namespace SESSION
+{
+class ATTR_DLL_LOCAL CStream
+{
+public:
+  CStream(adaptive::AdaptiveTree& tree,
+          adaptive::AdaptiveTree::AdaptationSet* adp,
+          adaptive::AdaptiveTree::Representation* initialRepr,
+          const std::map<std::string, std::string>& mediaHeaders,
+          CHOOSER::IRepresentationChooser* reprChooser,
+          bool playTimeshiftBuffer,
+          bool chooseRep)
+    : m_isEnabled{false},
+      m_isEncrypted{false},
+      m_mainId{0},
+      m_adStream{tree, adp, initialRepr, mediaHeaders, playTimeshiftBuffer, chooseRep},
+      m_hasSegmentChanged{false},
+      m_isValid{true} {};
+
+
+  ~CStream() { Disable(); };
+
+  /*!
+   * \brief Stop/disable the AdaptiveStream and reset
+   */
+  void Disable();
+
+  /*!
+   * \brief Reset the stream components in preparation for opening a new stream
+   */
+  void Reset();
+
+  /*!
+   * \brief Get the stream sample reader pointer
+   * \return The sample reader, otherwise nullptr if not set
+   */
+  ISampleReader* GetReader() const { return m_streamReader.get(); }
+
+  /*!
+   * \brief Set the stream sample reader
+   * \param reader The reader
+   */
+  void SetReader(std::unique_ptr<ISampleReader> reader) { m_streamReader = std::move(reader); }
+
+  /*!
+   * \brief Get the stream file handler pointer
+   * \return The stream file handler, otherwise nullptr if not set
+   */
+  AP4_File* GetStreamFile() const { return m_streamFile.get(); }
+
+  /*!
+   * \brief Set the stream file handler
+   * \param streamFile The stream file handler
+   */
+  void SetStreamFile(std::unique_ptr<AP4_File> streamFile) { m_streamFile = std::move(streamFile); }
+
+  /*!
+   * \brief Get the adaptive byte stream handler pointer
+   * \return The adaptive byte stream handler, otherwise nullptr if not set
+   */
+  CAdaptiveByteStream* GetAdByteStream() const { return m_adByteStream.get(); }
+
+  /*!
+   * \brief Set the adaptive byte stream handler
+   * \param dataStream The adaptive byte stream handler
+   */
+  void SetAdByteStream(std::unique_ptr<CAdaptiveByteStream> adByteStream)
+  {
+    m_adByteStream = std::move(adByteStream);
+  }
+
+  bool m_isEnabled;
+  bool m_isEncrypted;
+  uint16_t m_mainId;
+  adaptive::AdaptiveStream m_adStream;
+  kodi::addon::InputstreamInfo m_info;
+  bool m_hasSegmentChanged;
+  bool m_isValid;
+
+private:
+  std::unique_ptr<ISampleReader> m_streamReader;
+  std::unique_ptr<CAdaptiveByteStream> m_adByteStream;
+  std::unique_ptr<AP4_File> m_streamFile;
+};
+} // namespace SESSION

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,1713 +9,32 @@
 #include "main.h"
 
 #include "ADTSReader.h"
+#include "Session.h"
+#include "Stream.h"
 #include "TSReader.h"
 #include "WebmReader.h"
-#include "aes_decrypter.h"
-#include "oscompat.h"
-#include "codechandler/AVCCodecHandler.h"
-#include "codechandler/HEVCCodecHandler.h"
-#include "codechandler/MPEGCodecHandler.h"
-#include "codechandler/TTMLCodecHandler.h"
-#include "codechandler/VP9CodecHandler.h"
-#include "codechandler/WebVTTCodecHandler.h"
+#include "parser/DASHTree.h"
+#include "parser/HLSTree.h"
+#include "parser/SmoothTree.h"
 #include "samplereader/ADTSSampleReader.h"
 #include "samplereader/DummySampleReader.h"
 #include "samplereader/FragmentedSampleReader.h"
 #include "samplereader/SubtitleSampleReader.h"
 #include "samplereader/TSSampleReader.h"
 #include "samplereader/WebmSampleReader.h"
-#include "parser/DASHTree.h"
-#include "parser/HLSTree.h"
-#include "parser/SmoothTree.h"
-#include "utils/Base64Utils.h"
-#include "utils/log.h"
-#include "utils/SettingsUtils.h"
-#include "utils/StringUtils.h"
 #include "utils/Utils.h"
+#include "utils/log.h"
+#include "utils/PropertiesUtils.h"
 
-#include <chrono>
-#include <algorithm>
-#include <iostream>
-#include <math.h>
-#include <sstream>
 #include <stdarg.h> // va_list, va_start, va_arg, va_end
-#include <stdio.h>
-#include <string.h>
-
-#include <kodi/Filesystem.h>
-#include <kodi/General.h>
-#include <kodi/addon-instance/VideoCodec.h>
-#include <kodi/addon-instance/inputstream/StreamCodec.h>
-#include "kodi/tools/StringUtils.h"
-
-#if defined(ANDROID)
-#include <kodi/platform/android/System.h>
-#endif
-
-#ifdef CreateDirectory
-#undef CreateDirectory
-#endif
-
-#define STREAM_TIME_BASE 1000000
 
 using namespace UTILS;
-using namespace kodi::tools;
+using namespace SESSION;
 
 static const AP4_Track::Type TIDC[adaptive::AdaptiveTree::STREAM_TYPE_COUNT] = {
     AP4_Track::TYPE_UNKNOWN, AP4_Track::TYPE_VIDEO, AP4_Track::TYPE_AUDIO,
-    AP4_Track::TYPE_SUBTITLES};
+    AP4_Track::TYPE_SUBTITLES };
 
-/*******************************************************
-kodi host - interface for decrypter libraries
-********************************************************/
-class ATTR_DLL_LOCAL KodiHost : public SSD::SSD_HOST
-{
-public:
-#if defined(ANDROID)
-  virtual void* GetJNIEnv() override { return m_androidSystem.GetJNIEnv(); };
-
-  virtual int GetSDKVersion() override { return m_androidSystem.GetSDKVersion(); };
-
-  virtual const char* GetClassName() override
-  {
-    m_retvalHelper = m_androidSystem.GetClassName();
-    return m_retvalHelper.c_str();
-  };
-
-#endif
-  virtual const char* GetLibraryPath() const override { return m_strLibraryPath.c_str(); };
-
-  virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); };
-
-  virtual void* CURLCreate(const char* strURL) override
-  {
-    kodi::vfs::CFile* file = new kodi::vfs::CFile;
-    if (!file->CURLCreate(strURL))
-    {
-      delete file;
-      return nullptr;
-    }
-    return file;
-  };
-
-  virtual bool CURLAddOption(void* file,
-                             CURLOPTIONS opt,
-                             const char* name,
-                             const char* value) override
-  {
-    const CURLOptiontype xbmcmap[] = {ADDON_CURL_OPTION_PROTOCOL, ADDON_CURL_OPTION_HEADER};
-    return static_cast<kodi::vfs::CFile*>(file)->CURLAddOption(xbmcmap[opt], name, value);
-  }
-
-  virtual const char* CURLGetProperty(void* file, CURLPROPERTY prop, const char* name) override
-  {
-    const FilePropertyTypes xbmcmap[] = {ADDON_FILE_PROPERTY_RESPONSE_HEADER};
-    m_strPropertyValue =
-        static_cast<kodi::vfs::CFile*>(file)->GetPropertyValue(xbmcmap[prop], name);
-    return m_strPropertyValue.c_str();
-  }
-
-  virtual bool CURLOpen(void* file) override
-  {
-    return static_cast<kodi::vfs::CFile*>(file)->CURLOpen(ADDON_READ_NO_CACHE);
-  };
-
-  virtual size_t ReadFile(void* file, void* lpBuf, size_t uiBufSize) override
-  {
-    return static_cast<kodi::vfs::CFile*>(file)->Read(lpBuf, uiBufSize);
-  };
-
-  virtual void CloseFile(void* file) override
-  {
-    return static_cast<kodi::vfs::CFile*>(file)->Close();
-  };
-
-  virtual bool CreateDir(const char* dir) override { return kodi::vfs::CreateDirectory(dir); };
-
-  void LogVA(const SSD::SSDLogLevel level, const char* format, va_list args) override
-  {
-    std::vector<char> data;
-    data.resize(256);
-
-    va_list argsStart;
-    va_copy(argsStart, args);
-
-    int ret;
-    while (static_cast<size_t>(ret = vsnprintf(data.data(), data.size(), format, args)) >
-           data.size())
-    {
-      data.resize(data.size() * 2);
-      args = argsStart;
-    }
-    LOG::Log(static_cast<LogLevel>(level), data.data());
-    va_end(argsStart);
-  };
-
-  void SetLibraryPath(const char* libraryPath)
-  {
-    m_strLibraryPath = libraryPath;
-
-    const char* pathSep(libraryPath[0] && libraryPath[1] == ':' && isalpha(libraryPath[0]) ? "\\"
-                                                                                           : "/");
-
-    if (m_strLibraryPath.size() && m_strLibraryPath.back() != pathSep[0])
-      m_strLibraryPath += pathSep;
-  }
-
-  void SetProfilePath(const std::string& profilePath)
-  {
-    m_strProfilePath = profilePath;
-
-    const char* pathSep(profilePath[0] && profilePath[1] == ':' && isalpha(profilePath[0]) ? "\\"
-                                                                                           : "/");
-
-    if (m_strProfilePath.size() && m_strProfilePath.back() != pathSep[0])
-      m_strProfilePath += pathSep;
-
-    //let us make cdm userdata out of the addonpath and share them between addons
-    m_strProfilePath.resize(
-        m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 2));
-    m_strProfilePath.resize(
-        m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1));
-    m_strProfilePath.resize(
-        m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1) + 1);
-
-    kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
-    m_strProfilePath += "cdm";
-    m_strProfilePath += pathSep;
-    kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
-  }
-
-  virtual bool GetBuffer(void* instance, SSD::SSD_PICTURE& picture) override
-  {
-    return instance ? static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->GetFrameBuffer(
-                          *reinterpret_cast<VIDEOCODEC_PICTURE*>(&picture))
-                    : false;
-  }
-
-  virtual void ReleaseBuffer(void* instance, void* buffer) override
-  {
-    if (instance)
-      static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->ReleaseFrameBuffer(buffer);
-  }
-
-private:
-  std::string m_strProfilePath, m_strLibraryPath, m_strPropertyValue;
-
-#if defined(ANDROID)
-  kodi::platform::CInterfaceAndroidSystem m_androidSystem;
-  std::string m_retvalHelper;
-#endif
-} * kodihost;
-
-/*******************************************************
-Main class Session
-********************************************************/
-
-void Session::STREAM::disable()
-{
-  if (enabled)
-  {
-    m_adStream.stop();
-    reset();
-    enabled = encrypted = false;
-  }
-}
-
-void Session::STREAM::reset()
-{
-  if (enabled)
-  {
-    m_streamReader.reset();
-    m_streamFile.reset();
-    m_adByteStream.reset();
-    mainId_ = 0;
-  }
-}
-
-Session::Session(const PROPERTIES::KodiProperties& kodiProps,
-                 const std::string& url,
-                 const std::map<std::string, std::string>& mediaHeaders,
-                 const std::string& profilePath)
-  : m_kodiProps(kodiProps),
-    manifestURL_(url),
-    media_headers_(mediaHeaders),
-    m_dummySampleReader(new CDummySampleReader)
-{
-  m_reprChooser = CHOOSER::CreateRepresentationChooser(kodiProps);
-
-  switch (kodiProps.m_manifestType)
-  {
-    case PROPERTIES::ManifestType::MPD:
-      adaptiveTree_ = new adaptive::DASHTree(kodiProps, m_reprChooser);
-      break;
-    case PROPERTIES::ManifestType::ISM:
-      adaptiveTree_ = new adaptive::SmoothTree(kodiProps, m_reprChooser);
-      break;
-    case PROPERTIES::ManifestType::HLS:
-      adaptiveTree_ =
-          new adaptive::HLSTree(kodiProps, m_reprChooser, new AESDecrypter(kodiProps.m_licenseKey));
-      break;
-    default:
-      LOG::LogF(LOGFATAL, "Manifest type not handled");
-      return;
-  };
-
-  m_settingNoSecureDecoder = kodi::addon::GetSettingBoolean("NOSECUREDECODER");
-  LOG::Log(LOGDEBUG, "Setting NOSECUREDECODER value: %d", m_settingNoSecureDecoder);
-
-  m_settingIsHdcpOverride = kodi::addon::GetSettingBoolean("HDCPOVERRIDE");
-  LOG::Log(LOGDEBUG, "Ignore HDCP status setting value: %i", m_settingIsHdcpOverride);
-
-  switch (kodi::addon::GetSettingInt("MEDIATYPE"))
-  {
-    case 1:
-      media_type_mask_ = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::AUDIO;
-      break;
-    case 2:
-      media_type_mask_ = static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO;
-      break;
-    case 3:
-      media_type_mask_ = (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::VIDEO) |
-                         (static_cast<uint8_t>(1U) << adaptive::AdaptiveTree::SUBTITLE);
-      break;
-    default:
-      media_type_mask_ = static_cast<uint8_t>(~0);
-  }
-
-  if (!kodiProps.m_serverCertificate.empty())
-  {
-    std::string decCert{ BASE64::Decode(kodiProps.m_serverCertificate) };
-    server_certificate_.SetData(reinterpret_cast<const AP4_Byte*>(decCert.data()), decCert.size());
-  }
-}
-
-Session::~Session()
-{
-  LOG::Log(LOGDEBUG, "Session::~Session()");
-  m_streams.clear();
-
-  DisposeDecrypter();
-
-  delete adaptiveTree_;
-  adaptiveTree_ = nullptr;
-
-  delete m_reprChooser;
-  m_reprChooser = nullptr;
-}
-
-void Session::GetSupportedDecrypterURN(std::string& key_system)
-{
-  typedef SSD::SSD_DECRYPTER* (*CreateDecryptorInstanceFunc)(SSD::SSD_HOST * host,
-                                                             uint32_t version);
-
-  std::string specialpath = kodi::addon::GetSettingString("DECRYPTERPATH");
-  if (specialpath.empty())
-  {
-    LOG::Log(LOGDEBUG, "DECRYPTERPATH not specified in settings.xml");
-    return;
-  }
-  kodihost->SetLibraryPath(kodi::vfs::TranslateSpecialProtocol(specialpath).c_str());
-
-  std::vector<std::string> searchPaths(2);
-  searchPaths[0] =
-      kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/");
-  searchPaths[1] = kodi::addon::GetAddonInfo("path");
-
-  std::vector<kodi::vfs::CDirEntry> items;
-
-  for (std::vector<std::string>::const_iterator path(searchPaths.begin());
-       !decrypter_ && path != searchPaths.end(); ++path)
-  {
-    LOG::Log(LOGDEBUG, "Searching for decrypters in: %s", path->c_str());
-
-    if (!kodi::vfs::GetDirectory(*path, "", items))
-      continue;
-
-    for (unsigned int i(0); i < items.size(); ++i)
-    {
-      if (strncmp(items[i].Label().c_str(), "ssd_", 4) &&
-          strncmp(items[i].Label().c_str(), "libssd_", 7))
-        continue;
-
-      bool success = false;
-      decrypterModule_ = new kodi::tools::CDllHelper;
-      if (decrypterModule_->LoadDll(items[i].Path()))
-        {
-        CreateDecryptorInstanceFunc startup;
-        if (decrypterModule_->RegisterSymbol(startup, "CreateDecryptorInstance"))
-          {
-            SSD::SSD_DECRYPTER* decrypter = startup(kodihost, SSD::SSD_HOST::version);
-            const char* suppUrn(0);
-
-            if (decrypter &&
-                (suppUrn = decrypter->SelectKeySytem(m_kodiProps.m_licenseType.c_str())))
-            {
-              LOG::Log(LOGDEBUG, "Found decrypter: %s", items[i].Path().c_str());
-              success = true;
-              decrypter_ = decrypter;
-              key_system = suppUrn;
-              break;
-            }
-          }
-      }
-      else
-      {
-        LOG::Log(LOGDEBUG, "%s", dlerror());
-      }
-      if (!success)
-      {
-        delete decrypterModule_;
-        decrypterModule_ = 0;
-      }
-    }
-  }
-}
-
-void Session::DisposeSampleDecrypter()
-{
-  if (decrypter_)
-  {
-    for (std::vector<CDMSESSION>::iterator b(cdm_sessions_.begin()), e(cdm_sessions_.end()); b != e;
-         ++b)
-    {
-      b->cdm_session_str_ = nullptr;
-      if (!b->shared_single_sample_decryptor_)
-      {
-        decrypter_->DestroySingleSampleDecrypter(b->single_sample_decryptor_);
-        b->single_sample_decryptor_ = nullptr;
-      }
-      else
-      {
-        b->single_sample_decryptor_ = nullptr;
-        b->shared_single_sample_decryptor_ = false;
-      }
-    }
-  }
-}
-
-void Session::DisposeDecrypter()
-{
-  if (!decrypterModule_)
-    return;
-
-  DisposeSampleDecrypter();
-
-  typedef void (*DeleteDecryptorInstanceFunc)(SSD::SSD_DECRYPTER*);
-  DeleteDecryptorInstanceFunc disposefn;
-  if (decrypterModule_->RegisterSymbol(disposefn, "DeleteDecryptorInstance"))
-    disposefn(decrypter_);
-
-  delete decrypterModule_;
-  decrypterModule_ = 0;
-  decrypter_ = 0;
-}
-
-/*----------------------------------------------------------------------
-|   initialize
-+---------------------------------------------------------------------*/
-
-bool Session::Initialize(const std::uint8_t config)
-{
-  if (!adaptiveTree_)
-    return false;
-
-  // Get URN's wich are supported by this addon
-  if (!m_kodiProps.m_licenseType.empty())
-  {
-    GetSupportedDecrypterURN(adaptiveTree_->supportedKeySystem_);
-    LOG::Log(LOGDEBUG, "Supported URN: %s", adaptiveTree_->supportedKeySystem_.c_str());
-  }
-
-  // Preinitialize the DRM, if pre-initialisation data are provided
-  std::map<std::string, std::string> additionalHeaders = std::map<std::string, std::string>();
-  bool isSessionOpened{false};
-
-  if (!m_kodiProps.m_drmPreInitData.empty())
-  {
-    std::string challengeB64;
-    std::string sessionId;
-    // Pre-initialize the DRM allow to generate the challenge and session ID data
-    // used to make licensed manifest requests (via proxy callback)
-    if (PreInitializeDRM(challengeB64, sessionId, isSessionOpened))
-    {
-      additionalHeaders["challengeB64"] = STRING::URLEncode(challengeB64);
-      additionalHeaders["sessionId"] = sessionId;
-    }
-    else
-      return false;
-  }
-
-  // Open manifest file with location redirect support  bool mpdSuccess;
-  std::string manifestUrl =
-      adaptiveTree_->location_.empty() ? manifestURL_ : adaptiveTree_->location_;
-  if (!adaptiveTree_->open(manifestUrl, m_kodiProps.m_manifestUpdateParam, additionalHeaders) ||
-      adaptiveTree_->empty())
-  {
-    LOG::Log(LOGERROR, "Could not open / parse manifest (%s)", manifestUrl.c_str());
-    return false;
-  }
-  LOG::Log(
-      LOGINFO,
-      "Successfully parsed manifest file (Periods: %ld, Streams in first period: %ld, Type: %s)",
-      adaptiveTree_->periods_.size(), adaptiveTree_->current_period_->adaptationSets_.size(),
-      adaptiveTree_->has_timeshift_buffer_ ? "live" : "VOD");
-
-  drmConfig_ = config;
-
-  // Always need at least 16s delay from live
-  if (adaptiveTree_->live_delay_ < 16)
-    adaptiveTree_->live_delay_ = 16;
-
-  return InitializePeriod(isSessionOpened);
-}
-
-bool Session::PreInitializeDRM(std::string& challengeB64,
-                               std::string& sessionId,
-                               bool& isSessionOpened)
-{
-  std::string psshData;
-  std::string kidData;
-  // Parse the PSSH/KID data
-  std::string::size_type posSplitter(m_kodiProps.m_drmPreInitData.find("|"));
-  if (posSplitter != std::string::npos)
-  {
-    psshData = m_kodiProps.m_drmPreInitData.substr(0, posSplitter);
-    kidData = m_kodiProps.m_drmPreInitData.substr(posSplitter + 1);
-  }
-
-  if (psshData.empty() || kidData.empty())
-  {
-    LOG::LogF(LOGERROR, "Invalid DRM pre-init data, must be as: {PSSH as base64}|{KID as base64}");
-    return false;
-  }
-
-  cdm_sessions_.resize(2);
-  memset(&cdm_sessions_.front(), 0, sizeof(CDMSESSION));
-  // Try to initialize an SingleSampleDecryptor
-  LOG::LogF(LOGDEBUG, "Entering encryption section");
-
-  if (m_kodiProps.m_licenseKey.empty())
-  {
-    LOG::LogF(LOGERROR, "Invalid license_key");
-    return false;
-  }
-
-  if (!decrypter_)
-  {
-    LOG::LogF(LOGERROR, "No decrypter found for encrypted stream");
-    return false;
-  }
-
-  if (!decrypter_->HasCdmSession())
-  {
-    if (!decrypter_->OpenDRMSystem(m_kodiProps.m_licenseKey.c_str(), server_certificate_,
-                                   drmConfig_))
-    {
-      LOG::LogF(LOGERROR, "OpenDRMSystem failed");
-      return false;
-    }
-  }
-
-  AP4_DataBuffer init_data;
-  init_data.SetBufferSize(1024);
-  const char* optionalKeyParameter(nullptr);
-
-  // Set the provided PSSH
-  std::string decPssh{BASE64::Decode(psshData)};
-  init_data.SetData(reinterpret_cast<const AP4_Byte*>(decPssh.data()), decPssh.size());
-
-  // Decode the provided KID
-  std::string decKid{BASE64::Decode(kidData)};
-
-  CDMSESSION& session(cdm_sessions_[1]);
-
-  std::string hexKid{StringUtils::ToHexadecimal(decKid)};
-  LOG::LogF(LOGDEBUG, "Initializing session with KID: %s", hexKid.c_str());
-
-  if (decrypter_ && init_data.GetDataSize() >= 4 &&
-      (session.single_sample_decryptor_ = decrypter_->CreateSingleSampleDecrypter(
-           init_data, optionalKeyParameter, decKid, true)) != 0)
-  {
-    session.cdm_session_str_ = session.single_sample_decryptor_->GetSessionId();
-    sessionId = session.cdm_session_str_;
-    challengeB64 = decrypter_->GetChallengeB64Data(session.single_sample_decryptor_);
-  }
-  else
-  {
-    LOG::LogF(LOGERROR, "Initialize failed (SingleSampleDecrypter)");
-    session.single_sample_decryptor_ = nullptr;
-    return false;
-  }
-#if defined(ANDROID)
-  // On android is not possible add the default KID key
-  // then we cannot re-use same session
-  DisposeSampleDecrypter();
-#else
-  isSessionOpened = true;
-#endif
-  return true;
-}
-
-bool Session::InitializeDRM(bool addDefaultKID /* = false */)
-{
-  bool isSecureVideoSession = false;
-  cdm_sessions_.resize(adaptiveTree_->current_period_->psshSets_.size());
-  memset(&cdm_sessions_.front(), 0, sizeof(CDMSESSION));
-
-  // Try to initialize an SingleSampleDecryptor
-  if (adaptiveTree_->current_period_->encryptionState_)
-  {
-    std::string licenseKey{m_kodiProps.m_licenseKey};
-
-    if (licenseKey.empty())
-      licenseKey = adaptiveTree_->license_url_;
-
-    LOG::Log(LOGDEBUG, "Entering encryption section");
-
-    if (licenseKey.empty())
-    {
-      LOG::Log(LOGERROR, "Invalid license_key");
-      return false;
-    }
-
-    if (!decrypter_)
-    {
-      LOG::Log(LOGERROR, "No decrypter found for encrypted stream");
-      return false;
-    }
-
-    if (!decrypter_->HasCdmSession())
-    {
-      if (!decrypter_->OpenDRMSystem(licenseKey.c_str(), server_certificate_, drmConfig_))
-      {
-        LOG::Log(LOGERROR, "OpenDRMSystem failed");
-        return false;
-      }
-    }
-    std::string strkey(adaptiveTree_->supportedKeySystem_.substr(9));
-    size_t pos;
-    while ((pos = strkey.find('-')) != std::string::npos)
-      strkey.erase(pos, 1);
-    if (strkey.size() != 32)
-    {
-      LOG::Log(LOGERROR, "Key system mismatch (%s)!",
-                adaptiveTree_->supportedKeySystem_.c_str());
-      return false;
-    }
-
-    unsigned char key_system[16];
-    AP4_ParseHex(strkey.c_str(), key_system, 16);
-    uint32_t currentSessionTypes = 0;
-
-    for (size_t ses(1); ses < cdm_sessions_.size(); ++ses)
-    {
-      AP4_DataBuffer init_data;
-      const char* optionalKeyParameter(nullptr);
-      adaptive::AdaptiveTree::Period::PSSH sessionPsshset =
-        adaptiveTree_->current_period_->psshSets_[ses];
-      uint32_t sessionType = 0;
-
-      if (sessionPsshset.media_ > 0)
-      {
-        sessionType = sessionPsshset.media_;
-      }
-      else
-      {
-        switch (sessionPsshset.adaptation_set_->type_)
-        {
-          case adaptive::AdaptiveTree::VIDEO:
-            sessionType = adaptive::AdaptiveTree::Period::PSSH::MEDIA_VIDEO;
-            break;
-          case adaptive::AdaptiveTree::AUDIO:
-            sessionType = adaptive::AdaptiveTree::Period::PSSH::MEDIA_AUDIO;
-            break;
-          default:
-            break;
-        }
-      }
-
-      if (sessionPsshset.pssh_ == "FILE")
-      {
-        LOG::Log(LOGDEBUG, "Searching PSSH data in FILE");
-
-        if (m_kodiProps.m_licenseData.empty())
-        {
-          adaptive::AdaptiveTree::Representation* initialRepr{
-              m_reprChooser->GetRepresentation(sessionPsshset.adaptation_set_)};
-
-          Session::STREAM stream(*adaptiveTree_, sessionPsshset.adaptation_set_, initialRepr,
-                                 media_headers_, m_reprChooser, m_kodiProps.m_playTimeshiftBuffer,
-                                 false);
-
-          stream.enabled = true;
-          stream.m_adStream.start_stream();
-          stream.SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream.m_adStream));
-          stream.SetStreamFile(std::make_unique<AP4_File>(*stream.GetAdByteStream(),
-                                                          AP4_DefaultAtomFactory::Instance_, true));
-          AP4_Movie* movie = stream.GetStreamFile()->GetMovie();
-          if (movie == NULL)
-          {
-            LOG::Log(LOGERROR, "No MOOV in stream!");
-            stream.disable();
-            return false;
-          }
-          AP4_Array<AP4_PsshAtom>& pssh = movie->GetPsshAtoms();
-
-          for (unsigned int i = 0; !init_data.GetDataSize() && i < pssh.ItemCount(); i++)
-          {
-            if (memcmp(pssh[i].GetSystemId(), key_system, 16) == 0)
-            {
-              init_data.AppendData(pssh[i].GetData().GetData(), pssh[i].GetData().GetDataSize());
-              if (sessionPsshset.defaultKID_.empty())
-              {
-                if (pssh[i].GetKid(0))
-                  sessionPsshset.defaultKID_ =
-                      std::string((const char*)pssh[i].GetKid(0), 16);
-                else if (AP4_Track* track = movie->GetTrack(TIDC[stream.m_adStream.get_type()]))
-                {
-                  AP4_ProtectedSampleDescription* m_protectedDesc =
-                      static_cast<AP4_ProtectedSampleDescription*>(track->GetSampleDescription(0));
-                  AP4_ContainerAtom* schi;
-                  if (m_protectedDesc->GetSchemeInfo() &&
-                      (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
-                  {
-                    AP4_TencAtom* tenc(
-                        AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
-                    if (tenc)
-                    {
-                      sessionPsshset.defaultKID_ =
-                          std::string(reinterpret_cast<const char*>(tenc->GetDefaultKid()), 16);
-                    }
-                    else
-                    {
-                      AP4_PiffTrackEncryptionAtom* piff(
-                          AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom,
-                                           schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
-                      if (piff)
-                      {
-                        sessionPsshset.defaultKID_ =
-                            std::string(reinterpret_cast<const char*>(piff->GetDefaultKid()), 16);
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          if (!init_data.GetDataSize())
-          {
-            LOG::Log(LOGERROR,
-                      "Could not extract license from video stream (PSSH not found)");
-            stream.disable();
-            return false;
-          }
-          stream.disable();
-        }
-        else if (!sessionPsshset.defaultKID_.empty())
-        {
-          init_data.SetData(reinterpret_cast<AP4_Byte*>(sessionPsshset.defaultKID_.data()), 16);
-
-          std::string decLicenseData{BASE64::Decode(m_kodiProps.m_licenseData)};
-          uint8_t* decLicDataUInt = reinterpret_cast<uint8_t*>(decLicenseData.data());
-
-          uint8_t* uuid(reinterpret_cast<uint8_t*>(strstr(decLicenseData.data(), "{KID}")));
-          if (uuid)
-          {
-            memmove(uuid + 11, uuid, m_kodiProps.m_licenseData.size() - (uuid - decLicDataUInt));
-            memcpy(uuid, init_data.GetData(), init_data.GetDataSize());
-            init_data.SetData(decLicDataUInt, m_kodiProps.m_licenseData.size() + 11);
-          }
-          else
-            init_data.SetData(decLicDataUInt, m_kodiProps.m_licenseData.size());
-        }
-        else
-          return false;
-      }
-      else
-      {
-        if (m_kodiProps.m_manifestType == PROPERTIES::ManifestType::ISM)
-        {
-          if (m_kodiProps.m_licenseType == "com.widevine.alpha")
-          {
-            std::string licenseData{m_kodiProps.m_licenseData};
-            if (licenseData.empty())
-              licenseData = "e0tJRH0="; // {KID}
-            std::vector<uint8_t> init_data_v;
-            CreateISMlicense(sessionPsshset.defaultKID_,
-                             licenseData, init_data_v);
-            init_data.SetData(init_data_v.data(), init_data_v.size());
-          }
-          else
-          {
-            init_data.SetData(reinterpret_cast<const uint8_t*>(
-                                  sessionPsshset.pssh_.data()),
-                              sessionPsshset.pssh_.size());
-            optionalKeyParameter =
-                m_kodiProps.m_licenseData.empty() ? nullptr : m_kodiProps.m_licenseData.c_str();
-          }
-        }
-        else
-        {
-          std::string decPssh{BASE64::Decode(sessionPsshset.pssh_)};
-          init_data.SetBufferSize(1024);
-          init_data.SetData(reinterpret_cast<const AP4_Byte*>(decPssh.data()), decPssh.size());
-        }
-      }
-
-      CDMSESSION& session(cdm_sessions_[ses]);
-      std::string defaultKid{sessionPsshset.defaultKID_};
-
-      const char* defkid = sessionPsshset.defaultKID_.empty()
-                               ? nullptr
-                               : sessionPsshset.defaultKID_.data();
-
-      if (addDefaultKID && ses == 1 && session.single_sample_decryptor_)
-      {
-        // If the CDM has been pre-initialized, on non-android systems
-        // we use the same session opened then we have to add the current KID
-        // because the session has been opened with a different PSSH/KID
-        session.single_sample_decryptor_->AddKeyId(defaultKid);
-        session.single_sample_decryptor_->SetDefaultKeyId(defaultKid);
-      }
-
-      if (decrypter_ && !defaultKid.empty())
-      {
-        std::string hexKid{StringUtils::ToHexadecimal(defaultKid)};
-        LOG::Log(LOGDEBUG, "Initializing stream with KID: %s", hexKid.c_str());
-
-        // use shared ssd session if we already have 1 of the same stream type
-        if (currentSessionTypes & sessionType)
-        {
-          for (unsigned int i(1); i < ses; ++i)
-          {
-            if (decrypter_->HasLicenseKey(cdm_sessions_[i].single_sample_decryptor_,
-                                          reinterpret_cast<const uint8_t*>(defkid)))
-            {
-              session.single_sample_decryptor_ = cdm_sessions_[i].single_sample_decryptor_;
-              session.shared_single_sample_decryptor_ = true;
-              break;
-            }
-          }
-        }
-      }
-      else if (!defkid && !session.single_sample_decryptor_)
-      {
-          LOG::Log(LOGWARNING, "Initializing stream with unknown KID!");
-      }
-
-      currentSessionTypes |= sessionType;
-
-      if (decrypter_ && init_data.GetDataSize() >= 4 &&
-          (session.single_sample_decryptor_ ||
-           (session.single_sample_decryptor_ = decrypter_->CreateSingleSampleDecrypter(
-                init_data, optionalKeyParameter, defaultKid, false)) != 0))
-      {
-        decrypter_->GetCapabilities(
-            session.single_sample_decryptor_, reinterpret_cast<const uint8_t*>(defaultKid.c_str()),
-            sessionPsshset.media_, session.decrypter_caps_);
-
-        if (session.decrypter_caps_.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_INVALID)
-          adaptiveTree_->current_period_->RemovePSSHSet(static_cast<std::uint16_t>(ses));
-        else if (session.decrypter_caps_.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_PATH)
-        {
-          session.cdm_session_str_ = session.single_sample_decryptor_->GetSessionId();
-          isSecureVideoSession = true;
-
-          if (m_settingNoSecureDecoder && !m_kodiProps.m_isLicenseForceSecureDecoder &&
-              !adaptiveTree_->current_period_->need_secure_decoder_)
-            session.decrypter_caps_.flags &= ~SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER;
-        }
-      }
-      else
-      {
-        LOG::Log(LOGERROR, "Initialize failed (SingleSampleDecrypter)");
-        for (unsigned int i(ses); i < cdm_sessions_.size(); ++i)
-          cdm_sessions_[i].single_sample_decryptor_ = nullptr;
-        return false;
-      }
-    }
-  }
-
-  adaptiveTree_->m_decrypterCaps.clear();
-  if (!m_settingIsHdcpOverride)
-  {
-    for (const Session::CDMSESSION& cdmsession : cdm_sessions_)
-    {
-      adaptiveTree_->m_decrypterCaps.emplace_back(cdmsession.decrypter_caps_);
-    }
-    adaptiveTree_->CheckHDCP();
-  }
-
-  m_reprChooser->SetSecureSession(isSecureVideoSession);
-  m_reprChooser->PostInit();
-
-  return true;
-}
-
-bool Session::InitializePeriod(bool isSessionOpened /* = false */)
-{
-  bool psshChanged = true;
-  if (adaptiveTree_->next_period_)
-  {
-    psshChanged =
-        !(adaptiveTree_->current_period_->psshSets_ == adaptiveTree_->next_period_->psshSets_);
-    adaptiveTree_->current_period_ = adaptiveTree_->next_period_;
-    adaptiveTree_->next_period_ = nullptr;
-  }
-
-  chapter_start_time_ = GetChapterStartTime();
-
-  if (adaptiveTree_->current_period_->encryptionState_ ==
-      adaptive::AdaptiveTree::ENCRYTIONSTATE_ENCRYPTED)
-  {
-    LOG::Log(LOGERROR, "Unable to handle decryption. Unsupported!");
-    return false;
-  }
-
-  // create SESSION::STREAM objects. One for each AdaptationSet
-  m_streams.clear();
-
-  if (!psshChanged)
-    LOG::Log(LOGDEBUG, "Reusing DRM psshSets for new period!");
-  else
-  {
-    if (isSessionOpened)
-    {
-      LOG::Log(LOGDEBUG, "New period, reinitialize by using same session");
-    }
-    else
-    {
-      LOG::Log(LOGDEBUG, "New period, dispose sample decrypter and reinitialize");
-      DisposeSampleDecrypter();
-    }
-    if (!InitializeDRM(isSessionOpened))
-      return false;
-  }
-
-  uint32_t adpIndex{0};
-  adaptive::AdaptiveTree::AdaptationSet* adp{nullptr};
-  SETTINGS::StreamSelection streamSelectionMode{m_reprChooser->GetStreamSelectionMode()};
-
-  while ((adp = adaptiveTree_->GetAdaptationSet(adpIndex++)))
-  {
-    if (adp->representations_.empty())
-      continue;
-
-    bool isManualStreamSelection;
-    if (adp->type_ == adaptive::AdaptiveTree::StreamType::VIDEO)
-      isManualStreamSelection = streamSelectionMode != SETTINGS::StreamSelection::AUTO;
-    else
-      isManualStreamSelection = streamSelectionMode == SETTINGS::StreamSelection::MANUAL;
-
-    // Get the default initial stream repr. based on "adaptive repr. chooser"
-    adaptive::AdaptiveTree::Representation* defaultRepr{m_reprChooser->GetRepresentation(adp)};
-
-    if (isManualStreamSelection)
-    {
-      // Add all stream representations
-      for (size_t i{0}; i < adp->representations_.size(); i++)
-      {
-        size_t reprIndex{adp->representations_.size() - i};
-        uint32_t uniqueId{adpIndex};
-        uniqueId |= reprIndex << 16;
-
-        adaptive::AdaptiveTree::Representation* currentRepr{adp->representations_[i]};
-        bool isDefaultRepr{currentRepr == defaultRepr};
-
-        AddStream(adp, currentRepr, isDefaultRepr, uniqueId);
-      }
-    }
-    else
-    {
-      // Add the default stream representation only
-      size_t reprIndex{adp->representations_.size()};
-      uint32_t uniqueId{adpIndex};
-      uniqueId |= reprIndex << 16;
-
-      AddStream(adp, defaultRepr, true, uniqueId);
-    }
-  }
-
-  first_period_initialized_ = true;
-  return true;
-}
-
-void Session::AddStream(adaptive::AdaptiveTree::AdaptationSet* adp,
-                        adaptive::AdaptiveTree::Representation* initialRepr,
-                        bool isDefaultRepr,
-                        uint32_t uniqueId)
-{
-  m_streams.push_back(std::make_unique<STREAM>(*adaptiveTree_, adp, initialRepr, media_headers_,
-                                               m_reprChooser, m_kodiProps.m_playTimeshiftBuffer,
-                                               first_period_initialized_));
-
-  STREAM& stream(*m_streams.back());
-
-  uint32_t flags = INPUTSTREAM_FLAG_NONE;
-  size_t copySize = adp->name_.size() > 255 ? 255 : adp->name_.size();
-  stream.info_.SetName(adp->name_);
-
-  switch (adp->type_)
-  {
-    case adaptive::AdaptiveTree::VIDEO:
-    {
-      stream.info_.SetStreamType(INPUTSTREAM_TYPE_VIDEO);
-      if (isDefaultRepr)
-        flags |= INPUTSTREAM_FLAG_DEFAULT;
-      break;
-    }
-    case adaptive::AdaptiveTree::AUDIO:
-    {
-      stream.info_.SetStreamType(INPUTSTREAM_TYPE_AUDIO);
-      if (adp->impaired_)
-        flags |= INPUTSTREAM_FLAG_VISUAL_IMPAIRED;
-      if (adp->default_)
-        flags |= INPUTSTREAM_FLAG_DEFAULT;
-      if (adp->original_ || (!m_kodiProps.m_audioLanguageOrig.empty() &&
-                             adp->language_ == m_kodiProps.m_audioLanguageOrig))
-      {
-        flags |= INPUTSTREAM_FLAG_ORIGINAL;
-      }
-      break;
-    }
-    case adaptive::AdaptiveTree::SUBTITLE:
-    {
-      stream.info_.SetStreamType(INPUTSTREAM_TYPE_SUBTITLE);
-      if (adp->impaired_)
-        flags |= INPUTSTREAM_FLAG_HEARING_IMPAIRED;
-      if (adp->forced_)
-        flags |= INPUTSTREAM_FLAG_FORCED;
-      if (adp->default_)
-        flags |= INPUTSTREAM_FLAG_DEFAULT;
-      break;
-    }
-    default:
-      break;
-  }
-
-  stream.info_.SetFlags(flags);
-  stream.info_.SetPhysicalIndex(uniqueId);
-  stream.info_.SetLanguage(adp->language_);
-  stream.info_.ClearExtraData();
-  stream.info_.SetFeatures(0);
-
-  stream.m_adStream.set_observer(dynamic_cast<adaptive::AdaptiveStreamObserver*>(this));
-
-  UpdateStream(stream);
-}
-
-void Session::UpdateStream(STREAM& stream)
-{
-  const adaptive::AdaptiveTree::Representation* rep(stream.m_adStream.getRepresentation());
-  const SSD::SSD_DECRYPTER::SSD_CAPS& caps = GetDecrypterCaps(rep->pssh_set_);
-
-  stream.info_.SetWidth(static_cast<uint32_t>(rep->width_));
-  stream.info_.SetHeight(static_cast<uint32_t>(rep->height_));
-  stream.info_.SetAspect(rep->aspect_);
-
-  if (stream.info_.GetAspect() == 0.0f && stream.info_.GetHeight())
-    stream.info_.SetAspect((float)stream.info_.GetWidth() / stream.info_.GetHeight());
-  stream.encrypted = rep->get_psshset() > 0;
-
-  stream.info_.SetExtraData(nullptr, 0);
-  if (rep->codec_private_data_.size())
-  {
-    std::string annexb;
-    const std::string* res(&annexb);
-
-    if ((caps.flags & SSD::SSD_DECRYPTER::SSD_CAPS::SSD_ANNEXB_REQUIRED) &&
-        stream.info_.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
-    {
-      LOG::Log(LOGDEBUG, "UpdateStream: Convert avc -> annexb");
-      annexb = AvcToAnnexb(rep->codec_private_data_);
-    }
-    else
-      res = &rep->codec_private_data_;
-
-    stream.info_.SetExtraData(reinterpret_cast<const uint8_t*>(res->data()), res->size());
-  }
-
-  // we currently use only the first track!
-  std::string::size_type pos = rep->codecs_.find(",");
-  if (pos == std::string::npos)
-    pos = rep->codecs_.size();
-
-  stream.info_.SetCodecInternalName(rep->codecs_);
-  stream.info_.SetCodecFourCC(0);
-
-#if INPUTSTREAM_VERSION_LEVEL > 0
-  stream.info_.SetColorSpace(INPUTSTREAM_COLORSPACE_UNSPECIFIED);
-  stream.info_.SetColorRange(INPUTSTREAM_COLORRANGE_UNKNOWN);
-  stream.info_.SetColorPrimaries(INPUTSTREAM_COLORPRIMARY_UNSPECIFIED);
-  stream.info_.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_UNSPECIFIED);
-#else
-  stream.info_.SetColorSpace(INPUTSTREAM_COLORSPACE_UNKNOWN);
-  stream.info_.SetColorRange(INPUTSTREAM_COLORRANGE_UNKNOWN);
-#endif
-  if (rep->codecs_.find("mp4a") == 0 || rep->codecs_.find("aac") == 0)
-    stream.info_.SetCodecName("aac");
-  else if (rep->codecs_.find("dts") == 0)
-    stream.info_.SetCodecName("dca");
-  else if (rep->codecs_.find("ac-3") == 0)
-    stream.info_.SetCodecName("ac3");
-  else if (rep->codecs_.find("ec-3") == 0)
-    stream.info_.SetCodecName("eac3");
-  else if (rep->codecs_.find("avc") == 0 || rep->codecs_.find("h264") == 0)
-    stream.info_.SetCodecName("h264");
-  else if (rep->codecs_.find("hev") == 0)
-    stream.info_.SetCodecName("hevc");
-  else if (rep->codecs_.find("hvc") == 0 || rep->codecs_.find("dvh") == 0)
-  {
-    stream.info_.SetCodecFourCC(
-        MakeFourCC(rep->codecs_[0], rep->codecs_[1], rep->codecs_[2], rep->codecs_[3]));
-    stream.info_.SetCodecName("hevc");
-  }
-  else if (rep->codecs_.find("vp9") == 0 || rep->codecs_.find("vp09") == 0)
-  {
-    stream.info_.SetCodecName("vp9");
-#if INPUTSTREAM_VERSION_LEVEL > 0
-    if ((pos = rep->codecs_.find(".")) != std::string::npos)
-      stream.info_.SetCodecProfile(static_cast<STREAMCODEC_PROFILE>(
-          VP9CodecProfile0 + atoi(rep->codecs_.c_str() + (pos + 1))));
-#endif
-  }
-  else if (rep->codecs_.find("opus") == 0)
-    stream.info_.SetCodecName("opus");
-  else if (rep->codecs_.find("vorbis") == 0)
-    stream.info_.SetCodecName("vorbis");
-  else if (rep->codecs_.find("stpp") == 0 || rep->codecs_.find("ttml") == 0)
-    stream.info_.SetCodecName("srt");
-  else if (rep->codecs_.find("wvtt") == 0)
-    stream.info_.SetCodecName("webvtt");
-  else
-  {
-    LOG::Log(LOGWARNING, "Unsupported codec %s in stream ID: %s", rep->codecs_.c_str(),
-             rep->id.c_str());
-    stream.valid = false;
-  }
-
-  // We support currently only mp4 / ts / adts
-  if (rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_NOTYPE &&
-      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_MP4 &&
-      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TS &&
-      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_ADTS &&
-      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_WEBM &&
-      rep->containerType_ != adaptive::AdaptiveTree::CONTAINERTYPE_TEXT)
-  {
-    LOG::Log(LOGWARNING, "Unsupported container in stream ID: %s", rep->id.c_str());
-    stream.valid = false;
-  }
-
-  stream.info_.SetFpsRate(rep->fpsRate_);
-  stream.info_.SetFpsScale(rep->fpsScale_);
-  stream.info_.SetSampleRate(rep->samplingRate_);
-  stream.info_.SetChannels(rep->channelCount_);
-  stream.info_.SetBitRate(rep->bandwidth_);
-}
-
-AP4_Movie* Session::PrepareStream(STREAM* stream, bool& needRefetch)
-{
-  needRefetch = false;
-  switch (adaptiveTree_->prepareRepresentation(stream->m_adStream.getPeriod(),
-                                               stream->m_adStream.getAdaptationSet(),
-                                               stream->m_adStream.getRepresentation()))
-  {
-    case adaptive::AdaptiveTree::PREPARE_RESULT_FAILURE:
-      return nullptr;
-    case adaptive::AdaptiveTree::PREPARE_RESULT_DRMCHANGED:
-      if (!InitializeDRM())
-        return nullptr;
-    case adaptive::AdaptiveTree::PREPARE_RESULT_DRMUNCHANGED:
-      stream->encrypted = stream->m_adStream.getRepresentation()->pssh_set_ > 0;
-      needRefetch = true;
-      break;
-    default:;
-  }
-
-  if (stream->m_adStream.getRepresentation()->containerType_ ==
-          adaptive::AdaptiveTree::CONTAINERTYPE_MP4 &&
-      (stream->m_adStream.getRepresentation()->flags_ &
-       adaptive::AdaptiveTree::Representation::INITIALIZATION_PREFIXED) == 0 &&
-      stream->m_adStream.getRepresentation()->get_initialization() == nullptr)
-  {
-    //We'll create a Movie out of the things we got from manifest file
-    //note: movie will be deleted in destructor of stream->input_file_
-    AP4_Movie* movie = new AP4_Movie();
-
-    AP4_SyntheticSampleTable* sample_table = new AP4_SyntheticSampleTable();
-
-    AP4_SampleDescription* sample_descryption;
-    if (stream->info_.GetCodecName() == "h264")
-    {
-      const std::string& extradata(stream->m_adStream.getRepresentation()->codec_private_data_);
-      AP4_MemoryByteStream ms((const uint8_t*)extradata.data(), extradata.size());
-      AP4_AvccAtom* atom = AP4_AvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms);
-      sample_descryption =
-          new AP4_AvcSampleDescription(AP4_SAMPLE_FORMAT_AVC1, stream->info_.GetWidth(),
-                                       stream->info_.GetHeight(), 0, nullptr, atom);
-    }
-    else if (stream->info_.GetCodecName() == "hevc")
-    {
-      const std::string& extradata(stream->m_adStream.getRepresentation()->codec_private_data_);
-      AP4_MemoryByteStream ms((const uint8_t*)extradata.data(), extradata.size());
-      AP4_HvccAtom* atom = AP4_HvccAtom::Create(AP4_ATOM_HEADER_SIZE + extradata.size(), ms);
-      sample_descryption =
-          new AP4_HevcSampleDescription(AP4_SAMPLE_FORMAT_HEV1, stream->info_.GetWidth(),
-                                        stream->info_.GetHeight(), 0, nullptr, atom);
-    }
-    else if (stream->info_.GetCodecName() == "srt")
-      sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_SUBTITLES,
-                                                     AP4_SAMPLE_FORMAT_STPP, 0);
-    else
-      sample_descryption = new AP4_SampleDescription(AP4_SampleDescription::TYPE_UNKNOWN, 0, 0);
-
-    if (stream->m_adStream.getRepresentation()->get_psshset() > 0)
-    {
-      AP4_ContainerAtom schi(AP4_ATOM_TYPE_SCHI);
-      schi.AddChild(
-          new AP4_TencAtom(AP4_CENC_CIPHER_AES_128_CTR, 8,
-                           GetDefaultKeyId(stream->m_adStream.getRepresentation()->get_psshset())));
-      sample_descryption = new AP4_ProtectedSampleDescription(
-          0, sample_descryption, 0, AP4_PROTECTION_SCHEME_TYPE_PIFF, 0, "", &schi);
-    }
-    sample_table->AddSampleDescription(sample_descryption);
-
-    movie->AddTrack(new AP4_Track(TIDC[stream->m_adStream.get_type()], sample_table,
-                                  CFragmentedSampleReader::TRACKID_UNKNOWN,
-                                  stream->m_adStream.getRepresentation()->timescale_, 0,
-                                  stream->m_adStream.getRepresentation()->timescale_, 0, "", 0, 0));
-    //Create a dumy MOOV Atom to tell Bento4 its a fragmented stream
-    AP4_MoovAtom* moov = new AP4_MoovAtom();
-    moov->AddChild(new AP4_ContainerAtom(AP4_ATOM_TYPE_MVEX));
-    movie->SetMoovAtom(moov);
-    return movie;
-  }
-  return nullptr;
-}
-
-void Session::EnableStream(STREAM* stream, bool enable)
-{
-  if (enable)
-  {
-    if (!timing_stream_)
-      timing_stream_ = stream;
-    stream->enabled = true;
-  }
-  else
-  {
-    if (stream == timing_stream_)
-      timing_stream_ = nullptr;
-    stream->disable();
-  }
-}
-
-uint64_t Session::PTSToElapsed(uint64_t pts)
-{
-  if (timing_stream_)
-  {
-    ISampleReader* timingReader = timing_stream_->GetReader();
-    if (!timingReader) {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-      return 0;
-    }
-
-    int64_t manifest_time = static_cast<int64_t>(pts) - timingReader->GetPTSDiff();
-    if (manifest_time < 0)
-      manifest_time = 0;
-
-    if (static_cast<uint64_t>(manifest_time) > timing_stream_->m_adStream.GetAbsolutePTSOffset())
-      return static_cast<uint64_t>(manifest_time) - timing_stream_->m_adStream.GetAbsolutePTSOffset();
-
-    return 0ULL;
-  }
-  else
-    return pts;
-}
-
-uint64_t Session::GetTimeshiftBufferStart()
-{
-  if (timing_stream_)
-  {
-    ISampleReader* timingReader = timing_stream_->GetReader();
-    if (!timingReader)
-    {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-      return 0;
-    }
-    return timing_stream_->m_adStream.GetAbsolutePTSOffset() + timingReader->GetPTSDiff();
-  }
-  else
-    return 0ULL;
-}
-
-void Session::StartReader(
-    STREAM* stream, uint64_t seekTimeCorrected, int64_t ptsDiff, bool preceeding, bool timing)
-{
-  bool bReset = true;
-  if (timing)
-    seekTimeCorrected += stream->m_adStream.GetAbsolutePTSOffset();
-  else
-    seekTimeCorrected -= ptsDiff;
-  stream->m_adStream.seek_time(
-      static_cast<double>(seekTimeCorrected / STREAM_TIME_BASE),
-      preceeding, bReset);
-
-  ISampleReader* streamReader = stream->GetReader();
-  if (!streamReader) {
-    LOG::LogF(LOGERROR, "Cannot get the stream reader");
-    return;
-  }
-
-  if (bReset)
-    streamReader->Reset(false);
-
-  bool bStarted = false;
-  streamReader->Start(bStarted);
-  if (bStarted && (streamReader->GetInformation(stream->info_)))
-    changed_ = true;
-}
-
-void Session::SetVideoResolution(int width, int height)
-{
-  m_reprChooser->SetScreenResolution(width, height);
-};
-
-ISampleReader* Session::GetNextSample()
-{
-  STREAM* res{nullptr};
-  STREAM* waiting{nullptr};
-
-  for (auto& stream : m_streams)
-  {
-    bool isStarted{false};
-    ISampleReader* streamReader = stream->GetReader();
-    if (!streamReader)
-      continue;
-
-    if (stream->enabled && !streamReader->EOS() && AP4_SUCCEEDED(streamReader->Start(isStarted)))
-    {
-      if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())
-      {
-        if (stream->m_adStream.waitingForSegment(true))
-          waiting = stream.get();
-        else
-          res = stream.get();
-      }
-    }
-
-    if (isStarted && streamReader->GetInformation(stream->info_))
-      changed_ = true;
-  }
-
-  if (res)
-  {
-    CheckFragmentDuration(*res);
-    if (res->GetReader()->GetInformation(res->info_))
-      changed_ = true;
-    if (res->GetReader()->PTS() != STREAM_NOPTS_VALUE)
-      elapsed_time_ = PTSToElapsed(res->GetReader()->PTS()) + GetChapterStartTime();
-    return res->GetReader();
-  }
-  else if (waiting)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return m_dummySampleReader.get();
-  }
-  return nullptr;
-}
-
-bool Session::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
-{
-  bool ret(false);
-
-  //we don't have pts < 0 here and work internally with uint64
-  if (seekTime < 0)
-    seekTime = 0;
-
-  // Check if we leave our current period
-  double chapterTime(0);
-  std::vector<adaptive::AdaptiveTree::Period*>::const_iterator pi;
-  for (pi = adaptiveTree_->periods_.cbegin(); pi != adaptiveTree_->periods_.cend(); ++pi)
-  {
-    chapterTime += double((*pi)->duration_) / (*pi)->timescale_;
-    if (chapterTime > seekTime)
-      break;
-  }
-
-  if (pi == adaptiveTree_->periods_.end())
-    --pi;
-  chapterTime -= double((*pi)->duration_) / (*pi)->timescale_;
-
-  if ((*pi) != adaptiveTree_->current_period_)
-  {
-    LOG::Log(LOGDEBUG, "SeekTime: seeking into new chapter: %d",
-              static_cast<int>((pi - adaptiveTree_->periods_.begin()) + 1));
-    SeekChapter((pi - adaptiveTree_->periods_.begin()) + 1);
-    chapter_seek_time_ = seekTime;
-    return true;
-  }
-
-  seekTime -= chapterTime;
-
-  // don't try to seek past the end of the stream, leave a sensible amount so we can buffer properly
-  if (adaptiveTree_->has_timeshift_buffer_)
-  {
-    double maxSeek(0);
-    uint64_t curTime, maxTime(0);
-    for (auto& stream : m_streams)
-    {
-      if (stream->enabled && (curTime = stream->m_adStream.getMaxTimeMs()) && curTime > maxTime)
-      {
-        maxTime = curTime;
-      }
-    }
-
-    maxSeek = (static_cast<double>(maxTime) / 1000) - adaptiveTree_->live_delay_;
-    if (maxSeek < 0)
-      maxSeek = 0;
-
-    if (seekTime > maxSeek)
-      seekTime = maxSeek;
-  }
-
-  // correct for starting segment pts value of chapter and chapter offset within program
-  uint64_t seekTimeCorrected = static_cast<uint64_t>(seekTime * STREAM_TIME_BASE);
-  int64_t ptsDiff = 0;
-  if (timing_stream_)
-  {
-    // after seeking across chapters with fmp4 streams the reader will not have started
-    // so we start here to ensure that we have the required information to correctly
-    // seek with proper stream alignment
-    ISampleReader* timingReader = timing_stream_->GetReader();
-    if (!timingReader)
-    {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-      return false;
-    }
-    if (!timingReader->IsStarted())
-      StartReader(timing_stream_, seekTimeCorrected, ptsDiff, preceeding, true);
-
-    seekTimeCorrected += timing_stream_->m_adStream.GetAbsolutePTSOffset();
-    ptsDiff = timingReader->GetPTSDiff();
-    if (ptsDiff < 0 && seekTimeCorrected + ptsDiff > seekTimeCorrected)
-      seekTimeCorrected = 0;
-    else
-      seekTimeCorrected += ptsDiff;
-  }
-
-  for (auto& stream : m_streams)
-  {
-    ISampleReader* streamReader = stream->GetReader();
-    if (!streamReader)
-    {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-      continue;
-    }
-    if (stream->enabled && (streamId == 0 || stream->info_.GetPhysicalIndex() == streamId))
-    {
-      bool reset{true};
-      // all streams must be started before seeking to ensure cross chapter seeks
-      // will seek to the correct location/segment
-      if (!streamReader->IsStarted())
-        StartReader(stream.get(), seekTimeCorrected, ptsDiff, preceeding, false);
-
-      double seekSecs{static_cast<double>(seekTimeCorrected - streamReader->GetPTSDiff()) /
-                      STREAM_TIME_BASE};
-      if (stream->m_adStream.seek_time(seekSecs, preceeding, reset))
-      {
-        if (reset)
-          streamReader->Reset(false);
-        // advance reader to requested time
-        if (!streamReader->TimeSeek(seekTimeCorrected, preceeding))
-        {
-          streamReader->Reset(true);
-        }
-        else
-        {
-          double destTime{static_cast<double>(PTSToElapsed(streamReader->PTS())) /
-                          STREAM_TIME_BASE};
-          LOG::Log(LOGINFO, "Seek time (%0.1lf) for stream: %d continues at %0.1lf (PTS: %llu)",
-                   seekTime, stream->info_.GetPhysicalIndex(), destTime, streamReader->PTS());
-          if (stream->info_.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
-          {
-            seekTime = destTime;
-            seekTimeCorrected = streamReader->PTS();
-            preceeding = false;
-          }
-          ret = true;
-        }
-      }
-      else
-        streamReader->Reset(true);
-    }
-  }
-
-  return ret;
-}
-
-void Session::OnSegmentChanged(adaptive::AdaptiveStream* adStream)
-{
-  for (auto& stream : m_streams)
-  {
-    if (&stream->m_adStream == adStream)
-    {
-      ISampleReader* streamReader = stream->GetReader();
-      if (!streamReader)
-        LOG::LogF(LOGWARNING, "Cannot get the stream sample reader");
-      else
-        streamReader->SetPTSOffset(stream->m_adStream.GetCurrentPTSOffset());
-
-      stream->segmentChanged = true;
-      break;
-    }
-  }
-}
-
-void Session::OnStreamChange(adaptive::AdaptiveStream* adStream)
-{
-  for (auto& stream : m_streams)
-  {
-    if (stream->enabled && &stream->m_adStream == adStream)
-    {
-      UpdateStream(*stream);
-      changed_ = true;
-    }
-  }
-}
-
-void Session::CheckFragmentDuration(STREAM& stream)
-{
-  uint64_t nextTs;
-  uint64_t nextDur;
-  ISampleReader* streamReader = stream.GetReader();
-  if (!streamReader)
-  {
-    LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-    return;
-  }
-
-  if (stream.segmentChanged && streamReader->GetNextFragmentInfo(nextTs, nextDur))
-  {
-    adaptiveTree_->SetFragmentDuration(
-        stream.m_adStream.getAdaptationSet(), stream.m_adStream.getRepresentation(),
-        stream.m_adStream.getSegmentPos(), nextTs, static_cast<uint32_t>(nextDur),
-        streamReader->GetTimeScale());
-  }
-  stream.segmentChanged = false;
-}
-
-const AP4_UI08* Session::GetDefaultKeyId(const uint16_t index) const
-{
-  static const AP4_UI08 default_key[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  if (adaptiveTree_->current_period_->psshSets_[index].defaultKID_.size() == 16)
-    return reinterpret_cast<const AP4_UI08*>(
-        adaptiveTree_->current_period_->psshSets_[index].defaultKID_.data());
-  return default_key;
-}
-
-Adaptive_CencSingleSampleDecrypter* Session::GetSingleSampleDecrypter(std::string sessionId)
-{
-  for (std::vector<CDMSESSION>::iterator b(cdm_sessions_.begin() + 1), e(cdm_sessions_.end());
-       b != e; ++b)
-    if (b->cdm_session_str_ && sessionId == b->cdm_session_str_)
-      return b->single_sample_decryptor_;
-  return nullptr;
-}
-
-uint32_t Session::GetIncludedStreamMask() const
-{
-  const INPUTSTREAM_TYPE adp2ips[] = {
-      INPUTSTREAM_TYPE_NONE, INPUTSTREAM_TYPE_VIDEO, INPUTSTREAM_TYPE_AUDIO,
-      INPUTSTREAM_TYPE_SUBTITLE};
-  uint32_t res(0);
-  for (unsigned int i(0); i < 4; ++i)
-    if (adaptiveTree_->current_period_->included_types_ & (1U << i))
-      res |= (1U << adp2ips[i]);
-  return res;
-}
-
-STREAM_CRYPTO_KEY_SYSTEM Session::GetCryptoKeySystem() const
-{
-  if (m_kodiProps.m_licenseType == "com.widevine.alpha")
-    return STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE;
-#if STREAMCRYPTO_VERSION_LEVEL >= 1
-  else if (m_kodiProps.m_licenseType == "com.huawei.wiseplay")
-    return STREAM_CRYPTO_KEY_SYSTEM_WISEPLAY;
-#endif
-  else if (m_kodiProps.m_licenseType == "com.microsoft.playready")
-    return STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY;
-  else
-    return STREAM_CRYPTO_KEY_SYSTEM_NONE;
-}
-
-int Session::GetChapter() const
-{
-  if (adaptiveTree_)
-  {
-    std::vector<adaptive::AdaptiveTree::Period*>::const_iterator res =
-        std::find(adaptiveTree_->periods_.cbegin(), adaptiveTree_->periods_.cend(),
-                  adaptiveTree_->current_period_);
-    if (res != adaptiveTree_->periods_.cend())
-      return (res - adaptiveTree_->periods_.cbegin()) + 1;
-  }
-  return -1;
-}
-
-int Session::GetChapterCount() const
-{
-  if (adaptiveTree_)
-    return adaptiveTree_->periods_.size() > 1 ? adaptiveTree_->periods_.size() : 0;
-  return 0;
-}
-
-const char* Session::GetChapterName(int ch) const
-{
-  --ch;
-  if (ch >= 0 && ch < static_cast<int>(adaptiveTree_->periods_.size()))
-    return adaptiveTree_->periods_[ch]->id_.c_str();
-  return "[Unknown]";
-}
-
-int64_t Session::GetChapterPos(int ch) const
-{
-  int64_t sum(0);
-  --ch;
-
-  for (; ch; --ch)
-    sum += (adaptiveTree_->periods_[ch - 1]->duration_ * STREAM_TIME_BASE) /
-           adaptiveTree_->periods_[ch - 1]->timescale_;
-  return sum / STREAM_TIME_BASE;
-}
-
-uint64_t Session::GetChapterStartTime() const
-{
-  uint64_t start_time = 0;
-  for (adaptive::AdaptiveTree::Period* p : adaptiveTree_->periods_)
-    if (p == adaptiveTree_->current_period_)
-      break;
-    else
-      start_time += (p->duration_ * STREAM_TIME_BASE) / p->timescale_;
-  return start_time;
-}
-
-int Session::GetPeriodId() const
-{
-  if (adaptiveTree_)
-  {
-    if (IsLive())
-      return adaptiveTree_->current_period_->sequence_ == adaptiveTree_->initial_sequence_
-                 ? 1
-                 : adaptiveTree_->current_period_->sequence_ + 1;
-    else
-      return GetChapter();
-  }
-  return -1;
-}
-
-bool Session::SeekChapter(int ch)
-{
-  if (adaptiveTree_->next_period_)
-    return true;
-
-  --ch;
-  if (ch >= 0 && ch < static_cast<int>(adaptiveTree_->periods_.size()) &&
-      adaptiveTree_->periods_[ch] != adaptiveTree_->current_period_)
-  {
-    adaptiveTree_->next_period_ = adaptiveTree_->periods_[ch];
-    for (auto& stream : m_streams)
-    {
-      if (stream->GetReader())
-        stream->GetReader()->Reset(true);
-    }
-    return true;
-  }
-
-  return false;
-}
-
-/***************************  Interface *********************************/
-
-class CInputStreamAdaptive;
-
-/*******************************************************/
-/*                     VideoCodec                      */
-/*******************************************************/
-
-class ATTR_DLL_LOCAL CVideoCodecAdaptive : public kodi::addon::CInstanceVideoCodec
-{
-public:
-  CVideoCodecAdaptive(const kodi::addon::IInstanceInfo& instance);
-  CVideoCodecAdaptive(const kodi::addon::IInstanceInfo& instance, CInputStreamAdaptive* parent);
-  virtual ~CVideoCodecAdaptive();
-
-  bool Open(const kodi::addon::VideoCodecInitdata& initData) override;
-  bool Reconfigure(const kodi::addon::VideoCodecInitdata& initData) override;
-  bool AddData(const DEMUX_PACKET& packet) override;
-  VIDEOCODEC_RETVAL GetPicture(VIDEOCODEC_PICTURE& picture) override;
-  const char* GetName() override { return m_name.c_str(); };
-  void Reset() override;
-
-private:
-  enum STATE : unsigned int
-  {
-    STATE_WAIT_EXTRADATA = 1
-  };
-
-  std::shared_ptr<Session> m_session;
-  unsigned int m_state;
-  std::string m_name;
-};
-
-/*******************************************************/
-/*                     InputStream                     */
-/*******************************************************/
-
-class ATTR_DLL_LOCAL CInputStreamAdaptive : public kodi::addon::CInstanceInputStream
-{
-public:
-  CInputStreamAdaptive(const kodi::addon::IInstanceInfo& instance);
-  ADDON_STATUS CreateInstance(const kodi::addon::IInstanceInfo& instance,
-                              KODI_ADDON_INSTANCE_HDL& hdl) override;
-
-  bool Open(const kodi::addon::InputstreamProperty& props) override;
-  void Close() override;
-  bool GetStreamIds(std::vector<unsigned int>& ids) override;
-  void GetCapabilities(kodi::addon::InputstreamCapabilities& caps) override;
-  bool GetStream(int streamid, kodi::addon::InputstreamInfo& info) override;
-  void EnableStream(int streamid, bool enable) override;
-  bool OpenStream(int streamid) override;
-  DEMUX_PACKET* DemuxRead() override;
-  bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
-  void SetVideoResolution(int width, int height) override;
-  bool PosTime(int ms) override;
-  int GetTotalTime() override;
-  int GetTime() override;
-  bool IsRealTimeStream() override;
-
-#if INPUTSTREAM_VERSION_LEVEL > 1
-  int GetChapter() override;
-  int GetChapterCount() override;
-  const char* GetChapterName(int ch) override;
-  int64_t GetChapterPos(int ch) override;
-  bool SeekChapter(int ch) override;
-#endif
-
-  std::shared_ptr<Session> GetSession() { return m_session; };
-
-private:
-  std::shared_ptr<Session> m_session{nullptr};
-  UTILS::PROPERTIES::KodiProperties m_kodiProps;
-  int m_currentVideoWidth{1280};
-  int m_currentVideoHeight{720};
-  uint32_t m_IncludedStreams[16];
-  bool m_checkChapterSeek = false;
-  int m_failedSeekTime = ~0;
-
-  void UnlinkIncludedStreams(Session::STREAM* stream);
-};
 
 CInputStreamAdaptive::CInputStreamAdaptive(const kodi::addon::IInstanceInfo& instance)
   : CInstanceInputStream(instance)
@@ -1761,12 +80,11 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
   if (mediaHeaders.empty())
     mediaHeaders = m_kodiProps.m_streamHeaders;
 
-  kodihost->SetProfilePath(props.GetProfileFolder());
-
-  m_session = std::make_shared<Session>(m_kodiProps, url, mediaHeaders, props.GetProfileFolder());
+  m_session = std::make_shared<CSession>(m_kodiProps, url, mediaHeaders, props.GetProfileFolder());
   m_session->SetVideoResolution(m_currentVideoWidth, m_currentVideoHeight);
 
-  if (!m_session->Initialize(drmConfig))
+  m_session->SetDrmConfig(drmConfig);
+  if (!m_session->Initialize())
   {
     m_session = nullptr;
     return false;
@@ -1795,7 +113,7 @@ bool CInputStreamAdaptive::GetStreamIds(std::vector<unsigned int>& ids)
     for (unsigned int i(1); i <= INPUTSTREAM_MAX_STREAM_COUNT && i <= m_session->GetStreamCount();
          ++i)
     {
-      Session::STREAM* stream = m_session->GetStream(i);
+      CStream* stream = m_session->GetStream(i);
       if (!stream)
       {
         LOG::LogF(LOGERROR, "Cannot get the stream from sid %u", i);
@@ -1803,7 +121,7 @@ bool CInputStreamAdaptive::GetStreamIds(std::vector<unsigned int>& ids)
       }
 
       uint8_t cdmId(static_cast<uint8_t>(stream->m_adStream.getRepresentation()->pssh_set_));
-      if (stream->valid &&
+      if (stream->m_isValid &&
           (m_session->GetMediaTypeMask() & static_cast<uint8_t>(1) << stream->m_adStream.get_type()))
       {
         if (m_session->GetMediaTypeMask() != 0xFF)
@@ -1852,12 +170,12 @@ bool CInputStreamAdaptive::GetStream(int streamid, kodi::addon::InputstreamInfo&
 {
   LOG::Log(LOGDEBUG, "GetStream(%d)", streamid);
 
-  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
+  CStream* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
 
   if (stream)
   {
     uint8_t cdmId(static_cast<uint8_t>(stream->m_adStream.getRepresentation()->pssh_set_));
-    if (stream->encrypted && m_session->GetCDMSession(cdmId) != nullptr)
+    if (stream->m_isEncrypted && m_session->GetCDMSession(cdmId) != nullptr)
     {
       kodi::addon::StreamCryptoSession cryptoSession;
 
@@ -1869,35 +187,35 @@ bool CInputStreamAdaptive::GetStream(int streamid, kodi::addon::InputstreamInfo&
 
       if (m_session->GetDecrypterCaps(cdmId).flags &
           SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SUPPORTS_DECODING)
-        stream->info_.SetFeatures(INPUTSTREAM_FEATURE_DECODE);
+        stream->m_info.SetFeatures(INPUTSTREAM_FEATURE_DECODE);
       else
-        stream->info_.SetFeatures(0);
+        stream->m_info.SetFeatures(0);
 
       cryptoSession.SetFlags((m_session->GetDecrypterCaps(cdmId).flags &
                           SSD::SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER)
                              ? STREAM_CRYPTO_FLAG_SECURE_DECODER
                              : 0);
-      stream->info_.SetCryptoSession(cryptoSession);
+      stream->m_info.SetCryptoSession(cryptoSession);
     }
 
-    info = stream->info_;
+    info = stream->m_info;
     return true;
   }
 
   return false;
 }
 
-void CInputStreamAdaptive::UnlinkIncludedStreams(Session::STREAM* stream)
+void CInputStreamAdaptive::UnlinkIncludedStreams(CStream* stream)
 {
-  if (stream->mainId_)
+  if (stream->m_mainId)
   {
-    Session::STREAM* mainStream(m_session->GetStream(stream->mainId_));
+    CStream* mainStream(m_session->GetStream(stream->m_mainId));
     if (mainStream->GetReader())
-      mainStream->GetReader()->RemoveStreamType(stream->info_.GetStreamType());
+      mainStream->GetReader()->RemoveStreamType(stream->m_info.GetStreamType());
   }
   const adaptive::AdaptiveTree::Representation* rep(stream->m_adStream.getRepresentation());
   if (rep->flags_ & adaptive::AdaptiveTree::Representation::INCLUDEDSTREAM)
-    m_IncludedStreams[stream->info_.GetStreamType()] = 0;
+    m_IncludedStreams[stream->m_info.GetStreamType()] = 0;
 }
 
 void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
@@ -1907,9 +225,9 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
   if (!m_session)
     return;
 
-  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
+  CStream* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
 
-  if (!enable && stream && stream->enabled)
+  if (!enable && stream && stream->m_isEnabled)
   {
     UnlinkIncludedStreams(stream);
     m_session->EnableStream(stream, false);
@@ -1925,17 +243,17 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (!m_session)
     return false;
 
-  Session::STREAM* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
+  CStream* stream(m_session->GetStream(streamid - m_session->GetPeriodId() * 1000));
 
   if (!stream)
     return false;
 
-  if (stream->enabled)
+  if (stream->m_isEnabled)
   {
     if (stream->m_adStream.StreamChanged())
     {
       UnlinkIncludedStreams(stream);
-      stream->reset();
+      stream->Reset();
       stream->m_adStream.Reset();
     }
     else
@@ -1943,7 +261,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   }
 
   bool needRefetch = false; //Make sure that Kodi fetches changes
-  stream->enabled = true;
+  stream->m_isEnabled = true;
 
   const adaptive::AdaptiveTree::Representation* rep(stream->m_adStream.getRepresentation());
 
@@ -1951,10 +269,10 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   // Dummy streams will be never enabled, they will only enable / activate audio track.
   if (rep->flags_ & adaptive::AdaptiveTree::Representation::INCLUDEDSTREAM)
   {
-    Session::STREAM* mainStream;
-    stream->mainId_ = 0;
-    while ((mainStream = m_session->GetStream(++stream->mainId_)))
-      if (mainStream->info_.GetStreamType() == INPUTSTREAM_TYPE_VIDEO && mainStream->enabled)
+    CStream* mainStream;
+    stream->m_mainId = 0;
+    while ((mainStream = m_session->GetStream(++stream->m_mainId)))
+      if (mainStream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO && mainStream->m_isEnabled)
         break;
     if (mainStream)
     {
@@ -1965,23 +283,23 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       }
       else
       {
-        mainReader->AddStreamType(stream->info_.GetStreamType(), streamid);
-        mainReader->GetInformation(stream->info_);
+        mainReader->AddStreamType(stream->m_info.GetStreamType(), streamid);
+        mainReader->GetInformation(stream->m_info);
       }
     }
     else
     {
-      stream->mainId_ = 0;
+      stream->m_mainId = 0;
     }
-    m_IncludedStreams[stream->info_.GetStreamType()] = streamid;
+    m_IncludedStreams[stream->m_info.GetStreamType()] = streamid;
     return false;
   }
 
   if (rep->flags_ & adaptive::AdaptiveTree::Representation::SUBTITLESTREAM)
   {
     stream->SetReader(std::make_unique<CSubtitleSampleReader>(
-        rep->url_, streamid, stream->info_.GetCodecInternalName()));
-    return stream->GetReader()->GetInformation(stream->info_);
+        rep->url_, streamid, stream->m_info.GetCodecInternalName()));
+    return stream->GetReader()->GetInformation(stream->m_info);
   }
 
   AP4_Movie* movie(m_session->PrepareStream(stream, needRefetch));
@@ -1995,19 +313,19 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   {
     stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
     stream->SetReader(std::make_unique<CSubtitleSampleReader>(stream, streamid,
-                                                             stream->info_.GetCodecInternalName()));
+                                                             stream->m_info.GetCodecInternalName()));
   }
   else if (rep->containerType_ == adaptive::AdaptiveTree::CONTAINERTYPE_TS)
   {
     stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
 
-    uint32_t mask{(1U << stream->info_.GetStreamType()) | m_session->GetIncludedStreamMask()};
+    uint32_t mask{(1U << stream->m_info.GetStreamType()) | m_session->GetIncludedStreamMask()};
     stream->SetReader(std::make_unique<CTSSampleReader>(
-        stream->GetAdByteStream(), stream->info_.GetStreamType(), streamid, mask));
+        stream->GetAdByteStream(), stream->m_info.GetStreamType(), streamid, mask));
 
     if (!stream->GetReader()->Initialize())
     {
-      stream->disable();
+      stream->Disable();
       return false;
     }
     m_session->OnSegmentChanged(&stream->m_adStream);
@@ -2023,7 +341,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     stream->SetReader(std::make_unique<CWebmSampleReader>(stream->GetAdByteStream(), streamid));
     if (!stream->GetReader()->Initialize())
     {
-      stream->disable();
+      stream->Disable();
       return false;
     }
   }
@@ -2067,7 +385,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     return false;
   }
 
-  if (stream->info_.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
+  if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
   {
     for (uint16_t i(0); i < 16; ++i)
     {
@@ -2075,17 +393,17 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       {
         stream->GetReader()->AddStreamType(static_cast<INPUTSTREAM_TYPE>(i), m_IncludedStreams[i]);
         unsigned int sid = m_IncludedStreams[i] - m_session->GetPeriodId() * 1000;
-        Session::STREAM* incStream = m_session->GetStream(sid);
+        CStream* incStream = m_session->GetStream(sid);
         if (!incStream) {
           LOG::LogF(LOGERROR, "Cannot get the stream from sid %u", sid);
         }
         stream->GetReader()->GetInformation(
-            m_session->GetStream(m_IncludedStreams[i] - m_session->GetPeriodId() * 1000)->info_);
+            m_session->GetStream(m_IncludedStreams[i] - m_session->GetPeriodId() * 1000)->m_info);
       }
     }
   }
   m_session->EnableStream(stream, true);
-  return stream->GetReader()->GetInformation(stream->info_) || needRefetch;
+  return stream->GetReader()->GetInformation(stream->m_info) || needRefetch;
 }
 
 
@@ -2384,20 +702,12 @@ class ATTR_DLL_LOCAL CMyAddon : public kodi::addon::CAddonBase
 {
 public:
   CMyAddon();
-  virtual ~CMyAddon();
   ADDON_STATUS CreateInstance(const kodi::addon::IInstanceInfo& instance,
                               KODI_ADDON_INSTANCE_HDL& hdl) override;
 };
 
 CMyAddon::CMyAddon()
 {
-  kodihost = nullptr;
-  ;
-}
-
-CMyAddon::~CMyAddon()
-{
-  delete kodihost;
 }
 
 ADDON_STATUS CMyAddon::CreateInstance(const kodi::addon::IInstanceInfo& instance,
@@ -2406,7 +716,6 @@ ADDON_STATUS CMyAddon::CreateInstance(const kodi::addon::IInstanceInfo& instance
   if (instance.IsType(ADDON_INSTANCE_INPUTSTREAM))
   {
     hdl = new CInputStreamAdaptive(instance);
-    kodihost = new KodiHost();
     return ADDON_STATUS_OK;
   }
   return ADDON_STATUS_NOT_IMPLEMENTED;

--- a/src/main.h
+++ b/src/main.h
@@ -8,250 +8,85 @@
 
 #pragma once
 
-#include "AdaptiveByteStream.h"
-#include "SSD_dll.h"
-#include "common/AdaptiveStream.h"
-#include "common/AdaptiveTree.h"
-#include "common/Chooser.h"
-#include "samplereader/SampleReader.h"
+#include "Session.h"
 #include "utils/PropertiesUtils.h"
 
-#include <float.h>
-#include <memory>
-#include <vector>
-
-#include <bento4/Ap4.h>
 #include <kodi/addon-instance/Inputstream.h>
-#include <kodi/tools/DllHelper.h>
+#include <kodi/addon-instance/VideoCodec.h>
 
-class Adaptive_CencSingleSampleDecrypter;
+/*******************************************************/
+/*                     InputStream                     */
+/*******************************************************/
 
-namespace XBMCFILE
-{
-  /* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
-  static const unsigned int READ_TRUNCATED = 0x01;
-
-  /* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
-  static const unsigned int READ_CHUNKED   = 0x02;
-
-  /* use cache to access this file */
-  static const unsigned int READ_CACHED    = 0x04;
-
-  /* open without caching. regardless to file type. */
-  static const unsigned int READ_NO_CACHE  = 0x08;
-
-  /* calcuate bitrate for file while reading */
-  static const unsigned int READ_BITRATE   = 0x10;
-}
-
-/*******************************************************
-Kodi Streams implementation
-********************************************************/
-
-class ATTR_DLL_LOCAL Session : public adaptive::AdaptiveStreamObserver
+class ATTR_DLL_LOCAL CInputStreamAdaptive : public kodi::addon::CInstanceInputStream
 {
 public:
-  Session(const UTILS::PROPERTIES::KodiProperties& properties,
-          const std::string& url,
-          const std::map<std::string, std::string>& mediaHeaders,
-          const std::string& profilePath);
-  virtual ~Session();
-  bool Initialize(const std::uint8_t config);
+  CInputStreamAdaptive(const kodi::addon::IInstanceInfo& instance);
+  ADDON_STATUS CreateInstance(const kodi::addon::IInstanceInfo& instance,
+                              KODI_ADDON_INSTANCE_HDL& hdl) override;
 
-  /*! \brief Pre-Initialize the DRM
-   *  \param challengeB64 [OUT] Provide the challenge data as base64
-   *  \param sessionId [OUT] Provide the session ID
-   *  \param isSessionOpened [OUT] Will be true if the DRM session has been opened
-   *  \return True if has success, false otherwise
-   */
-  bool PreInitializeDRM(std::string& challengeB64,
-                        std::string& sessionId,
-                        bool& isSessionOpened);
+  bool Open(const kodi::addon::InputstreamProperty& props) override;
+  void Close() override;
+  bool GetStreamIds(std::vector<unsigned int>& ids) override;
+  void GetCapabilities(kodi::addon::InputstreamCapabilities& caps) override;
+  bool GetStream(int streamid, kodi::addon::InputstreamInfo& info) override;
+  void EnableStream(int streamid, bool enable) override;
+  bool OpenStream(int streamid) override;
+  DEMUX_PACKET* DemuxRead() override;
+  bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
+  void SetVideoResolution(int width, int height) override;
+  bool PosTime(int ms) override;
+  int GetTotalTime() override;
+  int GetTime() override;
+  bool IsRealTimeStream() override;
 
-  /*! \brief Initialize the DRM
-   *  \param addDefaultKID Set True to add the default KID to the first session
-   *  \return True if has success, false otherwise
-   */
-  bool InitializeDRM(bool addDefaultKID = false);
+#if INPUTSTREAM_VERSION_LEVEL > 1
+  int GetChapter() override;
+  int GetChapterCount() override;
+  const char* GetChapterName(int ch) override;
+  int64_t GetChapterPos(int ch) override;
+  bool SeekChapter(int ch) override;
+#endif
 
-  /*! \brief Initialize adaptive tree period
-   *  \param isSessionOpened Set True to kept and re-use the DRM session opened,
-   *         otherwise False to reinitialize the DRM session
-   *  \return True if has success, false otherwise
-   */
-  bool InitializePeriod(bool isSessionOpened = false);
-
-  ISampleReader *GetNextSample();
-
-  struct STREAM
-  {
-    STREAM(adaptive::AdaptiveTree& t,
-           adaptive::AdaptiveTree::AdaptationSet* adp,
-           adaptive::AdaptiveTree::Representation* initialRepr,
-           const std::map<std::string, std::string>& media_headers,
-           CHOOSER::IRepresentationChooser* reprChooser,
-           bool play_timeshift_buffer,
-           bool choose_rep)
-      : enabled(false),
-        encrypted(false),
-        mainId_(0),
-        current_segment_(0),
-        m_adStream(t, adp, initialRepr, media_headers, play_timeshift_buffer, choose_rep),
-        segmentChanged(false),
-        valid(true){};
-
-    ~STREAM() { disable(); };
-
-    void disable();
-    void reset();
-
-    /*!
-     * \brief Get the stream sample reader pointer
-     * \return The sample reader, otherwise nullptr if not set
-     */
-    ISampleReader* GetReader() const { return m_streamReader.get(); }
-
-    /*!
-     * \brief Set the stream sample reader
-     * \param reader The reader
-     */
-    void SetReader(std::unique_ptr<ISampleReader> reader) { m_streamReader = std::move(reader); }
-
-    /*!
-     * \brief Get the stream file handler pointer
-     * \return The stream file handler, otherwise nullptr if not set
-     */
-    AP4_File* GetStreamFile() const { return m_streamFile.get(); }
-
-    /*!
-     * \brief Set the stream file handler
-     * \param streamFile The stream file handler
-     */
-    void SetStreamFile(std::unique_ptr<AP4_File> streamFile)
-    {
-      m_streamFile = std::move(streamFile);
-    }
-
-    /*!
-     * \brief Get the adaptive byte stream handler pointer
-     * \return The adaptive byte stream handler, otherwise nullptr if not set
-     */
-    CAdaptiveByteStream* GetAdByteStream() const { return m_adByteStream.get(); }
-
-    /*!
-     * \brief Set the adaptive byte stream handler
-     * \param dataStream The adaptive byte stream handler
-     */
-    void SetAdByteStream(std::unique_ptr<CAdaptiveByteStream> adByteStream)
-    {
-      m_adByteStream = std::move(adByteStream);
-    }
-
-    bool enabled, encrypted;
-    uint16_t mainId_;
-    uint32_t current_segment_;
-    adaptive::AdaptiveStream m_adStream;
-    kodi::addon::InputstreamInfo info_;
-    bool segmentChanged;
-    bool valid;
-
-  private:
-    std::unique_ptr<ISampleReader> m_streamReader;
-    std::unique_ptr<CAdaptiveByteStream> m_adByteStream;
-    std::unique_ptr<AP4_File> m_streamFile;
-  };
-
-  void AddStream(adaptive::AdaptiveTree::AdaptationSet* adp,
-                 adaptive::AdaptiveTree::Representation* repr,
-                 bool isDefaultRepr,
-                 uint32_t uniqueId);
-  void UpdateStream(STREAM& stream);
-
-  AP4_Movie* PrepareStream(STREAM* stream, bool& needRefetch);
-
-  STREAM* GetStream(unsigned int sid) const
-  {
-    return sid - 1 < m_streams.size() ? m_streams[sid - 1].get() : nullptr;
-  }
-  void EnableStream(STREAM* stream, bool enable);
-  unsigned int GetStreamCount() const { return m_streams.size(); };
-  const char *GetCDMSession(int nSet) { return cdm_sessions_[nSet].cdm_session_str_; };;
-  uint8_t GetMediaTypeMask() const { return media_type_mask_; };
-  Adaptive_CencSingleSampleDecrypter* GetSingleSampleDecryptor(unsigned int nIndex) const
-  {
-    return cdm_sessions_[nIndex].single_sample_decryptor_;
-  };
-  SSD::SSD_DECRYPTER *GetDecrypter() { return decrypter_; };
-  Adaptive_CencSingleSampleDecrypter* GetSingleSampleDecrypter(std::string sessionId);
-  const SSD::SSD_DECRYPTER::SSD_CAPS &GetDecrypterCaps(unsigned int nIndex) const{ return cdm_sessions_[nIndex].decrypter_caps_; };
-  uint64_t GetTotalTimeMs()const { return adaptiveTree_->overallSeconds_ * 1000; };
-  uint64_t GetElapsedTimeMs()const { return elapsed_time_ / 1000; };
-  uint64_t PTSToElapsed(uint64_t pts);
-  uint64_t GetTimeshiftBufferStart();
-  void StartReader(
-      STREAM* stream, uint64_t seekTimeCorrected, int64_t ptsDiff, bool preceeding, bool timing);
-  bool CheckChange(bool bSet = false){ bool ret = changed_; changed_ = bSet; return ret; };
-  void SetVideoResolution(int width, int height);
-  bool SeekTime(double seekTime, unsigned int streamId = 0, bool preceeding=true);
-  bool IsLive() const { return adaptiveTree_->has_timeshift_buffer_; };
-  UTILS::PROPERTIES::ManifestType GetManifestType() const { return m_kodiProps.m_manifestType; }
-  const AP4_UI08 *GetDefaultKeyId(const uint16_t index) const;
-  uint32_t GetIncludedStreamMask() const;
-  STREAM_CRYPTO_KEY_SYSTEM GetCryptoKeySystem() const;
-  uint32_t GetInitialSequence() const { return adaptiveTree_->initial_sequence_; }
-
-  int GetChapter() const;
-  int GetChapterCount() const;
-  const char* GetChapterName(int ch) const;
-  int64_t GetChapterPos(int ch) const;
-  int GetPeriodId() const;
-  bool SeekChapter(int ch);
-  uint64_t GetChapterStartTime() const;
-  double GetChapterSeekTime() { return chapter_seek_time_; };
-  void ResetChapterSeekTime() { chapter_seek_time_ = 0; };
-
-  //Observer Section
-  void OnSegmentChanged(adaptive::AdaptiveStream* adStream) override;
-  void OnStreamChange(adaptive::AdaptiveStream* adStream) override;
-
-protected:
-  void CheckFragmentDuration(STREAM &stream);
-  void GetSupportedDecrypterURN(std::string &key_system);
-  void DisposeSampleDecrypter();
-  void DisposeDecrypter();
+  std::shared_ptr<SESSION::CSession> GetSession() { return m_session; };
 
 private:
-  const UTILS::PROPERTIES::KodiProperties m_kodiProps;
-  std::string manifestURL_;
-  std::map<std::string, std::string> media_headers_;
-  AP4_DataBuffer server_certificate_;
-  kodi::tools::CDllHelper* decrypterModule_{nullptr};
-  SSD::SSD_DECRYPTER* decrypter_{nullptr};
-  std::unique_ptr<ISampleReader> m_dummySampleReader;
+  std::shared_ptr<SESSION::CSession> m_session{nullptr};
+  UTILS::PROPERTIES::KodiProperties m_kodiProps;
+  int m_currentVideoWidth{1280};
+  int m_currentVideoHeight{720};
+  uint32_t m_IncludedStreams[16];
+  bool m_checkChapterSeek = false;
+  int m_failedSeekTime = ~0;
 
-  struct CDMSESSION
+  void UnlinkIncludedStreams(SESSION::CStream* stream);
+};
+
+/*******************************************************/
+/*                     VideoCodec                      */
+/*******************************************************/
+
+class ATTR_DLL_LOCAL CVideoCodecAdaptive : public kodi::addon::CInstanceVideoCodec
+{
+public:
+  CVideoCodecAdaptive(const kodi::addon::IInstanceInfo& instance);
+  CVideoCodecAdaptive(const kodi::addon::IInstanceInfo& instance, CInputStreamAdaptive* parent);
+  virtual ~CVideoCodecAdaptive();
+
+  bool Open(const kodi::addon::VideoCodecInitdata& initData) override;
+  bool Reconfigure(const kodi::addon::VideoCodecInitdata& initData) override;
+  bool AddData(const DEMUX_PACKET& packet) override;
+  VIDEOCODEC_RETVAL GetPicture(VIDEOCODEC_PICTURE& picture) override;
+  const char* GetName() override { return m_name.c_str(); };
+  void Reset() override;
+
+private:
+  enum STATE : unsigned int
   {
-    SSD::SSD_DECRYPTER::SSD_CAPS decrypter_caps_;
-    Adaptive_CencSingleSampleDecrypter* single_sample_decryptor_;
-    const char* cdm_session_str_ = nullptr;
-    bool shared_single_sample_decryptor_ = false;
+    STATE_WAIT_EXTRADATA = 1
   };
-  std::vector<CDMSESSION> cdm_sessions_;
 
-  adaptive::AdaptiveTree* adaptiveTree_{nullptr};
-  CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
-
-  std::vector<std::unique_ptr<STREAM>> m_streams;
-  STREAM* timing_stream_{nullptr};
-
-  uint32_t fixed_bandwidth_{0};
-  bool changed_{false};
-  uint64_t elapsed_time_{0};
-  uint64_t chapter_start_time_{0}; // In STREAM_TIME_BASE
-  double chapter_seek_time_{0.0}; // In seconds
-  uint8_t media_type_mask_{0};
-  uint8_t drmConfig_{0};
-  bool m_settingNoSecureDecoder{false};
-  bool m_settingIsHdcpOverride{false};
-  bool first_period_initialized_{0};
+  std::shared_ptr<SESSION::CSession> m_session;
+  unsigned int m_state;
+  std::string m_name;
 };

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -8,7 +8,7 @@
 
 #include "HLSTree.h"
 
-#include "../Iaes_decrypter.h"
+#include "../aes_decrypter.h"
 #include "../utils/Base64Utils.h"
 #include "../utils/StringUtils.h"
 #include "../utils/UrlUtils.h"
@@ -84,14 +84,19 @@ static std::string getAudioCodec(const std::string& codecs)
     return "aac";
 }
 
-HLSTree::HLSTree(const HLSTree& left)
-  : AdaptiveTree(left.m_kodiProps, left.m_reprChooser), m_decrypter(left.m_decrypter)
+HLSTree::HLSTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
+                 CHOOSER::IRepresentationChooser* reprChooser)
+  : AdaptiveTree(kodiProps, reprChooser)
+{
+  m_decrypter = std::make_unique<AESDecrypter>(kodiProps.m_licenseKey);
+};
+
+HLSTree::HLSTree(const HLSTree& left) : AdaptiveTree(left.m_kodiProps, left.m_reprChooser) 
 {
 }
 
 HLSTree::~HLSTree()
 {
-  delete m_decrypter;
 }
 
 int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::string>& map)

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -9,11 +9,10 @@
 #pragma once
 
 #include "../common/AdaptiveTree.h"
+#include "../Iaes_decrypter.h"
 
 #include <map>
 #include <sstream>
-
-class IAESDecrypter;
 
 namespace adaptive
 {
@@ -30,9 +29,7 @@ public:
     ENCRYPTIONTYPE_UNKNOWN = 4,
   };
   HLSTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-          CHOOSER::IRepresentationChooser* reprChooser,
-          IAESDecrypter* decrypter)
-    : AdaptiveTree(kodiProps, reprChooser), m_decrypter(decrypter){};
+          CHOOSER::IRepresentationChooser* reprChooser);
   HLSTree(const HLSTree& left);
 
   virtual ~HLSTree();
@@ -67,6 +64,7 @@ public:
 protected:
   virtual bool ParseManifest(std::stringstream& stream);
   virtual void RefreshLiveSegments() override;
+  std::unique_ptr<IAESDecrypter> m_decrypter;
 
 private:
   int processEncryption(std::string baseUrl, std::map<std::string, std::string>& map);
@@ -91,7 +89,6 @@ private:
   std::map<std::string, EXTGROUP> m_extGroups;
   bool m_refreshPlayList = true;
   uint8_t m_segmentIntervalSec = 4;
-  IAESDecrypter *m_decrypter;
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;
 };

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -10,6 +10,10 @@
 
 #include "../utils/log.h"
 
+#include <kodi/Filesystem.h>
+
+using namespace SESSION;
+
 CSubtitleSampleReader::CSubtitleSampleReader(const std::string& url,
                                            AP4_UI32 streamId,
                                            const std::string& codecInternalName)
@@ -42,7 +46,7 @@ CSubtitleSampleReader::CSubtitleSampleReader(const std::string& url,
   m_codecHandler->Transform(0, 0, result, 1000);
 }
 
-CSubtitleSampleReader::CSubtitleSampleReader(Session::STREAM* stream,
+CSubtitleSampleReader::CSubtitleSampleReader(CStream* stream,
                                            AP4_UI32 streamId,
                                            const std::string& codecInternalName)
   : m_streamId{streamId}, m_adByteStream{stream->GetAdByteStream()}, m_adStream{&stream->m_adStream}

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -9,7 +9,7 @@
 #include "../codechandler/TTMLCodecHandler.h"
 #include "../codechandler/WebVTTCodecHandler.h"
 #include "../common/AdaptiveStream.h"
-#include "../main.h" //! @todo: Relying on for STREAM objects, to be removed in a future cleanup
+#include "../Stream.h"
 #include "SampleReader.h"
 
 class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
@@ -19,7 +19,7 @@ public:
                        AP4_UI32 streamId,
                        const std::string& codecInternalName);
 
-  CSubtitleSampleReader(Session::STREAM* stream,
+  CSubtitleSampleReader(SESSION::CStream* stream,
                        AP4_UI32 streamId,
                        const std::string& codecInternalName);
 

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -23,7 +23,7 @@ protected:
     m_reprChooser = new CTestRepresentationChooserDefault();
     m_reprChooser->Initialize(kodiProps.m_chooserProps);
 
-    tree = new HLSTestTree(kodiProps, m_reprChooser, new AESDecrypter(std::string()));
+    tree = new HLSTestTree(kodiProps, m_reprChooser);
     tree->supportedKeySystem_ = "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
   }
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -131,6 +131,13 @@ bool DASHTestTree::download(const std::string& url,
   return false;
 }
 
+HLSTestTree::HLSTestTree(UTILS::PROPERTIES::KodiProperties kodiProps,
+  CHOOSER::IRepresentationChooser* reprChooser)
+  : HLSTree(kodiProps, reprChooser) 
+{
+  m_decrypter = std::make_unique<AESDecrypter>(AESDecrypter(std::string()));
+}
+
 bool HLSTestTree::download(const std::string& url,
                            const std::map<std::string, std::string>& reqHeaders,
                            std::stringstream& data,

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -112,9 +112,7 @@ class HLSTestTree : public adaptive::HLSTree
 {
 public:
   HLSTestTree(UTILS::PROPERTIES::KodiProperties kodiProps,
-              CHOOSER::IRepresentationChooser* reprChooser,
-              IAESDecrypter* decrypter)
-    : HLSTree(kodiProps, reprChooser, decrypter){};
+              CHOOSER::IRepresentationChooser* reprChooser);
 
   virtual HLSTestTree* Clone() const override { return new HLSTestTree{*this}; }
 


### PR DESCRIPTION
@CastagnaIT So far have done:

* Move KodiHost out of main.cpp
* Move Session out of main.cpp
* Move STREAM out of Session
* Changed some raw pointers to managed in Session. For this HLSTree now also creates its own AES decrypter instead of being injected
* Comments/docstrings for all methods in Session

I don't want to get too much more changes made, would rather limit the scope and have this reviewed/merged first. 

At the moment could you have a quick look and let me know if you think there's anything majorly incorrect about the work so far. Thanks.