### PR TITLE
[googletest] fix missing debug postfix

### DIFF
--- a/depends/common/googletest/CMakeLists.txt
+++ b/depends/common/googletest/CMakeLists.txt
@@ -18,6 +18,11 @@ endif (POLICY CMP0077)
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.13.0)
 
+# Workaround for missing debug postfix
+# may be fixed on future versions
+# https://github.com/google/googletest/issues/3843
+set(CMAKE_DEBUG_POSTFIX "d")
+
 if (CMAKE_VERSION VERSION_LESS "3.1")
   add_definitions(-std=c++14)
 else()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add missing debug postfix without this the libs generated have wrong filename
seems upstream have removed postfix for his purposes

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
debug build broken
catched only now weird

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
builded release and debug mode

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
