### PR TITLE
ChooserDefault: initialize "limited" bandwidth if automatic turned off

### DIFF
--- a/src/common/ChooserDefault.cpp
+++ b/src/common/ChooserDefault.cpp
@@ -96,6 +96,7 @@ void CRepresentationChooserDefault::PostInit()
   if (!m_bandwidthInitAuto)
   {
     m_bandwidthCurrent = std::max(m_bandwidthInit, m_bandwidthMin);
+    m_bandwidthCurrentLimited = m_bandwidthCurrent;
   }
   else if (m_bandwidthCurrent == 0)
   {


### PR DESCRIPTION
## Description
GetNextRepresentation uses m_bandwidthCurrentLimited, so we need to initialize also this value.

## Motivation and context
I encountered some high(ish)-bandwidth MPD streams with 2 representations (9.6Mbps and 15Mbps) but low initial download speed, due to which ISA selects low-bandwidth representation and switches to higher quality stream later. I wanted to start with high bandwidth stream and only switch to lower if required due to network conditions - in other words, keep automatic stream selection working. However, with "Auto determines initial bandwidth" disabled and initial bandwidth set to 50Mbps, still the lower-bandwidth representation is selected:
```
 info <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Resolution set: 1920x1080, max allowed: 3840x2160, Adjust refresh rate: 1
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Type: Default
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Configuration
                 Resolution max: 0x0
                 Resolution max for secure decoder: 1280x720
                 Bandwidth limits (bit/s): min 0, max 0
 info <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Resolution set: 1920x1080, max allowed: 3840x2160, Adjust refresh rate: 1
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Screen resolution has changed: 3840x2160
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Current average bandwidth: 2027768 bit/s (filtered to 1824991 bit/s)
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Selected representation
                 ID 1 (Bandwidth: 9600000 bit/s, Resolution: 3840x2144)
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Stream selection conditions
                 Screen resolution: 3840x2160 (may be limited by settings)
                 Initial bandwidth: 50000000 bit/s
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Current average bandwidth: 50000000 bit/s (filtered to 1824991 bit/s)
debug <general>: AddOnLog: inputstream.adaptive: [Repr. chooser] Selected representation
                 ID 1 (Bandwidth: 9600000 bit/s, Resolution: 3840x2144)
```
This line: `Current average bandwidth: 50000000 bit/s (filtered to 1824991 bit/s)` indicates the issue - we also need to initialize the "filtered" value.

## How has this been tested?
As described above: open stream with 2 representations. Now with "Auto determines initial bandwidth" disabled and initial bandwidth set to 50Mbps, the higher bandwidth representation is selected.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
