### PR TITLE
FragmentedSampleReader: prevent crash if track is not present in reader

### DIFF
--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -319,18 +319,24 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
                                                 AP4_Position mdat_payload_offset,
                                                 AP4_UI64 mdat_payload_size)
 {
-  // For prefixed initialization (usually ISM) we don't yet know the
-  // proper track id, let's find it now
-  if (m_track->GetId() == TRACKID_UNKNOWN)
+  AP4_MovieFragment fragment =
+      AP4_MovieFragment(AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->Clone()));
+  AP4_Array<AP4_UI32> ids;
+  fragment.GetTrackIds(ids);
+  if (ids.ItemCount() == 1)
   {
-    AP4_MovieFragment fragment =
-        AP4_MovieFragment(AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->Clone()));
-    AP4_Array<AP4_UI32> ids;
-    fragment.GetTrackIds(ids);
-    if (ids.ItemCount() == 1)
+    // For prefixed initialization (usually ISM) we don't yet know the
+    // proper track id, let's find it now
+    if (m_track->GetId() == TRACKID_UNKNOWN)
+    {
       m_track->SetId(ids[0]);
-    else
+      LOG::LogF(LOGDEBUG, "Track ID changed from UNKNOWN to %u", ids[0]);
+    }
+    else if (ids[0] != m_track->GetId())
+    {
+      LOG::LogF(LOGDEBUG, "Track ID does not match! Expected: %u Got: %u", m_track->GetId(), ids[0]);
       return AP4_ERROR_NO_SUCH_ITEM;
+    }
   }
 
   AP4_Result result;


### PR DESCRIPTION
Despite several fixes for SIGSEGV introduced recently to ISA, I was still getting segmentation faults on a regular basis with 4K HEVC titles from Player.pl addon (paid login required, geofenced, cannot provide a sample stream, unfortunately): https://github.com/xbmc/inputstream.adaptive/issues/829#issuecomment-1001952771

While [a workaround](https://github.com/xbmc/inputstream.adaptive/issues/829#issuecomment-946686094) is available and working, introducing a hack to Bento4 is not something that we want, so I tried to track this issue.

There are only 2 streams in the movie: one video and one audio stream. I added some logging to `CFragmentedSampleReader::ProcessMoof` and noted the following:
* Both Video and Audio track IDs are initialized to a value different than `TRACKID_UNKNOWN`
* Video track Id == 3 from the start
* Audio track Id == 1 from the start
* At some point Video track Id changes to 2 and Kodi segfaults

The reason why video track ID is bitrate change: 15Mbps video track is chosen over 9.6Mbps video track. 

Since I am not familiar with Representation Chooser, I was only able to propose a workaround: commit in this Pull Request simply modifies track ID in `m_track` but perhaps there is a better place to update it?
