### PR TITLE
[HLSTree] Fix container type not set for video

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -532,8 +532,20 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
                 rep->containerType_ = CONTAINERTYPE_TEXT;
               else
               {
-                rep->containerType_ = CONTAINERTYPE_INVALID;
-                continue;
+                if (adp->type_ == VIDEO)
+                {
+                  // Streams that have a media url encoded as a parameter of the url itself
+                  // cannot be detected in safe way, so we try fallback to .ts
+                  // e.g. https://cdn-prod.tv/beacon?streamId=1&rp=https%3A%2F%2Ftest.com%2F167037ac3%2Findex_4_0.ts&sessionId=abc&assetId=OD
+                  rep->containerType_ = CONTAINERTYPE_TS;
+                  LOG::LogF(LOGDEBUG, "Cannot detect container type from media url, fallback to TS");
+                }
+                else
+                {
+                  rep->containerType_ = CONTAINERTYPE_INVALID;
+                  LOG::LogF(LOGDEBUG, "Cannot detect container type from media url");
+                  continue;
+                }
               }
             }
             else


### PR DESCRIPTION
Following test stream cannot currently played
https://cdn-ue1-prod.tsv2.amagi.tv/avod/simplestream-lds-ldtimln/ODYPPCS001EP001/ODYPPCS001EP001.m3u8

this because the real video media link is encoded as url paramater
i have not found info about this way, could be a custom implementation
so in any case i think better fallback to TS when it is a video adaptationset
