### PR TITLE
Reinitialize cdm video decoder only when codec change

### DIFF
--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -42,7 +42,7 @@ namespace SSD
     {
       PROPERTY_HEADER
   };
-    static const uint32_t version = 18;
+    static const uint32_t version = 19;
 #if defined(ANDROID)
     virtual void* GetJNIEnv() = 0;
     virtual int GetSDKVersion() = 0;
@@ -154,14 +154,40 @@ namespace SSD
 
     int64_t pts;
 
-    uint16_t numSubSamples; //number of subsamples
-    uint16_t flags; //flags for later use
+    struct CRYPTO_INFO
+    {
+      /// @brief Number of subsamples.
+      uint16_t numSubSamples;
 
-    uint16_t *clearBytes; // numSubSamples uint16_t's wich define the size of clear size of a subsample
-    uint32_t *cipherBytes; // numSubSamples uint32_t's wich define the size of cipher size of a subsample
+      /// @brief Flags for later use.
+      uint16_t flags;
 
-    uint8_t *iv;  // initialization vector
-    uint8_t *kid; // key id
+      /// @brief @ref numSubSamples uint16_t's which define the size of clear size
+      /// of a subsample.
+      uint16_t* clearBytes;
+
+      /// @brief @ref numSubSamples uint32_t's which define the size of cipher size
+      /// of a subsample.
+      uint32_t* cipherBytes;
+
+      /// @brief Initialization vector
+      uint8_t* iv;
+      uint32_t ivSize;
+
+      /// @brief Key id
+      uint8_t* kid;
+      uint32_t kidSize;
+
+      /// @brief Encryption mode
+      uint16_t mode;
+
+      /// @brief Crypt blocks - number of blocks to encrypt in sample encryption pattern
+      uint8_t cryptBlocks;
+
+      /// @brief Skip blocks - number of blocks to skip in sample encryption pattern
+      uint8_t skipBlocks;
+
+    } cryptoInfo;
   } SSD_SAMPLE;
 
   enum SSD_DECODE_RETVAL
@@ -223,7 +249,8 @@ namespace SSD
 
     virtual bool OpenVideoDecoder(Adaptive_CencSingleSampleDecrypter* decrypter,
                                   const SSD_VIDEOINITDATA* initData) = 0;
-    virtual SSD_DECODE_RETVAL DecodeVideo(void* instance, SSD_SAMPLE *sample, SSD_PICTURE *picture) = 0;
+    virtual SSD_DECODE_RETVAL DecryptAndDecodeVideo(void* hostInstance, SSD_SAMPLE* sample) = 0;
+    virtual SSD_DECODE_RETVAL VideoFrameDataToPicture(void* hostInstance, SSD_PICTURE* picture) = 0;
     virtual void ResetVideo() = 0;
   };
 }; // namespace

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -6,11 +6,21 @@
  *  See LICENSES/README.md for more information.
  */
 
+#pragma once
+
 #include <bento4/Ap4.h>
-#include "../samplereader/SampleReader.h"
 
 #include <stdexcept>
 #include <string_view>
+
+// These values must match their respective constant values
+// defined in the Android MediaCodec class
+enum class CryptoMode
+{
+  NONE = 0,
+  AES_CTR = 1,
+  AES_CBC = 2
+};
 
 class Adaptive_CencSingleSampleDecrypter : public AP4_CencSingleSampleDecrypter
 {
@@ -22,7 +32,7 @@ public:
     m_CryptBlocks = static_cast<uint32_t>(cryptBlocks);
     m_SkipBlocks = static_cast<uint32_t>(skipBlocks);
   };
-  virtual void SetEncryptionScheme(CryptoMode encryptionScheme){};
+  virtual void SetEncryptionMode(CryptoMode encryptionMode){};
 
   /*! \brief Add a Key ID to the current session
    *  \param keyId The KID

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -419,7 +419,7 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
         else
           m_readerCryptoInfo.m_mode = CryptoMode::AES_CBC;
         
-        m_singleSampleDecryptor->SetEncryptionScheme(m_readerCryptoInfo.m_mode);
+        m_singleSampleDecryptor->SetEncryptionMode(m_readerCryptoInfo.m_mode);
         m_singleSampleDecryptor->SetCrypto(m_readerCryptoInfo.m_cryptBlocks,
                                            m_readerCryptoInfo.m_skipBlocks);
       }

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -49,6 +49,7 @@ public:
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override;
   uint32_t GetTimeScale() const override { return m_track->GetMediaTimeScale(); }
+  ReaderCryptoInfo GetReaderCryptoInfo() const override { return m_readerCryptoInfo; }
 
   static const AP4_UI32 TRACKID_UNKNOWN = -1;
 
@@ -86,5 +87,5 @@ private:
   AP4_CencSampleDecrypter* m_decrypter{nullptr};
   uint64_t m_nextDuration{0};
   uint64_t m_nextTimestamp{0};
-  ReaderCryptoInfo m_readerCryptoInfo{ReaderCryptoInfo()};
+  ReaderCryptoInfo m_readerCryptoInfo{};
 };

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "../AdaptiveByteStream.h"
+#include "../common/AdaptiveDecrypter.h"
 
 #include <bento4/Ap4.h>
 
@@ -18,15 +19,6 @@
 #include <kodi/AddonBase.h>
 #include <kodi/addon-instance/Inputstream.h>
 #endif
-
-// These values must match their respective constant values
-// defined in the Android MediaCodec class 
-enum class CryptoMode : uint16_t
-{
-  NONE = 0,
-  AES_CTR = 1,
-  AES_CBC = 2
-};
 
 struct ReaderCryptoInfo
 {

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -17,9 +17,7 @@
 
 #include <utility>
 
-// To keep in sync with other interfaces:
-// SSDLogLevel on SSD_dll.h
-// CDMLogLevel on cdm_adapter.h
+// To keep in sync with SSDLogLevel on SSD_dll.h
 enum LogLevel
 {
   LOGDEBUG,

--- a/wvdecrypter/CMakeLists.txt
+++ b/wvdecrypter/CMakeLists.txt
@@ -32,6 +32,7 @@ set(BENTOUSESTCFS 1)
 if(CORE_SYSTEM_NAME STREQUAL android)
   subdirs ( jni )
   add_library ( ssd_wv SHARED
+	Helper.cpp
 	wvdecrypter_android.cpp
 	jsmn.c
     ../src/utils/Utils.cpp
@@ -52,6 +53,7 @@ else()
   endif()
 
   add_library ( ssd_wv SHARED
+        Helper.cpp
         wvdecrypter.cpp
         jsmn.c
         ../src/utils/Utils.cpp
@@ -61,6 +63,7 @@ else()
         cdm/base/native_library.cc
         cdm/base/native_library_${CDMTYPE}
         cdm/media/cdm/cdm_adapter.cc
+        cdm/media/cdm/cdm_type_conversion.cc
   )
 endif()
 

--- a/wvdecrypter/Helper.cpp
+++ b/wvdecrypter/Helper.cpp
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Helper.h"
+
+SSD::SSD_HOST* GLOBAL::Host = nullptr;
+
+void LOG::Log(SSD::SSDLogLevel level, const char* format, ...)
+{
+  if (!GLOBAL::Host)
+    return;
+
+  va_list args;
+  va_start(args, format);
+  GLOBAL::Host->LogVA(level, format, args);
+  va_end(args);
+}

--- a/wvdecrypter/Helper.h
+++ b/wvdecrypter/Helper.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../src/SSD_dll.h"
+
+namespace GLOBAL
+{
+// Give shared access to the host interface
+extern SSD::SSD_HOST* Host;
+} // namespace GLOBAL
+
+namespace LOG
+{
+void Log(SSD::SSDLogLevel level, const char* format, ...);
+
+#define LogF(level, format, ...) Log((level), ("%s: " format), __FUNCTION__, ##__VA_ARGS__)
+
+} // namespace LOG

--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.cc
@@ -7,6 +7,9 @@
  */
 
 #include "cdm_adapter.h"
+
+#include "../../../Helper.h"
+
 #include <chrono>
 #include <thread>
 
@@ -181,8 +184,8 @@ void CdmAdapter::Initialize()
 
   if (!library_)
   {
-    client_->Log(CDMERROR, "%s: Failed to load library: %s", __FUNCTION__,
-                 error.ToString().c_str());
+    LOG::Log(SSD::SSDERROR, "%s: Failed to load library: %s", __FUNCTION__,
+             error.ToString().c_str());
     return;
   }
 
@@ -199,7 +202,7 @@ void CdmAdapter::Initialize()
   }
 
   std::string version{get_cdm_verion_func()};
-  client_->Log(CDMDEBUG, "CDM version: %s", version.c_str());
+  LOG::Log(SSD::SSDDEBUG, "CDM version: %s", version.c_str());
 
 #if defined(OS_WIN)
   // Load DXVA before sandbox lockdown to give CDM access to Output Protection
