### PR TITLE
[AdaptiveStream] Fix IV decrypter, range format regressions

### DIFF
--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -59,7 +59,6 @@ std::string AESDecrypter::convertIV(const std::string &input)
 
 void AESDecrypter::ivFromSequence(uint8_t *buffer, uint64_t sid)
 {
-  memset(buffer, 0, 16);
   AP4_BytesFromUInt64BE(buffer + 8, sid);
 }
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -701,12 +701,12 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Representation* rep,
         uint64_t fileOffset = ~segNum ? m_segmentFileOffset : 0;
         if (~seg->range_end_)
         {
-          rangeHeader = StringUtils::Format("bytes=%u-%u", seg->range_begin_ + fileOffset,
+          rangeHeader = StringUtils::Format("bytes=%llu-%llu", seg->range_begin_ + fileOffset,
                                             seg->range_end_ + fileOffset);
         }
         else
         {
-          rangeHeader = StringUtils::Format("bytes=%u-", seg->range_begin_ + fileOffset);
+          rangeHeader = StringUtils::Format("bytes=%llu-", seg->range_begin_ + fileOffset);
         }
       }
     }
@@ -735,12 +735,12 @@ bool AdaptiveStream::prepareDownload(const AdaptiveTree::Representation* rep,
       uint64_t fileOffset = ~segNum ? m_segmentFileOffset : 0;
       if (~seg->range_end_)
       {
-        rangeHeader = StringUtils::Format("bytes=%u-%u", seg->range_begin_ + fileOffset,
+        rangeHeader = StringUtils::Format("bytes=%llu-%llu", seg->range_begin_ + fileOffset,
                                           seg->range_end_ + fileOffset);
       }
       else
       {
-        rangeHeader = StringUtils::Format("bytes=%u-", seg->range_begin_ + fileOffset);
+        rangeHeader = StringUtils::Format("bytes=%llu-", seg->range_begin_ + fileOffset);
       }
     }
   }

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -462,8 +462,7 @@ bool AdaptiveStream::write_data(const void* buffer,
 
     size_t insertPos(segment_buffer.size());
     segment_buffer.resize(insertPos + buffer_size);
-    uint8_t iv[16];
-    tree_.OnDataArrived(downloadInfo.m_segmentNumber, downloadInfo.m_psshSet, iv,
+    tree_.OnDataArrived(downloadInfo.m_segmentNumber, downloadInfo.m_psshSet,
                         reinterpret_cast<const uint8_t*>(buffer), segment_buffer, insertPos,
                         buffer_size, lastChunk);
   }

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -180,7 +180,6 @@ namespace adaptive
 
   void AdaptiveTree::OnDataArrived(uint64_t segNum,
                                    uint16_t psshSet,
-                                   uint8_t iv[16],
                                    const uint8_t* src,
                                    std::string& dst,
                                    size_t dstOffset,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -542,7 +542,6 @@ public:
   virtual std::chrono::time_point<std::chrono::system_clock> GetRepLastUpdated(const Representation* rep) { return std::chrono::system_clock::now(); }
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
-                             uint8_t iv[16],
                              const uint8_t* src,
                              std::string& dst,
                              size_t dstOffset,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -44,7 +44,6 @@ public:
 
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
-                             uint8_t iv[16],
                              const uint8_t* src,
                              std::string& dst,
                              size_t dstOffset,
@@ -67,6 +66,7 @@ protected:
   virtual bool ParseManifest(std::stringstream& stream);
   virtual void RefreshLiveSegments() override;
   std::unique_ptr<IAESDecrypter> m_decrypter;
+  uint8_t m_decrypterIv[16]{};
 
 private:
   int processEncryption(std::string baseUrl, std::map<std::string, std::string>& map);


### PR DESCRIPTION
I made a couple of regression from PR #1102

The use of decrypter IV variable was stored in the main AdaptiveStream class, but its only for HLS implementation, so i misinterpreted its use, now i have moved and stored this value on the HLSTree class.

The conversion of range to string its a clear oversight and ~may~ fix #1117