### PR TITLE
[DASHTree] handle new Period better

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1542,7 +1542,10 @@ bool CSession::SeekChapter(int ch)
   if (ch >= 0 && ch < static_cast<int>(m_adaptiveTree->periods_.size()) &&
       m_adaptiveTree->periods_[ch] != m_adaptiveTree->current_period_)
   {
-    m_adaptiveTree->next_period_ = m_adaptiveTree->periods_[ch];
+    auto newPd = m_adaptiveTree->periods_[ch];
+    m_adaptiveTree->next_period_ = newPd;
+    LOG::LogF(LOGDEBUG, "Switching to new Period (id=%s, start=%ld, seq=%d)", newPd->id_.c_str(),
+              newPd->start_, newPd->sequence_);
     for (auto& stream : m_streams)
     {
       ISampleReader* sr{stream->GetReader()};

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1115,7 +1115,7 @@ bool AdaptiveStream::seek_time(double seek_seconds, bool preceeding, bool& needR
 
 bool AdaptiveStream::waitingForSegment(bool checkTime) const
 {
-  if (tree_.HasUpdateThread())
+  if (tree_.HasUpdateThread() && state_ == RUNNING)
   {
     std::lock_guard<std::mutex> lckTree(tree_.GetTreeMutex());
     if (current_rep_ && (current_rep_->flags_ & AdaptiveTree::Representation::WAITFORSEGMENT) != 0)

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -50,6 +50,7 @@ public:
 
   uint64_t pts_helper_, timeline_time_;
   uint64_t firstStartNumber_;
+  uint32_t current_sequence_;
   std::string current_playready_wrmheader_;
   std::string mpd_url_;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

i observed that on a playlist where new `<Period>` is added when going into commercial break, the player would stall out for 30s and then jump ahead in the stream.

the logs showed it as so:

```
2023-02-24 15:44:06.453 T:21159   debug <general>: CVideoPlayerVideo - Stillframe detected, switching to forced 29.970030 fps
2023-02-24 15:44:06.453 T:21146   debug <general>: Stream stalled, start buffering. Audio: 0 - Video: 0
2023-02-24 15:44:06.453 T:21159   debug <general>: CPtsTracker: pattern lost on diff 166833.335938, number of losses 1
2023-02-24 15:44:06.453 T:21146   debug <general>: CVideoPlayer::SetCaching - caching state 1
2023-02-24 15:44:06.453 T:21146   debug <general>: CDVDClock::SetSpeedAdjust - adjusted:0.000000
2023-02-24 15:44:06.453 T:21164   debug <general>: CDVDAudio::Pause - pausing audio stream
2023-02-24 15:44:07.244 T:2472    debug <general>: AddOnLog: inputstream.adaptive: ensureSegment: Begin WaitForSegment stream 1654049944917item-06item
2023-02-24 15:44:08.248 T:2475     info <general>: Skipped 9 duplicate messages..
...
2023-02-24 15:44:41.121 T:2763    debug <general>: AddOnLog: inputstream.adaptive: ensureSegment: Begin WaitForSegment stream 1654049944917item-06item
2023-02-24 15:44:41.808 T:21164    info <general>: Skipped 1 duplicate messages..
2023-02-24 15:44:41.808 T:21164    info <general>: CVideoPlayerAudio::Process - stream stalled
2023-02-24 15:44:41.808 T:21146   debug <general>: Stream stalled, start buffering. Audio: 0 - Video: 2
2023-02-24 15:44:41.809 T:21146   debug <general>: CVideoPlayer::SetCaching - caching state 1
2023-02-24 15:44:41.809 T:21164   debug <general>: CDVDAudio::Pause - pausing audio stream
2023-02-24 15:44:41.809 T:21146   debug <general>: CDVDClock::SetSpeedAdjust - adjusted:0.000000
2023-02-24 15:44:42.121 T:2768    debug <general>: AddOnLog: inputstream.adaptive: ensureSegment: Begin WaitForSegment stream 1654049944917item-06item
2023-02-24 15:44:42.323 T:21159    info <general>: Skipped 2 duplicate messages..
2023-02-24 15:44:42.323 T:21159 warning <general>: OutputPicture - timeout waiting for buffer
2023-02-24 15:44:42.422 T:2769    debug <general>: AddOnLog: inputstream.adaptive: ensureSegment: Begin WaitForSegment stream 1654049944917item-06item
2023-02-24 15:44:43.125 T:2771     info <general>: Skipped 6 duplicate messages..
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The code would not previously deal with new `<Period>` appearing, and would only map Period entries based on their index. 

So if originally the MPD had one period, then all of a sudden it had two, only the first would be updated.

Eventually, if the old period was removed then all of a sudden it would resume playback but skip ahead because it would start adding segments from the new period into the old period again once the position (idx==0) matched again.

Now the code will properly insert new periods into the tree, and also notice when one period ends and switch into the next one.

This looks as so in the new logs:

```
RefreshLiveSegments: Inserting new Period (id=45124, start=23478067190)
ensureSegment: Switching to new Period (id=45124, start=23478067190)
ensureSegment: Switching to new AdaptationSet (startNumber=6014396)
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

compile and runtime tested using a local news stream that keeps adding new Period and was not working previously

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