@@ -535,7 +538,7 @@ void CdmAdapter::OnSessionKeysChange(const char* session_id,
     char* bufferPtr{buffer};
     for (uint32_t j{0}; j < keys_info[i].key_id_size; ++j)
       bufferPtr += sprintf(bufferPtr, "%02X", (int)keys_info[i].key_id[j]);
-    client_->Log(CDMDEBUG, "%s: Sessionkey %s status: %d syscode: %u", __func__, buffer,
+    LOG::Log(SSD::SSDDEBUG, "%s: Sessionkey %s status: %d syscode: %u", __func__, buffer,
                  keys_info[i].status, keys_info[i].system_code);
 
     SendClientMessage(session_id, session_id_size, CdmAdapterClient::kSessionKeysChange,
@@ -611,7 +614,7 @@ void CdmAdapter::RequestStorageId(uint32_t version)
 
 void CdmAdapter::OnInitialized(bool success)
 {
-  client_->Log(CDMDEBUG, "CDM is initialized: %s", success ? "true" : "false");
+  LOG::Log(SSD::SSDDEBUG, "CDM is initialized: %s", success ? "true" : "false");
 }
 
 

--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.h
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.h
@@ -26,16 +26,6 @@ namespace media {
 
 uint64_t gtc();
 
-// Must match to LogLevel on utils/log.h
-enum CDMLogLevel
-{
-  CDMDEBUG,
-  CDMINFO,
-  CDMWARNING,
-  CDMERROR,
-  CDMFATAL
-};
-
 class CdmAdapterClient
 {
 public:
@@ -51,8 +41,6 @@ public:
 
   virtual void OnCDMMessage(const char* session, uint32_t session_size, CDMADPMSG msg, const uint8_t *data, size_t data_size, uint32_t status) = 0;
   virtual cdm::Buffer *AllocateBuffer(size_t sz) = 0;
-
-  virtual void Log(CDMLogLevel level, const char* format, ...) = 0;
 };
 
 class CdmVideoFrame : public cdm::VideoFrame, public cdm::VideoFrame_2 {

--- a/wvdecrypter/cdm/media/cdm/cdm_type_conversion.cc
+++ b/wvdecrypter/cdm/media/cdm/cdm_type_conversion.cc
@@ -1,0 +1,188 @@
+/*
+ *  Copyright (C) 2018 The Chromium Authors. All rights reserved.
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cdm_type_conversion.h"
+#include "../../../Helper.h"
+
+using namespace SSD;
+
+std::string media::CdmStatusToString(const cdm::Status status)
+{
+  switch (status)
+  {
+    case cdm::kSuccess:
+      return "kSuccess";
+    case cdm::kNoKey:
+      return "kNoKey";
+    case cdm::kNeedMoreData:
+      return "kNeedMoreData";
+    case cdm::kDecryptError:
+      return "kDecryptError";
+    case cdm::kDecodeError:
+      return "kDecodeError";
+    case cdm::kInitializationError:
+      return "kInitializationError";
+    case cdm::kDeferredInitialization:
+      return "kDeferredInitialization";
+    default:
+      return "Invalid Status!";
+  }
+}
+
+cdm::EncryptionScheme media::ToCdmEncryptionScheme(const CryptoMode cryptoMode)
+{
+  switch (cryptoMode)
+  {
+    case CryptoMode::NONE:
+      return cdm::EncryptionScheme::kUnencrypted;
+    case CryptoMode::AES_CTR:
+      return cdm::EncryptionScheme::kCenc;
+    case CryptoMode::AES_CBC:
+      return cdm::EncryptionScheme::kCbcs;
+    default:
+      return cdm::EncryptionScheme::kCenc;
+  }
+}
+
+cdm::VideoCodec media::ToCdmVideoCodec(const SSD::Codec codec)
+{
+  switch (codec)
+  {
+    case SSD::Codec::CodecH264:
+      return cdm::VideoCodec::kCodecH264;
+    case SSD::Codec::CodecVp8:
+      return cdm::VideoCodec::kCodecVp8;
+    case SSD::Codec::CodecVp9:
+      return cdm::VideoCodec::kCodecVp9;
+    default:
+      LOG::LogF(SSDWARNING, "Unknown video codec %i", codec);
+      return cdm::VideoCodec::kUnknownVideoCodec;
+  }
+}
+
+cdm::VideoCodecProfile media::ToCdmVideoCodecProfile(const SSD::CodecProfile profile)
+{
+  switch (profile)
+  {
+    case SSD::CodecProfile::H264CodecProfileBaseline:
+      return cdm::VideoCodecProfile::kH264ProfileBaseline;
+    case SSD::CodecProfile::H264CodecProfileMain:
+      return cdm::VideoCodecProfile::kH264ProfileMain;
+    case SSD::CodecProfile::H264CodecProfileExtended:
+      return cdm::VideoCodecProfile::kH264ProfileExtended;
+    case SSD::CodecProfile::H264CodecProfileHigh:
+      return cdm::VideoCodecProfile::kH264ProfileHigh;
+    case SSD::CodecProfile::H264CodecProfileHigh10:
+      return cdm::VideoCodecProfile::kH264ProfileHigh10;
+    case SSD::CodecProfile::H264CodecProfileHigh422:
+      return cdm::VideoCodecProfile::kH264ProfileHigh422;
+    case SSD::CodecProfile::H264CodecProfileHigh444Predictive:
+      return cdm::VideoCodecProfile::kH264ProfileHigh444Predictive;
+    case SSD::CodecProfile::VP9CodecProfile0:
+      return cdm::VideoCodecProfile::kVP9Profile0;
+    case SSD::CodecProfile::VP9CodecProfile1:
+      return cdm::VideoCodecProfile::kVP9Profile1;
+    case SSD::CodecProfile::VP9CodecProfile2:
+      return cdm::VideoCodecProfile::kVP9Profile2;
+    case SSD::CodecProfile::VP9CodecProfile3:
+      return cdm::VideoCodecProfile::kVP9Profile3;
+    case SSD::CodecProfile::CodecProfileNotNeeded:
+      return cdm::VideoCodecProfile::kProfileNotNeeded;
+    default:
+      LOG::LogF(SSDWARNING, "Unknown codec profile %i", profile);
+      return cdm::VideoCodecProfile::kUnknownVideoCodecProfile;
+  }
+}
+
+cdm::VideoFormat media::ToCdmVideoFormat(const SSD::SSD_VIDEOFORMAT format)
+{
+  switch (format)
+  {
+    case SSD::SSD_VIDEOFORMAT::VideoFormatYV12:
+      return cdm::VideoFormat::kYv12;
+    case SSD::SSD_VIDEOFORMAT::VideoFormatI420:
+      return cdm::VideoFormat::kI420;
+    default:
+      LOG::LogF(SSDWARNING, "Unknown video format %i", format);
+      return cdm::VideoFormat::kUnknownVideoFormat;
+  }
+}
+
+SSD::SSD_VIDEOFORMAT media::ToSSDVideoFormat(const cdm::VideoFormat format)
+{
+  switch (format)
+  {
+    case cdm::VideoFormat::kYv12:
+      return SSD::SSD_VIDEOFORMAT::VideoFormatYV12;
+    case cdm::VideoFormat::kI420:
+      return SSD::SSD_VIDEOFORMAT::VideoFormatI420;
+    default:
+      LOG::LogF(SSDWARNING, "Unknown video format %i", format);
+      return SSD::SSD_VIDEOFORMAT::UnknownVideoFormat;
+  }
+}
+
+// Warning: The returned config contains raw pointers to the extra data in the
+// input |config|. Hence, the caller must make sure the input |config| outlives
+// the returned config.
+cdm::VideoDecoderConfig_3 media::ToCdmVideoDecoderConfig(const SSD::SSD_VIDEOINITDATA* initData,
+                                                         const CryptoMode cryptoMode)
+{
+  cdm::VideoDecoderConfig_3 cdmConfig{};
+  cdmConfig.codec = ToCdmVideoCodec(initData->codec);
+  cdmConfig.profile = ToCdmVideoCodecProfile(initData->codecProfile);
+
+  cdmConfig.format = ToCdmVideoFormat(initData->videoFormats[0]);
+
+  //! @todo: Color space not implemented
+  cdmConfig.color_space = {2, 2, 2, cdm::ColorRange::kInvalid}; // Unspecified
+
+  cdmConfig.coded_size.width = initData->width;
+  cdmConfig.coded_size.height = initData->height;
+  cdmConfig.extra_data = const_cast<uint8_t*>(initData->extraData);
+  cdmConfig.extra_data_size = initData->extraDataSize;
+  cdmConfig.encryption_scheme = ToCdmEncryptionScheme(cryptoMode);
+  return cdmConfig;
+}
+
+void media::ToCdmInputBuffer(const SSD::SSD_SAMPLE* encryptedBuffer,
+                             std::vector<cdm::SubsampleEntry>* subsamples,
+                             cdm::InputBuffer_2* inputBuffer)
+{
+  inputBuffer->data = encryptedBuffer->data;
+  inputBuffer->data_size = encryptedBuffer->dataSize;
+  inputBuffer->timestamp = encryptedBuffer->pts;
+
+  inputBuffer->key_id = encryptedBuffer->cryptoInfo.kid;
+  inputBuffer->key_id_size = encryptedBuffer->cryptoInfo.kidSize;
+  inputBuffer->iv = encryptedBuffer->cryptoInfo.iv;
+  inputBuffer->iv_size = encryptedBuffer->cryptoInfo.ivSize;
+
+  const uint16_t numSubsamples = encryptedBuffer->cryptoInfo.numSubSamples;
+  if (numSubsamples > 0)
+  {
+    subsamples->reserve(numSubsamples);
+    for (uint16_t i = 0; i < numSubsamples; i++)
+    {
+      subsamples->push_back(
+          {encryptedBuffer->cryptoInfo.clearBytes[i], encryptedBuffer->cryptoInfo.cipherBytes[i]});
+    }
+  }
+
+  inputBuffer->subsamples = subsamples->data();
+  inputBuffer->num_subsamples = numSubsamples;
+
+  inputBuffer->encryption_scheme =
+      ToCdmEncryptionScheme(static_cast<CryptoMode>(encryptedBuffer->cryptoInfo.mode));
+
+  if (inputBuffer->encryption_scheme != cdm::EncryptionScheme::kUnencrypted)
+  {
+    inputBuffer->pattern = {encryptedBuffer->cryptoInfo.cryptBlocks,
+                            encryptedBuffer->cryptoInfo.skipBlocks};
+  }
+}

--- a/wvdecrypter/cdm/media/cdm/cdm_type_conversion.h
+++ b/wvdecrypter/cdm/media/cdm/cdm_type_conversion.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2018 The Chromium Authors. All rights reserved.
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../../../../src/SSD_dll.h"
+#include "../../../../src/common/AdaptiveDecrypter.h"
+#include "api/content_decryption_module.h"
+
+#include <string>
+#include <vector>
+
+namespace media
+{
+
+// CDM Converters
+
+std::string CdmStatusToString(const cdm::Status status);
+
+cdm::EncryptionScheme ToCdmEncryptionScheme(const CryptoMode cryptoMode);
+
+cdm::VideoCodec ToCdmVideoCodec(const SSD::Codec codec);
+
+cdm::VideoCodecProfile ToCdmVideoCodecProfile(const SSD::CodecProfile profile);
+
+// Video Converters
+
+cdm::VideoFormat ToCdmVideoFormat(const SSD::SSD_VIDEOFORMAT videoFormat);
+
+SSD::SSD_VIDEOFORMAT ToSSDVideoFormat(const cdm::VideoFormat format);
+
+// Aggregated Types
+
+// Warning: The returned config contains raw pointers to the extra data in the
+// input |config|. Hence, the caller must make sure the input |config| outlives
+// the returned config.
+cdm::VideoDecoderConfig_3 ToCdmVideoDecoderConfig(const SSD::SSD_VIDEOINITDATA* initData,
+                                                  const CryptoMode cryptoMode);
+
+// Fill |input_buffer| based on the values in |encrypted|. |subsamples|
+// is used to hold some of the data. |input_buffer| will contain pointers
+// to data contained in |encrypted| and |subsamples|, so the lifetime of
+// |input_buffer| must be <= the lifetime of |encrypted| and |subsamples|.
+void ToCdmInputBuffer(const SSD::SSD_SAMPLE* encryptedBuffer,
+                      std::vector<cdm::SubsampleEntry>* subsamples,
+                      cdm::InputBuffer_2* inputBuffer);
+
+} // namespace media

--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -6,13 +6,14 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "../src/SSD_dll.h"
+#include "../src/common/AdaptiveDecrypter.h"
 #include "../src/utils/Base64Utils.h"
 #include "../src/utils/DigestMD5Utils.h"
 #include "../src/utils/StringUtils.h"
 #include "../src/utils/Utils.h"
+#include "Helper.h"
 #include "cdm/media/cdm/cdm_adapter.h"
-#include "../src/common/AdaptiveDecrypter.h"
+#include "cdm/media/cdm/cdm_type_conversion.h"
 #include "jsmn.h"
 #include "kodi/tools/StringUtils.h"
 
@@ -33,24 +34,6 @@
 using namespace SSD;
 using namespace UTILS;
 using namespace kodi::tools;
-
-SSD_HOST *host = 0;
-
-namespace
-{
-void Log(SSD::SSDLogLevel level, const char* format, ...)
-{
-  if (!host)
-    return;
-
-  va_list args;
-  va_start(args, format);
-  host->LogVA(level, format, args);
-  va_end(args);
-}
-
-#define LogF(level, format, ...) Log((level), ("%s: " format), __FUNCTION__, ##__VA_ARGS__)
-} // namespace
 
 /*******************************************************
 CDM
@@ -116,7 +99,7 @@ public:
 
   virtual void Destroy() override
   {
-    host->ReleaseBuffer(instance_, buffer_);
+    GLOBAL::Host->ReleaseBuffer(instance_, buffer_);
     delete this;
   };
 
@@ -161,8 +144,6 @@ private:
   void *instance_;
 };
 
-
-
 /*----------------------------------------------------------------------
 |   WV_CencSingleSampleDecrypter
 +---------------------------------------------------------------------*/
@@ -186,7 +167,7 @@ public:
 
     session_ = std::string(session, session_size);
     challenge_.SetData(data, data_size);
-    Log(SSDDEBUG, "Opened widevine session ID: %s", session_.c_str());
+    LOG::Log(SSDDEBUG, "Opened widevine session ID: %s", session_.c_str());
   }
 
   void AddSessionKey(const uint8_t *data, size_t data_size, uint32_t status);
@@ -215,10 +196,11 @@ public:
     const AP4_UI32* bytes_of_encrypted_data) override;
 
   bool OpenVideoDecoder(const SSD_VIDEOINITDATA *initData);
-  SSD_DECODE_RETVAL DecodeVideo(void* hostInstance, SSD_SAMPLE *sample, SSD_PICTURE *picture);
+  SSD_DECODE_RETVAL DecryptAndDecodeVideo(void* hostInstance, SSD_SAMPLE* sample);
+  SSD_DECODE_RETVAL VideoFrameDataToPicture(void* hostInstance, SSD_PICTURE *picture);
   void ResetVideo();
 
-  void SetEncryptionScheme(CryptoMode encryptionScheme) override;
+  void SetEncryptionMode(CryptoMode encryptionMode) override;
   void SetDefaultKeyId(std::string_view keyId) override;
   void AddKeyId(std::string_view keyId) override;
 
@@ -242,8 +224,6 @@ private:
   int hdcp_limit_;
   int resolution_limit_;
 
-  unsigned int max_subsample_count_decrypt_, max_subsample_count_video_;
-  cdm::SubsampleEntry *subsample_buffer_decrypt_, *subsample_buffer_video_;
   AP4_DataBuffer decrypt_in_, decrypt_out_;
 
   struct FINFO
@@ -258,9 +238,9 @@ private:
   uint32_t promise_id_;
   bool drained_;
 
-  std::list<media::CdmVideoFrame> videoFrames_;
+  std::list<media::CdmVideoFrame> m_videoFrames;
   std::mutex renewal_lock_;
-  cdm::EncryptionScheme m_EncryptionScheme;
+  CryptoMode m_EncryptionMode;
 
   std::optional<cdm::VideoDecoderConfig_3> m_currentVideoDecConfig;
 };
@@ -274,22 +254,11 @@ public:
 
   virtual void OnCDMMessage(const char* session, uint32_t session_size, CDMADPMSG msg, const uint8_t *data, size_t data_size, uint32_t status) override;
 
-  void Log(media::CDMLogLevel level, const char* format, ...) override
-  {
-    if (!host)
-      return;
-
-    va_list args;
-    va_start(args, format);
-    host->LogVA(static_cast<SSD::SSDLogLevel>(level), format, args);
-    va_end(args);
-  }
-
   virtual cdm::Buffer *AllocateBuffer(size_t sz) override
   {
     SSD_PICTURE pic;
     pic.decodedDataSize = sz;
-    if (host->GetBuffer(host_instance_, pic))
+    if (GLOBAL::Host->GetBuffer(host_instance_, pic))
     {
       CdmFixedBuffer *buf = new CdmFixedBuffer;
       buf->initialize(host_instance_, pic.decodedData, pic.decodedDataSize, pic.buffer);
@@ -311,6 +280,9 @@ public:
 
   cdm::Status DecryptAndDecodeFrame(void* hostInstance, cdm::InputBuffer_2 &cdm_in, media::CdmVideoFrame *frame)
   {
+    // DecryptAndDecodeFrame calls CdmAdapter::Allocate which calls Host->GetBuffer
+    // that cast hostInstance to CInstanceVideoCodec to get the frame buffer
+    // so we have temporary set the host instance
     host_instance_ = hostInstance;
     cdm::Status ret = wv_adapter->DecryptAndDecodeFrame(cdm_in, frame);
     host_instance_ = nullptr;
@@ -329,30 +301,30 @@ WV_DRM::WV_DRM(const char* licenseURL, const AP4_DataBuffer &serverCert, const u
   : license_url_(licenseURL)
   , host_instance_(0)
 {
-  std::string strLibPath = host->GetLibraryPath();
+  std::string strLibPath = GLOBAL::Host->GetLibraryPath();
   if (strLibPath.empty())
   {
-    Log(media::CDMERROR, "No Widevine library path specified in settings");
+    LOG::Log(SSDERROR, "No Widevine library path specified in settings");
     return;
   }
   strLibPath += WIDEVINECDMFILENAME;
 
-  std::string strBasePath = host->GetProfilePath();
+  std::string strBasePath = GLOBAL::Host->GetProfilePath();
   char cSep = strBasePath.back();
   strBasePath += "widevine";
   strBasePath += cSep;
-  host->CreateDir(strBasePath.c_str());
+  GLOBAL::Host->CreateDir(strBasePath.c_str());
 
   //Build up a CDM path to store decrypter specific stuff. Each domain gets it own path
   const char* bspos(strchr(license_url_.c_str(), ':'));
   if (!bspos || bspos[1] != '/' || bspos[2] != '/' || !(bspos = strchr(bspos + 3, '/')))
   {
-    Log(media::CDMERROR, "Unable to find protocol inside license URL");
+    LOG::Log(SSDERROR, "Unable to find protocol inside license URL");
     return;
   }
   if (bspos - license_url_.c_str() > 256)
   {
-    Log(media::CDMERROR, "Length of license URL domain exeeds max. size of 256");
+    LOG::Log(SSDERROR, "Length of license URL domain exeeds max. size of 256");
     return;
   }
   char buffer[1024];
@@ -361,7 +333,7 @@ WV_DRM::WV_DRM(const char* licenseURL, const AP4_DataBuffer &serverCert, const u
 
   strBasePath += buffer;
   strBasePath += cSep;
-  host->CreateDir(strBasePath.c_str());
+  GLOBAL::Host->CreateDir(strBasePath.c_str());
 
   wv_adapter = std::shared_ptr<media::CdmAdapter>(new media::CdmAdapter(
     "com.widevine.alpha",
@@ -371,7 +343,7 @@ WV_DRM::WV_DRM(const char* licenseURL, const AP4_DataBuffer &serverCert, const u
     dynamic_cast<media::CdmAdapterClient*>(this)));
   if (!wv_adapter->valid())
   {
-    Log(media::CDMERROR, "Unable to load widevine shared library (%s)", strLibPath.c_str());
+    LOG::Log(SSDERROR, "Unable to load widevine shared library (%s)", strLibPath.c_str());
     wv_adapter = nullptr;
     return;
   }
@@ -398,7 +370,7 @@ WV_DRM::~WV_DRM()
 
 void WV_DRM::OnCDMMessage(const char* session, uint32_t session_size, CDMADPMSG msg, const uint8_t *data, size_t data_size, uint32_t status)
 {
-  Log(media::CDMDEBUG, "CDMMessage: %u arrived!", msg);
+  LOG::Log(SSDDEBUG, "CDMMessage: %u arrived!", msg);
   std::vector<WV_CencSingleSampleDecrypter*>::iterator b(ssds.begin()), e(ssds.end());
   for (; b != e; ++b)
     if (!(*b)->GetSessionId() || strncmp((*b)->GetSessionId(), session, session_size) == 0)
@@ -428,28 +400,24 @@ WV_CencSingleSampleDecrypter::WV_CencSingleSampleDecrypter(WV_DRM& drm,
     hdcp_version_(99),
     hdcp_limit_(0),
     resolution_limit_(0),
-    max_subsample_count_decrypt_(0),
-    max_subsample_count_video_(0),
-    subsample_buffer_decrypt_(0),
-    subsample_buffer_video_(0),
     promise_id_(1),
     drained_(true),
     m_defaultKeyId{defaultKeyId}
 {
   SetParentIsOwner(false);
-  m_EncryptionScheme = cdm::EncryptionScheme::kCenc;
+  m_EncryptionMode = CryptoMode::AES_CTR; // cenc
 
   if (pssh.GetDataSize() > 4096)
   {
-    LogF(SSDERROR, "PSSH init data with length %u seems not to be cenc init data",
-         pssh.GetDataSize());
+    LOG::LogF(SSDERROR, "PSSH init data with length %u seems not to be cenc init data",
+              pssh.GetDataSize());
     return;
   }
 
   drm_.insertssd(this);
 
 #ifdef LOCLICENSE
-  std::string strDbg = host->GetProfilePath();
+  std::string strDbg = GLOBAL::Host->GetProfilePath();
   strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init";
   FILE*f = fopen(strDbg.c_str(), "wb");
   if (f) {
@@ -457,7 +425,7 @@ WV_CencSingleSampleDecrypter::WV_CencSingleSampleDecrypter(WV_DRM& drm,
     fclose(f);
   }
   else
-    LogF(SSDDEBUG, "Could not open debug file for writing (init)!");
+    LOG::LogF(SSDDEBUG, "Could not open debug file for writing (init)!");
 #endif
 
   if (memcmp(pssh.GetData() + 4, "pssh", 4) != 0)
@@ -490,7 +458,7 @@ WV_CencSingleSampleDecrypter::WV_CencSingleSampleDecrypter(WV_DRM& drm,
 
   if (session_.empty())
   {
-    LogF(SSDERROR, "Cannot perform License update, no session available");
+    LOG::LogF(SSDERROR, "Cannot perform License update, no session available");
     return;
   }
 
@@ -503,8 +471,6 @@ WV_CencSingleSampleDecrypter::WV_CencSingleSampleDecrypter(WV_DRM& drm,
 WV_CencSingleSampleDecrypter::~WV_CencSingleSampleDecrypter()
 {
   drm_.removessd(this);
-  free(subsample_buffer_decrypt_);
-  free(subsample_buffer_video_);
 }
 
 void WV_CencSingleSampleDecrypter::GetCapabilities(const uint8_t* key, uint32_t media, SSD_DECRYPTER::SSD_CAPS &caps)
@@ -591,10 +557,10 @@ void WV_CencSingleSampleDecrypter::CloseSessionId()
 {
   if (!session_.empty())
   {
-    LogF(SSDDEBUG, "Closing widevine session ID: %s", session_.c_str());
+    LOG::LogF(SSDDEBUG, "Closing widevine session ID: %s", session_.c_str());
     drm_.GetCdmAdapter()->CloseSession(++promise_id_, session_.data(), session_.size());
 
-    LogF(SSDDEBUG, "Widevine session ID %s closed", session_.c_str());
+    LOG::LogF(SSDDEBUG, "Widevine session ID %s closed", session_.c_str());
     session_.clear();
   }
 }
@@ -620,13 +586,13 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
 
   if (blocks.size() != 4)
   {
-    LogF(SSDERROR, "Wrong \"|\" blocks in license URL. Four blocks (req | header | body | "
-                   "response) are expected in license URL");
+    LOG::LogF(SSDERROR, "Wrong \"|\" blocks in license URL. Four blocks (req | header | body | "
+                        "response) are expected in license URL");
     return false;
   }
 
 #ifdef LOCLICENSE
-  std::string strDbg = host->GetProfilePath();
+  std::string strDbg = GLOBAL::Host->GetProfilePath();
   strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge";
   FILE*f = fopen(strDbg.c_str(), "wb");
   if (f) {
@@ -634,7 +600,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
     fclose(f);
   }
   else
-    LogF(SSDDEBUG, "Could not open debug file for writing (challenge)!");
+    LOG::LogF(SSDDEBUG, "Could not open debug file for writing (challenge)!");
 #endif
 
   //Process placeholder in GET String
@@ -649,7 +615,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
     }
     else
     {
-      Log(SSDERROR, "Unsupported License request template (command)");
+      LOG::Log(SSDERROR, "Unsupported License request template (command)");
       return false;
     }
   }
@@ -663,7 +629,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
     blocks[0].replace(insPos, 6, md5.HexDigest());
   }
 
-  void* file = host->CURLCreate(blocks[0].c_str());
+  void* file = GLOBAL::Host->CURLCreate(blocks[0].c_str());
 
   size_t nbRead;
   std::string response, resLimit, contentType;
@@ -671,9 +637,9 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
   bool serverCertRequest;
 
   //Set our std headers
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "acceptencoding", "gzip, deflate");
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "seekable", "0");
-  host->CURLAddOption(file, SSD_HOST::OPTION_HEADER, "Expect", "");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "acceptencoding", "gzip, deflate");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "seekable", "0");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_HEADER, "Expect", "");
 
   //Process headers
   std::vector<std::string> headers{StringUtils::Split(blocks[1], '&')};
@@ -687,7 +653,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
       StringUtils::Trim(header[1]);
       value = STRING::URLDecode(header[1]);
     }
-    host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, header[0].c_str(), value.c_str());
+    GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, header[0].c_str(), value.c_str());
   }
 
   //Process body
@@ -741,7 +707,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
       }
       else
       {
-        Log(SSDERROR, "Unsupported License request template (body / ?{SSM})");
+        LOG::Log(SSDERROR, "Unsupported License request template (body / ?{SSM})");
         goto SSMFAIL;
       }
 
@@ -776,7 +742,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
         }
         else
         {
-          LogF(SSDERROR, "Unsupported License request template (body / ?{SID})");
+          LOG::LogF(SSDERROR, "Unsupported License request template (body / ?{SID})");
           goto SSMFAIL;
         }
       }
