### PR TITLE
[utils][base64] Improved decoding

### DIFF
--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -16,13 +16,13 @@ namespace UTILS
 namespace BASE64
 {
 
-void Encode(const char* input, size_t length, std::string& output);
-std::string Encode(const unsigned char* input, size_t length);
-std::string Encode(const char* input, size_t length);
+void Encode(const char* input, const size_t length, std::string& output);
+std::string Encode(const unsigned char* input, const size_t length);
+std::string Encode(const char* input, const size_t length);
 void Encode(const std::string& input, std::string& output);
 std::string Encode(const std::string& input);
-void Decode(const char* input, size_t length, std::string& output);
-std::string Decode(const char* input, size_t length);
+void Decode(const char* input, const size_t length, std::string& output);
+std::string Decode(const char* input, const size_t length);
 void Decode(std::string_view input, std::string& output);
 std::string Decode(std::string_view input);
 

--- a/wvdecrypter/CMakeLists.txt
+++ b/wvdecrypter/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
 endif()
 
 set(BENTOUSESTCFS 1)
+add_definitions(-DINPUTSTREAM_SSD_BUILD)
 
 if(CORE_SYSTEM_NAME STREQUAL android)
   subdirs ( jni )


### PR DESCRIPTION
Improved base 64 decode method,
compared to the method implemented in kodi core this has been backported from cpython
which performs more secure decoding checks
and also automatically filters out characters that do not fit into the table of 64 ascii
so allow to decoding malformed base64 string case like #1003
