### PR TITLE
[FFmpeg] Use size_t size by default for AVPacketSideData

### DIFF
--- a/src/utils/FFmpeg.h
+++ b/src/utils/FFmpeg.h
@@ -296,10 +296,10 @@ enum AVPacketSideDataType
 typedef struct AVPacketSideData
 {
   uint8_t* data;
-#if HAVE_FFMPEG_5 // Enable when kodi will be built with FFmpeg >= v5.0
-  size_t size;
-#else
+#if HAVE_FFMPEG_4 // To enable when kodi will be built with FFmpeg v4.0
   int size;
+#else
+  size_t size;
 #endif
   enum AVPacketSideDataType type;
 } AVPacketSideData;


### PR DESCRIPTION
Kodi 21 now use ffmpeg 5,
so we have to change size param of `AVPacketSideData` to `size_t` data type

There is no `Omega` branch yet
so we have to wait team complete repos transition to merge it to the right branch
