### PR TITLE
Removed features marked as deprecated on Kodi 20

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|max_bandwidth|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,23 +65,6 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
   if (m_kodiProps.m_isLicensePersistentStorage)
     drmConfig |= SSD::SSD_DECRYPTER::CONFIG_PERSISTENTSTORAGE;
 
-  // If the manifest URL contains headers then replace the manifest headers set with property
-  //! @todo: remove pipe support on Kodi v21
-  size_t posHeader = url.find("|");
-  if (posHeader != std::string::npos)
-  {
-    LOG::Log(LOGWARNING, "Set headers to the manifest url by using pipe \"|\" char is deprecated, "
-                         "and will be removed in future.\n"
-                         "Use \"inputstream.adaptive.manifest_headers\" and "
-                         "\"inputstream.adaptive.stream_headers\" properties instead.");
-    m_kodiProps.m_manifestHeaders.clear();
-    ParseHeaderString(m_kodiProps.m_manifestHeaders, url.substr(posHeader + 1));
-    url = url.substr(0, posHeader);
-
-    if (m_kodiProps.m_streamHeaders.empty())
-      m_kodiProps.m_streamHeaders = m_kodiProps.m_manifestHeaders;
-  }
-
   //! @todo: remove this old forced behaviour on Kodi v21
   if (m_kodiProps.m_manifestHeaders.empty() && !m_kodiProps.m_streamHeaders.empty())
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,17 +65,6 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
   if (m_kodiProps.m_isLicensePersistentStorage)
     drmConfig |= SSD::SSD_DECRYPTER::CONFIG_PERSISTENTSTORAGE;
 
-  //! @todo: remove this old forced behaviour on Kodi v21
-  if (m_kodiProps.m_manifestHeaders.empty() && !m_kodiProps.m_streamHeaders.empty())
-  {
-    LOG::Log(
-        LOGWARNING,
-        "Set headers to the manifest by using \"inputstream.adaptive.stream_headers\" property "
-        "is a deprecated behaviour that will be removed in future.\n"
-        "To set headers to the manifest, use \"inputstream.adaptive.manifest_headers\" property.");
-    m_kodiProps.m_manifestHeaders = m_kodiProps.m_streamHeaders;
-  }
-
   m_session = std::make_shared<CSession>(m_kodiProps, url, props.GetProfileFolder());
   m_session->SetVideoResolution(m_currentVideoWidth, m_currentVideoHeight, m_currentVideoMaxWidth,
                                 m_currentVideoMaxHeight);

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -36,7 +36,6 @@ constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_par
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 
 constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
-constexpr std::string_view PROP_BANDWIDTH_MAX = "inputstream.adaptive.max_bandwidth"; //! @todo: deprecated, to be removed on next Kodi release
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
 
@@ -117,13 +116,6 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     else if (prop.first == PROP_AUDIO_LANG_ORIG)
     {
       props.m_audioLanguageOrig = prop.second;
-    }
-    else if (prop.first == PROP_BANDWIDTH_MAX) //! @todo: deprecated, to be removed on next Kodi release
-    {
-      LOG::Log(LOGWARNING, "Warning \"inputstream.adaptive.max_bandwidth\" property is deprecated "
-                           "and may not works. Please read \"Integration\" and \"Stream selection types\" "
-                           "pages on the Wiki to learn more about the new properties.");
-      props.m_chooserProps.m_bandwidthMax = static_cast<uint32_t>(std::stoi(prop.second));
     }
     else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Removed some deprecated features, recap in short:

- Removed `inputstream.adaptive.max_bandwidth` now we use the new [Stream selection properties](https://github.com/xbmc/inputstream.adaptive/wiki/Stream-selection-types-properties)
- Removed support to specify headers in-line of manifest url by using pipe char `|`, now must be set by using the relative properties (manifest_headers, stream_headers)
- Removed the old behaviour that allow to use `inputstream.adaptive.stream_headers` to set headers also to the manifest

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These features has been marked as deprecated on Kodi 20 so we cleanup the code

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the Wiki documentation
- [x] I have updated the documentation accordingly
