### PR TITLE
[ISM] Fix regression from refactor

### DIFF
--- a/src/parser/PRProtectionParser.cpp
+++ b/src/parser/PRProtectionParser.cpp
@@ -79,6 +79,7 @@ PRProtectionParser::PRProtectionParser(std::string wwrmheader)
   }
 
   std::string xmlData{ BASE64::Decode(wwrmheader) };
+  m_strPSSH = xmlData;
 
   size_t dataStartPoint = xmlData.find('<', 0);
   if (dataStartPoint == std::string::npos)


### PR DESCRIPTION
`m_strPSSH` is needed to be set for `insert_pssh` to add the pssh set.