### PR TITLE
Fix segfault when there is no STSD atom in MP4 stream

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -358,6 +358,13 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       }
     }
 
+    if (!track->GetSampleDescription(0))
+    {
+      LOG::LogF(LOGERROR, "No STSD atom in stream");
+      m_session->EnableStream(stream, false);
+      return false;
+    }
+
     auto sampleDecrypter =
         m_session->GetSingleSampleDecryptor(stream->m_adStream.getRepresentation()->pssh_set_);
     auto caps = m_session->GetDecrypterCaps(stream->m_adStream.getRepresentation()->pssh_set_);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
With this patch inputstream.adaptive not crash with a segfault anymore when a MP4 stream doesn't contain a STSD atom but just log an error message that there is no STSD in stream.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have a copy of a BBC dash test stream on my local webserver and due a bug in my webserver I found that inputstream.adaptive causes a segfault. After some debugging I found out that when inputstream.adaptive process a stream without a STSD atom it try to use a null-pointer in the CFragmentedSampleReader constructor what causes the segfault.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To exploit this I change in the initial MP4 file with a hex editor the stsd atom into something like stsq (just some unknown atom). Before apply the patch an segfault happen. After the patch there should be a 'No STSD in stream!' in the log.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
