### PR TITLE
Fix seek audio/video, various subtitle fixes

### DIFF
--- a/src/Session.h
+++ b/src/Session.h
@@ -292,10 +292,20 @@ public:
    */
   uint64_t GetChapterStartTime() const;
 
+  /*! \brief Get starting PTS of the timing stream
+   *  \return PTS at start of the timing stream
+   */
+  uint64_t GetTimingStartPTS() const;
+
   /*! \brief Get value of m_chapterSeekTime
    *  \return Time stored in m_chapterSeekTime
    */
   double GetChapterSeekTime() { return m_chapterSeekTime; };
+
+  /*! \brief Get the timing stream
+   *  \return Timing stream if exists
+   */
+  CStream* GetTimingStream() const { return m_timingStream; }
 
   /*! \brief Set m_chapterSeekTime back to 0
    */

--- a/src/TSReader.cpp
+++ b/src/TSReader.cpp
@@ -10,10 +10,8 @@
 #include <bento4/Ap4ByteStream.h>
 #include <stdlib.h>
 
-TSReader::TSReader(AP4_ByteStream *stream, uint32_t requiredMask)
-  : m_stream(stream)
-  , m_requiredMask(requiredMask)
-  , m_typeMask(0)
+TSReader::TSReader(AP4_ByteStream* stream, uint32_t requiredMask)
+  : m_stream(stream), m_requiredMask(requiredMask), m_typeMask(0), m_startPts{STREAM_NOPTS_VALUE}
 {
 }
 
@@ -27,6 +25,7 @@ bool TSReader::Initialize()
     m_AVContext = nullptr;
     return false;
   }
+  m_startPts = GetPts();
   return true;
 }
 

--- a/src/TSReader.h
+++ b/src/TSReader.h
@@ -35,6 +35,7 @@ public:
 
   uint64_t GetDts() const { return m_pkt.dts == PTS_UNSET ? PTS_UNSET : m_pkt.dts; }
   uint64_t GetPts() const { return m_pkt.pts == PTS_UNSET ? PTS_UNSET : m_pkt.pts; }
+  uint64_t GetStartPts() const { return m_startPts; }
   uint64_t GetDuration() const { return m_pkt.duration; }
   const AP4_Byte *GetPacketData() const { return m_pkt.data; };
   const AP4_Size GetPacketSize() const { return m_pkt.size; };
@@ -53,6 +54,7 @@ private:
   AP4_Position m_startPos;
   uint32_t m_requiredMask;
   uint32_t m_typeMask;
+  uint64_t m_startPts;
 
   struct TSINFO
   {

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -10,6 +10,7 @@
 
 #include "AdaptiveTree.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <map>
 #include <mutex>
@@ -183,7 +184,7 @@ namespace adaptive
     uint64_t absolute_position_;
     uint64_t currentPTSOffset_, absolutePTSOffset_;
 
-    bool worker_processing_;
+    std::atomic<bool> worker_processing_;
     bool m_fixateInitialization;
     uint64_t m_segmentFileOffset;
     bool play_timeshift_buffer_;

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -44,6 +44,13 @@ namespace adaptive
     void info(std::ostream &s);
     uint64_t getMaxTimeMs();
 
+    /*!
+    * \brief Set the current segment to the one specified, and reset
+    *   the buffer
+    * \param newSegment The new segment
+    */
+    void ResetCurrentSegment(const AdaptiveTree::Segment* newSegment);
+
     unsigned int get_type()const{ return current_adp_->type_; };
 
     bool ensureSegment();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -489,14 +489,15 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
 
       if (srHaveData)
       {
-        p->dts = static_cast<double>(sr->DTS() + m_session->GetChapterStartTime());
-        p->pts = static_cast<double>(sr->PTS() + m_session->GetChapterStartTime());
+        p->dts = static_cast<double>(sr->DTS());
+        p->pts = static_cast<double>(sr->PTS());
         p->duration = static_cast<double>(sr->GetDuration());
         p->iStreamId = sr->GetStreamId();
         p->iGroupId = 0;
         p->iSize = iSize;
         std::memcpy(p->pData, pData, iSize);
-
+        //! @todo: on Kodi 21, sending of subtitles packet side data is no longer 
+        //! needed and can be removed
         sr->SetDemuxPacketSideData(p, m_session);
       }
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -672,6 +672,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           segment.range_end_ = 0;
           segment.startPTS_ = ~0ULL;
           segment.pssh_set_ = 0;
+          pts = 0;
 
           if (currentEncryptionType == ENCRYPTIONTYPE_WIDEVINE)
           {

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -29,6 +29,8 @@ public:
   }
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
+  uint64_t GetStartPTS() const override { return m_startPts; }
+  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
   uint32_t GetTimeScale() const override { return 90000; }
@@ -45,5 +47,6 @@ private:
   uint64_t m_pts{0};
   int64_t m_ptsDiff{0};
   uint64_t m_ptsOffs{~0ULL};
+  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   CAdaptiveByteStream* m_adByteStream;
 };

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -188,6 +188,9 @@ AP4_Result CFragmentedSampleReader::ReadSample()
 
   m_dts = (m_sample.GetDts() * m_timeBaseExt) / m_timeBaseInt;
   m_pts = (m_sample.GetCts() * m_timeBaseExt) / m_timeBaseInt;
