### PR TITLE
[DASHTree] fix representation updates when two identical adaptation sets exist

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1787,19 +1787,14 @@ void DASHTree::RefreshLiveSegments()
           if (!updAdaptationSet)
             continue;
 
-          auto& adaptationSets = periods_[index]->adaptationSets_;
-          auto itAs = std::find_if(adaptationSets.begin(), adaptationSets.end(),
-                                   [&updAdaptationSet](const AdaptationSet* item)
-                                   {
-                                     return item->id_ == updAdaptationSet->id_ &&
-                                            item->group_ == updAdaptationSet->group_ &&
-                                            item->type_ == updAdaptationSet->type_ &&
-                                            item->mimeType_ == updAdaptationSet->mimeType_ &&
-                                            item->language_ == updAdaptationSet->language_;
-                                   });
-          if (itAs != adaptationSets.end()) // Found adaptationset
+          for (auto adaptationSet : periods_[index]->adaptationSets_)
           {
-            auto adaptationSet = *itAs;
+            if (!(adaptationSet->id_ == updAdaptationSet->id_ &&
+                  adaptationSet->group_ == updAdaptationSet->group_ &&
+                  adaptationSet->type_ == updAdaptationSet->type_ &&
+                  adaptationSet->mimeType_ == updAdaptationSet->mimeType_ &&
+                  adaptationSet->language_ == updAdaptationSet->language_))
+              continue;
 
             for (auto updRepr : updAdaptationSet->representations_)
             {


### PR DESCRIPTION
## Description

fixes issue where MPD with multiple audio sets would not process updates if second audio set representation was used

## Motivation and context

given mpd as so:

```
    <Period start="PT6207H10M5.1481183S" id="1">
        <AdaptationSet mimeType="video/mp4" startWithSAP="1" segmentAlignment="true" par="16:9" />
        <AdaptationSet mimeType="audio/mp4" startWithSAP="1" lang="eng" segmentAlignment="true" />
        <AdaptationSet mimeType="audio/mp4" startWithSAP="1" lang="eng" segmentAlignment="true" />
```

observed that representations inside the last AdaptationSet were never updated because the code only processed the first match.

## How has this been tested?

compiled and ran against problem stream to verify fix

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
