### PR TITLE
Add alt binary addons dir to search paths

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -120,9 +120,10 @@ void CSession::SetSupportedDecrypterURN(std::string& key_system)
   }
   m_KodiHost->SetLibraryPath(kodi::vfs::TranslateSpecialProtocol(specialpath).c_str());
 
-  std::array<std::string, 2> searchPaths =
+  std::array<std::string, 3> searchPaths =
   {
     kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/"),
+    kodi::vfs::TranslateSpecialProtocol("special://xbmcaltbinaddons/inputstream.adaptive/"),
     kodi::addon::GetAddonInfo("path"),
   };
 

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1173,7 +1173,7 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
             timingStream->GetReader()->GetStartPTS() != STREAM_NOPTS_VALUE &&
             streamReader->GetStartPTS() == STREAM_NOPTS_VALUE)
         {
-          // want this to be the internal data's (not segment's) pts of 
+          // want this to be the internal data's (not segment's) pts of
           // the first segment in period
           streamReader->SetStartPTS(GetTimingStartPTS());
         }

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -23,6 +23,8 @@
 #include "utils/Utils.h"
 #include "utils/log.h"
 
+#include <array>
+
 #include <kodi/addon-instance/Inputstream.h>
 
 using namespace UTILS;
@@ -118,10 +120,11 @@ void CSession::SetSupportedDecrypterURN(std::string& key_system)
   }
   m_KodiHost->SetLibraryPath(kodi::vfs::TranslateSpecialProtocol(specialpath).c_str());
 
-  std::vector<std::string> searchPaths{2};
-  searchPaths[0] =
-      kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/");
-  searchPaths[1] = kodi::addon::GetAddonInfo("path");
+  std::array<std::string, 2> searchPaths =
+  {
+    kodi::vfs::TranslateSpecialProtocol("special://xbmcbinaddons/inputstream.adaptive/"),
+    kodi::addon::GetAddonInfo("path"),
+  };
 
   std::vector<kodi::vfs::CDirEntry> items;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This adds xbmcaltbinaddons to the search paths. 

I also changed it to use std::array as it's of known size at compile time.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On linux this can be another location for binary add-ons as they may be split across lib dir and data dir.

I use it with:
```
KODI_BINADDON_PATH=/usr/local/lib64/kodi/addons
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
2023-03-13 20:49:55.615 T:1153157   debug <general>: AddOnLog: inputstream.adaptive: Searching for decrypters in: /home/lukas/Documents/git/xbmc/build/addons/inputstream.adaptive/
2023-03-13 20:49:55.615 T:1153157   error <general>: GetDirectory - Error getting /home/lukas/Documents/git/xbmc/build/addons/inputstream.adaptive/
2023-03-13 20:49:55.615 T:1153157   debug <general>: AddOnLog: inputstream.adaptive: Searching for decrypters in: /usr/local/lib64/kodi/addons/inputstream.adaptive/
2023-03-13 20:49:55.623 T:1153157   debug <general>: AddOnLog: inputstream.adaptive: Found decrypter: /usr/local/lib64/kodi/addons/inputstream.adaptive/libssd_wv.so
2023-03-13 20:49:55.623 T:1153157   debug <general>: AddOnLog: inputstream.adaptive: Searching for decrypters in: /usr/local/share/kodi/addons/inputstream.adaptive/
2023-03-13 20:49:55.630 T:1153157   debug <general>: AddOnLog: inputstream.adaptive: Found decrypter: /usr/local/lib64/kodi/addons/inputstream.adaptive/libssd_wv.so
```


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