@@ -810,24 +776,26 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
     }
 
     std::string encData{BASE64::Encode(blocks[2])};
-    host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "postdata", encData.c_str());
+    GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "postdata", encData.c_str());
   }
 
   serverCertRequest = challenge_.GetDataSize() == 2;
   challenge_.SetDataSize(0);
 
-  if (!host->CURLOpen(file))
+  if (!GLOBAL::Host->CURLOpen(file))
   {
-    Log(SSDERROR, "License server returned failure");
+    LOG::Log(SSDERROR, "License server returned failure");
     goto SSMFAIL;
   }
 
   // read the file
-  while ((nbRead = host->ReadFile(file, buf, 1024)) > 0)
+  while ((nbRead = GLOBAL::Host->ReadFile(file, buf, 1024)) > 0)
     response += std::string((const char*)buf, nbRead);
 
-  resLimit = host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "X-Limit-Video");
-  contentType = host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "Content-Type");
+  resLimit =
+      GLOBAL::Host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "X-Limit-Video");
+  contentType =
+      GLOBAL::Host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "Content-Type");
 
   if (!resLimit.empty())
   {
@@ -836,17 +804,17 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
       resolution_limit_ = std::atoi(resLimit.data() + (posMax + 4));
   }
 
-  host->CloseFile(file);
+  GLOBAL::Host->CloseFile(file);
   file = 0;
 
   if (nbRead != 0)
   {
-    LogF(SSDERROR, "Could not read full SessionMessage response");
+    LOG::LogF(SSDERROR, "Could not read full SessionMessage response");
     goto SSMFAIL;
   }
 
 #ifdef LOCLICENSE
