### PR TITLE
[AdaptiveTree] Implemented save manifest setting for debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(ADP_SOURCES
 	src/samplereader/WebmSampleReader.cpp
 	src/utils/Base64Utils.cpp
 	src/utils/DigestMD5Utils.cpp
+	src/utils/FileUtils.cpp
 	src/utils/MemUtils.cpp
 	src/utils/PropertiesUtils.cpp
 	src/utils/StringUtils.cpp
@@ -91,6 +92,7 @@ set(ADP_HEADERS
 	src/samplereader/WebmSampleReader.h
 	src/utils/Base64Utils.h
 	src/utils/DigestMD5Utils.h
+	src/utils/FileUtils.h
 	src/utils/log.h
 	src/utils/MemUtils.h
 	src/utils/PropertiesUtils.h

--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -311,3 +311,18 @@ msgstr ""
 msgctxt "#30236"
 msgid "Override settings"
 msgstr ""
+
+#. Category group title for debug settings
+msgctxt "#30237"
+msgid "Debug logging"
+msgstr ""
+
+#. Debug setting to save stream manifests
+msgctxt "#30238"
+msgid "Save stream manifests"
+msgstr ""
+
+#. Description of setting with label #30238
+msgctxt "#30239"
+msgid "Saves stream manifests downloaded during playback in the user data folder of InputStream Adaptive."
+msgstr ""

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -235,6 +235,13 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="debug" label="30237">
+        <setting id="debug.save.manifest" type="boolean" label="30238" help="30239">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
   </section>
 </settings>

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -611,6 +611,7 @@ public:
   Settings m_settings;
 
 protected:
+
   /*!
    * \brief Download manifest file.
    * \param url The url of the file to download
@@ -638,6 +639,16 @@ protected:
                         std::stringstream& data,
                         HTTPRespHeaders& respHeaders);
 
+  /*!
+   * \brief Save manifest data to a file for debugging purpose.
+   * \param fileNameSuffix Suffix to add to the filename generated.
+   * \param data The manifest data to save.
+   * \param info Additionals info to be add before the data.
+   */
+  virtual void SaveManifest(const std::string& fileNameSuffix,
+                            const std::stringstream& data,
+                            std::string_view info);
+
   bool PreparePaths(const std::string &url);
   void SortTree();
 
@@ -653,6 +664,9 @@ protected:
   std::string m_manifestParams;
   std::map<std::string, std::string> m_manifestHeaders;
   CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
+
+  // Provide the path where the manifests will be saved, if debug enabled
+  std::string m_pathSaveManifest;
 
 private:
   void SegmentUpdateWorker();

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1622,6 +1622,8 @@ bool DASHTree::open(const std::string& url, std::map<std::string, std::string> a
   if (!DownloadManifest(url, addHeaders, data, respHeaders))
     return false;
 
+  SaveManifest("", data, url);
+
   effective_url_ = respHeaders.m_effectiveUrl;
   m_manifestRespHeaders = respHeaders;
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -66,6 +66,11 @@ public:
 protected:
   virtual bool ParseManifest(std::stringstream& stream);
   virtual void RefreshLiveSegments() override;
+
+  virtual void SaveManifest(AdaptationSet* adp,
+                            const std::stringstream& data,
+                            std::string_view info);
+
   std::unique_ptr<IAESDecrypter> m_decrypter;
 
 private:

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -369,6 +369,8 @@ bool SmoothTree::open(const std::string& url, std::map<std::string, std::string>
   if (!DownloadManifest(url, addHeaders, data, respHeaders))
     return false;
 
+  SaveManifest("", data, url);
+
   effective_url_ = respHeaders.m_effectiveUrl;
 
   if (!PreparePaths(effective_url_))

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${BINARY}
     ../common/ReprSelector.cpp
     ../oscompat.cpp
     ../utils/Base64Utils.cpp
+    ../utils/FileUtils.cpp
     ../utils/PropertiesUtils.cpp
     ../utils/SettingsUtils.cpp
     ../utils/StringUtils.cpp

--- a/src/test/KodiStubs.h
+++ b/src/test/KodiStubs.h
@@ -93,6 +93,11 @@ inline bool GetSettingBoolean(const std::string& settingName, bool defaultValue 
   return defaultValue;
 }
 
+inline std::string GetUserPath(const std::string& append = "")
+{
+  return "C:\\isa_stub_test\\" + append;
+}
+
 } // namespace addon
 
 namespace vfs
@@ -158,6 +163,16 @@ public:
 
   double GetFileDownloadSpeed() const { return 0.0; }
 };
+
+inline bool FileExists(const std::string& filename, bool usecache = false)
+{
+  return false;
+}
+
+inline bool RemoveDirectory(const std::string& path, bool recursive = false)
+{
+  return true;
+}
 
 } // namespace vfs
 

--- a/src/utils/FileUtils.cpp
+++ b/src/utils/FileUtils.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileUtils.h"
+
+#include "log.h"
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "../test/KodiStubs.h"
+#else
+#include <kodi/AddonBase.h>
+#include <kodi/Filesystem.h>
+#endif
+
+#include <cctype> // isalpha
+
+bool UTILS::FILESYS::SaveFile(std::string_view filePath, std::string_view data, bool overwrite)
+{
+  if (filePath.empty())
+    return false;
+
+  kodi::vfs::CFile saveFile;
+  if (!saveFile.OpenFileForWrite(filePath.data(), overwrite))
+  {
+    LOG::LogF(LOGERROR, "Cannot create file \"%s\".", filePath.data());
+    return false;
+  }
+
+  bool isWritten = saveFile.Write(data.data(), data.size()) != -1;
+  saveFile.Close();
+  return isWritten;
+}
+
+std::string UTILS::FILESYS::PathCombine(std::string path, std::string filePath)
+{
+  if (path.empty())
+    return filePath;
+
+  const char separator = path[1] == ':' && std::isalpha(path[0]) ? '\\' : '/';
+
+  if (path.back() == separator)
+    path.pop_back();
+
+  if (filePath.front() == separator)
+    filePath.erase(0, 1);
+
+  return path + separator + filePath;
+}
+
+std::string UTILS::FILESYS::GetAddonUserPath()
+{
+  return kodi::addon::GetUserPath();
+}
+
+bool UTILS::FILESYS::CheckDuplicateFilePath(std::string& filePath, uint32_t filesLimit /* = 0 */)
+{
+  const size_t extensionPos = filePath.rfind('.');
+  std::string renamedFilePath = filePath;
+
+  for (uint32_t index = 1; kodi::vfs::FileExists(renamedFilePath, false); index++)
+  {
+    if (filesLimit != 0 && index > filesLimit)
+    {
+      LOG::LogF(LOGERROR, "The file path \"%s\" exceeds the maximum amount of duplicate files.",
+                filePath.c_str());
+      return false;
+    }
+
+    if (extensionPos != std::string::npos)
+    {
+      renamedFilePath = filePath.substr(0, extensionPos) + "_" + std::to_string(index) +
+                        filePath.substr(extensionPos);
+    }
+    else
+    {
+      renamedFilePath = filePath + "_" + std::to_string(index);
+    }
+  }
+
+  filePath = renamedFilePath;
+  return true;
+}
+
+bool UTILS::FILESYS::RemoveDirectory(std::string_view path, bool recursive /* = true */)
+{
+  return kodi::vfs::RemoveDirectory(path.data(), recursive);
+}

--- a/src/utils/FileUtils.h
+++ b/src/utils/FileUtils.h
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace UTILS
+{
+namespace FILESYS
+{
+
+/*!
+ * \brief Save the data into a file
+ * \param filePath The file path where to save the file, if the path is missing will be created.
+ * \param data The data to be saved.
+ * \param overwrite If true will overwrite the existing file.
+ * \return True if success, otherwise false.
+ */
+bool SaveFile(std::string_view filePath, std::string_view data, bool overwrite);
+
+/*!
+ * \brief Combine a path with another one
+ * \param path The starting path.
+ * \param filePath The path to be combined, like filename or another path.
+ * \return The combined path.
+ */
+std::string PathCombine(std::string path, std::string filePath);
+
+/*!
+ * \brief Get the user-related data folder of the addon.
+ * \return The path.
+ */
+std::string GetAddonUserPath();
+
+/*!
+ * \brief Check for duplicates for the file path, and change the filename
+ *        based on the number of duplicate files.
+ * \param path [IN][OUT] The file path. based on the number of duplicate files found,
+ *             the file name will be renamed by appending the duplicate count number,
+ *             for example: if "test.txt" exists, the next become "text_1.txt", "text_2.txt", ...
+ * \param filesLimit Maximum limit of duplicate files allowed, if 0 there is no limit.
+ * \return True is successful, otherwise false if exceeds the number of duplicate files allowed.
+ */
+bool CheckDuplicateFilePath(std::string& filePath, uint32_t filesLimit = 0);
+
+/*!
+ * \brief Remove a directory.
+ * \param path The directory to be deleted.
+ * \param recursive If true all sub-folders will be deleted,
+ *                  otherwise only the specified folder will be emptied.
+ * \return True is success, otherwise false.
+ */
+bool RemoveDirectory(std::string_view path, bool recursive = true);
+
+} // namespace FILESYS
+} // namespace UTILS

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -12,7 +12,9 @@
 #include "StringUtils.h"
 #include "kodi/tools/StringUtils.h"
 
+#include <chrono>
 #include <cstring>
+#include <ctime>
 #include <stdio.h>
 
 using namespace UTILS;
@@ -341,4 +343,11 @@ std::string UTILS::GetVideoCodecDesc(std::string_view codecName)
   }
   else
     return "";
