### PR TITLE
Remove unneeded unique ptr, resolves crash

### DIFF
--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -323,11 +323,10 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
   // proper track id, let's find it now
   if (m_track->GetId() == TRACKID_UNKNOWN)
   {
-    auto fragment = std::make_unique<AP4_MovieFragment>(
-        AP4_MovieFragment(AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->Clone())));
+    AP4_MovieFragment fragment =
+        AP4_MovieFragment(AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->Clone()));
     AP4_Array<AP4_UI32> ids;
-    fragment->GetTrackIds(ids);
-
+    fragment.GetTrackIds(ids);
     if (ids.ItemCount() == 1)
       m_track->SetId(ids[0]);
     else


### PR DESCRIPTION
`fragment` was being destroyed straight after construction (not an expert so not sure why, something went out of scope??) so removed this variable being defined as a unique pointer. `AP4_MovieFragment` takes ownership of the moof pointer anyway and deletes it upon destruction. Partial fix for issues in #1072 