### PR TITLE
Configurable headers/parameters for manifests/streams

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|stream_headers|manifest_update_parameter|original_audio_language|max_bandwidth|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|max_bandwidth|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/Session.h
+++ b/src/Session.h
@@ -28,7 +28,6 @@ class ATTR_DLL_LOCAL CSession : public adaptive::AdaptiveStreamObserver
 public:
   CSession(const UTILS::PROPERTIES::KodiProperties& properties,
            const std::string& manifestUrl,
-           const std::map<std::string, std::string>& mediaHeaders,
            const std::string& profilePath);
   virtual ~CSession();
 
@@ -340,7 +339,6 @@ protected:
 private:
   const UTILS::PROPERTIES::KodiProperties m_kodiProps;
   std::string m_manifestUrl;
-  std::map<std::string, std::string> m_mediaHeaders;
   AP4_DataBuffer m_serverCertificate;
   std::unique_ptr<kodi::tools::CDllHelper> m_dllHelper;
   SSD::SSD_DECRYPTER* m_decrypter{nullptr};
@@ -354,7 +352,7 @@ private:
   };
   std::vector<CCdmSession> m_cdmSessions;
 
-  adaptive::AdaptiveTree* m_adaptiveTree;
+  adaptive::AdaptiveTree* m_adaptiveTree{nullptr};
   CHOOSER::IRepresentationChooser* m_reprChooser;
 
   std::vector<std::unique_ptr<CStream>> m_streams;

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -23,14 +23,12 @@ public:
   CStream(adaptive::AdaptiveTree& tree,
           adaptive::AdaptiveTree::AdaptationSet* adp,
           adaptive::AdaptiveTree::Representation* initialRepr,
-          const std::map<std::string, std::string>& mediaHeaders,
-          CHOOSER::IRepresentationChooser* reprChooser,
-          bool playTimeshiftBuffer,
+          const UTILS::PROPERTIES::KodiProperties& kodiProps,
           bool chooseRep)
     : m_isEnabled{false},
       m_isEncrypted{false},
       m_mainId{0},
-      m_adStream{tree, adp, initialRepr, mediaHeaders, playTimeshiftBuffer, chooseRep},
+      m_adStream{tree, adp, initialRepr, kodiProps, chooseRep},
       m_hasSegmentChanged{false},
       m_isValid{true} {};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,20 +65,35 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
   if (m_kodiProps.m_isLicensePersistentStorage)
     drmConfig |= SSD::SSD_DECRYPTER::CONFIG_PERSISTENTSTORAGE;
 
-  std::map<std::string, std::string> mediaHeaders{m_kodiProps.m_streamHeaders};
-
-  // If the URL contains headers then replace the stream headers
-  std::string::size_type posHeader(url.find("|"));
+  // If the manifest URL contains headers then replace the manifest headers set with property
+  //! @todo: remove pipe support on Kodi v21
+  size_t posHeader = url.find("|");
   if (posHeader != std::string::npos)
   {
-    m_kodiProps.m_streamHeaders.clear();
-    ParseHeaderString(m_kodiProps.m_streamHeaders, url.substr(posHeader + 1));
+    LOG::Log(LOGWARNING, "Set headers to the manifest url by using pipe \"|\" char is deprecated, "
+                         "and will be removed in future.\n"
+                         "Use \"inputstream.adaptive.manifest_headers\" and "
+                         "\"inputstream.adaptive.stream_headers\" properties instead.");
+    m_kodiProps.m_manifestHeaders.clear();
+    ParseHeaderString(m_kodiProps.m_manifestHeaders, url.substr(posHeader + 1));
     url = url.substr(0, posHeader);
-  }
-  if (mediaHeaders.empty())
-    mediaHeaders = m_kodiProps.m_streamHeaders;
 
-  m_session = std::make_shared<CSession>(m_kodiProps, url, mediaHeaders, props.GetProfileFolder());
+    if (m_kodiProps.m_streamHeaders.empty())
+      m_kodiProps.m_streamHeaders = m_kodiProps.m_manifestHeaders;
+  }
+
+  //! @todo: remove this old forced behaviour on Kodi v21
+  if (m_kodiProps.m_manifestHeaders.empty() && !m_kodiProps.m_streamHeaders.empty())
+  {
+    LOG::Log(
+        LOGWARNING,
+        "Set headers to the manifest by using \"inputstream.adaptive.stream_headers\" property "
+        "is a deprecated behaviour that will be removed in future.\n"
+        "To set headers to the manifest, use \"inputstream.adaptive.manifest_headers\" property.");
+    m_kodiProps.m_manifestHeaders = m_kodiProps.m_streamHeaders;
+  }
+
+  m_session = std::make_shared<CSession>(m_kodiProps, url, props.GetProfileFolder());
   m_session->SetVideoResolution(m_currentVideoWidth, m_currentVideoHeight, m_currentVideoMaxWidth,
                                 m_currentVideoMaxHeight);
 

