### PR TITLE
[backport] [AdaptiveStream] reduce debug WaitForSegment logging

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -904,8 +904,11 @@ bool AdaptiveStream::ensureSegment()
     }
     else if (tree_.HasUpdateThread() && current_period_ == tree_.periods_.back())
     {
-      current_rep_->flags_ |= AdaptiveTree::Representation::WAITFORSEGMENT;
-      LOG::LogF(LOGDEBUG, "Begin WaitForSegment stream %s", current_rep_->id.c_str());
+      if ((current_rep_->flags_ & AdaptiveTree::Representation::WAITFORSEGMENT) == 0)
+      {
+        current_rep_->flags_ |= AdaptiveTree::Representation::WAITFORSEGMENT;
+        LOG::LogF(LOGDEBUG, "Begin WaitForSegment stream %s", current_rep_->id.c_str());
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       return false;
     }


### PR DESCRIPTION
## Description

backport for https://github.com/xbmc/inputstream.adaptive/pull/1169

produce debug log message for "WaitForSegment" only when first transitioning into `WAITFORSEGMENT` state

## Motivation and context

I noticed sometimes you will see repeated logging like this:

```
2023-02-24 14:01:32.315 T:5691    debug <general>: AddOnLog: inputstream.adaptive: ensureSegment: Begin WaitForSegment stream 1654049944917item-06item
2023-02-24 14:01:34.321 T:5700     info <general>: Skipped 11 duplicate messages..
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

compile and runtime tested looking at debug logs

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
