### PR TITLE
Fix use after free crash from readsample thread

### DIFF
--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -27,6 +27,8 @@ void CStream::Reset()
 {
   if (m_isEnabled)
   {
+    if (m_streamReader)
+      m_streamReader->WaitReadSampleAsyncComplete();
     m_streamReader.reset();
     m_streamFile.reset();
     m_adByteStream.reset();


### PR DESCRIPTION
fixes #1028 (see for full explanation) - thanks @basilgello 

Decided to go with altering the `Reset` function to wait for the async readsample thread to finish. Changing the call in main.cpp from `stream->Reset()` to `stream->Disable()` although solving the problem seems the wrong way to do it (at the very least from how the functions are named) - we only want to reset the stream, not fully disable.

@basilgello are you able to verify this fixes the issue for you? (cannot reproduce here)