--- a/src/main.h
+++ b/src/main.h
@@ -37,7 +37,7 @@ public:
   void SetVideoResolution(unsigned int width,
                           unsigned int height,
                           unsigned int maxWidth,
-                          unsigned int maxHeight);
+                          unsigned int maxHeight) override;
   bool PosTime(int ms) override;
   int GetTotalTime() override;
   int GetTime() override;

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -16,13 +16,11 @@ namespace adaptive
 class ATTR_DLL_LOCAL DASHTree : public AdaptiveTree
 {
 public:
-  DASHTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-           CHOOSER::IRepresentationChooser* reprChooser)
-    : AdaptiveTree(kodiProps, reprChooser){};
+  DASHTree(CHOOSER::IRepresentationChooser* reprChooser) : AdaptiveTree(reprChooser) {}
   DASHTree(const DASHTree& left);
 
-  virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
-  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
+  virtual bool open(const std::string& url) override;
+  virtual bool open(const std::string& url, std::map<std::string, std::string> addHeaders) override;
   virtual void RefreshSegments(Period* period,
                                AdaptationSet* adp,
                                Representation* rep,
@@ -36,6 +34,20 @@ public:
   virtual void SetLastUpdated(std::chrono::system_clock::time_point tm){};
   void SetUpdateInterval(uint32_t interval) { updateInterval_ = interval; };
 
+  /*!
+   * \brief Set the manifest update url parameter, used to force enabling manifest updates.
+   *        This implementation has optional support to use the placeholder $START_NUMBER$
+   *        to make next manifest update requests by adding a parameter with segment start number.
+   *        e.g. ?start_seq=$START_NUMBER$
+   *        This can be set directly in the manifest url or as separate parameter (see Kodi property).
+   * \param manifestUrl The manifest url, if contains the placeholder $START_NUMBER$ the
+   *                    the parameter will be removed from the original url value,
+   *                    and used to request next manifest updates.
+   * \param param The update parameter, is accepted "full" value,
+   *              or an url parameter with $START_NUMBER$ placeholder.
+   */
+  virtual void SetManifestUpdateParam(std::string& manifestUrl, std::string_view param) override;
+
   uint64_t pts_helper_, timeline_time_;
   uint64_t firstStartNumber_;
   std::string current_playready_wrmheader_;
@@ -46,5 +58,7 @@ protected:
   virtual void RefreshLiveSegments() override;
 
   virtual DASHTree* Clone() const override { return new DASHTree{*this}; }
+
+  HTTPRespHeaders m_manifestRespHeaders;
 };
 } // namespace adaptive

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -28,14 +28,15 @@ public:
     ENCRYPTIONTYPE_WIDEVINE = 3,
     ENCRYPTIONTYPE_UNKNOWN = 4,
   };
-  HLSTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-          CHOOSER::IRepresentationChooser* reprChooser);
+  HLSTree(CHOOSER::IRepresentationChooser* reprChooser);
   HLSTree(const HLSTree& left);
+
+  virtual void Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps) override;
 
   virtual ~HLSTree();
 
-  virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
-  virtual bool open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders) override;
+  virtual bool open(const std::string& url) override;
+  virtual bool open(const std::string& url, std::map<std::string, std::string> additionalHeaders) override;
   virtual PREPARE_RESULT prepareRepresentation(Period* period,
                                                AdaptationSet* adp,
                                                Representation* rep,

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -26,17 +26,19 @@ using namespace adaptive;
 using namespace kodi::tools;
 using namespace UTILS;
 
-SmoothTree::SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-                       CHOOSER::IRepresentationChooser* reprChooser)
-  : AdaptiveTree(kodiProps, reprChooser)
+SmoothTree::SmoothTree(CHOOSER::IRepresentationChooser* reprChooser) : AdaptiveTree(reprChooser)
 {
-  current_period_ = new AdaptiveTree::Period;
-  periods_.push_back(current_period_);
 }
 
