### PR TITLE
[AdaptiveStream] Fix unreleased mutex and a/v freeze

### DIFF
--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -14,10 +14,17 @@ void CStream::Disable()
 {
   if (m_isEnabled)
   {
+    // Stop downloads
+    m_adStream.Stop();
+    // ReadSample async thread may still working despite stop download signal
+    // for example segmented webvtt use CSubtitleSampleReader -> retrieveCurrentSegmentBufferSize
     if (m_streamReader)
       m_streamReader->WaitReadSampleAsyncComplete();
-    m_adStream.stop();
+    // Dispose the thread worker data only after async thread is complete otherwise mutex go to nirvana
+    m_adStream.DisposeWorker();
+
     Reset();
+
     m_isEnabled = false;
     m_isEncrypted = false;
   }

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -135,7 +135,7 @@ AP4_Result CSubtitleSampleReader::ReadSample()
       }
       else
       {
-        LOG::LogF(LOGERROR, "Failed to get subtitle segment buffer size");
+        LOG::LogF(LOGWARNING, "Failed to get subtitle segment buffer size");
       }
     }
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR fix two problems:

1) Unreleased mutex can make kodi crash on stop

When stop playback the "worker" mutex `mutex_dl_` in the thread could be never released when the worker is stopped and deleted

that mutex is also used here:
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/common/AdaptiveStream.cpp#L1018
and when the subtitle reader fall here
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/samplereader/SubtitleSampleReader.cpp#L106
wait a release of mutex that never happens
then block the chain of methods and stuck kodi until crashes

there is a bit of mess that depends from this problem from `CStream::Disable()`
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/Stream.cpp#L17-L19
it wait aysnc is completed and just after stop and delete the thread
but also make the thread in awaiting for next download
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/common/AdaptiveStream.cpp#L117-L119
that never happens and can stuck the thread

other times is also possible to see from the log that after stop continue to download webvtt segments

catch this problem when playback is hard
on the royal sample HLS stream press stop at 35 secs there is sometime the possibility to get the stop crash

now i have reworked whole things in this way:
1) `CStream::Disable()` signal stop
2) async ReadSample if still running in the middle we wait for it (and stop signal abort possible operations)
3) dispose download thread worker

When this happens you can now recognise it in the log by seeing the warning `Failed to get subtitle segment buffer size` after `EnableStream(1004: false)` so when kodi close the stream, this means that `retrieveCurrentSegmentBufferSize` has been aborted
```
2023-04-06 14:18:22.097 T:8316    debug <general>: AddOnLog: inputstream.adaptive: EnableStream(1002: false)
2023-04-06 14:18:22.097 T:8316     info <general>: Waiting for audio thread to exit
2023-04-06 14:18:22.097 T:3644     info <general>: VideoPlayer: waiting for threads to exit
2023-04-06 14:18:22.140 T:8316     info <general>: Closing stream player 2
2023-04-06 14:18:22.140 T:8316    debug <general>: AddOnLog: inputstream.adaptive: EnableStream(1001: false)
2023-04-06 14:18:22.144 T:15136   debug <general>: AddOnLog: inputstream.adaptive: The download has been cancelled: https://de01f3f6df1b7dd47615d3ac316fe973.egress.mediapackage-vod.us-east-1.amazonaws.com/out/v1/fbaeea46395a4bfe8fb72781ea0b933f/026e891eaf274c53b8d86a0d617f5831/03bf7bef4a7f4dc7bc44a589bd104d7c/d2167037ac3646d6b7cfa58d45a72981/index_3_47.ts
2023-04-06 14:18:22.214 T:8316     info <general>: Closing stream player 3
2023-04-06 14:18:22.214 T:8316    debug <general>: AddOnLog: inputstream.adaptive: EnableStream(1004: false)
2023-04-06 14:18:22.288 T:17600   debug <general>: AddOnLog: inputstream.adaptive: The download has been cancelled: https://de01f3f6df1b7dd47615d3ac316fe973.egress.mediapackage-vod.us-east-1.amazonaws.com/out/v1/fbaeea46395a4bfe8fb72781ea0b933f/026e891eaf274c53b8d86a0d617f5831/03bf7bef4a7f4dc7bc44a589bd104d7c/d2167037ac3646d6b7cfa58d45a72981/index_6_5.vtt
2023-04-06 14:18:22.289 T:20712   warning <general>: AddOnLog: inputstream.adaptive: CSubtitleSampleReader::ReadSample: Failed to get subtitle segment buffer size
2023-04-06 14:18:22.308 T:8316    debug <general>: AddOnLog: inputstream.adaptive: Close()
2023-04-06 14:18:22.308 T:8316    debug <general>: AddOnLog: inputstream.adaptive: CSession::~CSession()
```

2) a/v freeze

related to subtitles segment donwloads, `state_ = STOPPED` has been introduced recently
and look to be the cause that sometimes stuck the download thread in a wrong waiting state
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/common/AdaptiveStream.cpp#L1017-L1020
where stuck subtitles downloads and then freeze the playback
changed with state PAUSED imo its much better, because we havent to abort download in progress (e.g. `write_data` method check for it)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1209 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
sample in the issue but not easy to catch these problems you need to start/stop tons of times
more possibility to catch the problems at secs 35 or 32

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
