### PR TITLE
[SmoothStreaming] Use case-insensitive comparer for IsLive

### DIFF
--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -14,6 +14,8 @@
 #include "../utils/log.h"
 #include "PRProtectionParser.h"
 
+#include "kodi/tools/StringUtils.h"
+
 #include <algorithm>
 #include <cstring>
 #include <float.h>
@@ -21,6 +23,7 @@
 #include <string>
 
 using namespace adaptive;
+using namespace kodi::tools;
 using namespace UTILS;
 
 SmoothTree::SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
@@ -268,7 +271,7 @@ static void XMLCALL start(void* data, const char* el, const char** attr)
         duration = atoll((const char*)*(attr + 1));
       else if (strcmp((const char*)*attr, "IsLive") == 0)
       {
-        dash->has_timeshift_buffer_ = strcmp((const char*)*(attr + 1), "TRUE") == 0;
+        dash->has_timeshift_buffer_ = StringUtils::CompareNoCase((const char*)*(attr + 1), "true") == 0;
         if (dash->has_timeshift_buffer_)
         {
           dash->stream_start_ = time(0);


### PR DESCRIPTION
Fix #1064

IsLive value is case-insensitive:
https://learn.microsoft.com/en-us/iis/extensions/smooth-streaming-manifest-structure/iis-smooth-streaming-client-manifest-smoothstreamingmedia-element