-  strDbg = host->GetProfilePath();
+  strDbg = GLOBAL::Host->GetProfilePath();
   strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response";
   f = fopen(strDbg.c_str(), "wb");
   if (f) {
@@ -854,7 +822,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
     fclose(f);
   }
   else
-    LogF(SSDDEBUG, "Could not open debug file for writing (response)!");
+    LOG::LogF(SSDDEBUG, "Could not open debug file for writing (response)!");
 #endif
 
   if (serverCertRequest && contentType.find("application/octet-stream") == std::string::npos)
@@ -921,7 +889,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
       }
       else
       {
-        LogF(SSDERROR, "Unable to find %s in JSON string", blocks[3].c_str() + 2);
+        LOG::LogF(SSDERROR, "Unable to find %s in JSON string", blocks[3].c_str() + 2);
         goto SSMFAIL;
       }
     }
@@ -937,13 +905,13 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
             reinterpret_cast<const uint8_t*>(response.c_str() + payloadPos), response.size() - payloadPos);
         else
         {
-          LogF(SSDERROR, "Unsupported HTTP payload data type definition");
+          LOG::LogF(SSDERROR, "Unsupported HTTP payload data type definition");
           goto SSMFAIL;
         }
       }
       else
       {
-        LogF(SSDERROR, "Unable to find HTTP payload in response");
+        LOG::LogF(SSDERROR, "Unable to find HTTP payload in response");
         goto SSMFAIL;
       }
     }
@@ -957,7 +925,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
     }
     else
     {
-      LogF(SSDERROR, "Unsupported License request template (response)");
+      LOG::LogF(SSDERROR, "Unsupported License request template (response)");
       goto SSMFAIL;
     }
   }
@@ -970,17 +938,18 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage()
 
   if (keys_.empty())
   {
-    LogF(SSDERROR, "License update not successful (no keys)");
+    LOG::LogF(SSDERROR, "License update not successful (no keys)");
     CloseSessionId();
     return false;
   }
 
-  Log(SSDDEBUG, "License update successful");
+  LOG::Log(SSDDEBUG, "License update successful");
   return true;
 
 SSMFAIL:
   if (file)
-    host->CloseFile(file);
+    GLOBAL::Host->CloseFile(file);
+
   return false;
 }
 
@@ -1064,7 +1033,7 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
   {
     if (fragInfo.nal_length_size_ > 4)
     {
-      LogF(SSDERROR, "Nalu length size > 4 not supported");
+      LOG::LogF(SSDERROR, "Nalu length size > 4 not supported");
       return AP4_ERROR_NOT_SUPPORTED;
     }
 
@@ -1145,10 +1114,10 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
           if (nalsize + fragInfo.nal_length_size_ + nalunitsum > summedBytes)
           {
-            LogF(SSDERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
-                 static_cast<unsigned int>(fragInfo.nal_length_size_),
-                 static_cast<unsigned int>(nalsize + fragInfo.nal_length_size_ + nalunitsum),
-                 summedBytes);
+            LOG::LogF(SSDERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
+                      static_cast<unsigned int>(fragInfo.nal_length_size_),
+                      static_cast<unsigned int>(nalsize + fragInfo.nal_length_size_ + nalunitsum),
+                      summedBytes);
             return AP4_ERROR_NOT_SUPPORTED;
           }
           nalunitsum = 0;
@@ -1158,9 +1127,9 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
       }
       if (packet_in != packet_in_e || subsample_count)
       {
-        Log(SSDERROR, "NAL Unit definition incomplete (nls: %u) %u -> %u ",
-            static_cast<unsigned int>(fragInfo.nal_length_size_),
-            static_cast<unsigned int>(packet_in_e - packet_in), subsample_count);
+        LOG::Log(SSDERROR, "NAL Unit definition incomplete (nls: %u) %u -> %u ",
+                 static_cast<unsigned int>(fragInfo.nal_length_size_),
+                 static_cast<unsigned int>(packet_in_e - packet_in), subsample_count);
         return AP4_ERROR_NOT_SUPPORTED;
       }
       data_out.SetDataSize(data_out.GetDataSize() + data_in.GetDataSize() + configSize + (4 - fragInfo.nal_length_size_) * nalunitcount);
@@ -1172,7 +1141,7 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
   if (!fragInfo.key_)
   {
-    LogF(SSDDEBUG, "No Key");
+    LOG::LogF(SSDDEBUG, "No Key");
     return AP4_ERROR_INVALID_PARAMETERS;
   }
 
@@ -1187,7 +1156,7 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
   if (subsample_count) {
     if (bytes_of_cleartext_data == NULL || bytes_of_encrypted_data == NULL)
     {
-      LogF(SSDDEBUG, "Invalid input params");
+      LOG::LogF(SSDDEBUG, "Invalid input params");
       return AP4_ERROR_INVALID_PARAMETERS;
     }
   }
@@ -1198,14 +1167,9 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
     bytes_of_encrypted_data = &cipherb;
   }
 
-  // transform ap4 format into cmd format
   cdm::InputBuffer_2 cdm_in;
-  if (subsample_count > max_subsample_count_decrypt_)
-  {
-    subsample_buffer_decrypt_ = (cdm::SubsampleEntry*)realloc(subsample_buffer_decrypt_, subsample_count*sizeof(cdm::SubsampleEntry));
-    max_subsample_count_decrypt_ = subsample_count;
-  }
-
+  std::vector<cdm::SubsampleEntry> subsamples;
+  subsamples.reserve(subsample_count);
   bool useSingleDecrypt(false);
 
   // CDM should get 1 block of encrypted data per sample, encrypted data
@@ -1218,17 +1182,16 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
     decrypt_in_.SetDataSize(0);
     size_t absPos = 0;
 
-    for (unsigned int i(0); i < subsample_count; ++i)
+    for (unsigned int i{0}; i < subsample_count; ++i)
     {
       absPos += bytes_of_cleartext_data[i];
       decrypt_in_.AppendData(data_in.GetData() + absPos, bytes_of_encrypted_data[i]);
       absPos += bytes_of_encrypted_data[i];
     }
