### PR TITLE
Fix CDM timer issues

### DIFF
--- a/wvdecrypter/cdm/media/cdm/cdm_adapter.h
+++ b/wvdecrypter/cdm/media/cdm/cdm_adapter.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mutex>
 #include <atomic>
+#include <future>
 
 #include "../../base/native_library.h"
 #include "../../base/compiler_specific.h"
@@ -80,7 +81,8 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>
   , public cdm::Host_11
 {
  public:
-	CdmAdapter(const std::string& key_system,
+   void timerfunc(CdmAdapter* adp, int64_t delay, void* context);
+   CdmAdapter(const std::string& key_system,
     const std::string& cdm_path,
     const std::string& base_path,
     const CdmConfig& cdm_config,
@@ -235,7 +237,12 @@ private:
   std::string cdm_path_;
   std::string cdm_base_path_;
   CdmAdapterClient *client_;
-  std::mutex client_mutex_, decrypt_mutex_;
+  std::mutex client_mutex_;
+  std::mutex decrypt_mutex_;
+  std::mutex m_closeSessionMutex;
+  std::atomic<bool> m_isClosingSession;
+  std::condition_variable m_sessionClosingCond;
+  std::vector<std::future<void>> m_asyncTimerTasks;
 
   std::string key_system_;
   CdmConfig cdm_config_;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Provide proper solution to the CDM timer calls.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For a long time now there have been crashes related to the CDM timer finish callback being executed in a separate thread after CdmAdapter object (and even inputstream.adaptive) has been destroyed.

The current code attempts to wait in the CdmAdapter destructor for the timers to finish, however the destructor isn't even called because of the existing shared_ptr references in the timer threads. wv_decrypter just removes its shared_ptr reference to CdmAdapter and continues destructing regardless.

The new code interrupts any timers that are waiting and removes the references when closing the session. Streams seem noticeably quicker to stop playback.

Additionally thanks to use of std::async to perform the timer task rather than std::thread detach we're not creating a new thread every second. std::async implementation uses its own thread pool of sorts. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Kayo add-on by starting stopping multiple streams, and also confirming playback continues after the 2 minute mark - if timer expired not called, the license renewal will fail and stream will stop decrypting at this point.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
