### PR TITLE
Send empty demux packets when waiting for data

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1107,7 +1107,7 @@ ISampleReader* CSession::GetNextSample()
     {
       if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())
       {
-        if (stream->m_adStream.waitingForSegment(true))
+        if (stream->m_adStream.WaitingForData() || stream->m_adStream.waitingForSegment(true))
           waiting = stream.get();
         else
           res = stream.get();

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1075,6 +1075,19 @@ bool AdaptiveStream::seek_time(double seek_seconds, bool preceeding, bool& needR
   return false;
 }
 
+bool AdaptiveStream::WaitingForData() const
+{
+  {
+    std::unique_lock<std::mutex> lckrw(thread_data_->mutex_rw_);
+    if (worker_processing_ && valid_segment_buffers_ == 1 &&
+      segment_buffers_[0].buffer.size() - segment_read_pos_ == 0)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool AdaptiveStream::waitingForSegment(bool checkTime) const
 {
   if (tree_.HasUpdateThread())

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -65,6 +65,7 @@ namespace adaptive
     size_t getSegmentPos() { return current_rep_->getCurrentSegmentPos(); };
     uint64_t GetCurrentPTSOffset() { return currentPTSOffset_; };
     uint64_t GetAbsolutePTSOffset() { return absolutePTSOffset_; };
+    bool WaitingForData() const;
     bool waitingForSegment(bool checkTime = false) const;
     void FixateInitialization(bool on);
     void SetSegmentFileOffset(uint64_t offset) { m_segmentFileOffset = offset; };


### PR DESCRIPTION
Very early test to see if this gives better behaviour when a stream is starved of data. To solve #976, and related to #973 and https://github.com/xbmc/xbmc/issues/20742

The idea here is to give the dummy sample reader when requesting the next sample for DemuxRead under the right conditions. So far the 'right' condition in my mind is that the download worker is flagged as processing (i.e trying to download), we only have 1 buffer that is valid, and the available bytes to read are 0 (segment read position is the size of the buffer currently).

Assuming that is the correct condition, I'm not sure about the threading part of this. I have it set to get the reading lock, I just get nervous because the way the locks are setup at the moment can cause deadlocking already in test conditions (unlikely to happen in real world though...)

Testing with normal streams seems to be fine for regular playback, however I'm yet to simulate a bad connection.

@kontell would you be able to try and test? Zips are at https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-1000/1/artifacts