-adaptive::SmoothTree::SmoothTree(const SmoothTree& left)
-  : AdaptiveTree(left.m_kodiProps, left.m_reprChooser)
+SmoothTree::SmoothTree(const SmoothTree& left) : AdaptiveTree(left)
 {
+}
+
+void SmoothTree::Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps)
+{
+  AdaptiveTree::Configure(kodiProps);
+  current_period_ = new AdaptiveTree::Period;
+  periods_.push_back(current_period_);
 }
 
 /*----------------------------------------------------------------------
@@ -353,25 +355,21 @@ static void XMLCALL end(void* data, const char* el)
 |   SmoothTree
 +---------------------------------------------------------------------*/
 
-bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam)
+bool SmoothTree::open(const std::string& url)
 {
-  return open(url, manifestUpdateParam, std::map<std::string, std::string>());
+  return open(url, std::map<std::string, std::string>());
 }
 
-bool SmoothTree::open(const std::string& url, const std::string& manifestUpdateParam, std::map<std::string, std::string> additionalHeaders)
+bool SmoothTree::open(const std::string& url, std::map<std::string, std::string> addHeaders)
 {
   currentNode_ = 0;
 
-  PrepareManifestUrl(url, manifestUpdateParam);
-  additionalHeaders.insert(m_streamHeaders.begin(), m_streamHeaders.end());
-
   std::stringstream data;
   HTTPRespHeaders respHeaders;
-  if (!download(manifest_url_, additionalHeaders, data, respHeaders))
+  if (!DownloadManifest(url, addHeaders, data, respHeaders))
     return false;
 
   effective_url_ = respHeaders.m_effectiveUrl;
-  m_manifestHeaders = respHeaders;
 
   if (!PreparePaths(effective_url_))
     return false;

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -16,14 +16,13 @@ namespace adaptive
 class ATTR_DLL_LOCAL SmoothTree : public AdaptiveTree
 {
 public:
-  SmoothTree(const UTILS::PROPERTIES::KodiProperties& kodiProps,
-             CHOOSER::IRepresentationChooser* reprChooser);
+  SmoothTree(CHOOSER::IRepresentationChooser* reprChooser);
   SmoothTree(const SmoothTree& left);
 
-  virtual bool open(const std::string& url, const std::string& manifestUpdateParam) override;
-  virtual bool open(const std::string& url,
-                    const std::string& manifestUpdateParam,
-                    std::map<std::string, std::string> additionalHeaders) override;
+  virtual void Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps) override;
+
+  virtual bool open(const std::string& url) override;
+  virtual bool open(const std::string& url, std::map<std::string, std::string> addHeaders) override;
 
   virtual SmoothTree* Clone() const override { return new SmoothTree{*this}; }
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -26,17 +26,16 @@ void SetFileName(std::string& file, std::string name)
   file = GetEnv("DATADIR") + "/" + name;
 }
 
-bool TestAdaptiveStream::download_segment()
+bool TestAdaptiveStream::download_segment(const DownloadInfo& downloadInfo)
 {
-  if (download_url_.empty())
+  if (downloadInfo.m_url.empty())
     return false;
-  testHelper::downloadList.push_back(download_url_);
+  testHelper::downloadList.push_back(downloadInfo.m_url);
 
-  return download(download_url_, download_headers_, nullptr);
+  return download(downloadInfo, nullptr);
 }
 