-    if (decrypt_in_.GetDataSize())
+    if (decrypt_in_.GetDataSize() > 0)
     {
       decrypt_out_.SetDataSize(decrypt_in_.GetDataSize());
-      subsample_buffer_decrypt_[0].clear_bytes = 0;
-      subsample_buffer_decrypt_[0].cipher_bytes = decrypt_in_.GetDataSize();
+      subsamples.push_back({0, decrypt_in_.GetDataSize()});
       cdm_in.data = decrypt_in_.GetData();
       cdm_in.data_size = decrypt_in_.GetDataSize();
       cdm_in.num_subsamples = 1;
@@ -1238,14 +1201,14 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
   if (!useSingleDecrypt)
   {
-    unsigned int i(0), numCipherBytes(0);
-    for (cdm::SubsampleEntry *b(subsample_buffer_decrypt_), *e(subsample_buffer_decrypt_ + subsample_count); b != e; ++b, ++i)
+    uint32_t numCipherBytes{0};
+
+    for (size_t i{0}; i < subsample_count; i++)
     {
-      b->clear_bytes = bytes_of_cleartext_data[i];
-      b->cipher_bytes = bytes_of_encrypted_data[i];
-      numCipherBytes += b->cipher_bytes;
+      subsamples.push_back({bytes_of_cleartext_data[i], bytes_of_encrypted_data[i]});
+      numCipherBytes += subsamples[i].cipher_bytes;
     }
-    if (numCipherBytes)
+    if (numCipherBytes > 0)
     {
       cdm_in.data = data_in.GetData();
       cdm_in.data_size = data_in.GetDataSize();
@@ -1262,8 +1225,8 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
   cdm_in.iv_size = 16; //Always 16, see AP4_CencSingleSampleDecrypter declaration.
   cdm_in.key_id = fragInfo.key_;
   cdm_in.key_id_size = 16;
-  cdm_in.subsamples = subsample_buffer_decrypt_;
-  cdm_in.encryption_scheme = m_EncryptionScheme;
+  cdm_in.subsamples = subsamples.data();
+  cdm_in.encryption_scheme = media::ToCdmEncryptionScheme(m_EncryptionMode);
   cdm_in.timestamp = 0;
   cdm_in.pattern = { m_CryptBlocks, m_SkipBlocks };
 
@@ -1291,99 +1254,15 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
   {
     char buf[36]; buf[32] = 0;
     AP4_FormatHex(fragInfo.key_, 16, buf);
-    LogF(SSDDEBUG, "Decrypt failed with error: %d and key: %s", ret, buf);
+    LOG::LogF(SSDDEBUG, "Decrypt failed with error: %d and key: %s", ret, buf);
   }
 
   return (ret == cdm::Status::kSuccess) ? AP4_SUCCESS : AP4_ERROR_INVALID_PARAMETERS;
 }
 
-bool WV_CencSingleSampleDecrypter::OpenVideoDecoder(const SSD_VIDEOINITDATA *initData)
+bool WV_CencSingleSampleDecrypter::OpenVideoDecoder(const SSD_VIDEOINITDATA* initData)
 {
-  cdm::VideoDecoderConfig_3 vconfig;
-
-  vconfig.extra_data = const_cast<uint8_t*>(initData->extraData);
-  vconfig.extra_data_size = initData->extraDataSize;
-
-  vconfig.coded_size.width = initData->width;
-  vconfig.coded_size.height = initData->height;
-
-  switch (initData->codec)
-  {
-    case SSD::Codec::CodecH264:
-      vconfig.codec = cdm::VideoCodec::kCodecH264;
-      break;
-    case SSD::Codec::CodecVp8:
-      vconfig.codec = cdm::VideoCodec::kCodecVp8;
-      break;
-    case SSD::Codec::CodecVp9:
-      vconfig.codec = cdm::VideoCodec::kCodecVp9;
-      break;
-    default:
-      vconfig.codec = cdm::VideoCodec::kUnknownVideoCodec;
-      LogF(SSDWARNING, "Unknown codec %i", initData->codec);
-      break;
-  }
-
-  switch (initData->codecProfile)
-  {
-    case SSD::CodecProfile::H264CodecProfileBaseline:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileBaseline;
-      break;
-    case SSD::CodecProfile::H264CodecProfileMain:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileMain;
-      break;
-    case SSD::CodecProfile::H264CodecProfileExtended:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileExtended;
-      break;
-    case SSD::CodecProfile::H264CodecProfileHigh:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh;
-      break;
-    case SSD::CodecProfile::H264CodecProfileHigh10:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh10;
-      break;
-    case SSD::CodecProfile::H264CodecProfileHigh422:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh422;
-      break;
-    case SSD::CodecProfile::H264CodecProfileHigh444Predictive:
-      vconfig.profile = cdm::VideoCodecProfile::kH264ProfileHigh444Predictive;
-      break;
-    case SSD::CodecProfile::VP9CodecProfile0:
-      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile0;
-      break;
-    case SSD::CodecProfile::VP9CodecProfile1:
-      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile1;
-      break;
-    case SSD::CodecProfile::VP9CodecProfile2:
-      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile2;
-      break;
-    case SSD::CodecProfile::VP9CodecProfile3:
-      vconfig.profile = cdm::VideoCodecProfile::kVP9Profile3;
-      break;
-    case SSD::CodecProfile::CodecProfileNotNeeded:
-      vconfig.profile = cdm::VideoCodecProfile::kProfileNotNeeded;
-      break;
-    default:
-      LogF(SSDWARNING, "Unknown codec profile %i", initData->codecProfile);
-      vconfig.profile = cdm::VideoCodecProfile::kUnknownVideoCodecProfile;
-      break;
-  }
-
-  switch (initData->videoFormats[0])
-  {
-  case SSD::SSD_VIDEOFORMAT::VideoFormatYV12:
-    vconfig.format = cdm::VideoFormat::kYv12;
-    break;
-  case SSD::SSD_VIDEOFORMAT::VideoFormatI420:
-    vconfig.format = cdm::VideoFormat::kI420;
-    break;
-  default:
-    LogF(SSDWARNING, "Unknown video format %i", initData->videoFormats[0]);
-    vconfig.format = cdm::VideoFormat::kUnknownVideoFormat;
-    break;
-  }
-
-  vconfig.color_space = { 2, 2, 2, cdm::ColorRange::kInvalid }; // Unspecified
-  vconfig.encryption_scheme = m_EncryptionScheme;
+  cdm::VideoDecoderConfig_3 vconfig = media::ToCdmVideoDecoderConfig(initData, m_EncryptionMode);
 
   // InputStream interface call OpenVideoDecoder also during playback when stream quality
   // change, so we reinitialize the decoder only when the codec change
@@ -1399,132 +1278,107 @@ bool WV_CencSingleSampleDecrypter::OpenVideoDecoder(const SSD_VIDEOINITDATA *ini
   m_currentVideoDecConfig = vconfig;
 
   cdm::Status ret = drm_.GetCdmAdapter()->InitializeVideoDecoder(vconfig);
-  videoFrames_.clear();
+  m_videoFrames.clear();
   drained_ = true;
 
-  LogF(SSDDEBUG, "WVDecoder initialization returned status %i", ret);
-
+  LOG::LogF(SSDDEBUG, "Initialization returned status: %s",
+            media::CdmStatusToString(ret).c_str());
   return ret == cdm::Status::kSuccess;
 }
 
-SSD_DECODE_RETVAL WV_CencSingleSampleDecrypter::DecodeVideo(void* hostInstance, SSD_SAMPLE *sample, SSD_PICTURE *picture)
+SSD_DECODE_RETVAL WV_CencSingleSampleDecrypter::DecryptAndDecodeVideo(void* hostInstance, SSD_SAMPLE* sample)
 {
-  if (sample)
-  {
-    // if we have an picture waiting, or not yet get the dest buffer, do nothing
-    if (videoFrames_.size() == 4)
-      return VC_ERROR;
-
-    cdm::InputBuffer_2 cdm_in;
-
-    if (sample->numSubSamples) {
-      if (sample->clearBytes == NULL || sample->cipherBytes == NULL) {
-        return VC_ERROR;
-      }
-    }
-
-    // transform ap4 format into cmd format
-    if (sample->numSubSamples > max_subsample_count_video_)
-    {
-      subsample_buffer_video_ = (cdm::SubsampleEntry*)realloc(subsample_buffer_video_, sample->numSubSamples * sizeof(cdm::SubsampleEntry));
-      max_subsample_count_video_ = sample->numSubSamples;
-    }
-    cdm_in.num_subsamples = sample->numSubSamples;
-    cdm_in.subsamples = subsample_buffer_video_;
-
-    const uint16_t *clearBytes(sample->clearBytes);
-    const uint32_t *cipherBytes(sample->cipherBytes);
-
-    for (cdm::SubsampleEntry *b(subsample_buffer_video_), *e(subsample_buffer_video_ + sample->numSubSamples); b != e; ++b, ++clearBytes, ++cipherBytes)
-    {
-      b->clear_bytes = *clearBytes;
-      b->cipher_bytes = *cipherBytes;
-    }
-    cdm_in.data = sample->data;
-    cdm_in.data_size = sample->dataSize;
-    cdm_in.iv = sample->iv;
-    cdm_in.iv_size = sample->iv ? 16 : 0;
-    cdm_in.timestamp = sample->pts;
-    cdm_in.encryption_scheme =
-        sample->kid ? m_EncryptionScheme : cdm::EncryptionScheme::kUnencrypted;
-    cdm_in.pattern = { m_CryptBlocks, m_SkipBlocks };
-
-    uint8_t unencryptedKID [] = { 0 };
-    cdm_in.key_id = sample->kid ? sample->kid : unencryptedKID;
-    cdm_in.key_id_size = sample->kid ? 16 : 0;
-
-    if (sample->dataSize)
-      drained_ = false;
-
-    //DecryptAndDecode calls Alloc wich cals kodi VideoCodec. Set instance handle.
-    //LICENSERENEWAL:
-    CheckLicenseRenewal();
-    media::CdmVideoFrame frame;
-    cdm::Status ret = drm_.DecryptAndDecodeFrame(hostInstance, cdm_in, &frame);
-
-    if (ret == cdm::Status::kSuccess)
-    {
-      std::list<media::CdmVideoFrame>::iterator f(videoFrames_.begin());
-      while (f != videoFrames_.end() && f->Timestamp() < frame.Timestamp())++f;
-      videoFrames_.insert(f, frame);
-    }
-
-    if (ret == cdm::Status::kSuccess || (cdm_in.data && ret == cdm::Status::kNeedMoreData))
-      return VC_NONE;
-    else
-    {
-      if (ret == cdm::Status::kNoKey)
-      {
-        char buf[36]; buf[0] = buf[32] = 0;
-        AP4_FormatHex(cdm_in.key_id, cdm_in.key_id_size, buf);
-        LogF(SSDERROR, "Returned CDM status kNoKey for key %s", buf);
-        return VC_EOF;
-      }
-      return VC_ERROR;
-    }
-  }
-  else if (picture)
-  {
-    if (videoFrames_.size() == 4 || (videoFrames_.size() && (picture->flags & SSD_PICTURE::FLAG_DRAIN)))
-    {
-      media::CdmVideoFrame &videoFrame_(videoFrames_.front());
-
-      picture->width = videoFrame_.Size().width;
-      picture->height = videoFrame_.Size().height;
-      picture->pts = videoFrame_.Timestamp();
-      picture->decodedData = videoFrame_.FrameBuffer()->Data();
-      picture->decodedDataSize = videoFrame_.FrameBuffer()->Size();
-      picture->buffer = static_cast<CdmFixedBuffer*>(videoFrame_.FrameBuffer())->Buffer();
-
-      for (unsigned int i(0); i < cdm::VideoPlane::kMaxPlanes; ++i)
-      {
-        picture->planeOffsets[i] = videoFrame_.PlaneOffset(static_cast<cdm::VideoPlane>(i));
-        picture->stride[i] = videoFrame_.Stride(static_cast<cdm::VideoPlane>(i));
-      }
-      picture->videoFormat = static_cast<SSD::SSD_VIDEOFORMAT>(videoFrame_.Format());
-      videoFrame_.SetFrameBuffer(nullptr); //marker for "No Picture"
-
-      delete (CdmFixedBuffer*)(videoFrame_.FrameBuffer());
-      videoFrames_.pop_front();
-
-      return VC_PICTURE;
-    }
-    else if ((picture->flags & SSD_PICTURE::FLAG_DRAIN))
-    {
-      static SSD_SAMPLE drainSample = { nullptr,0,0,0,0,nullptr,nullptr,nullptr,nullptr };
-      if (drained_ || DecodeVideo(hostInstance, &drainSample, nullptr) == VC_ERROR)
-      {
-        drained_ = true;
-        return VC_EOF;
-      }
-      else
-        return VC_NONE;
-    }
-    else
-      return VC_BUFFER;
-  }
-  else
+  // if we have an picture waiting, or not yet get the dest buffer, do nothing
+  if (m_videoFrames.size() == 4)
     return VC_ERROR;
+
+  if (sample->cryptoInfo.numSubSamples > 0 &&
+      (!sample->cryptoInfo.clearBytes || !sample->cryptoInfo.cipherBytes))
+  {
+    return VC_ERROR;
+  }
+
+  cdm::InputBuffer_2 inputBuffer{};
+  std::vector<cdm::SubsampleEntry> subsamples;
+
+  media::ToCdmInputBuffer(sample, &subsamples, &inputBuffer);
+
+  if (sample->dataSize > 0)
+    drained_ = false;
+
+  //LICENSERENEWAL:
+  CheckLicenseRenewal();
+
+  media::CdmVideoFrame videoFrame;
+  cdm::Status status = drm_.DecryptAndDecodeFrame(hostInstance, inputBuffer, &videoFrame);
+
+  if (status == cdm::Status::kSuccess)
+  {
+    std::list<media::CdmVideoFrame>::iterator f(m_videoFrames.begin());
+    while (f != m_videoFrames.end() && f->Timestamp() < videoFrame.Timestamp())
+    {
+      ++f;
+    }
+    m_videoFrames.insert(f, videoFrame);
+    return VC_NONE;
+  }
+  else if (status == cdm::Status::kNeedMoreData && inputBuffer.data)
+  {
+    return VC_NONE;
+  }
+  else if (status == cdm::Status::kNoKey)
+  {
+    char buf[36];
+    buf[0] = 0;
+    buf[32] = 0;
+    AP4_FormatHex(inputBuffer.key_id, inputBuffer.key_id_size, buf);
+    LOG::LogF(SSDERROR, "Returned CDM status kNoKey for key %s", buf);
+    return VC_EOF;
+  }
+
+  LOG::LogF(SSDDEBUG, "Returned CDM status: %i", status);
+  return VC_ERROR;
+}
+
+SSD_DECODE_RETVAL WV_CencSingleSampleDecrypter::VideoFrameDataToPicture(void* hostInstance, SSD_PICTURE* picture)
+{
+  if (m_videoFrames.size() == 4 || (m_videoFrames.size() > 0 && (picture->flags & SSD_PICTURE::FLAG_DRAIN)))
+  {
+    media::CdmVideoFrame& videoFrame(m_videoFrames.front());
+
+    picture->width = videoFrame.Size().width;
+    picture->height = videoFrame.Size().height;
+    picture->pts = videoFrame.Timestamp();
+    picture->decodedData = videoFrame.FrameBuffer()->Data();
+    picture->decodedDataSize = videoFrame.FrameBuffer()->Size();
+    picture->buffer = static_cast<CdmFixedBuffer*>(videoFrame.FrameBuffer())->Buffer();
+
+    for (unsigned int i(0); i < cdm::VideoPlane::kMaxPlanes; ++i)
+    {
+      picture->planeOffsets[i] = videoFrame.PlaneOffset(static_cast<cdm::VideoPlane>(i));
+      picture->stride[i] = videoFrame.Stride(static_cast<cdm::VideoPlane>(i));
+    }
+    picture->videoFormat = media::ToSSDVideoFormat(videoFrame.Format());
+    videoFrame.SetFrameBuffer(nullptr); //marker for "No Picture"
+
+    delete (CdmFixedBuffer*)(videoFrame.FrameBuffer());
+    m_videoFrames.pop_front();
+
+    return VC_PICTURE;
+  }
+  else if ((picture->flags & SSD_PICTURE::FLAG_DRAIN))
+  {
+    static SSD_SAMPLE drainSample{};
+    if (drained_ || DecryptAndDecodeVideo(hostInstance, &drainSample) == VC_ERROR)
+    {
+      drained_ = true;
+      return VC_EOF;
+    }
+    else
+      return VC_NONE;
+  }
+
+  return VC_BUFFER;
 }
 
 void WV_CencSingleSampleDecrypter::ResetVideo()
@@ -1533,22 +1387,9 @@ void WV_CencSingleSampleDecrypter::ResetVideo()
   drained_ = true;
 }
 
-void WV_CencSingleSampleDecrypter::SetEncryptionScheme(CryptoMode encryptionScheme)
+void WV_CencSingleSampleDecrypter::SetEncryptionMode(CryptoMode encryptionMode)
 {
-  switch (encryptionScheme)
-  {
-  case CryptoMode::NONE:
-      m_EncryptionScheme = cdm::EncryptionScheme::kUnencrypted;
-      break;
-    case CryptoMode::AES_CTR:
-      m_EncryptionScheme = cdm::EncryptionScheme::kCenc;
-      break;
-    case CryptoMode::AES_CBC:
-      m_EncryptionScheme = cdm::EncryptionScheme::kCbcs;
-      break;
-    default:
-      m_EncryptionScheme = cdm::EncryptionScheme::kCenc;
-  }
+  m_EncryptionMode = encryptionMode;
 }
 
 void WV_CencSingleSampleDecrypter::SetDefaultKeyId(std::string_view keyId)
@@ -1664,12 +1505,20 @@ public:
     return decoding_decrypter_->OpenVideoDecoder(initData);
   }
 
-  virtual SSD_DECODE_RETVAL DecodeVideo(void* hostInstance, SSD_SAMPLE *sample, SSD_PICTURE *picture) override
+  virtual SSD_DECODE_RETVAL DecryptAndDecodeVideo(void* hostInstance, SSD_SAMPLE* sample) override
   {
     if (!decoding_decrypter_)
       return VC_ERROR;
 
-    return decoding_decrypter_->DecodeVideo(hostInstance, sample, picture);
+    return decoding_decrypter_->DecryptAndDecodeVideo(hostInstance, sample);
+  }
+
+  virtual SSD_DECODE_RETVAL VideoFrameDataToPicture(void* hostInstance, SSD_PICTURE* picture) override
+  {
+    if (!decoding_decrypter_)
+      return VC_ERROR;
+
+    return decoding_decrypter_->VideoFrameDataToPicture(hostInstance, picture);
   }
 
   virtual void ResetVideo() override
@@ -1695,7 +1544,7 @@ extern "C" {
   {
     if (host_version != SSD_HOST::version)
       return 0;
-    host = h;
+    GLOBAL::Host = h;
     return new WVDecrypter();
   };
 

--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -6,13 +6,13 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "../src/SSD_dll.h"
 #include "../src/common/AdaptiveDecrypter.h"
 #include "../src/utils/Base64Utils.h"
 #include "../src/utils/DigestMD5Utils.h"
 #include "../src/utils/StringUtils.h"
 #include "../src/utils/Utils.h"
 #include "ClassLoader.h"
+#include "Helper.h"
 #include "jni/src/MediaDrm.h"
 #include "jni/src/MediaDrmOnEventListener.h"
 #include "jni/src/UUID.h"
@@ -31,25 +31,7 @@ using namespace SSD;
 using namespace UTILS;
 using namespace kodi::tools;
 
-SSD_HOST *host = 0;
-
 //#define LOCLICENSE
-
-namespace
-{
-  void Log(SSD::SSDLogLevel level, const char* format, ...)
-  {
-    if (!host)
-      return;
-
-    va_list args;
-    va_start(args, format);
-    host->LogVA(level, format, args);
-    va_end(args);
-  }
-
-#define LogF(level, format, ...) Log((level), ("%s: " format), __FUNCTION__, ##__VA_ARGS__)
-} // namespace
 
 /*******************************************************
 CDM
@@ -99,22 +81,22 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
   , media_drm_(0)
   , license_url_(licenseURL)
 {
-  std::string strBasePath = host->GetProfilePath();
+  std::string strBasePath = GLOBAL::Host->GetProfilePath();
   char cSep = strBasePath.back();
   strBasePath += ks == WIDEVINE ? "widevine" : ks == PLAYREADY ? "playready" : "wiseplay";
   strBasePath += cSep;
-  host->CreateDir(strBasePath.c_str());
+  GLOBAL::Host->CreateDir(strBasePath.c_str());
 
   //Build up a CDM path to store decrypter specific stuff. Each domain gets it own path
   const char* bspos(strchr(license_url_.c_str(), ':'));
   if (!bspos || bspos[1] != '/' || bspos[2] != '/' || !(bspos = strchr(bspos + 3, '/')))
   {
-    Log(SSDERROR, "Unable to find protocol inside license URL");
+    LOG::Log(SSDERROR, "Unable to find protocol inside license URL");
     return;
   }
   if (bspos - license_url_.c_str() > 256)
   {
-    Log(SSDERROR, "Length of license URL exeeds max. size of 256");
+    LOG::Log(SSDERROR, "Length of license URL exeeds max. size of 256");
     return;
   }
   char buffer[1024];
@@ -123,7 +105,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
 
   strBasePath += buffer;
   strBasePath += cSep;
-  host->CreateDir(strBasePath.c_str());
+  GLOBAL::Host->CreateDir(strBasePath.c_str());
   m_strBasePath = strBasePath;
 
   int64_t mostSigBits(0), leastSigBits(0);
@@ -137,7 +119,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
   media_drm_ = new jni::CJNIMediaDrm(uuid);
   if (xbmc_jnienv()->ExceptionCheck() || !*media_drm_)
   {
-    LogF(SSDERROR, "Unable to initialize MediaDrm");
+    LOG::LogF(SSDERROR, "Unable to initialize MediaDrm");
     xbmc_jnienv()->ExceptionClear();
     delete media_drm_, media_drm_ = nullptr;
     return;
@@ -146,7 +128,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
   media_drm_->setOnEventListener(*listener);
   if (xbmc_jnienv()->ExceptionCheck())
   {
-    LogF(SSDERROR, "Exception during installation of EventListener");
+    LOG::LogF(SSDERROR, "Exception during installation of EventListener");
     xbmc_jnienv()->ExceptionClear();
     media_drm_->release();
     delete media_drm_, media_drm_ = nullptr;
@@ -171,7 +153,7 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
 
     if (xbmc_jnienv()->ExceptionCheck())
     {
-      LogF(SSDERROR, "Exception setting Service Certificate");
+      LOG::LogF(SSDERROR, "Exception setting Service Certificate");
       xbmc_jnienv()->ExceptionClear();
       media_drm_->release();
       delete media_drm_, media_drm_ = nullptr;
@@ -179,9 +161,9 @@ WV_DRM::WV_DRM(WV_KEYSYSTEM ks, const char* licenseURL, const AP4_DataBuffer &se
     }
   }
 
-  Log(SSDDEBUG,
-      "MediaDrm initialized (Device unique ID size: %ld, System ID: %s, Security level: %s)",
-      strDeviceId.size(), strSystemId.c_str(), strSecurityLevel.c_str());
+  LOG::Log(SSDDEBUG,
+           "MediaDrm initialized (Device unique ID size: %ld, System ID: %s, Security level: %s)",
+           strDeviceId.size(), strSystemId.c_str(), strSecurityLevel.c_str());
 
   if (license_url_.find('|') == std::string::npos)
   {
@@ -201,7 +183,7 @@ WV_DRM::~WV_DRM()
     media_drm_->release();
     if (xbmc_jnienv()->ExceptionCheck())
     {
-      LogF(SSDERROR, "Exception releasing media drm");
+      LOG::LogF(SSDERROR, "Exception releasing media drm");
       xbmc_jnienv()->ExceptionClear();
     }
     delete media_drm_, media_drm_ = nullptr;
@@ -236,12 +218,12 @@ void WV_DRM::LoadServiceCertificate()
   }
   if (!data)
   {
-    Log(SSDDEBUG, "Requesting new Service Certificate");
+    LOG::Log(SSDDEBUG, "Requesting new Service Certificate");
     media_drm_->setPropertyString("privacyMode", "enable");
   }
   else
   {
-    Log(SSDDEBUG, "Use stored Service Certificate");
+    LOG::Log(SSDDEBUG, "Use stored Service Certificate");
     free(data), data = nullptr;
   }
 }
@@ -251,14 +233,14 @@ void WV_DRM::SaveServiceCertificate()
   std::vector<char> sc = media_drm_->getPropertyByteArray("serviceCertificate");
   if (xbmc_jnienv()->ExceptionCheck())
   {
-    LogF(SSDWARNING, "Exception retrieving Service Certificate");
+    LOG::LogF(SSDWARNING, "Exception retrieving Service Certificate");
     xbmc_jnienv()->ExceptionClear();
     return;
   }
 
   if (sc.empty())
   {
-    LogF(SSDWARNING, "Empty Service Certificate");
+    LOG::LogF(SSDWARNING, "Empty Service Certificate");
     return;
   }
 
@@ -367,13 +349,13 @@ WV_CencSingleSampleDecrypter::WV_CencSingleSampleDecrypter(WV_DRM& drm,
 
   if (pssh.GetDataSize() > 65535)
   {
-    LogF(SSDERROR, "PSSH init data with length %u seems not to be cenc init data",
-         pssh.GetDataSize());
+    LOG::LogF(SSDERROR, "PSSH init data with length %u seems not to be cenc init data",
+              pssh.GetDataSize());
     return;
   }
 
 #ifdef LOCLICENSE
-  std::string strDbg = host->GetProfilePath();
+  std::string strDbg = GLOBAL::Host->GetProfilePath();
   strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init";
   FILE*f = fopen(strDbg.c_str(), "wb");
   fwrite(pssh.GetData(), 1, pssh.GetDataSize(), f);
@@ -421,13 +403,13 @@ RETRY_OPEN:
     xbmc_jnienv()->ExceptionClear();
     if (!provisionRequested)
     {
-      LogF(SSDWARNING, "Exception during open session - provisioning...");
+      LOG::LogF(SSDWARNING, "Exception during open session - provisioning...");
       provisionRequested = true;
       if (!ProvisionRequest())
       {
         if (!L3FallbackRequested && media_drm_.GetMediaDrm()->getPropertyString("securityLevel") == "L1")
         {
-          LogF(SSDWARNING, "L1 provisioning failed - retrying with L3...");
+          LOG::LogF(SSDWARNING, "L1 provisioning failed - retrying with L3...");
           L3FallbackRequested = true;
           provisionRequested = false;
           media_drm_.GetMediaDrm()->setPropertyString("securityLevel", "L3");
@@ -440,14 +422,14 @@ RETRY_OPEN:
     }
     else
     {
-      LogF(SSDERROR, "Exception during open session - abort");
+      LOG::LogF(SSDERROR, "Exception during open session - abort");
       return;
     }
   }
 
   if (session_id_.size() == 0)
   {
-    LogF(SSDERROR, "Unable to open DRM session");
+    LOG::LogF(SSDERROR, "Unable to open DRM session");
     return;
   }
 
@@ -459,7 +441,7 @@ RETRY_OPEN:
     int maxSecuritylevel = media_drm_.GetMediaDrm()->getMaxSecurityLevel();
     xbmc_jnienv()->ExceptionClear();
 
-    Log(SSDDEBUG, "Session ID: %s, Max security level: %d", session_id_char_, maxSecuritylevel);
+    LOG::Log(SSDDEBUG, "Session ID: %s, Max security level: %d", session_id_char_, maxSecuritylevel);
   }
 }
 
@@ -470,13 +452,13 @@ WV_CencSingleSampleDecrypter::~WV_CencSingleSampleDecrypter()
     media_drm_.GetMediaDrm()->removeKeys(session_id_);
     if (xbmc_jnienv()->ExceptionCheck())
     {
-      LogF(SSDERROR, "removeKeys has raised an exception");
+      LOG::LogF(SSDERROR, "removeKeys has raised an exception");
       xbmc_jnienv()->ExceptionClear();
     }
     media_drm_.GetMediaDrm()->closeSession(session_id_);
     if (xbmc_jnienv()->ExceptionCheck())
     {
-      LogF(SSDERROR, "closeSession has raised an exception");
+      LOG::LogF(SSDERROR, "closeSession has raised an exception");
       xbmc_jnienv()->ExceptionClear();
     }
   }
@@ -511,19 +493,19 @@ void WV_CencSingleSampleDecrypter::GetCapabilities(const uint8_t *keyid, uint32_
     caps.hdcpLimit = resolution_limit_; //No restriction
     caps.flags |= SSD_DECRYPTER::SSD_CAPS::SSD_SECURE_DECODER;
   }
-  LogF(SSDDEBUG, "hdcpLimit: %i", caps.hdcpLimit);
+  LOG::LogF(SSDDEBUG, "hdcpLimit: %i", caps.hdcpLimit);
 
   caps.hdcpVersion = 99;
 }
 
 bool WV_CencSingleSampleDecrypter::ProvisionRequest()
 {
-  Log(SSDWARNING, "Provision data request (DRM:%p)" , media_drm_.GetMediaDrm());
+  LOG::Log(SSDWARNING, "Provision data request (DRM:%p)" , media_drm_.GetMediaDrm());
 
   jni::CJNIMediaDrmProvisionRequest request = media_drm_.GetMediaDrm()->getProvisionRequest();
   if (xbmc_jnienv()->ExceptionCheck())
   {
-    LogF(SSDERROR, "getProvisionRequest has raised an exception");
+    LOG::LogF(SSDERROR, "getProvisionRequest has raised an exception");
     xbmc_jnienv()->ExceptionClear();
     return false;
   }
@@ -531,21 +513,21 @@ bool WV_CencSingleSampleDecrypter::ProvisionRequest()
   std::vector<char> provData = request.getData();
   std::string url = request.getDefaultUrl();
 
-  Log(SSDDEBUG, "Provision data size: %lu, url: %s", provData.size(), url.c_str());
+  LOG::Log(SSDDEBUG, "Provision data size: %lu, url: %s", provData.size(), url.c_str());
 
   std::string reqData("{\"signedRequest\":\"");
   reqData += std::string(provData.data(), provData.size());
   reqData += "\"}";
   reqData = BASE64::Encode(reqData);
 
-  void* file = host->CURLCreate(url.c_str());
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "Content-Type", "application/json");
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "seekable", "0");
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "postdata", reqData.c_str());
+  void* file = GLOBAL::Host->CURLCreate(url.c_str());
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "Content-Type", "application/json");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "seekable", "0");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "postdata", reqData.c_str());
 
-  if (!host->CURLOpen(file))
+  if (!GLOBAL::Host->CURLOpen(file))
   {
-    Log(SSDERROR, "Provisioning server returned failure");
+    LOG::Log(SSDERROR, "Provisioning server returned failure");
     return false;
   }
   provData.clear();
@@ -553,13 +535,13 @@ bool WV_CencSingleSampleDecrypter::ProvisionRequest()
   size_t nbRead;
 
   // read the file
-  while ((nbRead = host->ReadFile(file, buf, 8192)) > 0)
+  while ((nbRead = GLOBAL::Host->ReadFile(file, buf, 8192)) > 0)
     provData.insert(provData.end(), buf, buf + nbRead);
 
   media_drm_.GetMediaDrm()->provideProvisionResponse(provData);
   if (xbmc_jnienv()->ExceptionCheck())
   {
-    LogF(SSDERROR, "provideProvisionResponse has raised an exception");
+    LOG::LogF(SSDERROR, "provideProvisionResponse has raised an exception");
     xbmc_jnienv()->ExceptionClear();
     return false;
   }
@@ -576,17 +558,17 @@ bool WV_CencSingleSampleDecrypter::GetKeyRequest(std::vector<char>& keyRequestDa
     xbmc_jnienv()->ExceptionClear();
     if (!provisionRequested)
     {
-      Log(SSDWARNING, "Key request not successful - trying provisioning");
+      LOG::Log(SSDWARNING, "Key request not successful - trying provisioning");
       provisionRequested = true;
       return GetKeyRequest(keyRequestData);
     }
     else
-      LogF(SSDERROR, "Key request not successful");
+      LOG::LogF(SSDERROR, "Key request not successful");
     return false;
   }
 
   keyRequestData = keyRequest.getData();
-  Log(SSDDEBUG, "Key request successful size: %lu", keyRequestData.size());
+  LOG::Log(SSDDEBUG, "Key request successful size: %lu", keyRequestData.size());
   return true;
 }
 
@@ -614,7 +596,7 @@ bool WV_CencSingleSampleDecrypter::KeyUpdateRequest(bool waitKeys, bool skipSess
       KeyUpdateRequest(false, false);
     else
     {
-      LogF(SSDERROR, "Timeout waiting for EVENT_KEYS_REQUIRED!");
+      LOG::LogF(SSDERROR, "Timeout waiting for EVENT_KEYS_REQUIRED!");
       return false;
     }
   }
@@ -623,13 +605,13 @@ bool WV_CencSingleSampleDecrypter::KeyUpdateRequest(bool waitKeys, bool skipSess
   {
     int securityLevel = media_drm_.GetMediaDrm()->getSecurityLevel(session_id_);
     xbmc_jnienv()->ExceptionClear();
-    Log(SSDDEBUG, "Security level: %d", securityLevel);
+    LOG::Log(SSDDEBUG, "Security level: %d", securityLevel);
 
     std::map<std::string, std::string> keyStatus = media_drm_.GetMediaDrm()->queryKeyStatus(session_id_);
-    Log(SSDDEBUG, "Key status (%ld):", keyStatus.size());
+    LOG::Log(SSDDEBUG, "Key status (%ld):", keyStatus.size());
     for (auto const& ks : keyStatus)
     {
-      Log(SSDDEBUG, "-> %s -> %s", ks.first.c_str(), ks.second.c_str());
+      LOG::Log(SSDDEBUG, "-> %s -> %s", ks.first.c_str(), ks.second.c_str());
     }
   }
   return true;
@@ -641,13 +623,13 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
 
   if (blocks.size() != 4)
   {
-    LogF(SSDERROR, "Wrong \"|\" blocks in license URL. Four blocks (req | header | body | "
-      "response) are expected in license URL");
+    LOG::LogF(SSDERROR, "Wrong \"|\" blocks in license URL. Four blocks (req | header | body | "
+                        "response) are expected in license URL");
     return false;
   }
 
 #ifdef LOCLICENSE
-  std::string strDbg = host->GetProfilePath();
+  std::string strDbg = GLOBAL::Host->GetProfilePath();
   strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge";
   FILE*f = fopen(strDbg.c_str(), "wb");
   fwrite(keyRequestData.data(), 1, keyRequestData.size(), f);
@@ -666,7 +648,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
     }
     else
     {
-      Log(SSDERROR, "Unsupported License request template (command)");
+      LOG::Log(SSDERROR, "Unsupported License request template (command)");
       return false;
     }
   }
@@ -680,15 +662,15 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
     blocks[0].replace(insPos, 6, md5.HexDigest());
   }
 
-  void* file = host->CURLCreate(blocks[0].c_str());
+  void* file = GLOBAL::Host->CURLCreate(blocks[0].c_str());
 
   size_t nbRead;
   std::string response, resLimit, contentType;
   char buf[2048];
 
   //Set our std headers
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "acceptencoding", "gzip, deflate");
-  host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "seekable", "0");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "acceptencoding", "gzip, deflate");
+  GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "seekable", "0");
 
   //Process headers
   std::vector<std::string> headers{StringUtils::Split(blocks[1], '&')};
@@ -702,7 +684,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
       StringUtils::Trim(header[1]);
       value = STRING::URLDecode(header[1]);
     }
-    host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, header[0].c_str(), value.c_str());
+    GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, header[0].c_str(), value.c_str());
   }
 
   //Process body
@@ -760,7 +742,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
       }
       else
       {
-        Log(SSDERROR, "Unsupported License request template (body / ?{SSM})");
+        LOG::Log(SSDERROR, "Unsupported License request template (body / ?{SSM})");
         goto SSMFAIL;
       }
 
@@ -796,7 +778,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
         }
         else
         {
-          Log(SSDERROR, "Unsupported License request template (body / ?{SID})");
+          LOG::Log(SSDERROR, "Unsupported License request template (body / ?{SID})");
           goto SSMFAIL;
         }
       }
@@ -847,7 +829,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
       }
 
 #ifdef LOCLICENSE
-      std::string strDbg = host->GetProfilePath();
+      std::string strDbg = GLOBAL::Host->GetProfilePath();
       strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.postdata";
       FILE*f = fopen(strDbg.c_str(), "wb");
       fwrite(blocks[2].data(), 1, blocks[2].size(), f);
@@ -856,21 +838,21 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
     }
 
     std::string encData{BASE64::Encode(blocks[2])};
-    host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "postdata", encData.c_str());
+    GLOBAL::Host->CURLAddOption(file, SSD_HOST::OPTION_PROTOCOL, "postdata", encData.c_str());
   }
 
-  if (!host->CURLOpen(file))
+  if (!GLOBAL::Host->CURLOpen(file))
   {
-    Log(SSDERROR, "License server returned failure");
+    LOG::Log(SSDERROR, "License server returned failure");
     goto SSMFAIL;
   }
 
   // read the file
-  while ((nbRead = host->ReadFile(file, buf, 1024)) > 0)
+  while ((nbRead = GLOBAL::Host->ReadFile(file, buf, 1024)) > 0)
     response += std::string((const char*)buf, nbRead);
 
-  resLimit = host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "X-Limit-Video");
-  contentType = host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "Content-Type");
+  resLimit = GLOBAL::Host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "X-Limit-Video");
+  contentType = GLOBAL::Host->CURLGetProperty(file, SSD_HOST::CURLPROPERTY::PROPERTY_HEADER, "Content-Type");
 
   if (!resLimit.empty())
   {
@@ -879,17 +861,17 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
       resolution_limit_ = std::atoi(resLimit.data() + (posMax + 4));
   }
 
-  host->CloseFile(file);
+  GLOBAL::Host->CloseFile(file);
   file = 0;
 
   if (nbRead != 0)
   {
-    LogF(SSDERROR, "Could not read full SessionMessage response");
+    LOG::LogF(SSDERROR, "Could not read full SessionMessage response");
     goto SSMFAIL;
   }
   else if (response.empty())
   {
-    LogF(SSDERROR, "Empty SessionMessage response - invalid");
+    LOG::LogF(SSDERROR, "Empty SessionMessage response - invalid");
     goto SSMFAIL;
   }
 
@@ -900,7 +882,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
     std::string::size_type srcPosS(challenge.find("<LicenseNonce>"));
     if (dstPos != std::string::npos && srcPosS != std::string::npos)
     {
-      Log(SSDDEBUG, "Inserting <LicenseNonce>");
+      LOG::Log(SSDDEBUG, "Inserting <LicenseNonce>");
       std::string::size_type srcPosE(challenge.find("</LicenseNonce>", srcPosS));
       if (srcPosE != std::string::npos)
         response.insert(dstPos + 11, challenge.c_str() + srcPosS, srcPosE - srcPosS + 15);
@@ -908,7 +890,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
   }
 
 #ifdef LOCLICENSE
-  strDbg = host->GetProfilePath();
+  strDbg = GLOBAL::Host->GetProfilePath();
   strDbg += "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response";
   f = fopen(strDbg.c_str(), "wb");
   fwrite(response.data(), 1, response.size(), f);
@@ -971,7 +953,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
       }
       else
       {
-        LogF(SSDERROR, "Unable to find %s in JSON string", blocks[3].c_str() + 2);
+        LOG::LogF(SSDERROR, "Unable to find %s in JSON string", blocks[3].c_str() + 2);
         goto SSMFAIL;
       }
     }
@@ -986,13 +968,13 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
           response = std::string(response.c_str() + payloadPos, response.c_str() + response.size());
         else
         {
-          LogF(SSDERROR, "Unsupported HTTP payload data type definition");
+          LOG::LogF(SSDERROR, "Unsupported HTTP payload data type definition");
           goto SSMFAIL;
         }
       }
       else
       {
-        LogF(SSDERROR, "Unable to find HTTP payload in response");
+        LOG::LogF(SSDERROR, "Unable to find HTTP payload in response");
         goto SSMFAIL;
       }
     }
@@ -1002,7 +984,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
     }
     else
     {
-      LogF(SSDERROR, "Unsupported License request template (response)");
+      LOG::LogF(SSDERROR, "Unsupported License request template (response)");
       goto SSMFAIL;
     }
   }
@@ -1010,7 +992,7 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
   keySetId_ = media_drm_.GetMediaDrm()->provideKeyResponse(session_id_, std::vector<char>(response.data(), response.data() + response.size()));
   if (xbmc_jnienv()->ExceptionCheck())
   {
-    LogF(SSDERROR, "provideKeyResponse has raised an exception");
+    LOG::LogF(SSDERROR, "provideKeyResponse has raised an exception");
     xbmc_jnienv()->ExceptionClear();
     return false;
   }
@@ -1018,12 +1000,12 @@ bool WV_CencSingleSampleDecrypter::SendSessionMessage(const std::vector<char> &k
   if (keyRequestData.size() == 2)
    media_drm_.SaveServiceCertificate();
 
-  Log(SSDDEBUG, "License update successful");
+  LOG::Log(SSDDEBUG, "License update successful");
   return true;
 
 SSMFAIL:
   if (file)
-    host->CloseFile(file);
+    GLOBAL::Host->CloseFile(file);
   return false;
 }
 
@@ -1088,7 +1070,7 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
     if (fragInfo.nal_length_size_ > 4)
     {
-      LogF(SSDERROR, "Nalu length size > 4 not supported");
+      LOG::LogF(SSDERROR, "Nalu length size > 4 not supported");
       return AP4_ERROR_NOT_SUPPORTED;
     }
 
@@ -1169,10 +1151,10 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
           if (nalsize + fragInfo.nal_length_size_ + nalunitsum > summedBytes)
           {
-            LogF(SSDERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
-                 static_cast<unsigned int>(fragInfo.nal_length_size_),
-                 static_cast<unsigned int>(nalsize + fragInfo.nal_length_size_ + nalunitsum),
-                 summedBytes);
+            LOG::LogF(SSDERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
+                      static_cast<unsigned int>(fragInfo.nal_length_size_),
+                      static_cast<unsigned int>(nalsize + fragInfo.nal_length_size_ + nalunitsum),
+                      summedBytes);
             return AP4_ERROR_NOT_SUPPORTED;
           }
           nalunitsum = 0;
@@ -1182,8 +1164,8 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
       }
       if (packet_in != packet_in_e || subsample_count)
       {
-        LogF(SSDERROR, "NAL Unit definition incomplete (nls: %d) %d -> %u ",
-             fragInfo.nal_length_size_, (int)(packet_in_e - packet_in), subsample_count);
+        LOG::LogF(SSDERROR, "NAL Unit definition incomplete (nls: %d) %d -> %u ",
+                  fragInfo.nal_length_size_, (int)(packet_in_e - packet_in), subsample_count);
         return AP4_ERROR_NOT_SUPPORTED;
       }
       data_out.SetDataSize(data_out.GetDataSize() + data_in.GetDataSize() + configSize + (4 - fragInfo.nal_length_size_) * nalunitcount);
@@ -1211,17 +1193,17 @@ public:
   {
 #ifdef DRMTHREAD
     std::unique_lock<std::mutex> lk(jniMutex_);
-    jniWorker = new std::thread(&WVDecrypter::JNIThread, this, reinterpret_cast<JavaVM*>(host->GetJNIEnv()));
+    jniWorker = new std::thread(&WVDecrypter::JNIThread, this, reinterpret_cast<JavaVM*>(GLOBAL::Host->GetJNIEnv()));
     jniCondition_.wait(lk);
 #endif
     if (xbmc_jnienv()->ExceptionCheck())
     {
-      LogF(SSDERROR, "Failed to load MediaDrmOnEventListener");
+      LOG::LogF(SSDERROR, "Failed to load MediaDrmOnEventListener");
       xbmc_jnienv()->ExceptionDescribe();
       xbmc_jnienv()->ExceptionClear();
       return;
     }
-    Log(SSDDEBUG, "WVDecrypter constructed");
+    LOG::Log(SSDDEBUG, "WVDecrypter constructed");
   };
 
   ~WVDecrypter()
@@ -1235,7 +1217,7 @@ public:
     delete jniWorker;
 #endif
 
-    Log(SSDDEBUG, "WVDecrypter destructed");
+    LOG::Log(SSDDEBUG, "WVDecrypter destructed");
   };
 
 #ifdef DRMTHREAD
@@ -1245,13 +1227,13 @@ public:
     std::unique_lock<std::mutex> lk(jniMutex_);
     jniCondition_.wait(lk);
 
-    Log(SSDDEBUG, "JNI thread terminated");
+    LOG::Log(SSDDEBUG, "JNI thread terminated");
   }
 #endif
 
   virtual const char *SelectKeySytem(const char* keySystem) override
   {
-    Log(SSDDEBUG, "Key system request: %s", keySystem);
+    LOG::Log(SSDDEBUG, "Key system request: %s", keySystem);
     if (strcmp(keySystem, "com.widevine.alpha") == 0)
     {
       key_system_ = WIDEVINE;
@@ -1355,7 +1337,13 @@ public:
     return false;
   }
 
-  virtual SSD_DECODE_RETVAL DecodeVideo(void* hostInstance, SSD_SAMPLE *sample, SSD_PICTURE *picture) override
+  virtual SSD_DECODE_RETVAL DecryptAndDecodeVideo(void* hostInstance, SSD_SAMPLE* sample) override
+  {
+    return VC_ERROR;
+  }
+
+  virtual SSD_DECODE_RETVAL VideoFrameDataToPicture(void* hostInstance,
+                                                    SSD_PICTURE* picture) override
   {
     return VC_ERROR;
   }
@@ -1366,7 +1354,7 @@ public:
 
   virtual void onEvent(const jni::CJNIMediaDrm &mediaDrm, const std::vector<char> &sessionId, int event, int extra, const std::vector<char> &data) override
   {
-    LogF(SSDDEBUG, "%d arrived, #decrypter: %lu", event, decrypterList.size());
+    LOG::LogF(SSDDEBUG, "%d arrived, #decrypter: %lu", event, decrypterList.size());
     //we have only one DRM system running (cdmsession_) so there is no need to compare mediaDrm
     std::lock_guard<std::mutex> lk(decrypterListMutex);
     for (std::vector<WV_CencSingleSampleDecrypter*>::iterator b(decrypterList.begin()), e(decrypterList.end()); b != e; ++b)
@@ -1382,7 +1370,7 @@ public:
       }
       else
       {
-        LogF(SSDDEBUG, "Session does not match: sizes: %lu -> %lu", sessionId.size(), (*b)->GetSessionIdRaw().size());
+        LOG::LogF(SSDDEBUG, "Session does not match: sizes: %lu -> %lu", sessionId.size(), (*b)->GetSessionIdRaw().size());
       }
   }
 
@@ -1400,7 +1388,7 @@ private:
 
 JNIEnv* xbmc_jnienv()
 {
-  return static_cast<JNIEnv*>(host->GetJNIEnv());
+  return static_cast<JNIEnv*>(GLOBAL::Host->GetJNIEnv());
 }
 
 extern "C" {
@@ -1417,13 +1405,13 @@ extern "C" {
   {
     if (host_version != SSD_HOST::version)
       return nullptr;
-    host = h;
+    
+    GLOBAL::Host = h;
 
+    CJNIBase::SetSDKVersion(GLOBAL::Host->GetSDKVersion());
+    CJNIBase::SetBaseClassName(GLOBAL::Host->GetClassName());
 
-    CJNIBase::SetSDKVersion(host->GetSDKVersion());
-    CJNIBase::SetBaseClassName(host->GetClassName());
-
-    Log(SSDDEBUG, "WVDecrypter JNI, SDK version: %d, class: %s", CJNIBase::GetSDKVersion(),
+    LOG::Log(SSDDEBUG, "WVDecrypter JNI, SDK version: %d, class: %s", CJNIBase::GetSDKVersion(),
         CJNIBase::GetBaseClassName().c_str());
 
     const char *apkEnv = getenv("XBMC_ANDROID_APK");
@@ -1438,7 +1426,7 @@ extern "C" {
     classLoader = new CJNIClassLoader(apkPath);
     if (xbmc_jnienv()->ExceptionCheck())
     {
-      LogF(SSDERROR, "Failed to create JNI::ClassLoader");
+      LOG::LogF(SSDERROR, "Failed to create JNI::ClassLoader");
       xbmc_jnienv()->ExceptionDescribe();
       xbmc_jnienv()->ExceptionClear();
 


### PR DESCRIPTION
`OpenVideoDecoder` is called each time that the stream quality change and currently force call `InitializeVideoDecoder` in the cdm during playback, at least with N@tflix this cause cdm errors when the stream quality is switched during the playback, so freeze the playback

A possible solution is call `DeinitializeDecoder` before recall `InitializeVideoDecoder`,
but as is implemented now cause a delay (image freezed for some secs),

from a search on chromium sources seem that they allow call `InitializeVideoDecoder`
during playback, but only in the situation that the codec change,
trying to do this i can see that the playback now works when stream quality change,
we will see if someone report a regression but it should not

Since i compared the sources, i took the opportunity to do some cleaning, and to make some parts more similar to chromium conterpart. Changes:
- `DecodeVideo` method is now splitted in to: `DecryptAndDecodeVideo`, `VideoFrameDataToPicture`
- Moved `host` global variable to new Helper.h, to allow have access to log methods without being restricted by each class (in a future prospective to have the main/ssd projects merged)
- Add cdm_type_conversions.h (adapted from chromium sources) to contains all cdm data type conversions
- Removed unnecessary reallocations and member variables in `WV_CencSingleSampleDecrypter` in favour of simple vectors
- Implemented all fields in `SSD_SAMPLE` struct, to have full `DEMUX_PACKET` crypto data

The only functional change in the cleanup is that the `cdm::InputBuffer_2 cdm_in;` defined in to previous `DecodeVideo` method
is now constructed by using all info of SSD_SAMPLE (DEMUX_PACKET) data, instead of take some info from members variables like m_CryptBlocks, m_SkipBlocks, m_EncryptionScheme

~WIP: not done android side cleanups~