### PR TITLE
Fix initialization/media templated segment urls

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -691,7 +691,7 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Representation* rep,
     }
     else if (~segNum) //templated segment
     {
-      download_url_ = rep->segtpl_.media;
+      download_url_ = rep->segtpl_.media_url;
       ReplacePlaceholder(download_url_, "$Number", seg->range_end_);
       ReplacePlaceholder(download_url_, "$Time", seg->range_begin_);
     }
@@ -702,7 +702,7 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Representation* rep,
   {
     if (rep->flags_ & AdaptiveTree::Representation::TEMPLATE && ~segNum)
     {
-      download_url_ = rep->segtpl_.media;
+      download_url_ = rep->segtpl_.media_url;
       ReplacePlaceholder(download_url_, "$Number", rep->startNumber_);
       ReplacePlaceholder(download_url_, "$Time", 0);
     }

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -191,6 +191,8 @@ public:
     SegmentTemplate() : timescale(0), duration(0) {};
     std::string initialization;
     std::string media;
+    // Same content of "media" property but with placeholder $RepresentationID$ and $Bandwidth$ filled
+    std::string media_url;
     unsigned int timescale, duration;
   };
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -78,15 +78,17 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         dash->current_representation_->timescale_ = dash->current_adaptationset_->timescale_;
         dash->current_representation_->flags_ |= AdaptiveTree::Representation::TEMPLATE;
         dash->current_representation_->segtpl_.media = dash->current_representation_->url_;
+        dash->current_representation_->segtpl_.media_url =
+            dash->current_representation_->segtpl_.media;
 
         std::string::size_type pos(
-            dash->current_representation_->segtpl_.media.find("{start time}"));
+            dash->current_representation_->segtpl_.media_url.find("{start time}"));
         if (pos != std::string::npos)
-          dash->current_representation_->segtpl_.media.replace(pos, 12, "$Time$");
+          dash->current_representation_->segtpl_.media_url.replace(pos, 12, "$Time$");
         else
           return;
 
-        pos = dash->current_representation_->segtpl_.media.find("{bitrate}");
+        pos = dash->current_representation_->segtpl_.media_url.find("{bitrate}");
         if (pos == std::string::npos)
           return;
 
@@ -165,7 +167,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
           dash->current_representation_->codec_private_data_[1] = esds & 0xFF;
         }
 
-        dash->current_representation_->segtpl_.media.replace(pos, 9, bw);
+        dash->current_representation_->segtpl_.media_url.replace(pos, 9, bw);
         dash->current_representation_->bandwidth_ = atoi(bw);
         dash->current_representation_->assured_buffer_duration_ =
             dash->m_settings.m_bufferAssuredDuration;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -151,7 +151,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithNoSlashes)
       tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
-  EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
+  EXPECT_EQ(segtpl.media_url, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
 }
 
 TEST_F(DASHTreeTest, CalculateSegTplWithMediaInitSlash)
@@ -163,7 +163,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithMediaInitSlash)
       tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/media-video=66000.dash");
-  EXPECT_EQ(segtpl.media, "https://foo.bar/media-video=66000-$Number$.m4s");
+  EXPECT_EQ(segtpl.media_url, "https://foo.bar/media-video=66000-$Number$.m4s");
 }
 
 TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLSlash)
@@ -175,7 +175,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLSlash)
       tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/guid.ism/dash/media-video=66000.dash");
-  EXPECT_EQ(segtpl.media, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
+  EXPECT_EQ(segtpl.media_url, "https://foo.bar/guid.ism/dash/media-video=66000-$Number$.m4s");
 }
 
 TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLAndMediaInitSlash)
@@ -187,7 +187,7 @@ TEST_F(DASHTreeTest, CalculateSegTplWithBaseURLAndMediaInitSlash)
       tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_;
 
   EXPECT_EQ(segtpl.initialization, "https://foo.bar/media-video=66000.dash");
