### PR TITLE
Fix audio / subtitles regressions

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -878,10 +878,10 @@ void CSession::UpdateStream(CStream& stream)
                                extraData->size());
   }
 
-  stream.m_info.SetCodecInternalName(rep->GetFirstCodec()); //! @todo: to be verified
   stream.m_info.SetCodecFourCC(0);
   stream.m_info.SetBitRate(rep->GetBandwidth());
 
+  // Original codec name
   std::string codecStr;
 
   if (streamType == StreamType::VIDEO)
@@ -902,9 +902,9 @@ void CSession::UpdateStream(CStream& stream)
     stream.m_info.SetColorPrimaries(INPUTSTREAM_COLORPRIMARY_UNSPECIFIED);
     stream.m_info.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_UNSPECIFIED);
 
-    if (rep->ContainsCodec("avc") || rep->ContainsCodec("h264"))
+    if (rep->ContainsCodec("avc", codecStr) || rep->ContainsCodec("h264", codecStr))
       stream.m_info.SetCodecName("h264");
-    else if (rep->ContainsCodec("hev"))
+    else if (rep->ContainsCodec("hev", codecStr))
       stream.m_info.SetCodecName("hevc");
     else if (rep->ContainsCodec("hvc", codecStr) || rep->ContainsCodec("dvh", codecStr))
     {
@@ -938,7 +938,7 @@ void CSession::UpdateStream(CStream& stream)
         }
       }
     }
-    else if (rep->ContainsCodec("av1") || rep->ContainsCodec("av01"))
+    else if (rep->ContainsCodec("av1", codecStr) || rep->ContainsCodec("av01", codecStr))
       stream.m_info.SetCodecName("av1");
     else
     {
@@ -951,17 +951,17 @@ void CSession::UpdateStream(CStream& stream)
     stream.m_info.SetSampleRate(rep->GetSampleRate());
     stream.m_info.SetChannels(rep->GetAudioChannels());
 
-    if (rep->ContainsCodec("mp4a") || rep->ContainsCodec("aac"))
+    if (rep->ContainsCodec("mp4a", codecStr) || rep->ContainsCodec("aac", codecStr))
       stream.m_info.SetCodecName("aac");
-    else if (rep->ContainsCodec("dts"))
+    else if (rep->ContainsCodec("dts", codecStr))
       stream.m_info.SetCodecName("dca");
-    else if (rep->ContainsCodec("ac-3"))
+    else if (rep->ContainsCodec("ac-3", codecStr))
       stream.m_info.SetCodecName("ac3");
-    else if (rep->ContainsCodec("ec-3"))
+    else if (rep->ContainsCodec("ec-3", codecStr))
       stream.m_info.SetCodecName("eac3");
-    else if (rep->ContainsCodec("opus"))
+    else if (rep->ContainsCodec("opus", codecStr))
       stream.m_info.SetCodecName("opus");
-    else if (rep->ContainsCodec("vorbis"))
+    else if (rep->ContainsCodec("vorbis", codecStr))
       stream.m_info.SetCodecName("vorbis");
     else
     {
@@ -971,9 +971,9 @@ void CSession::UpdateStream(CStream& stream)
   }
   else if (streamType == StreamType::SUBTITLE)
   {
-    if (rep->ContainsCodec("stpp") || rep->ContainsCodec("ttml"))
+    if (rep->ContainsCodec("stpp", codecStr) || rep->ContainsCodec("ttml", codecStr))
       stream.m_info.SetCodecName("srt");
-    else if (rep->ContainsCodec("wvtt"))
+    else if (rep->ContainsCodec("wvtt", codecStr))
       stream.m_info.SetCodecName("webvtt");
     else
     {
@@ -981,6 +981,8 @@ void CSession::UpdateStream(CStream& stream)
       LOG::LogF(LOGERROR, "Unhandled subtitle codec");
     }
   }
+
+  stream.m_info.SetCodecInternalName(codecStr);
 }
 
 AP4_Movie* CSession::PrepareStream(CStream* stream, bool& needRefetch)

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -124,7 +124,6 @@ protected:
   uint64_t m_startPts{0};
   uint64_t m_duration{0};
 
