### PR TITLE
[backport][widevine] add support for linux arm64

### DIFF
--- a/wvdecrypter/wvdecrypter.cpp
+++ b/wvdecrypter/wvdecrypter.cpp
@@ -23,6 +23,9 @@
 #include <thread>
 #include <vector>
 
+#if defined(__linux__) && defined(__aarch64__) && !defined(ANDROID)
+#include <sys/auxv.h>
+#endif
 #include <bento4/Ap4.h>
 
 #ifndef WIDEVINECDMFILENAME
@@ -1670,6 +1673,69 @@ private:
 };
 
 extern "C" {
+
+// Linux arm64 version of libwidevinecdm.so depends on two
+// dynamic symbols. See https://github.com/xbmc/inputstream.adaptive/issues/1128
+// These implementations are based on libgcc.a lse.S
+#if defined(__linux__) && defined(__aarch64__) && !defined(ANDROID)
+static int have_lse_atomics;
+
+static void __attribute__((constructor (101))) init_have_lse_atomics()
+{
+  unsigned long hwcap = getauxval (AT_HWCAP);
+  have_lse_atomics = (hwcap & HWCAP_ATOMICS) != 0;
+}
+
+int32_t __aarch64_ldadd4_acq_rel(int32_t value, int32_t *ptr)
+{
+  int32_t ret;
+  if (have_lse_atomics) {
+    __asm__ __volatile__ (
+      ".inst 0x38200020 + 0x0000 + 0x80000000 + 0xc00000\r\n"
+      : "=&r" (ret)
+      :
+    );
+  } else {
+    __asm__ __volatile__ (
+      "0:\r\n"
+      "ldaxr w16, [%[ptr]]\r\n"
+      "add   w17, w16, %w[value]\r\n"
+      "stlxr w15, w17, [%[ptr]]\r\n"
+      "cbnz  w15, 0b\r\n"
+      "mov   %w[result], w16\r\n"
+      : [result]   "=&r" (ret)
+      : [ptr]      "r"   (ptr),
+        [value]    "r"   (value)
+      : "w15", "w16", "w17", "memory"
+    );
+  }
+  return ret;
+}
+
+int32_t __aarch64_swp4_acq_rel(int32_t value, int32_t *ptr)
+{
+  int32_t ret;
+  if (have_lse_atomics) {
+    __asm__ __volatile__ (
+      ".inst 0x38208020 + 0x80000000 + 0xc00000\r\n"
+      : "=&r" (ret)
+      :
+    );
+  } else {
+    __asm__ __volatile__ (
+      "0:\r\n"
+      "ldaxr %w[result], [%[ptr]]\r\n"
+      "stlxr w15, %w[value], [%[ptr]]\r\n"
+      "cbnz  w15, 0b\r\n"
+      : [result]   "=&r" (ret)
+      : [ptr]      "r"   (ptr),
+        [value]    "r"   (value)
+      : "w15", "memory"
+    );
+  }
+  return ret;
+}
+#endif
 
 #ifdef _WIN32
 #define MODULE_API __declspec(dllexport)


### PR DESCRIPTION
without these changes, the following error is observed:

    Initialize: Failed to load library: libwidevinecdm.so: undefined symbol: __aarch64_ldadd4_acq_rel
    Unable to load widevine shared library (libwidevinecdm.so)

cc #1128 https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/530

cc @matthuisman @glennguy @peak3d @knaerzche @jernejsk

for reference:
- https://github.com/devins2518/zig/blob/545c3117ff2f88ee9f29414429a06cedebc0d8c0/lib/compiler_rt/aarch64_outline_atomics.zig#L1421-L1461
- https://github.com/gcc-mirror/gcc/blob/fe4608efc15b881ac908a3f90d7322736495ae72/libgcc/config/aarch64/lse-init.c
- https://github.com/gcc-mirror/gcc/blob/fe4608efc15b881ac908a3f90d7322736495ae72/libgcc/config/aarch64/lse.S
- https://godbolt.org/z/z8W7z1cqx