### PR TITLE
[HLSTree] Fix resolution of URI with relative path

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -122,7 +122,7 @@ int HLSTree::processEncryption(std::string baseUrl, std::map<std::string, std::s
   if (map["METHOD"] == "AES-128" && !map["URI"].empty())
   {
     current_pssh_ = map["URI"];
-    if (!URL::IsUrlRelative(current_pssh_) && !URL::IsUrlAbsolute(current_pssh_))
+    if (URL::IsUrlRelative(current_pssh_) && !URL::IsUrlAbsolute(current_pssh_))
       current_pssh_ = URL::Join(baseUrl, current_pssh_);
 
     current_iv_ = m_decrypter->convertIV(map["IV"]);
@@ -722,7 +722,7 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
           {
             std::string uri = map["URI"];
 
-            if (!URL::IsUrlRelative(uri) && !URL::IsUrlAbsolute(uri))
+            if (URL::IsUrlRelative(uri) && !URL::IsUrlAbsolute(uri))
               map_url = URL::Join(base_url, uri);
             else
               map_url = uri;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Relative URI was not resolved

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #496

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
live Dailymotion stream taken from: https://www.dailymotion.com/video/x5gv5rr
and: https://www.weo.fr/direct/ (stream link on html code)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