-  EXPECT_EQ(segtpl.media, "https://foo.bar/media-video=66000-$Number$.m4s");
+  EXPECT_EQ(segtpl.media_url, "https://foo.bar/media-video=66000-$Number$.m4s");
 }
 
 TEST_F(DASHTreeTest, CalculateBaseURLInRepRangeBytes)
@@ -451,22 +451,22 @@ TEST_F(DASHTreeTest, CalculateMultipleSegTpl)
   EXPECT_EQ(tree->base_url_, "https://foo.bar/dash/");
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.initialization, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media_url, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252_$Number%09d$.mp4");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.timescale, 120000);
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segments_.Get(0)->range_end_, 3);
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.initialization, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.media, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.media_url, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080_$Number%09d$.mp4");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.timescale, 90000);
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segments_.Get(0)->range_end_, 5);
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_aac1init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_aac1_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media_url, "https://foo.bar/dash/3c1055cb-a842-4449-b393-7f31693b4a8f_aac1_$Number%09d$.mp4");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.timescale, 48000);
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segments_.Get(0)->range_end_, 1);
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.initialization, "https://foo.bar/dash/abc_aac1init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.media, "https://foo.bar/dash/abc2_$Number%09d$.mp4");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.media_url, "https://foo.bar/dash/abc2_$Number%09d$.mp4");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segtpl_.timescale, 68000);
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[2]->representations_[0]->segments_.Get(0)->range_end_, 5);
 }
@@ -477,10 +477,10 @@ TEST_F(DASHTreeTest, CalculateRedirectSegTpl)
   OpenTestFile("mpd/segtpl.mpd", "https://bit.ly/abcd.mpd", "");
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.initialization, "https://foo.bar/mpd/V300/init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media, "https://foo.bar/mpd/V300/$Number$.m4s");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media_url, "https://foo.bar/mpd/V300/$Number$.m4s");
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/A48/init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/A48/$Number$.m4s");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media_url, "https://foo.bar/A48/$Number$.m4s");
 }
 
 TEST_F(DASHTreeTest, CalculateReprensentationBaseURL)
@@ -488,16 +488,31 @@ TEST_F(DASHTreeTest, CalculateReprensentationBaseURL)
   OpenTestFile("mpd/rep_base_url.mpd", "https://bit.ly/mpd/abcd.mpd", "");
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.initialization, "https://foo.bar/mpd/slices/A_init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media, "https://foo.bar/mpd/slices/A$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media_url, "https://foo.bar/mpd/slices/A$Number%08d$.m4f");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.initialization, "https://bit.ly/mpd/B_init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.media, "https://bit.ly/mpd/B$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[1]->segtpl_.media_url, "https://bit.ly/mpd/B$Number%08d$.m4f");
 
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://foo.bar/mpd/slices/A_init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media, "https://foo.bar/mpd/slices/A$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media_url, "https://foo.bar/mpd/slices/A$Number%08d$.m4f");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[1]->segtpl_.initialization, "https://foo.bar/mpd/slices2/B_init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[1]->segtpl_.media, "https://foo.bar/mpd/slices2/B$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[1]->segtpl_.media_url, "https://foo.bar/mpd/slices2/B$Number%08d$.m4f");
   EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[2]->segtpl_.initialization, "https://foo.bar/mpd/slices2/C_init.mp4");
-  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[2]->segtpl_.media, "https://foo.bar/mpd/slices2/C$Number%08d$.m4f");
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[2]->segtpl_.media_url, "https://foo.bar/mpd/slices2/C$Number%08d$.m4f");
+}
+
+TEST_F(DASHTreeTest, CalculateReprensentationBaseURLMultiple)
+{
+  OpenTestFile(
+      "mpd/rep_base_url_multiple.mpd",
+      "https://pl.foobar.com/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/manifest.mpd", "");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.initialization, "https://pl.foobar.com/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/init-f1-v1-x3.mp4");
+  //! @TODO: Currently return the last BaseURL where instead should be the first one
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[0]->representations_[0]->segtpl_.media_url, "https://ll.foo.co/video/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/fragment-$Number$-f1-v1-x3.m4s");
+
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.initialization, "https://pl.foobar.com/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/init-f1-a1-x3.mp4");
+  //! @TODO: Currently return the last BaseURL where instead should be the first one
+  EXPECT_EQ(tree->periods_[0]->adaptationSets_[1]->representations_[0]->segtpl_.media_url, "https://ll.foo.co/audio/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/fragment-$Number$-f1-a1-x3.m4s");
 }
 
 TEST_F(DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline)