-bool TestAdaptiveStream::download(const std::string& url,
-                                  const std::map<std::string, std::string>& mediaHeaders,
+bool TestAdaptiveStream::download(const DownloadInfo& downloadInfo,
                                   std::string* lockfreeBuffer)
 {
   size_t nbRead = ~0UL;
@@ -50,7 +49,7 @@ bool TestAdaptiveStream::download(const std::string& url,
   {
     ss.read(buf, 16);
     nbRead = ss.gcount();
-    if (!nbRead || !~nbRead || !write_data(buf, nbRead, lockfreeBuffer, false))
+    if (!nbRead || !~nbRead || !write_data(buf, nbRead, lockfreeBuffer, false, downloadInfo))
       break;
     nbReadOverall += nbRead;
   }
@@ -135,9 +134,8 @@ bool DASHTestTree::download(const std::string& url,
   return false;
 }
 
-HLSTestTree::HLSTestTree(UTILS::PROPERTIES::KodiProperties kodiProps,
-  CHOOSER::IRepresentationChooser* reprChooser)
-  : HLSTree(kodiProps, reprChooser) 
+HLSTestTree::HLSTestTree(CHOOSER::IRepresentationChooser* reprChooser)
+  : HLSTree(reprChooser) 
 {
   m_decrypter = std::make_unique<AESDecrypter>(AESDecrypter(std::string()));
 }

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -26,9 +26,15 @@ constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"
 constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data";
 constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags";
 constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate";
+
 constexpr std::string_view PROP_MANIFEST_TYPE = "inputstream.adaptive.manifest_type";
 constexpr std::string_view PROP_MANIFEST_UPD_PARAM = "inputstream.adaptive.manifest_update_parameter";
+constexpr std::string_view PROP_MANIFEST_PARAMS = "inputstream.adaptive.manifest_params";
+constexpr std::string_view PROP_MANIFEST_HEADERS = "inputstream.adaptive.manifest_headers";
+
+constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_params";
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
+
 constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
 constexpr std::string_view PROP_BANDWIDTH_MAX = "inputstream.adaptive.max_bandwidth"; //! @todo: deprecated, to be removed on next Kodi release
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
@@ -91,6 +97,18 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     else if (prop.first == PROP_MANIFEST_UPD_PARAM)
     {
       props.m_manifestUpdateParam = prop.second;
+    }
+    else if (prop.first == PROP_MANIFEST_PARAMS)
+    {
+      props.m_manifestParams = prop.second;
+    }
+    else if (prop.first == PROP_MANIFEST_HEADERS)
+    {
+      ParseHeaderString(props.m_manifestHeaders, prop.second);
+    }
+    else if (prop.first == PROP_STREAM_PARAMS)
+    {
+      props.m_streamParams = prop.second;
     }
     else if (prop.first == PROP_STREAM_HEADERS)
     {

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -41,8 +41,16 @@ struct KodiProperties
   bool m_isLicenseForceSecureDecoder{false};
   std::string m_serverCertificate;
   ManifestType m_manifestType{ManifestType::UNKNOWN};
+  // Can be used to force enable manifest updates,
+  // and optionally to set a specific url parameter
   std::string m_manifestUpdateParam;
-  // HTTP headers used to download manifest and streams
+  // HTTP parameters used to download manifests
+  std::string m_manifestParams;
+  // HTTP headers used to download manifests
+  std::map<std::string, std::string> m_manifestHeaders;
+  // HTTP parameters used to download streams
+  std::string m_streamParams;
+  // HTTP headers used to download streams
   std::map<std::string, std::string> m_streamHeaders;
   std::string m_audioLanguageOrig;
   bool m_playTimeshiftBuffer{false};

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -142,7 +142,7 @@ void UTILS::URL::AppendParameters(std::string& url, std::string params)
     url += "&";
 
   if (params.front() == '&' || params.front() == '?')
-    params.pop_back();
+    params.erase(params.begin());
 
   url += params;
 }


### PR DESCRIPTION
As discussed on #1093
this PR has the purpose to introduce configurable url parameters for manifest and streams separately, by using kodi properties,
and also the url parameters sets will be propagated to all manifest childrens (e.g. HLS case)

Since to implement this i had to do some clean up/rework, i also revisited how the headers are handled,

I also found that in a recent PR i have partially broken the purpose of old behaviour (see #625),
with reference to this i have deprecated the possibility to inject headers on manifest url, by using `|` char e.g.
`http:\\www.media.com\manifest.m3u8|?token=example`
This was the first implementation before adding the possibility to use kodi properties to set headers,
_this method has been never documented_ and i think few addons use or are aware of this,
has no sense still keep it (url inject) imo better remove it on Kodi v21 to make easier code management
and is a minor change for addons, that will have to use `inputstream.adaptive.manifest_headers` property.

Others relative rework/cleanups related to this:

I added `AdaptiveTree::Configure` class method this to avoid store another kodiProps to tree class and to allow more easy cloning

On `AdaptiveStream` class the PrepareDownload/Download/write_data methods,
now no longer use class variable members to share data, now data are passed as reference,
which result fewer parameters for methods and better thread safe

What new and changed on kodi parameters:
- new `inputstream.adaptive.manifest_params` to apply params to manifest and children manifests
- new `inputstream.adaptive.manifest_headers` to apply headers to manifest and children manifests
- new `inputstream.adaptive.stream_params` to apply params to streams
- deprecated behaviour `inputstream.adaptive.stream_headers` for now still can be used to set headers to manifests AND streams, but this behaviour is now deprecated and will be removed on Kodi v21, so in future this property will be used to set headers to streams only.

Sidenote:
if you play a manifest url that already include parameters, and you also set `inputstream.adaptive.manifest_params` property,
the parameters of the url will have the precedence over the kodi property, but only for the master manifest, not for the childrens (like HLS)

Tested with live Dash/HLS with subtitles stream samples
