### PR TITLE
[AdaptiveStream] Restored decrypter IV variable as class member

### DIFF
--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -59,6 +59,7 @@ std::string AESDecrypter::convertIV(const std::string &input)
 
 void AESDecrypter::ivFromSequence(uint8_t *buffer, uint64_t sid)
 {
+  memset(buffer, 0, 16);
   AP4_BytesFromUInt64BE(buffer + 8, sid);
 }
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -462,8 +462,7 @@ bool AdaptiveStream::write_data(const void* buffer,
 
     size_t insertPos(segment_buffer.size());
     segment_buffer.resize(insertPos + buffer_size);
-    uint8_t iv[16];
-    tree_.OnDataArrived(downloadInfo.m_segmentNumber, downloadInfo.m_psshSet, iv,
+    tree_.OnDataArrived(downloadInfo.m_segmentNumber, downloadInfo.m_psshSet, m_decrypterIv,
                         reinterpret_cast<const uint8_t*>(buffer), segment_buffer, insertPos,
                         buffer_size, lastChunk);
   }

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -462,7 +462,8 @@ bool AdaptiveStream::write_data(const void* buffer,
 
     size_t insertPos(segment_buffer.size());
     segment_buffer.resize(insertPos + buffer_size);
-    tree_.OnDataArrived(downloadInfo.m_segmentNumber, downloadInfo.m_psshSet,
+    uint8_t iv[16];
+    tree_.OnDataArrived(downloadInfo.m_segmentNumber, downloadInfo.m_psshSet, iv,
                         reinterpret_cast<const uint8_t*>(buffer), segment_buffer, insertPos,
                         buffer_size, lastChunk);
   }

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -169,6 +169,10 @@ namespace adaptive
     AdaptiveTree::AdaptationSet* current_adp_;
     AdaptiveTree::Representation *current_rep_;
 
+    // Decrypter IV used to decrypt HLS segment
+    // We need to store here because linked to representation
+    uint8_t m_decrypterIv[16];
+
     static const size_t MAXSEGMENTBUFFER;
     // number of segmentbuffers whith valid segment, always >= valid_segment_buffers_
     size_t available_segment_buffers_;

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -180,6 +180,7 @@ namespace adaptive
 
   void AdaptiveTree::OnDataArrived(uint64_t segNum,
                                    uint16_t psshSet,
+                                   uint8_t iv[16],
                                    const uint8_t* src,
                                    std::string& dst,
                                    size_t dstOffset,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -542,6 +542,7 @@ public:
   virtual std::chrono::time_point<std::chrono::system_clock> GetRepLastUpdated(const Representation* rep) { return std::chrono::system_clock::now(); }
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
+                             uint8_t iv[16],
                              const uint8_t* src,
                              std::string& dst,
                              size_t dstOffset,

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -829,6 +829,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
 
 void HLSTree::OnDataArrived(uint64_t segNum,
                             uint16_t psshSet,
+                            uint8_t iv[16],
                             const uint8_t* src,
                             std::string& dst,
                             size_t dstOffset,
@@ -890,19 +891,20 @@ void HLSTree::OnDataArrived(uint64_t segNum,
     else if (!dstOffset)
     {
       if (pssh.iv.empty())
-        m_decrypter->ivFromSequence(m_decrypterIv, segNum);
+        m_decrypter->ivFromSequence(iv, segNum);
       else
       {
-        memcpy(m_decrypterIv, pssh.iv.data(), pssh.iv.size() < 16 ? pssh.iv.size() : 16);
+        memset(iv, 0, 16);
+        memcpy(iv, pssh.iv.data(), pssh.iv.size() < 16 ? pssh.iv.size() : 16);
       }
     }
-    m_decrypter->decrypt(reinterpret_cast<const uint8_t*>(pssh.defaultKID_.data()), m_decrypterIv,
-                         src, dst, dstOffset, dataSize, lastChunk);
+    m_decrypter->decrypt(reinterpret_cast<const uint8_t*>(pssh.defaultKID_.data()), iv, src, dst,
+                         dstOffset, dataSize, lastChunk);
     if (dataSize >= 16)
-      memcpy(m_decrypterIv, src + (dataSize - 16), 16);
+      memcpy(iv, src + (dataSize - 16), 16);
   }
   else
-    AdaptiveTree::OnDataArrived(segNum, psshSet, src, dst, dstOffset, dataSize, lastChunk);
+    AdaptiveTree::OnDataArrived(segNum, psshSet, iv, src, dst, dstOffset, dataSize, lastChunk);
 }
 
 //Called each time before we switch to a new segment

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -44,6 +44,7 @@ public:
 
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
+                             uint8_t iv[16],
                              const uint8_t* src,
                              std::string& dst,
                              size_t dstOffset,
@@ -66,7 +67,6 @@ protected:
   virtual bool ParseManifest(std::stringstream& stream);
   virtual void RefreshLiveSegments() override;
   std::unique_ptr<IAESDecrypter> m_decrypter;
-  uint8_t m_decrypterIv[16]{};
 
 private:
   int processEncryption(std::string baseUrl, std::map<std::string, std::string>& map);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Revert to original state, the current code that manage IV/PSSH is a real panic of a mess...
every attempt i tried to clean up the code was a failure

by looking at ffmpeg hls source, there is no all this mess
ffmpeg set the missing IV directly when create the segments when parsing the manifest (in our case by using ivFromSequence when parsing) trying do a similar thing dont work
one reason is around the variable `else if (!dstOffset)` on `HLSTree::OnDataArrived` used to set the IV that its totally unclear
the variables from which the data originate are so confusing
which are poorly implemented and IMO require a rework

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1132

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
