### PR TITLE
[SampleReader] Removed use of subtitle demux packet sidedata

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -496,9 +496,6 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
         p->iGroupId = 0;
         p->iSize = iSize;
         std::memcpy(p->pData, pData, iSize);
-        //! @todo: on Kodi 21, sending of subtitles packet side data is no longer 
-        //! needed and can be removed
-        sr->SetDemuxPacketSideData(p, m_session);
       }
 
       //LOG::Log(LOGDEBUG, "DTS: %0.4f, PTS:%0.4f, ID: %u SZ: %d", p->dts, p->pts, p->iStreamId, p->iSize);

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -93,15 +93,6 @@ public:
                std::future_status::ready;
   }
 
-  /*
-   * \brief Set the side data to the demux packet
-   * \param pkt The packet where set the side data
-   * \param session The current session
-   */
-  virtual void SetDemuxPacketSideData(DEMUX_PACKET* pkt, std::shared_ptr<SESSION::CSession> session)
-  {
-  }
-
 private:
   std::future<AP4_Result> m_readSampleAsyncState;
 };

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -8,7 +8,6 @@
 
 #include "SubtitleSampleReader.h"
 
-#include "../Session.h"
 #include "../utils/FFmpeg.h"
 #include "../utils/MemUtils.h"
 #include "../utils/log.h"
@@ -16,16 +15,6 @@
 #include <kodi/Filesystem.h>
 
 using namespace UTILS;
-
-namespace
-{
-// This struct must match the same on:
-// xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
-struct SubtitlePacketExtraData
-{
-  double m_chapterStartTime;
-};
-} // unnamed namespace
 
 CSubtitleSampleReader::CSubtitleSampleReader(const std::string& url,
                                            AP4_UI32 streamId,
@@ -192,39 +181,4 @@ bool CSubtitleSampleReader::TimeSeek(uint64_t pts, bool preceeding)
       return AP4_SUCCEEDED(ReadSample());
     return false;
   }
-}
-
-void CSubtitleSampleReader::SetDemuxPacketSideData(DEMUX_PACKET* pkt,
-                                                   std::shared_ptr<SESSION::CSession> session)
-{
-  if (!m_isSideDataRequired || !pkt)
-    return;
-
-  pkt->pSideData = MEMORY::AlignedMalloc(sizeof(struct UTILS::FFMPEG::AVPacketSideData));
-  if (!pkt->pSideData)
-  {
-    LOG::Log(LOGERROR, "Cannot allocate AVPacketSideData");
-    return;
-  }
-  void* subPktDataPtr{MEMORY::AlignedMalloc(sizeof(struct SubtitlePacketExtraData))};
-  if (!subPktDataPtr)
-  {
-    MEMORY::AlignedFree(pkt->pSideData);
-    pkt->pSideData = nullptr;
-    LOG::Log(LOGERROR, "Cannot allocate SubtitlePacketExtraData");
-    return;
-  }
-
-  auto subPktData{reinterpret_cast<SubtitlePacketExtraData*>(subPktDataPtr)};
-  // HSL multi-period require to sync the cues timestamps of Segmented WebVTT
-  // with the current chapter start time (period start)
-  // so we have to provide the chapter start time to Kodi subtitle parser
-  subPktData->m_chapterStartTime = session->GetChapterStartTime();
-
-  auto avpList{static_cast<UTILS::FFMPEG::AVPacketSideData*>(pkt->pSideData)};
-  avpList[0].data = reinterpret_cast<uint8_t*>(subPktDataPtr);
-  avpList[0].type = UTILS::FFMPEG::AV_PKT_DATA_NEW_EXTRADATA;
-  avpList[0].size = sizeof(struct SubtitlePacketExtraData);
-
-  pkt->iSideDataElems = 1;
 }

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -43,7 +43,6 @@ public:
   const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); }
   uint64_t GetDuration() const override { return m_sample.GetDuration() * 1000; }
   bool IsEncrypted() const override { return false; }
-  void SetDemuxPacketSideData(DEMUX_PACKET* pkt, std::shared_ptr<SESSION::CSession> session) override;
 
 private:
   uint64_t m_pts{0};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Removed use of subtitle demux packet

note: kept memory utils is intentional

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since now the fixes has been merged on xbmc for Kodi 21 this code is now obsolete and is not needed anymore

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