+  
+  if (m_startPts == STREAM_NOPTS_VALUE)
+    SetStartPTS(m_pts - GetPTSDiff());
 
   m_codecHandler->UpdatePPSId(m_sampleData);
 

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -41,6 +41,8 @@ public:
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override;
+  uint64_t GetStartPTS() const override { return m_startPts; }
+  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override;
   uint32_t GetTimeScale() const override { return m_track->GetMediaTimeScale(); }
@@ -69,6 +71,7 @@ private:
   int64_t m_dts{0};
   int64_t m_pts{0};
   int64_t m_ptsDiff{0};
+  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   AP4_UI64 m_ptsOffs{~0ULL};
   uint64_t m_timeBaseExt;
   uint64_t m_timeBaseInt;

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -50,6 +50,8 @@ public:
   virtual bool TimeSeek(uint64_t pts, bool preceeding) = 0;
   virtual void SetPTSOffset(uint64_t offset) = 0;
   virtual int64_t GetPTSDiff() const = 0;
+  virtual void SetStartPTS(uint64_t pts) = 0;
+  virtual uint64_t GetStartPTS() const = 0;
   virtual bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) = 0;
   virtual uint32_t GetTimeScale() const = 0;
   virtual AP4_UI32 GetStreamId() const = 0;

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -80,6 +80,12 @@ CSubtitleSampleReader::CSubtitleSampleReader(SESSION::CStream* stream,
 AP4_Result CSubtitleSampleReader::Start(bool& bStarted)
 {
   m_eos = false;
+  if (m_started)
+    return AP4_SUCCESS;
+
+  m_started = true;
+  m_pts = GetStartPTS();
+  m_ptsDiff = GetStartPTS();
   return AP4_SUCCESS;
 }
 
@@ -88,7 +94,7 @@ AP4_Result CSubtitleSampleReader::ReadSample()
   if (m_codecHandler->ReadNextSample(m_sample,
                                      m_sampleData)) // Read the sample data from a file url
   {
-    m_pts = m_sample.GetCts() * 1000;
+    m_pts = (m_sample.GetCts() * 1000) + GetStartPTS();
     return AP4_SUCCESS;
   }
   else if (m_adByteStream) // Read the sample data from a segment file stream (e.g. HLS)
@@ -125,8 +131,8 @@ AP4_Result CSubtitleSampleReader::ReadSample()
           auto currentSegment = rep->current_segment_;
           if (currentSegment)
           {
-            m_codecHandler->Transform(currentSegment->startPTS_, currentSegment->m_duration,
-                                      segData, 1000);
+            m_codecHandler->Transform(currentSegment->startPTS_ + GetStartPTS(),
+                                      currentSegment->m_duration, segData, 1000);
             if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))
             {
               m_pts = m_sample.GetCts();

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -154,6 +154,7 @@ void CSubtitleSampleReader::Reset(bool bEOS)
 {
   if (m_adByteStream || bEOS)
   {
+    m_sampleData.SetDataSize(0);
     m_eos = bEOS;
     m_codecHandler->Reset();
   }

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -23,7 +23,7 @@ public:
                        AP4_UI32 streamId,
                        const std::string& codecInternalName);
 
-  bool IsStarted() const override { return true; }
+  bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_pts; }
   uint64_t PTS() const override { return m_pts; }
