### PR TITLE
[DASHTree] Fix out ouf bounds vector access in DASHTree::RefreshLiveSegments

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1842,7 +1842,14 @@ void DASHTree::RefreshLiveSegments()
                         if (segment.range_begin_ == search_pts)
                           break;
                         else if (segment.range_begin_ > search_pts)
+                        {
+                          if (&repr->segments_.data.front() == &segment)
+                          {
+                            --repr->startNumber_;
+                            break;
+                          }
                           misaligned = search_pts - (&segment - 1)->range_begin_;
+                        }
                         else
                           ++repr->startNumber_;
                       }


### PR DESCRIPTION
Fixes following crash:

```
Core was generated by `/usr/lib/kodi/kodi.bin --standalone'. Program terminated with signal SIGSEGV, Segmentation fault.
1845                              misaligned = search_pts - (&segment - 1)->range_begin_;
```

When ```segment.range_begin_ > search_pts``` is true in first loop iteration we access vector element before its buffer.

I'm able to see this crash once in a while. If someone has a better way to fix it I would be glad. Full gdb output:
```
           PID: 5571 (kodi.bin)
           UID: 976 (kodi)
           GID: 976 (kodi)
        Signal: 11 (SEGV)
     Timestamp: Wed 2022-09-21 17:28:22 CEST (44min ago)
  Command Line: /usr/lib/kodi/kodi.bin --standalone
    Executable: /usr/lib/kodi/kodi.bin
 Control Group: /user.slice/user-976.slice/session-28.scope
          Unit: session-28.scope
         Slice: user-976.slice
       Session: 28
     Owner UID: 976 (kodi)
       Boot ID: bd260f7fbdec42188dc02b80ba565480
    Machine ID: 819d20fab4294d6686a522c17a697df3
      Hostname: alarmpi
       Storage: /var/lib/systemd/coredump/core.kodi\x2ebin.976.bd260f7fbdec42188dc02b80ba565480.5571.1663774102000000.zst (present)
     Disk Size: 48.0M
       Message: Process 5571 (kodi.bin) of user 976 dumped core.
                
                Module /var/lib/kodi/.kodi/cdm/libwidevinecdm.so with build-id 198c24420532efa5d52062bad8a2d1cff06ae364
                Module linux-vdso.so.1 with build-id 561dc4829e5dd19d9eec22b8858caaa380b92584
                Module librt.so.1 with build-id 8330feb9780d34c51dc6429c5e1b168cb635ed8b
                Module libssd_wv.so with build-id adb027291c132ab4e30c5c7cd80e36bbb2df77bb
                Module inputstream.adaptive.so.20.3.0 with build-id 1877e8232b4e8486494171d9862f8cb1a38de9b4
                Module _posixsubprocess.cpython-310-arm-linux-gnueabihf.so with build-id 734a93ba0eb8fc8679f234b005318f4afefe74fb
                Module fcntl.cpython-310-arm-linux-gnueabihf.so with build-id e440fe2d5c0ee941bfd1fbbea77aa81132f36d05
                Module libnss_resolve.so.2 with build-id 72f8357b56e2478578d18f5b9de48c4687add1da
                Module libnss_mymachines.so.2 with build-id cbf3c01af04a0c039408f966a90d7620d32d210a
                Module unicodedata.cpython-310-arm-linux-gnueabihf.so with build-id 956187e5aa052d47efe8dc927594533b594469af
                Module _lzma.cpython-310-arm-linux-gnueabihf.so with build-id bd3c8416672b27eaec86ef91b80f621953a89000
                Module _bz2.cpython-310-arm-linux-gnueabihf.so with build-id be46ca344b2bf6cd1bfbe402791c9e9e4aace5e1
                Module _speedups.cpython-310-arm-linux-gnueabihf.so with build-id fa0d15fea351a4f8eed1ec05fc6a5dd5b4f400e9
                Module _contextvars.cpython-310-arm-linux-gnueabihf.so with build-id 019b0a9cc5018f10005f97bee9e20b9237bd3bb2
                Module zlib.cpython-310-arm-linux-gnueabihf.so with build-id 6f5a044a3e8eadf8a55babd7e748813bdba66bf4
                Module _queue.cpython-310-arm-linux-gnueabihf.so with build-id 5e6af044a1b051af79f018ea0b314c6347d4744e
                Module _heapq.cpython-310-arm-linux-gnueabihf.so with build-id 84c3415b123781d5c586e1bba761f6106eb24efd
                Module _ssl.cpython-310-arm-linux-gnueabihf.so with build-id a2e2ece7d26b3ed0224ea7eea3429272c992a30d
                Module array.cpython-310-arm-linux-gnueabihf.so with build-id 9245ccee45dded3288458a5f48414e385906433f
                Module select.cpython-310-arm-linux-gnueabihf.so with build-id 57d170c8a7bd7ac236dd3c294d7ab229362d3cec
                Module _socket.cpython-310-arm-linux-gnueabihf.so with build-id fab11c50579a6604b3a947ccfbf0cf7e966c40a8
                Module _sha512.cpython-310-arm-linux-gnueabihf.so with build-id 095012bc81698fbd93dedd1873cea7bea539a1a4
                Module _random.cpython-310-arm-linux-gnueabihf.so with build-id 4cbe6d492a16b9ead80dc457d29f54e10df11405
                Module _bisect.cpython-310-arm-linux-gnueabihf.so with build-id c30b603f88f6811c1ec763a4c2e66b40899748d4
                Module _json.cpython-310-arm-linux-gnueabihf.so with build-id 736457967e22fecf034447c234beca548178b956
                Module _blake2.cpython-310-arm-linux-gnueabihf.so with build-id a88debeadb896dd5177730575bf00f0c40b18d48
                Module _hashlib.cpython-310-arm-linux-gnueabihf.so with build-id 11edf437a9ab622c03b8e0fb47b4a51af2437058
                Module binascii.cpython-310-arm-linux-gnueabihf.so with build-id 6637cf296dfc0a4991fac2d8a9eae49883d75b94
                Module _struct.cpython-310-arm-linux-gnueabihf.so with build-id c28301c3467e2132be3bdd6f19b186d74d9bbd3e
                Module _datetime.cpython-310-arm-linux-gnueabihf.so with build-id b5d6bb4209925ea3e04123fe49cb70b1be9bba78
                Module math.cpython-310-arm-linux-gnueabihf.so with build-id 194e3e72578818aabcfb0c475329e3c29bb9a2cf
                Module libpugixml.so.1 with build-id 65e6dc499db9a37d9c8f63eb7c2bc31ad6764245
                Module pvr.iptvsimple.so.20.6.0 with build-id e89c5b5a4be2778608cd63724d0d75ebe80b24e3
                Module libncursesw.so.6 with build-id c2cf02aec7a84fba14f24713a5da197c9e7fb763
                Module libedit.so.0 with build-id a8fbcee9c4d054a18ea4ad6e5ff0c33dfba98829
                Module libvulkan.so.1 with build-id 7ad2d0c4d66ba4ff1cc39a30108f6e42d8bbe39a
                Module libdrm_nouveau.so.2 with build-id d209ecd6f2dbd03cb37995f7e20b997a3b09afe5
                Module libdrm_amdgpu.so.1 with build-id 32c3f312d49b9c798a23a7d947da24aba22451c1
                Module libelf.so.1 with build-id 2cac962173c8bacf1b0b35fffaf5b590e0420e48
                Module libdrm_radeon.so.1 with build-id aee8efec812d79b60c2ba927c95fdf246bc4c6eb
                Module libsensors.so.5 with build-id c57d03894fe94e2e7eb0a905d8ff7433fb914dca
                Module libLLVM-14.so with build-id 78abcbf8c118aa8889463e225675aa49dd60d1a9
                Module vc4_dri.so with build-id 747c1c3f99e73ed7b5e2323ad2618fff1ad8230e
                Module libxshmfence.so.1 with build-id 24702e75a05bb77c3358a4411ed5a4ee9939084d
                Module libxcb-sync.so.1 with build-id cd76ee89dfa46244da2f288c4524beed0fc456ba
                Module libxcb-present.so.0 with build-id 4ba1fa96091e521f5dcaa0f16d87c71b3ab5cf5f
                Module libxcb-dri3.so.0 with build-id a1f28402c84fc4486ca16324a6ea38e842a6cb48
                Module libwayland-client.so.0 with build-id 8b14f23b3ac023606cadc37c7cdd2eedfd4c7a00
                Module libxcb-xfixes.so.0 with build-id 344dd1c0cc0168da6b4c30abb143d9355f6721c6
                Module libxcb-dri2.so.0 with build-id 44199d7bc8f2892988bf93c35700a39cea7f18e6
                Module libX11-xcb.so.1 with build-id 46420f5d1682e6ebcee99f28d3fef3305999b2b5
                Module libglapi.so.0 with build-id 9493fd2f268c593d34a21b697aa0faf9cbdf1acc
                Module libEGL_mesa.so.0 with build-id 9af8838078ffd25f94df59e03586f77a0ced40d1
                Module UTF-32.so with build-id ec9dc3287ce1b68b64dfa36b0d1ad2987cbf1d46
                Module libflag-mapping-samba4.so with build-id a9beb3905ef507e39ec494eb9b74bcb0f08687de
                Module libndr-krb5pac.so.0 with build-id d3456e03dc0533a5f0ea09c8c45b159c405526ae
                Module libcli-ldap-common-samba4.so with build-id 5cabea8138da6c55a5e0582ef1fe92e5aa492d2e
                Module libclidns-samba4.so with build-id eb95095227f310b1a007618a9ce31b496e2b79c6
                Module libhcrypto-samba4.so with build-id 8357e711f659f08419bb29b58f13f78a4fe8b4bb
                Module libwind-samba4.so with build-id 7a14c4d9f7c93b05825bb1f49649b298a066b3ce
                Module libheimbase-samba4.so with build-id f61f03f2422cb37dff497d66291f4da0747d5fa0
                Module libhx509-samba4.so with build-id 7c102fe17b583bf84817ccd6cf4cfebcb32de5b9
                Module libroken-samba4.so with build-id 50ef93ba9a8b3c3c4ff217f86e1f3c8da919b534
                Module libsasl2.so.3 with build-id 3ddb4e70a14e67ff93007f4199d60d02dbde1d01
                Module libmsghdr-samba4.so with build-id 47577e4d75fd9899a9e97c6d89a888074d294536
                Module libjansson.so.4 with build-id a1242a42cfefbd750751a7f6080eebaeec69e155
                Module libMESSAGING-SEND-samba4.so with build-id 0fa801d61955f37f25cd307dd5d7403a83099e3e
                Module libsamdb.so.0 with build-id 36789b4773883b3ab17c492333344869c5790194
                Module libwbclient.so.0 with build-id 986e569e8e6c32945ad4b67f1267709178459b4f
                Module libsamba-modules-samba4.so with build-id 361563b2edbfc82cfcca8ac145efe1c52b34a784
                Module libasn1-samba4.so with build-id e33819a412ad7a934948f1ff1fb9dc3ab3983549
                Module libogg.so.0 with build-id 5259a713a506a7fa60e99086bf1d208c0c7ee9d8
                Module libvorbis.so.0 with build-id 7704f90d1573e7e9e613055f53bb06415ae01a3e
                Module libopus.so.0 with build-id 3531740befbd4f7fee6a927894ac4eec4c065526
                Module libFLAC.so.12 with build-id 87dcce40dda00855949456f8b2a4452481095668
                Module libvorbisenc.so.2 with build-id e41f82e798a995e1a99d5fdc6c34564bcd6730cc
                Module libgpg-error.so.0 with build-id 0c8e226b5d9baa9b73cac8ddb7309120b31cb2b5
                Module libgobject-2.0.so.0 with build-id a28cd38106fe3fc3b770a22ab7e6749b8a49559e
                Module libgudev-1.0.so.0 with build-id 568dd91f4e3921711c021fbd076b38ce771b29bd
                Module libffi.so.8 with build-id 218e198d7c786e474efd2d9b745615880c5120df
                Module libXdmcp.so.6 with build-id e8f38d32dd6142cd1c2e586948ac0aa7b4776713
                Module libXau.so.6 with build-id e351a4e95642478cb2cf488270c975bde9d4f6c6
                Module libbrotlicommon.so.1 with build-id 16a2209565ae10def8e4faecb229b40270d9d761
                Module libresolv.so.2 with build-id af1c55781b98221fc6d49b1e7392eae5c9ce6a8a
                Module libkeyutils.so.1 with build-id 80652a048f08ee7d77823d362ad45290e05282a5
                Module libkrb5support.so.0 with build-id 3491ec159e0cccbd43d914449eb4d9802efddd1a
                Module libcom_err.so.2 with build-id 4d54d505572d42616be78281fd3a55aa198e8a08
                Module libk5crypto.so.3 with build-id 746de6643b9cb1e32cf93521eff9a05cf1478f58
                Module libkrb5.so.3 with build-id 6b0bf73ac2835c76c382e551327be8b6d5f72784
                Module libicudata.so.71 with build-id 6cc8de6e324af28249cb0bc1b940163d85fcdca2
                Module libmd.so.0 with build-id 32950fc341df8a38414a38a7f2f8b33af478d280
                Module libldb.so.2 with build-id 2b54020e1f80eff5ea09ba2539fe0ac01f99c059
                Module libsamdb-common-samba4.so with build-id 73248ef75858498a2c8169dfaa5748b9caf2f1af
                Module libldbsamba-samba4.so with build-id 628f2fec6cc1ad882740845851a73fca2b105114
                Module libcli-nbt-samba4.so with build-id 04e495fb25afbdafa9c49c6f962b82106bdd7d05
                Module libauthkrb5-samba4.so with build-id b894f9789936022b4e7c2d18c7db1852c7720d54
                Module libcli-cldap-samba4.so with build-id 248ed6de1963d130abac6a7b37fdfe46200d3737
                Module libgssapi-samba4.so with build-id e5285117bf755f15f7259adee303e907f7bdceb9
                Module libaddns-samba4.so with build-id be37919fea2fb28b287b7a65ba2d7cbec3967089
                Module libndr-nbt.so.0 with build-id 44b3fa17eb9029f47fc6afd015d7decf60205c57
                Module libkrb5-samba4.so with build-id 7da9274637106f872d7880e1aa0afbfa05a9be2b
                Module libicui18n.so.71 with build-id 8e566423600e0cc81437cfedd797511b0af7e536
                Module liblber.so.2 with build-id da7da18ba0c35735e346220546d7758c4fd016b0
                Module libtdb.so.1 with build-id cb478106c13f7dbeaec6b4266eca014878e29779
                Module libldap.so.2 with build-id 75bb62829e20d1e9c205eea2760aeeb25eac201d
                Module libserver-role-samba4.so with build-id c2d88931359ad8971490b786de376e5d353d8a24
                Module libutil-setid-samba4.so with build-id 226c5a53d9d3cca9bf69cc708969cb0289078f2b
                Module libtdb-wrap-samba4.so with build-id 960cabf346946ef52de57ccbcda007b6077e931e
                Module libtime-basic-samba4.so with build-id 3b047897efa7e4e0552e74ecec82ae5b8de5b63c
                Module libsamba-cluster-support-samba4.so with build-id 7307354ed9808e7051c15df52fc4a9281e5e6b7b
                Module libinterfaces-samba4.so with build-id a0ef7a16b89ea969b6b14294e7daf66b7c625e17
                Module libmessages-dgm-samba4.so with build-id 5ebd32cd387fafe9678a7e3ba0d58581b96c7acd
                Module libiov-buf-samba4.so with build-id 5e314619f9d6edc635c2597322f96a928bc26e91
                Module libtalloc-report-printf-samba4.so with build-id 57677dcace65bafc37c717d736ee26ff492c1841
                Module libserver-id-db-samba4.so with build-id c4cd908d6ded1544aae4c925c150b4410638a0e7
                Module libsys-rw-samba4.so with build-id 414002484b2a6148199c6dd663927a9153eefd52
                Module libmessages-util-samba4.so with build-id 052f651b303391dc41da279a9ce0d878420c6532
                Module libutil-reg-samba4.so with build-id e5a1fc28d47c80105e2466746c12cbbfa217adc4
                Module libsmbd-shim-samba4.so with build-id 29dfca6fe6efc68ef9c5d62d272010fe15c75aec
                Module libcommon-auth-samba4.so with build-id 551c7733750f89a1cdc796b8877937fd75d44b62
                Module libsocket-blocking-samba4.so with build-id 34bf5cca4dcfee55034ebdfb744b552f7e6e5236
                Module libutil-tdb-samba4.so with build-id 133535edc858788b26b9d1c311574c1eb9470000
                Module libnpa-tstream-samba4.so with build-id c379a805e8f12169406a26cf740238426e3cee8d
                Module libsamba-sockets-samba4.so with build-id d35abacfde4d1f7729851d9e7cfb8e9b65b63740
                Module libndr-samba-samba4.so with build-id 0ea7b80ccc01b9bba2100b0f354925040ee38bc3
                Module libdbwrap-samba4.so with build-id e3728dc8d2e07200f4a7283730eba7ba4288fe44
                Module libdcerpc-binding.so.0 with build-id b233d3a4699430fbd8b57ecbb874a316c9a9fb24
                Module libsmb-transport-samba4.so with build-id f7b2e00a7f395c1de7aca07337214471178ef67c
                Module libcom-err-samba4.so with build-id ff56fe8f4a79ea3653e896d44232f3acf287b403
                Module libcliauth-samba4.so with build-id a654f507ca72a83d5ff59bbca39ec0b0e0e7f301
                Module libgensec-samba4.so with build-id fd1555b57820e63ec143280ede91dd128a26d11b
                Module libCHARSET3-samba4.so with build-id ad9696ae54ed89c8b6b3c8ca3224570e71b87534
                Module libkrb5samba-samba4.so with build-id fb42b5a0509ed19e53de5daebe96eb6290f21ede
                Module libasn1util-samba4.so with build-id 2089dce5b85a56b4ee3f080371edacc5c43bd6ce
                Module libasyncns.so.0 with build-id c41631561af6594aa143d49925b628f1d00a792c
                Module libsndfile.so.1 with build-id c0b78e3b05702f7ac7b068c4c637c9dae6322138
                Module liblz4.so.1 with build-id 707207a9dba243bdea7324c5cf0de3f3160b0cf4
                Module libgcrypt.so.20 with build-id 3c9050e11f3f585c5498b216e3de3d4c28d39342
                Module libgmp.so.10 with build-id 7bd5f887dd5d49d177b8784d891a6e9f0679dec8
                Module libhogweed.so.6 with build-id 654027ba1187af156053d9d50cb4cbf0384159dc
                Module libnettle.so.8 with build-id f9d88c6731e08ea6e5959811cf6504d71e6296c2
                Module libtasn1.so.6 with build-id 2c545b3a84f2b27da87f20263d541db4f80c2a0f
                Module libunistring.so.2 with build-id d18f0340a8d5384f752839d7b8eadba68f347e00
                Module libbrotlienc.so.1 with build-id 98d06fcf9bc122e42959b0e3d7e6c482e1802b50
                Module libp11-kit.so.0 with build-id 8166838a069281c28c7f9434827c3f73d45d5451
                Module libwacom.so.9 with build-id 49747e795abcad4ec1ff6dfaf671a72dd408c445
                Module libevdev.so.2 with build-id 4737bc6ef28d2ca349eec934852229735df97bf6
                Module libmtdev.so.1 with build-id 947f6e3db087a866b4a9f5bd407ad18fc8137fcf
                Module libexpat.so.1 with build-id 4e420fff0e69acfadf231bfd4d225e342f71e701
                Module libwayland-server.so.0 with build-id 2ae002a049e5f5ec975a213a4edecd84d5301663
                Module libXrender.so.1 with build-id a4585c3fb6575b0b2fc5870da455bd6d1eb68db4
                Module libxcb.so.1 with build-id 0d7ed3bf7c43662e7a2b16eec9bc85f94c09a61b
                Module libGLdispatch.so.0 with build-id 6aa7600f112cbf6d0b80264094c60f1942212736
                Module libglib-2.0.so.0 with build-id 2d5c89eb80a24d91e817bea2ed1fd8538b439336
                Module libgraphite2.so.3 with build-id d25b6cf53d38f0dd7f6b72adef24c7aaf660f271
                Module libpng16.so.16 with build-id d8ec93839825909a2d99bbf971a6465752e46105
                Module libbrotlidec.so.1 with build-id 08c1a3d81610ff219a792a8f4b6ebba7c67cfde9
                Module libzstd.so.1 with build-id 868d3235e7ad5dd60b12362498357931a40ac1eb
                Module libgssapi_krb5.so.2 with build-id 10f3114c7a7946178a56bc45960b24ad8a2171e0
                Module libssl.so.1.1 with build-id a49a376c1b29176381cecac9144568d3a1efe951
                Module libpsl.so.5 with build-id da80004bc52ca94ad9b49cd16db35e64611831b0
                Module libssh2.so.1 with build-id 78b481eb35c6f89b4c9a3a5d92c3ea6fa4378f42
                Module libidn2.so.0 with build-id 89bf1a0a4458a7b476027062b6ac3444388c38e9
                Module libnghttp2.so.14 with build-id cbd9d1da252e03ed75004c9071281c98ddb5544b
                Module libicuuc.so.71 with build-id c02bc25bb4f37532ef14d81d869ad5c5c07d324a
                Module libbsd.so.0 with build-id 6e2e941c50e55806cb865ced72e3ed8a4047b983
                Module libtalloc.so.2 with build-id b918b7703146a1034fefe55d73bc07ca5869e6cb
                Module libtevent.so.0 with build-id 8eab0e85d8942a6185038a96f79b4260f2b19590
                Module libsecrets3-samba4.so with build-id 48e392924d2b4a78e943540096f04588df564d72
                Module libgenrand-samba4.so with build-id 8f37956e646870bce2a25929d320c0c702f12fc8
                Module libsamba-debug-samba4.so with build-id 420b9148e8f46f1c21ee9c493acd6f282a77573f
                Module libsamba3-util-samba4.so with build-id 431cfbf771fa0e5a08be0dba34d6821b0bb3a7e4
                Module libndr-standard.so.0 with build-id 8cf9647b057329b7d0fcfbafb19dd47b450dddd7
                Module libsamba-hostconfig.so.0 with build-id 24ad880ee58bf5397c0c0a16e3f0e1f920b27dca
                Module libtevent-util.so.0 with build-id 590f7df1d08a4602e20391c7233e40264a402ac4
                Module libsamba-credentials.so.1 with build-id 4ccb752684568184fcd84bed427f2702d9bf9b6c
                Module libdcerpc-samba-samba4.so with build-id bf4b73d3092fb3ef89169f9182ac2b4be49f3fa8
                Module libcli-smb-common-samba4.so with build-id 975343343817af66f5bfaf827e116a00fc952027
                Module libgse-samba4.so with build-id eb8a0d883c0a579d31bc313dde39e7bc858e015d
                Module libsamba-errors.so.1 with build-id d0a681a3f000ca8a3c56b80ef526c64ddb67b2c9
                Module libreplace-samba4.so with build-id 2de36bf6d6bd2df04458bbe3fd3b7f37dd17f1fc
                Module libsamba-util.so.0 with build-id 75f3a2fc90b58dca3c2594b648032496e453a48e
                Module libsmbconf.so.0 with build-id 089d83bae38b8694ec2f04f4215ed7fe32f3c01f
                Module libmsrpc3-samba4.so with build-id ae35724243708efdd722f1174a651ec06c8bf377
                Module libsamba-security-samba4.so with build-id 57b063e43fbeb7167728f6447ab1f478663f9825
                Module liblibcli-lsa3-samba4.so with build-id 9891baa715e697a25171ff865e786c34a2a9487e
                Module liblibsmb-samba4.so with build-id d325c486c324d8a8334fdd0840b64fe128f5ddd3
                Module libndr.so.3 with build-id 0dd3cb68c710d4ce282e5ea7ad967806901c3689
                Module libpulsecommon-16.1.so with build-id 7f25bc66ec97edcfb524e3a6d429b7378110598d
                Module libsystemd.so.0 with build-id 4170c11650ed7670389fa743925d676a43f8e0c2
                Module libp8-platform.so.2 with build-id 8a4b2c8392d145b3e4faf7d4e8b44d575434b6c9
                Module libfontconfig.so.1 with build-id 26f16498b9ec83178227cd13fed9fbe8c745884f
                Module libpthread.so.0 with build-id 689f7989d96e0836248bcb8cf0a87f5e81a30f3f
                Module libdl.so.2 with build-id 45929678fb99d6c160914952b8445dd8abba948d
                Module libgcc_s.so.1 with build-id 5dfba9be74e9275dc2b88197d5e4a7eb31caa30b
                Module libstdc++.so.6 with build-id 175c218d382097ad38dbbaf2ab615dd39f641b1b
                Module libgnutls.so.30 with build-id e48b64ac1c1d9075bf1c69029faaf60a5f455ba0
                Module libbz2.so.1.0 with build-id d45bd23a4ae9b7fd2b33c17c6a8a2df600003228
                Module libm.so.6 with build-id a5c1c7401511763e6ff32da3aa25b82eb2283f7f
                Module liblzma.so.5 with build-id f5dc6b46762ea3bd5c7b91124cd1fb0e4135989a
                Module ld-linux-armhf.so.3 with build-id 55325894fcaa182c135406ddae4b0250796a5394
                Module libc.so.6 with build-id 9db8016ba0f0dca00188137249ded790ac769fd8
                Module libshairplay.so.0 with build-id b8a02639d4a9c7b1a7034946d2d929a4dd88190b
                Module libmariadb.so.3 with build-id 3c0bf54df30e59056d6380060e0d6e766bf7f2d3
                Module libxkbcommon.so.0 with build-id ce82dbf28f7416c336a60adafcb3d52955c6da10
                Module libinput.so.10 with build-id 7d0101f14b0daa5b95a7a273d6023192d5d52921
                Module libgbm.so.1 with build-id cb8561810d1fbd53431563a8b5f07fb7d7caa873
                Module libGLESv2.so.2 with build-id 161d2ae5a013423bf5babbacf0d3267910723faa
                Module libdrm.so.2 with build-id a5694da60db6372269840857c5814e1d58b1eb71
                Module libXrandr.so.2 with build-id 77712ff4a800d0d232c941b56c4d42dfbe1b2a9d
                Module libXext.so.6 with build-id e35d9b3968884ce14b7e021bd2b9e7332ea0231c
                Module libX11.so.6 with build-id 64426d28dd63f6b613f9ce282ccdf1a7c19bd1a7
                Module libEGL.so.1 with build-id 5fe7b0aafafda0084508d9179bbe12bd0e227125
                Module libz.so.1 with build-id f5e8b23636191e87948dc2c6f3c5fc2f243d9b08
                Module libtinyxml.so.0 with build-id 0b8d17e7c46726667a5d27005f7a8d7b6a9c79a4
                Module libtag.so.1 with build-id ca2ea3979a4e7eba8076bae8fe2d51d080d16d55
                Module libsqlite3.so.0 with build-id a1aa8920d08fa6698bf378863d4091987008af55
                Module libpcre.so.1 with build-id 5167447f2406db9d05faf3a2c1dfac34ec900d15
                Module libpcrecpp.so.0 with build-id a123544566a170439fd218ea3288b0bb7b50f583
                Module libcrypto.so.1.1 with build-id 5261d99d530924d3ff0ffdc8b67d1caece137c63
                Module liblzo2.so.2 with build-id 7f1c7e05ed2068528e09d77ace5e6da3f93ecc76
                Module libharfbuzz.so.0 with build-id 38ccb6d6131d11bed5f91985cc5858f20d212c69
                Module libfribidi.so.0 with build-id 19a9d1d9f8f75d22c9b6644b1f420761009a2be8
                Module libfreetype.so.6 with build-id 885e72cf139d5a3a88dfc31c388151ab502c4ac6
                Module libcurl.so.4 with build-id 53692f713ee70e1f4dd79e7c7e79e7f525dea570
                Module libuuid.so.1 with build-id 947b7cde12a3ea2c57d31d8406fa9a8dcafa3e35
                Module libass.so.9 with build-id b20f00cf8823c2a3bbca26db1f2a34b9835b05c7
                Module libxml2.so.2 with build-id cb6099a1c7d33d26b9f9c93a1a24fcb9c879bf0b
                Module libxslt.so.1 with build-id 3c339dfdee3fd7ec68b8d1e8f776b0422be2b125
                Module libudev.so.1 with build-id de0c40c027640d89ba9a8390fba682a6edfc1acf
                Module libsmbclient.so.0 with build-id e4e4a2b82895c6ee11d1de04a3c6b1cd788d4f5b
                Module libpython3.10.so.1.0 with build-id f14a52f584ad92df66ed0f3e910404e85fa83923
                Module libpulse-simple.so.0 with build-id dbd8e68be28294c079699ac7bfc14f7bfb26aefd
                Module libpulse.so.0 with build-id ae2a5426e008396cb4e107889297dcabaa2a4000
                Module libplist-2.0.so.3 with build-id 47f3a411cc7fdcf2a488e7c7aee820f0c03b4b34
                Module libnfs.so.14 with build-id e962ca6bdd05b962c3ff85ee2f065a481d481182
                Module libmicrohttpd.so.12 with build-id 5247809d3e92b709a025ebcd8faa4de81fee3d12
                Module liblirc_client.so.0 with build-id 98af8e97202a1813222a4a8cce89c8cd7f5dd10e
                Module liblcms2.so.2 with build-id 2344767615a5d225a0f5028c9d3ffaaf3ab188d8
                Module libcdio.so.19 with build-id 46e0b78f9a05626a91ba09e42847b3b6ce489c05
                Module libiso9660.so.11 with build-id f9bd0b2526839fcf27fc7479e973803d1349fcc0
                Module libdbus-1.so.3 with build-id cf52c51b3f812d1b607de69417bfe9e3106f486e
                Module libdav1d.so.6 with build-id 5b9cbd7ecc2aa24556160493aa7270f5c314e6a5
                Module libcec.so.6 with build-id c62cbe10e67109b659382d0182dafd3953a1470c
                Module libcap.so.2 with build-id c8915eef2afd10412d2b223460e12be4771263b8
                Module libbluray.so.2 with build-id ee55a908457cda99ae7bdfe43dfee39f9cd2568d
                Module libbluetooth.so.3 with build-id 67e2ebbccc00af56798495347ac69a346a7c4b3b
                Module libavahi-common.so.3 with build-id 02181df33a17fbe6592b197d35b00fb6e7122ac6
                Module libavahi-client.so.3 with build-id 3842d1e840dc5ee35158482955035c9d96c4bf99
                Module libasound.so.2 with build-id c9bc72f6925deb095f45a74b73d4718f457ef535
                Module kodi.bin with build-id c9d7c152a9ee1a4eab8d43da5ded59b1f36ce9b3
                Stack trace of thread 8472:
                #0  0x000000008efe079c n/a (inputstream.adaptive.so.20.3.0 + 0x8079c)
                ELF object binary architecture: ARM