+}
+
+uint64_t UTILS::GetTimestamp()
+{
+  std::chrono::seconds unix_timestamp = std::chrono::seconds(std::time(NULL));
+  using dCast = std::chrono::duration<std::uint64_t>;
+  return std::chrono::duration_cast<dCast>(std::chrono::milliseconds(unix_timestamp)).count();
 }

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -34,6 +34,12 @@ void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std:
 std::string GetVideoCodecDesc(std::string_view codecName);
 
 /*!
+ * \brief Get the current timestamp
+ * \return The timestamp in milliseconds
+ */
+uint64_t GetTimestamp();
+
+/*!
  * \brief Make a FourCC code as unsigned integer value
  * \param c1 The first FourCC char
  * \param c2 The second FourCC char


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This implement a way to automatically save downloaded manifests during playback,
with a configurable debug setting

The downloaded manifest files are saved in to the addon user data folder, under "manifests" folder, e.g.
`..\userdata\addon_data\inputstream.adaptive\manifests`

the filenames are created by using timestamp in the following format:
`manifest_[timestamp number][optional suffix info].txt`

suffix info is used for HLS case (see filenames on attached files below)

in the case where many files are saved too quickly, and the timestamp used have the same number,
the number of the duplicate file count, will be appended to the file name itself, for example:

manifest_1676539356.txt
manifest_1676539356_1.txt
manifest_1676539356_2.txt
...

this will keep also the order of sequential downloads

if the duplicate saved files (with same timestamp) are more than 10, an error will be raised to the log and it stop to save new files with same timestamp, this limit case however should be for some kind of bug to be solved

Each time you start play a new video, the addon delete all previously saved (old) manifests in the data folder.

Plus for each manifest saved:
- will be included in the txt file also the URL where has been downloaded, see attached file example below.
- will be printed in to the log `Manifest saved to: [path of the file]` to have a kind of reference of the filename

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More times is happened that users are not able to provide the manifest

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
with HLS live stream you can see all the downloaded manifest in the InputStreamAdaptive addon userfolder

example of saved files:
[manifest_1676561200_master.txt](https://github.com/xbmc/inputstream.adaptive/files/10757855/manifest_1676561200_master.txt)
[manifest_1676561202_child-audio.txt](https://github.com/xbmc/inputstream.adaptive/files/10757856/manifest_1676561202_child-audio.txt)
[manifest_1676561202_child-subtitle.txt](https://github.com/xbmc/inputstream.adaptive/files/10757857/manifest_1676561202_child-subtitle.txt)
[manifest_1676561202_child-video.txt](https://github.com/xbmc/inputstream.adaptive/files/10757859/manifest_1676561202_child-video.txt)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