@@ -33,6 +33,8 @@ public:
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffset = offset; }
+  uint64_t GetStartPTS() const override { return m_startPts; }
+  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
   uint32_t GetTimeScale() const override { return 1000; }
@@ -47,8 +49,10 @@ private:
   uint64_t m_pts{0};
   uint64_t m_ptsOffset{0};
   uint64_t m_ptsDiff{0};
+  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   AP4_UI32 m_streamId;
   bool m_eos{false};
+  bool m_started{false};
   CodecHandler* m_codecHandler;
   AP4_Sample m_sample;
   AP4_DataBuffer m_sampleData;

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -20,6 +20,16 @@ CTSSampleReader::CTSSampleReader(AP4_ByteStream* input,
   m_typeMap[type] = streamId;
 }
 
+bool CTSSampleReader::Initialize()
+{
+  if (TSReader::Initialize())
+  {
+    SetStartPTS(((TSReader::GetStartPts() * 100) / 9) - GetPTSDiff());
+    return true;
+  }
+  return false;
+}
+
 void CTSSampleReader::AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid)
 {
   m_typeMap[type] = sid;

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -18,7 +18,7 @@ public:
                   AP4_UI32 streamId,
                   uint32_t requiredMask);
 
-  bool Initialize() override { return TSReader::Initialize(); }
+  bool Initialize() override;
   void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
   void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
   bool RemoveStreamType(INPUTSTREAM_TYPE type) override;
@@ -35,6 +35,8 @@ public:
   }
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
+  uint64_t GetStartPTS() const override { return m_startPts; }
+  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
   uint32_t GetTimeScale() const override { return 90000; }
@@ -51,6 +53,7 @@ private:
   uint64_t m_dts{0};
   uint64_t m_ptsOffs{~0ULL};
   int64_t m_ptsDiff{0};
+  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   bool m_eos{false};
   bool m_started{false};
   CAdaptiveByteStream* m_adByteStream;

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -29,6 +29,8 @@ public:
   }
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
+  uint64_t GetStartPTS() const override { return m_startPts; }
+  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetNextFragmentInfo(uint64_t& ts, uint64_t& dur) override { return false; }
   uint32_t GetTimeScale() const override { return 1000; }
@@ -44,6 +46,7 @@ private:
   uint64_t m_dts{0};
   uint64_t m_ptsOffs{~0ULL};
   int64_t m_ptsDiff{0};
+  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   bool m_eos{false};
   bool m_started{false};
   CAdaptiveByteStream* m_adByteStream;

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -288,7 +288,7 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
   uint64_t pts =
       tree->periods_[1]->adaptationSets_[0]->representations_[1]->segments_.data[0].startPTS_;
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(pts, 21000000);
+  EXPECT_EQ(pts, 0);
 
   var_download_url = tree->BuildDownloadUrl(
       tree->current_period_->adaptationSets_[1]->representations_[0]->source_url_);
@@ -299,5 +299,5 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
 
   pts = tree->periods_[1]->adaptationSets_[1]->representations_[0]->segments_.data[0].startPTS_;
   EXPECT_EQ(res, adaptive::HLSTree::PREPARE_RESULT_OK);
-  EXPECT_EQ(pts, 20993000);
+  EXPECT_EQ(pts, 0);
 }


### PR DESCRIPTION
Subtitle fixes (regarding webvtt/hls):
* Solves the duplicate subtitle issue. This was happening after a seek because the last segment to be read before seek would always be sent to VP - now it is flushed first
* Subtitle stream was blocking until the segment buffer was full. Now behaves normally
* Fix for all known cases to align the subtitles properly. This requires changes in Kodi to be able to adjust for timing correction in VP

Regarding seeking - this still keeps the code path to deal with re-starting stopped streams. The relevant section currently in `seek_time` is impossible to read, and evidently doesn't match 1:1 with what was before the change that introduced this issue.
Should fix #1043, #1090