--- a/src/test/manifests/mpd/rep_base_url_multiple.mpd
+++ b/src/test/manifests/mpd/rep_base_url_multiple.mpd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="static" mediaPresentationDuration="PT1430.906S" minBufferTime="PT4S" profiles="urn:mpeg:dash:profile:full:2011">
+    <Period>
+        <AdaptationSet id="1" segmentAlignment="true" maxWidth="1920" maxHeight="1080" maxFrameRate="45000/1877">
+            <SegmentTemplate timescale="1000" media="fragment-$Number$-$RepresentationID$.m4s" initialization="init-$RepresentationID$.mp4" startNumber="1">
+                <SegmentTimeline>
+                    <S d="4004"/>
+                </SegmentTimeline>
+            </SegmentTemplate>
+            <Representation id="f1-v1-x3" mimeType="video/mp4" codecs="avc1.640028" width="1280" height="720" frameRate="45000/1877" sar="1:1" startWithSAP="1" bandwidth="3989784">
+                <BaseURL>https://prod.foobar.com/video/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/</BaseURL>
+                <BaseURL>https://ll.foo.co/video/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/</BaseURL>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="2" segmentAlignment="true">
+            <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="1"/>
+            <SegmentTemplate timescale="1000" media="fragment-$Number$-$RepresentationID$.m4s" initialization="init-$RepresentationID$.mp4" startNumber="1">
+                <SegmentTimeline>
+                    <S d="4017"/>
+                </SegmentTimeline>
+            </SegmentTemplate>
+            <Representation id="f1-a1-x3" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="44100" startWithSAP="1" bandwidth="128000">
+                <BaseURL>https://prod.foobar.com/audio/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/</BaseURL>
+                <BaseURL>https://ll.foo.co/audio/assets/p/c30668ab1d7d10166938f06b9643a254.urlset/</BaseURL>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>


### PR DESCRIPTION
This is more a workaround to fix the current incomplete implementation of BaseURL manegement,
so i also had to add a new `media_url` property to the `SegmentTemplate` struct, to avoid that subsequential BaseURL parsing corrupt data with previous BaseURL parsing

There is currently no real management of BaseURL's, so ISA parses all XML BaseURL's by replacing previous data, then only the last base url will be kept, that is wrong

Trying fix #1039

Considerations:

Thinking of stopping the subsequential BaseURL parsing sooner seems impossible as the current implementation of SegmentTemplate parser and ReplacePlaceHolders is splitted at various points in the parser which we have little control over the flow

A full implementation is also too difficult because the DASH parser while parse the XML file also processing the dash data at same time, where these two operations should be completely decoupled to implement this feature in right way

Multiple BaseURL can have two cases:
1) BaseURL without properties
`<BaseURL>https://cdnurl1/</BaseURL>`
in this case the player select the first base url by default and fallback
to the others when an address is no longer available or not reachable.
2) BaseURL with DVB properties (as ETSI TS 103 285 - DVB document spec)
`<BaseURL dvb:priority="1" dvb:weight="10" serviceLocation="A" >https://cdnurl1/</BaseURL>`
these properties affect the behaviour of the previous (sequential) url selection.

A partial example of the implementation is https://github.com/google/ExoPlayer/commit/3f9093cc02efec218429d5eb6fcd697136a86f2c#diff-0ae29831d9edd392f64e10675099307f2c655820987edac16a39e61cb8e77697

An example of incomplete raw draft for BaseURL class: https://github.com/CastagnaIT/inputstream.adaptive/commit/ae0f38cc7b0751f08079ede9b037b17f855544c0
