### PR TITLE
[Cleanup] Print stream id in log when seeks

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1273,8 +1273,11 @@ bool CSession::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
         {
           double destTime{static_cast<double>(PTSToElapsed(streamReader->PTS())) /
                           STREAM_TIME_BASE};
-          LOG::Log(LOGINFO, "Seek time (%0.1lf) for stream: %d continues at %0.1lf (PTS: %llu)",
-                   seekTime, stream->m_info.GetPhysicalIndex(), destTime, streamReader->PTS());
+          LOG::Log(LOGINFO,
+                   "Seek time %0.1lf for stream: %u (physical index %u) continues at %0.1lf "
+                   "(PTS: %llu)",
+                   seekTime, streamReader->GetStreamId(), stream->m_info.GetPhysicalIndex(),
+                   destTime, streamReader->PTS());
           if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
           {
             seekTime = destTime;


### PR DESCRIPTION
Just add the stream id in log when seeks
so make more easy identify the appropriate stream

before:
```
2022-09-18 10:52:15.654 T:15646    INFO <general>: AddOnLog: inputstream.adaptive: Seek time (290.7) for stream: 393217 continues at 294.8 (PTS: 294919625)
2022-09-18 10:52:15.723 T:15646    INFO <general>: AddOnLog: inputstream.adaptive: Seek time (294.8) for stream: 327682 continues at 294.7 (PTS: 294912000)
2022-09-18 10:52:15.723 T:15646    INFO <general>: AddOnLog: inputstream.adaptive: Seek time (294.8) for stream: 65556 continues at 294.8 (PTS: 294919625)
```

after:
```
2022-09-18 11:39:15.683 T:13204    INFO <general>: AddOnLog: inputstream.adaptive: Seek time 709.0 for stream: 1001 (physical index 458753) continues at 714.1 (PTS: 714125000)
2022-09-18 11:39:15.902 T:13204    INFO <general>: AddOnLog: inputstream.adaptive: Seek time 714.1 for stream: 1002 (physical index 327682) continues at 714.1 (PTS: 714112000)
2022-09-18 11:39:15.902 T:13204    INFO <general>: AddOnLog: inputstream.adaptive: Seek time 714.1 for stream: 1020 (physical index 65556) continues at 714.1 (PTS: 714125000)
```