-  std::string m_mimeType;
   std::set<std::string> m_codecs;
   StreamType m_streamType{StreamType::NOTYPE};
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1078,7 +1078,7 @@ bool AdaptiveStream::retrieveCurrentSegmentBufferSize(size_t& size)
 
 uint64_t AdaptiveStream::getMaxTimeMs()
 {
-  if (current_rep_->IsSubtitleStream())
+  if (current_rep_->IsSubtitleFileStream())
     return 0;
 
   if (current_rep_->SegmentTimeline().IsEmpty())
@@ -1152,7 +1152,7 @@ bool AdaptiveStream::seek_time(double seek_seconds, bool preceeding, bool& needR
   if (!current_rep_)
     return false;
 
-  if (current_rep_->IsSubtitleStream())
+  if (current_rep_->IsSubtitleFileStream())
     return true;
 
   std::unique_lock<std::mutex> lckTree(tree_.GetTreeMutex());

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -100,9 +100,16 @@ public:
   uint64_t GetDuration() const { return m_duration; }
   void SetDuration(uint64_t duration) { m_duration = duration; }
 
-  //! @todo: to investigate to know the reason why we need to have/use IsSubtitleStream for DASH
-  bool IsSubtitleStream() const { return m_isSubtitleStream; }
-  void SetIsSubtitleStream(bool isSubtitleStream) { m_isSubtitleStream = isSubtitleStream; }
+  /*!
+   * \brief Determines when the representation contains subtitles as single file
+   *        for the entire duration of the video.
+   * \return True if subtitles are as single file, otherwise false
+   */
+  bool IsSubtitleFileStream() const { return m_isSubtitleFileStream; }
+  void SetIsSubtitleFileStream(bool isSubtitleFileStream)
+  {
+    m_isSubtitleFileStream = isSubtitleFileStream;
+  }
 
   //! @todo: the use of HasInitialization/SetHasInitialization need to be improved maybe std::optional use
   bool HasInitialization() const { return m_hasInitialization; }
@@ -279,7 +286,7 @@ protected:
   uint64_t m_duration{0};
   uint32_t m_timescale{0};
 
-  bool m_isSubtitleStream{false};
+  bool m_isSubtitleFileStream{false};
   bool m_hasInitialization{false};
   bool m_hasInitPrefixed{false};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,7 +276,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     return false;
   }
 
-  if (rep->IsSubtitleStream())
+  if (rep->IsSubtitleFileStream())
   {
     stream->SetReader(std::make_unique<CSubtitleSampleReader>(
         rep->GetUrl(), streamid, stream->m_info.GetCodecInternalName()));
@@ -295,8 +295,8 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (reprContainerType == ContainerType::TEXT)
   {
     stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
-    stream->SetReader(std::make_unique<CSubtitleSampleReader>(stream, streamid,
-                                                             stream->m_info.GetCodecInternalName()));
+    stream->SetReader(std::make_unique<CSubtitleSampleReader>(
+        stream, streamid, stream->m_info.GetCodecInternalName()));
   }
   else if (reprContainerType == ContainerType::TS)
   {

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -90,6 +90,12 @@ CSubtitleSampleReader::CSubtitleSampleReader(SESSION::CStream* stream,
 
 AP4_Result CSubtitleSampleReader::Start(bool& bStarted)
 {
+  if (!m_codecHandler)
+  {
+    m_eos = true;
+    return AP4_FAILURE;
+  }
+
   m_eos = false;
   if (m_started)
     return AP4_SUCCESS;

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -22,9 +22,9 @@ CSubtitleSampleReader::CSubtitleSampleReader(const std::string& url,
 {
   // Single subtitle file
   if (STRING::Contains(codecInternalName, "wvtt"))
-    m_codecHandler = new WebVTTCodecHandler(nullptr, true);
+    m_codecHandler = std::make_unique<WebVTTCodecHandler>(nullptr, true);
   else if (STRING::Contains(codecInternalName, "ttml"))
-    m_codecHandler = new TTMLCodecHandler(nullptr);
+    m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr);
   else
   {
     LOG::LogF(LOGERROR, "Codec \"%s\" not implemented", codecInternalName.data());
@@ -81,9 +81,9 @@ CSubtitleSampleReader::CSubtitleSampleReader(SESSION::CStream* stream,
 {
   // Segmented subtitle
   if (STRING::Contains(codecInternalName, "wvtt"))
-    m_codecHandler = new WebVTTCodecHandler(nullptr, false);
+    m_codecHandler = std::make_unique<WebVTTCodecHandler>(nullptr, false);
   else if (STRING::Contains(codecInternalName, "ttml"))
-    m_codecHandler = new TTMLCodecHandler(nullptr);
+    m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr);
   else
     LOG::LogF(LOGERROR, "Codec \"%s\" not implemented", codecInternalName.data());
 }
@@ -198,7 +198,7 @@ bool CSubtitleSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
 
 bool CSubtitleSampleReader::TimeSeek(uint64_t pts, bool preceeding)
 {
-  if (dynamic_cast<WebVTTCodecHandler*>(m_codecHandler))
+  if (dynamic_cast<WebVTTCodecHandler*>(m_codecHandler.get()))
   {
     m_pts = pts;
     return true;

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -12,6 +12,7 @@
 #include "../Stream.h"
 #include "SampleReader.h"
 
+#include <memory>
 #include <string_view>
 
 class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
@@ -54,7 +55,7 @@ private:
   AP4_UI32 m_streamId;
   bool m_eos{false};
   bool m_started{false};
-  CodecHandler* m_codecHandler;
+  std::unique_ptr<CodecHandler> m_codecHandler;
   AP4_Sample m_sample;
   AP4_DataBuffer m_sampleData;
   CAdaptiveByteStream* m_adByteStream{nullptr};

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -12,16 +12,18 @@
 #include "../Stream.h"
 #include "SampleReader.h"
 
+#include <string_view>
+
 class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
 {
 public:
   CSubtitleSampleReader(const std::string& url,
-                       AP4_UI32 streamId,
-                       const std::string& codecInternalName);
+                        AP4_UI32 streamId,
+                        std::string_view codecInternalName);
 
   CSubtitleSampleReader(SESSION::CStream* stream,
-                       AP4_UI32 streamId,
-                       const std::string& codecInternalName);
+                        AP4_UI32 streamId,
+                        std::string_view codecInternalName);
 
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -393,43 +393,43 @@ TEST_F(DASHTreeAdaptiveStreamTest, subtitles)
   auto& adpSets = tree->m_periods[0]->GetAdaptationSets();
 
   EXPECT_EQ(adpSets[1]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
 
   EXPECT_EQ(adpSets[2]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
 
   EXPECT_EQ(adpSets[3]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[3]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[3]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[3]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
 
   EXPECT_EQ(adpSets[4]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[4]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[4]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[4]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
 
   EXPECT_EQ(adpSets[5]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[5]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[5]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[5]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
 
   EXPECT_EQ(adpSets[6]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[6]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[6]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[6]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
 
   EXPECT_EQ(adpSets[7]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[7]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[7]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[7]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
 
   EXPECT_EQ(adpSets[8]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[8]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[8]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[8]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
 
   EXPECT_EQ(adpSets[9]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[9]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[9]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[9]->GetRepresentations()[0]->ContainsCodec("my_codec"), true);
 
   EXPECT_EQ(adpSets[10]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
-  EXPECT_EQ(adpSets[10]->GetRepresentations()[0]->IsSubtitleStream(), true);
+  EXPECT_EQ(adpSets[10]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
   EXPECT_EQ(adpSets[10]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
 
   EXPECT_EQ(adpSets[11]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After reworking the parsers, it was not entirely clear to me how the original previous dash code around this worked it was quite a mess, now i fixed whole things hope in better way

`SetCodecInternalName` is not really used we could also drop it and get codec from representation but
i kept it to have the original codec string associated to the stream

in the dashparser i have better written the use subtitles type use cases before it was not intuitive at all

This restore also HLS audio codec workaround where now we have understand the reason why was there
ref: https://github.com/xbmc/inputstream.adaptive/issues/1212#issuecomment-1501309356

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
problem found while investigating for #1212

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webvtt ISOBMFF now works correctly
verified also
webvtt as file and webvtt segmented

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