GNU gdb (GDB) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "armv7l-unknown-linux-gnueabihf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/lib/kodi/kodi.bin...
(No debugging symbols found in /usr/lib/kodi/kodi.bin)
[New LWP 8472]
[New LWP 5582]
[New LWP 5595]
[New LWP 5591]
[New LWP 5596]
[New LWP 5597]
[New LWP 5601]
[New LWP 5603]
[New LWP 8462]
[New LWP 5610]
[New LWP 5579]
[New LWP 5647]
[New LWP 5588]
[New LWP 5654]
[New LWP 5604]
[New LWP 5575]
[New LWP 5627]
[New LWP 5656]
[New LWP 5580]
[New LWP 5590]
[New LWP 5631]
[New LWP 5617]
[New LWP 5614]
[New LWP 5643]
[New LWP 5613]
[New LWP 5600]
[New LWP 5594]
[New LWP 5606]
[New LWP 5592]
[New LWP 5602]
[New LWP 5583]
[New LWP 5574]
[New LWP 5599]
[New LWP 5589]
[New LWP 5581]
[New LWP 5608]
[New LWP 5607]
[New LWP 5611]
[New LWP 5615]
[New LWP 5655]
[New LWP 8473]
[New LWP 5571]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
--Type <RET> for more, q to quit, c to continue without paging--
Core was generated by `/usr/lib/kodi/kodi.bin --standalone'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  adaptive::DASHTree::RefreshLiveSegments (this=0xaf0d08c8) at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/parser/DASHTree.cpp:1845
1845                              misaligned = search_pts - (&segment - 1)->range_begin_;
[Current thread is 1 (Thread 0x88d2d000 (LWP 8472))]
(gdb) bt
#0  adaptive::DASHTree::RefreshLiveSegments() (this=0xaf0d08c8) at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/parser/DASHTree.cpp:1845
#1  0x8efca78c in adaptive::AdaptiveStream::ensureSegment() (this=0x1) at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/common/AdaptiveStream.cpp:753
#2  0x8efb0b6c in adaptive::AdaptiveStream::read(void*, unsigned int) (bytesToRead=0, buffer=0x0, this=0x8edecd90)
    at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/common/AdaptiveStream.cpp:909
#3  adaptive::AdaptiveStream::tell() (this=0x8edecd90) at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/common/AdaptiveStream.h:52
#4  CAdaptiveByteStream::Tell(unsigned long long&) (this=<optimized out>, position=@0x88d2c700: 0)
    at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/AdaptiveByteStream.cpp:33
#5  0x8f029b44 in AP4_LinearReader::AdvanceFragment() (this=this@entry=0x8ed06190)
    at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/bento4/src/bento4/Source/C++/Core/Ap4LinearReader.cpp:376
#6  0x8f02be10 in AP4_LinearReader::Advance(bool) (this=0x8ed06190, read_data=<optimized out>)
    at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/bento4/src/bento4/Source/C++/Core/Ap4LinearReader.cpp:474
#7  0x8f02c0b0 in AP4_LinearReader::ReadNextSample(unsigned int, AP4_Sample&, AP4_DataBuffer&) (this=0x8ed06190, track_id=<optimized out>, sample=..., sample_data=...)
    at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/bento4/src/bento4/Source/C++/Core/Ap4LinearReader.cpp:562
#8  0x8eff10bc in CFragmentedSampleReader::ReadSample() (this=0x8ed06180)
    at /usr/src/debug/inputstream.adaptive-20.3.0-Nexus/src/samplereader/FragmentedSampleReader.cpp:114
#9  0x8efbd800 in std::__invoke_impl<int, int (ISampleReader::*)(), ISampleReader*>(std::__invoke_memfun_deref, int (ISampleReader::*&&)(), ISampleReader*&&)
    (__t=<optimized out>, __f=<optimized out>) at /usr/include/c++/12.1.0/bits/invoke.h:74
#10 std::__invoke<int (ISampleReader::*)(), ISampleReader*>(int (ISampleReader::*&&)(), ISampleReader*&&) (__fn=<optimized out>)
    at /usr/include/c++/12.1.0/bits/invoke.h:96
#11 std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >::_M_invoke<0u, 1u>(std::_Index_tuple<0u, 1u>) (this=<optimized out>)
    at /usr/include/c++/12.1.0/bits/std_thread.h:252
#12 std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >::operator()() (this=<optimized out>) at /usr/include/c++/12.1.0/bits/std_thread.h:259
#13 std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >, int>::operator()() const (this=0x88d2c8ec) at /usr/include/c++/12.1.0/future:1387                                             
#14 std::__invoke_impl<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >, int>&>(std::__invoke_other, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >, int>&) (__f=...) at /usr/include/c++/12.1.0/bits/invoke.h:61                                                      
#15 std::__invoke_r<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >, int>&>(std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >, int>&) (__fn=...) at /usr/include/c++/12.1.0/bits/invoke.h:116                                                                            
#16 std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<int>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<int (ISampleReader::*)(), ISampleReader*> >, int> >::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/include/c++/12.1.0/bits/std_function.h:291                                                                  
#17 0x011d78c0 in std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) ()                                                                                                                                                      
#18 0xb5621f58 in  () at /usr/lib/libc.so.6
(gdb) p segment
$1 = (const adaptive::AdaptiveTree::Segment &) @0x8ec3a008: {range_begin_ = 19094120913600, range_end_ = 1, url = "", startPTS_ = 19094120913600, m_duration = 0, 
  pssh_set_ = 0}
(gdb) p repr->segments_
$2 = {basePos = 0, data = std::vector of length 4219, capacity 4219 = {{range_begin_ = 19094120913600, range_end_ = 1, url = "", startPTS_ = 19094120913600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094121144000, range_end_ = 2, url = "", startPTS_ = 19094121144000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094121374400, range_end_ = 3, url = "", startPTS_ = 19094121374400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094121604800, 
      range_end_ = 4, url = "", startPTS_ = 19094121604800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094121835200, range_end_ = 5, url = "", 
      startPTS_ = 19094121835200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094122065600, range_end_ = 6, url = "", startPTS_ = 19094122065600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094122296000, range_end_ = 7, url = "", startPTS_ = 19094122296000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094122526400, range_end_ = 8, url = "", startPTS_ = 19094122526400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094122756800, 
      range_end_ = 9, url = "", startPTS_ = 19094122756800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094122987200, range_end_ = 10, url = "", 
      startPTS_ = 19094122987200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094123217600, range_end_ = 11, url = "", startPTS_ = 19094123217600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094123448000, range_end_ = 12, url = "", startPTS_ = 19094123448000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094123678400, range_end_ = 13, url = "", startPTS_ = 19094123678400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094123908800, 
      range_end_ = 14, url = "", startPTS_ = 19094123908800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094124139200, range_end_ = 15, url = "", 
      startPTS_ = 19094124139200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094124369600, range_end_ = 16, url = "", startPTS_ = 19094124369600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094124600000, range_end_ = 17, url = "", startPTS_ = 19094124600000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094124830400, range_end_ = 18, url = "", startPTS_ = 19094124830400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094125060800, 
      range_end_ = 19, url = "", startPTS_ = 19094125060800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094125291200, range_end_ = 20, url = "", 
      startPTS_ = 19094125291200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094125521600, range_end_ = 21, url = "", startPTS_ = 19094125521600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094125752000, range_end_ = 22, url = "", startPTS_ = 19094125752000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094125982400, range_end_ = 23, url = "", startPTS_ = 19094125982400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094126212800, 
      range_end_ = 24, url = "", startPTS_ = 19094126212800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094126443200, range_end_ = 25, url = "", 
      startPTS_ = 19094126443200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094126673600, range_end_ = 26, url = "", startPTS_ = 19094126673600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094126904000, range_end_ = 27, url = "", startPTS_ = 19094126904000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094127134400, range_end_ = 28, url = "", startPTS_ = 19094127134400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094127364800, 
      range_end_ = 29, url = "", startPTS_ = 19094127364800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094127595200, range_end_ = 30, url = "", 
      startPTS_ = 19094127595200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094127825600, range_end_ = 31, url = "", startPTS_ = 19094127825600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094128056000, range_end_ = 32, url = "", startPTS_ = 19094128056000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094128286400, range_end_ = 33, url = "", startPTS_ = 19094128286400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094128516800, 
      range_end_ = 34, url = "", startPTS_ = 19094128516800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094128747200, range_end_ = 35, url = "", 
      startPTS_ = 19094128747200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094128977600, range_end_ = 36, url = "", startPTS_ = 19094128977600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094129208000, range_end_ = 37, url = "", startPTS_ = 19094129208000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094129438400, range_end_ = 38, url = "", startPTS_ = 19094129438400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094129668800, 
      range_end_ = 39, url = "", startPTS_ = 19094129668800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094129899200, range_end_ = 40, url = "", 
      startPTS_ = 19094129899200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094130129600, range_end_ = 41, url = "", startPTS_ = 19094130129600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094130360000, range_end_ = 42, url = "", startPTS_ = 19094130360000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094130590400, range_end_ = 43, url = "", startPTS_ = 19094130590400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094130820800, 
      range_end_ = 44, url = "", startPTS_ = 19094130820800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094131051200, range_end_ = 45, url = "", 
      startPTS_ = 19094131051200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094131281600, range_end_ = 46, url = "", startPTS_ = 19094131281600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094131512000, range_end_ = 47, url = "", startPTS_ = 19094131512000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094131742400, range_end_ = 48, url = "", startPTS_ = 19094131742400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094131972800, 
--Type <RET> for more, q to quit, c to continue without paging--
      range_end_ = 49, url = "", startPTS_ = 19094131972800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094132203200, range_end_ = 50, url = "", 
      startPTS_ = 19094132203200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094132433600, range_end_ = 51, url = "", startPTS_ = 19094132433600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094132664000, range_end_ = 52, url = "", startPTS_ = 19094132664000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094132894400, range_end_ = 53, url = "", startPTS_ = 19094132894400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094133124800, 
      range_end_ = 54, url = "", startPTS_ = 19094133124800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094133355200, range_end_ = 55, url = "", 
      startPTS_ = 19094133355200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094133585600, range_end_ = 56, url = "", startPTS_ = 19094133585600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094133816000, range_end_ = 57, url = "", startPTS_ = 19094133816000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094134046400, range_end_ = 58, url = "", startPTS_ = 19094134046400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094134276800, 
      range_end_ = 59, url = "", startPTS_ = 19094134276800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094134507200, range_end_ = 60, url = "", 
      startPTS_ = 19094134507200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094134737600, range_end_ = 61, url = "", startPTS_ = 19094134737600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094134968000, range_end_ = 62, url = "", startPTS_ = 19094134968000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094135198400, range_end_ = 63, url = "", startPTS_ = 19094135198400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094135428800, 
      range_end_ = 64, url = "", startPTS_ = 19094135428800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094135659200, range_end_ = 65, url = "", 
      startPTS_ = 19094135659200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094135889600, range_end_ = 66, url = "", startPTS_ = 19094135889600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094136120000, range_end_ = 67, url = "", startPTS_ = 19094136120000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094136350400, range_end_ = 68, url = "", startPTS_ = 19094136350400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094136580800, 
      range_end_ = 69, url = "", startPTS_ = 19094136580800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094136811200, range_end_ = 70, url = "", 
      startPTS_ = 19094136811200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094137041600, range_end_ = 71, url = "", startPTS_ = 19094137041600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094137272000, range_end_ = 72, url = "", startPTS_ = 19094137272000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094137502400, range_end_ = 73, url = "", startPTS_ = 19094137502400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094137732800, 
      range_end_ = 74, url = "", startPTS_ = 19094137732800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094137963200, range_end_ = 75, url = "", 
      startPTS_ = 19094137963200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094138193600, range_end_ = 76, url = "", startPTS_ = 19094138193600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094138424000, range_end_ = 77, url = "", startPTS_ = 19094138424000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094138654400, range_end_ = 78, url = "", startPTS_ = 19094138654400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094138884800, 
      range_end_ = 79, url = "", startPTS_ = 19094138884800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094139115200, range_end_ = 80, url = "", 
      startPTS_ = 19094139115200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094139345600, range_end_ = 81, url = "", startPTS_ = 19094139345600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094139576000, range_end_ = 82, url = "", startPTS_ = 19094139576000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094139806400, range_end_ = 83, url = "", startPTS_ = 19094139806400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094140036800, 
      range_end_ = 84, url = "", startPTS_ = 19094140036800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094140267200, range_end_ = 85, url = "", 
      startPTS_ = 19094140267200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094140497600, range_end_ = 86, url = "", startPTS_ = 19094140497600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094140728000, range_end_ = 87, url = "", startPTS_ = 19094140728000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094140958400, range_end_ = 88, url = "", startPTS_ = 19094140958400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094141188800, 
      range_end_ = 89, url = "", startPTS_ = 19094141188800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094141419200, range_end_ = 90, url = "", 
      startPTS_ = 19094141419200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094141649600, range_end_ = 91, url = "", startPTS_ = 19094141649600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094141880000, range_end_ = 92, url = "", startPTS_ = 19094141880000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094142110400, range_end_ = 93, url = "", startPTS_ = 19094142110400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094142340800, 
      range_end_ = 94, url = "", startPTS_ = 19094142340800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094142571200, range_end_ = 95, url = "", 
      startPTS_ = 19094142571200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094142801600, range_end_ = 96, url = "", startPTS_ = 19094142801600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094143032000, range_end_ = 97, url = "", startPTS_ = 19094143032000, m_duration = 0, pssh_set_ = 0}, {
--Type <RET> for more, q to quit, c to continue without paging--
      range_begin_ = 19094143262400, range_end_ = 98, url = "", startPTS_ = 19094143262400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094143492800, 
      range_end_ = 99, url = "", startPTS_ = 19094143492800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094143723200, range_end_ = 100, url = "", 
      startPTS_ = 19094143723200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094143953600, range_end_ = 101, url = "", startPTS_ = 19094143953600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094144184000, range_end_ = 102, url = "", startPTS_ = 19094144184000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094144414400, range_end_ = 103, url = "", startPTS_ = 19094144414400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094144644800, 
      range_end_ = 104, url = "", startPTS_ = 19094144644800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094144875200, range_end_ = 105, url = "", 
      startPTS_ = 19094144875200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094145105600, range_end_ = 106, url = "", startPTS_ = 19094145105600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094145336000, range_end_ = 107, url = "", startPTS_ = 19094145336000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094145566400, range_end_ = 108, url = "", startPTS_ = 19094145566400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094145796800, 
      range_end_ = 109, url = "", startPTS_ = 19094145796800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094146027200, range_end_ = 110, url = "", 
      startPTS_ = 19094146027200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094146257600, range_end_ = 111, url = "", startPTS_ = 19094146257600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094146488000, range_end_ = 112, url = "", startPTS_ = 19094146488000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094146718400, range_end_ = 113, url = "", startPTS_ = 19094146718400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094146948800, 
      range_end_ = 114, url = "", startPTS_ = 19094146948800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094147179200, range_end_ = 115, url = "", 
      startPTS_ = 19094147179200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094147409600, range_end_ = 116, url = "", startPTS_ = 19094147409600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094147640000, range_end_ = 117, url = "", startPTS_ = 19094147640000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094147870400, range_end_ = 118, url = "", startPTS_ = 19094147870400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094148100800, 
      range_end_ = 119, url = "", startPTS_ = 19094148100800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094148331200, range_end_ = 120, url = "", 
      startPTS_ = 19094148331200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094148561600, range_end_ = 121, url = "", startPTS_ = 19094148561600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094148792000, range_end_ = 122, url = "", startPTS_ = 19094148792000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094149022400, range_end_ = 123, url = "", startPTS_ = 19094149022400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094149252800, 
      range_end_ = 124, url = "", startPTS_ = 19094149252800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094149483200, range_end_ = 125, url = "", 
      startPTS_ = 19094149483200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094149713600, range_end_ = 126, url = "", startPTS_ = 19094149713600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094149944000, range_end_ = 127, url = "", startPTS_ = 19094149944000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094150174400, range_end_ = 128, url = "", startPTS_ = 19094150174400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094150404800, 
      range_end_ = 129, url = "", startPTS_ = 19094150404800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094150635200, range_end_ = 130, url = "", 
      startPTS_ = 19094150635200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094150865600, range_end_ = 131, url = "", startPTS_ = 19094150865600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094151096000, range_end_ = 132, url = "", startPTS_ = 19094151096000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094151326400, range_end_ = 133, url = "", startPTS_ = 19094151326400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094151556800, 
      range_end_ = 134, url = "", startPTS_ = 19094151556800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094151787200, range_end_ = 135, url = "", 
      startPTS_ = 19094151787200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094152017600, range_end_ = 136, url = "", startPTS_ = 19094152017600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094152248000, range_end_ = 137, url = "", startPTS_ = 19094152248000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094152478400, range_end_ = 138, url = "", startPTS_ = 19094152478400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094152708800, 
      range_end_ = 139, url = "", startPTS_ = 19094152708800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094152939200, range_end_ = 140, url = "", 
      startPTS_ = 19094152939200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094153169600, range_end_ = 141, url = "", startPTS_ = 19094153169600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094153400000, range_end_ = 142, url = "", startPTS_ = 19094153400000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094153630400, range_end_ = 143, url = "", startPTS_ = 19094153630400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094153860800, 
      range_end_ = 144, url = "", startPTS_ = 19094153860800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094154091200, range_end_ = 145, url = "", 
      startPTS_ = 19094154091200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094154321600, range_end_ = 146, url = "", startPTS_ = 19094154321600, 
--Type <RET> for more, q to quit, c to continue without paging--
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094154552000, range_end_ = 147, url = "", startPTS_ = 19094154552000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094154782400, range_end_ = 148, url = "", startPTS_ = 19094154782400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094155012800, 
      range_end_ = 149, url = "", startPTS_ = 19094155012800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094155243200, range_end_ = 150, url = "", 
      startPTS_ = 19094155243200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094155473600, range_end_ = 151, url = "", startPTS_ = 19094155473600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094155704000, range_end_ = 152, url = "", startPTS_ = 19094155704000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094155934400, range_end_ = 153, url = "", startPTS_ = 19094155934400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094156164800, 
      range_end_ = 154, url = "", startPTS_ = 19094156164800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094156395200, range_end_ = 155, url = "", 
      startPTS_ = 19094156395200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094156625600, range_end_ = 156, url = "", startPTS_ = 19094156625600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094156856000, range_end_ = 157, url = "", startPTS_ = 19094156856000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094157086400, range_end_ = 158, url = "", startPTS_ = 19094157086400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094157316800, 
      range_end_ = 159, url = "", startPTS_ = 19094157316800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094157547200, range_end_ = 160, url = "", 
      startPTS_ = 19094157547200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094157777600, range_end_ = 161, url = "", startPTS_ = 19094157777600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094158008000, range_end_ = 162, url = "", startPTS_ = 19094158008000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094158238400, range_end_ = 163, url = "", startPTS_ = 19094158238400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094158468800, 
      range_end_ = 164, url = "", startPTS_ = 19094158468800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094158699200, range_end_ = 165, url = "", 
      startPTS_ = 19094158699200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094158929600, range_end_ = 166, url = "", startPTS_ = 19094158929600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094159160000, range_end_ = 167, url = "", startPTS_ = 19094159160000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094159390400, range_end_ = 168, url = "", startPTS_ = 19094159390400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094159620800, 
      range_end_ = 169, url = "", startPTS_ = 19094159620800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094159851200, range_end_ = 170, url = "", 
      startPTS_ = 19094159851200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094160081600, range_end_ = 171, url = "", startPTS_ = 19094160081600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094160312000, range_end_ = 172, url = "", startPTS_ = 19094160312000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094160542400, range_end_ = 173, url = "", startPTS_ = 19094160542400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094160772800, 
      range_end_ = 174, url = "", startPTS_ = 19094160772800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094161003200, range_end_ = 175, url = "", 
      startPTS_ = 19094161003200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094161233600, range_end_ = 176, url = "", startPTS_ = 19094161233600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094161464000, range_end_ = 177, url = "", startPTS_ = 19094161464000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094161694400, range_end_ = 178, url = "", startPTS_ = 19094161694400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094161924800, 
      range_end_ = 179, url = "", startPTS_ = 19094161924800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094162155200, range_end_ = 180, url = "", 
      startPTS_ = 19094162155200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094162385600, range_end_ = 181, url = "", startPTS_ = 19094162385600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094162616000, range_end_ = 182, url = "", startPTS_ = 19094162616000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094162846400, range_end_ = 183, url = "", startPTS_ = 19094162846400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094163076800, 
      range_end_ = 184, url = "", startPTS_ = 19094163076800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094163307200, range_end_ = 185, url = "", 
      startPTS_ = 19094163307200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094163537600, range_end_ = 186, url = "", startPTS_ = 19094163537600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094163768000, range_end_ = 187, url = "", startPTS_ = 19094163768000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094163998400, range_end_ = 188, url = "", startPTS_ = 19094163998400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094164228800, 
      range_end_ = 189, url = "", startPTS_ = 19094164228800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094164459200, range_end_ = 190, url = "", 
      startPTS_ = 19094164459200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094164689600, range_end_ = 191, url = "", startPTS_ = 19094164689600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094164920000, range_end_ = 192, url = "", startPTS_ = 19094164920000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094165150400, range_end_ = 193, url = "", startPTS_ = 19094165150400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094165380800, 
      range_end_ = 194, url = "", startPTS_ = 19094165380800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094165611200, range_end_ = 195, url = "", 
--Type <RET> for more, q to quit, c to continue without paging--
      startPTS_ = 19094165611200, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094165841600, range_end_ = 196, url = "", startPTS_ = 19094165841600, 
      m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094166072000, range_end_ = 197, url = "", startPTS_ = 19094166072000, m_duration = 0, pssh_set_ = 0}, {
      range_begin_ = 19094166302400, range_end_ = 198, url = "", startPTS_ = 19094166302400, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094166532800, 
      range_end_ = 199, url = "", startPTS_ = 19094166532800, m_duration = 0, pssh_set_ = 0}, {range_begin_ = 19094166763200, range_end_ = 200, url = "", 
      startPTS_ = 19094166763200, m_duration = 0, pssh_set_ = 0}...}}
(gdb) 
```