### PR TITLE
Handle AES PKCS7 padding

### DIFF
--- a/src/Iaes_decrypter.h
+++ b/src/Iaes_decrypter.h
@@ -20,8 +20,10 @@ public:
   virtual void decrypt(const AP4_UI08* aes_key,
                        const AP4_UI08* aes_iv,
                        const AP4_UI08* src,
-                       AP4_UI08* dst,
-                       size_t dataSize) = 0;
+                       std::string& dst,
+                       size_t dstOffset,
+                       size_t& dataSize,
+                       bool lastChunk) = 0;
   virtual std::string convertIV(const std::string& input) = 0;
   virtual void ivFromSequence(uint8_t* buffer, uint64_t sid) = 0;
   virtual const std::string& getLicenseKey() const = 0;

--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -7,11 +7,18 @@
  */
 
 #include "aes_decrypter.h"
-#include <bento4/Ap4Protection.h>
+#include "utils/log.h"
+#include <bento4/Ap4StreamCipher.h>
 #include <kodi/Filesystem.h>
 #include <vector>
 
-void AESDecrypter::decrypt(const AP4_UI08 *aes_key, const AP4_UI08 *aes_iv, const AP4_UI08 *src, AP4_UI08 *dst, size_t dataSize)
+void AESDecrypter::decrypt(const AP4_UI08* aes_key,
+                           const AP4_UI08* aes_iv,
+                           const AP4_UI08* src,
+                           std::string& dst,
+                           size_t dstOffset,
+                           size_t& dataSize,
+                           bool lastChunk)
 {
   AP4_BlockCipher* cbc_d_block_cipher;
   AP4_DefaultBlockCipherFactory::Instance.CreateCipher(
@@ -23,9 +30,16 @@ void AESDecrypter::decrypt(const AP4_UI08 *aes_key, const AP4_UI08 *aes_iv, cons
     16,
     cbc_d_block_cipher);
 
-  cbc_d_block_cipher->Process(src, dataSize, dst, aes_iv);
-
-  delete cbc_d_block_cipher;
+  AP4_CbcStreamCipher cbcStreamCipher{cbc_d_block_cipher};
+  cbcStreamCipher.SetIV(aes_iv);
+  AP4_Result result{
+      cbcStreamCipher.ProcessBuffer(src, dataSize, reinterpret_cast<AP4_UI08*>(&dst[0] + dstOffset),
+                                    reinterpret_cast<AP4_Size*>(&dataSize), lastChunk)};
+  if (!AP4_SUCCEEDED(result))
+  {
+    LOG::LogF(LOGERROR, "AES decryption failed: %d", result);
+  }
+  dst.resize(dstOffset + dataSize);
 }
 
 std::string AESDecrypter::convertIV(const std::string &input)

--- a/src/aes_decrypter.h
+++ b/src/aes_decrypter.h
@@ -29,8 +29,10 @@ public:
   void decrypt(const AP4_UI08* aes_key,
                const AP4_UI08* aes_iv,
                const AP4_UI08* src,
-               AP4_UI08* dst,
-               size_t dataSize);
+               std::string& dst,
+               size_t dstOffset,
+               size_t& dataSize,
+               bool lastChunk);
   std::string convertIV(const std::string& input);
   void ivFromSequence(uint8_t* buffer, uint64_t sid);
   const std::string& getLicenseKey() const { return m_licenseKey; };

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -245,7 +245,7 @@ bool AdaptiveStream::download(const std::string& url,
       else
       {
         // Store the data
-        if (write_data(bufferData.data(), byteRead, lockfreeBuffer))
+        if (write_data(bufferData.data(), byteRead, lockfreeBuffer, file.AtEnd()))
         {
           totalReadBytes += byteRead;
         }
@@ -414,7 +414,10 @@ bool AdaptiveStream::parseIndexRange(AdaptiveTree::Representation* rep, const st
   return false;
 }
 
-bool AdaptiveStream::write_data(const void* buffer, size_t buffer_size, std::string* lockfreeBuffer)
+bool AdaptiveStream::write_data(const void* buffer,
+                                size_t buffer_size,
+                                std::string* lockfreeBuffer,
+                                bool lastChunk)
 {
   if (lockfreeBuffer)
   {
@@ -437,7 +440,7 @@ bool AdaptiveStream::write_data(const void* buffer, size_t buffer_size, std::str
     segment_buffer.resize(insertPos + buffer_size);
     tree_.OnDataArrived(download_segNum_, download_pssh_set_, m_iv,
                         reinterpret_cast<const uint8_t*>(buffer),
-                        reinterpret_cast<uint8_t*>(&segment_buffer[0]), insertPos, buffer_size);
+                        segment_buffer, insertPos, buffer_size, lastChunk);
   }
   thread_data_->signal_rw_.notify_one();
   return true;

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -75,7 +75,10 @@ namespace adaptive
                           const std::map<std::string, std::string>& mediaHeaders,
                           std::string* lockfreeBuffer);
     virtual bool parseIndexRange(AdaptiveTree::Representation* rep, const std::string& buffer);
-    bool write_data(const void* buffer, size_t buffer_size, std::string* lockfreeBuffer);
+    bool write_data(const void* buffer,
+                    size_t buffer_size,
+                    std::string* lockfreeBuffer,
+                    bool lastChunk);
     virtual void SetLastUpdated(std::chrono::system_clock::time_point tm) {};
     std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
     virtual bool download_segment();

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -220,9 +220,16 @@ namespace adaptive
       (*b)->segments_.insert(segment);
   }
 
-  void AdaptiveTree::OnDataArrived(uint64_t segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize)
+  void AdaptiveTree::OnDataArrived(uint64_t segNum,
+                                   uint16_t psshSet,
+                                   uint8_t iv[16],
+                                   const uint8_t* src,
+                                   std::string& dst,
+                                   size_t dstOffset,
+                                   size_t dataSize,
+                                   bool lastChunk)
   {
-    memcpy(dst + dstOffset, src, dataSize);
+    memcpy(&dst[0] + dstOffset, src, dataSize);
   }
 
   uint16_t AdaptiveTree::insert_psshset(StreamType type,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -523,7 +523,14 @@ public:
     return PREPARE_RESULT_OK;
   };
   virtual std::chrono::time_point<std::chrono::system_clock> GetRepLastUpdated(const Representation* rep) { return std::chrono::system_clock::now(); }
-  virtual void OnDataArrived(uint64_t segNum, uint16_t psshSet, uint8_t iv[16], const uint8_t *src, uint8_t *dst, size_t dstOffset, size_t dataSize);
+  virtual void OnDataArrived(uint64_t segNum,
+                             uint16_t psshSet,
+                             uint8_t iv[16],
+                             const uint8_t* src,
+                             std::string& dst,
+                             size_t dstOffset,
+                             size_t dataSize,
+                             bool lastChunk);
   virtual void RefreshSegments(Period* period,
                                AdaptationSet* adp,
                                Representation* rep,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -45,9 +45,10 @@ public:
                              uint16_t psshSet,
                              uint8_t iv[16],
                              const uint8_t* src,
-                             uint8_t* dst,
+                             std::string& dst,
                              size_t dstOffset,
-                             size_t dataSize) override;
+                             size_t dataSize,
+                             bool lastChunk) override;
   virtual void RefreshSegments(Period* period,
                                AdaptationSet* adp,
                                Representation* rep,

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -50,7 +50,7 @@ bool TestAdaptiveStream::download(const std::string& url,
   {
     ss.read(buf, 16);
     nbRead = ss.gcount();
-    if (!nbRead || !~nbRead || !write_data(buf, nbRead, lockfreeBuffer))
+    if (!nbRead || !~nbRead || !write_data(buf, nbRead, lockfreeBuffer, false))
       break;
     nbReadOverall += nbRead;
   }
@@ -66,8 +66,12 @@ bool TestAdaptiveStream::download(const std::string& url,
 void AESDecrypter::decrypt(const AP4_UI08* aes_key,
                            const AP4_UI08* aes_iv,
                            const AP4_UI08* src,
-                           AP4_UI08* dst,
-                           size_t dataSize){}
+                           std::string& dst,
+                           size_t dstOffset,
+                           size_t& dataSize,
+                           bool lastChunk)
+{
+}
 
 std::string AESDecrypter::convertIV(const std::string& input)
 {

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -74,8 +74,10 @@ public:
   void decrypt(const AP4_UI08* aes_key,
                const AP4_UI08* aes_iv,
                const AP4_UI08* src,
-               AP4_UI08* dst,
-               size_t dataSize);
+               std::string& dst,
+               size_t dstOffset,
+               size_t& dataSize,
+               bool lastChunk);
   std::string convertIV(const std::string& input);
   void ivFromSequence(uint8_t* buffer, uint64_t sid);
   const std::string& getLicenseKey() const { return m_licenseKey; };


### PR DESCRIPTION
To fix the issue in #996 

Quick rundown of how padding works:
Before encryption padding is added to all files to round up to the nearest 16 byte boundary. The characters added all have the value of how many padding bytes are added. And if the file length is already divisible by 16 then 16 bytes are added eg.
21 byte file will be padded out to 32 bytes, last 11 bytes are all `0b`. 32 byte file will be padded out to 48 bytes, last 16 bytes are all `10`
After decryption this padding is detected and removed.

This does not happen currently however 99% of AES-128 encrypted HLS is TS files, which are apparently robust enough to not cause any problems. However in the issue above it's fmp4 and bad things happen when there's random stuff added to the end of the file.

Changes made to accomplish this:
I don't know if this is a very nice way to do this but I stuck largely with how the buffers are laid out - the underlying object in `segment_buffers_` is a string put on the stack and now this must be available to operate on inside aes_decrypter, as it needs to be resized once the whole file is processed.
Also the aes decrypter needs to have knowledge of when the end of a file is being decrypted, so the `lastChunk` flag needs to be passed through to it.

@CastagnaIT maybe this is not for this PR but do you have any ideas around how this chain of functions could be improved? There's lots of parameters being passed around and I wonder if it would be better to wrap it into an object?

@TermeHansen could you please test out one of the builds [here](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-998/1/artifacts) for Nexus?