### PR TITLE
[AdaptiveStream] Add class id for debug log purpose

### DIFF
--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -219,5 +219,9 @@ class AdaptiveStream;
     bool play_timeshift_buffer_;
     bool stream_changed_ = false;
     bool choose_rep_;
+
+    // Class ID for debug log purpose, allow the LOG prints of each AdaptiveStream to be distinguished
+    uint32_t clsId;
+    static uint32_t globalClsId; // Incremental value for each new class created
   };
 };

--- a/src/common/AdaptiveUtils.cpp
+++ b/src/common/AdaptiveUtils.cpp
@@ -11,6 +11,23 @@
 #include <cstdio> // sscanf
 #include <inttypes.h>
 
+std::string_view PLAYLIST::StreamTypeToString(const StreamType streamType)
+{
+  switch (streamType)
+  {
+    case StreamType::VIDEO:
+      return "video";
+    case StreamType::AUDIO:
+      return "audio";
+    case StreamType::SUBTITLE:
+      return "subtitle";
+    case StreamType::VIDEO_AUDIO:
+      return "video-audio";
+    default:
+      return "unknown";
+  }
+}
+
 bool PLAYLIST::ParseRangeRFC(std::string_view range, uint64_t& start, uint64_t& end)
 {
   //! @todo: must be reworked as https://httpwg.org/specs/rfc7233.html

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -82,6 +82,13 @@ enum class StreamType
 };
 
 /*!
+ * \brief Convert StreamType enum value into a human readable string.
+ * \param streamType The stream type to convert
+ * \return Human readable StreamType string
+ */
+std::string_view StreamTypeToString(const StreamType streamType);
+
+/*!
  * \brief Parse a range string, as RFC 7233 (e.g. for DASH).
  * \param range The range string to parse of format like "n-n"
  * \param start [OUT] The start position

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1124,21 +1124,8 @@ void adaptive::CHLSTree::SaveManifest(PLAYLIST::CAdaptationSet* adpSet,
   std::string fileNameSuffix = "master";
   if (adpSet)
   {
-    switch (adpSet->GetStreamType())
-    {
-      case StreamType::VIDEO:
-        fileNameSuffix = "child-video";
-        break;
-      case StreamType::AUDIO:
-        fileNameSuffix = "child-audio";
-        break;
-      case StreamType::SUBTITLE:
-        fileNameSuffix = "child-subtitle";
-        break;
-      default:
-        fileNameSuffix = "child";
-        break;
-    }
+    fileNameSuffix += "child-";
+    fileNameSuffix += StreamTypeToString(adpSet->GetStreamType());
   }
 
   AdaptiveTree::SaveManifest(fileNameSuffix, data, info);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
CAdaptiveStream is created by CStream, CStream's are created usually by the default representations used for playback
so when in playback we have more CAdaptiveStream' s at same time that print to the log the same log text
not allow to easy distinguish for what CAdaptiveStream the printed text is referred

all CAdaptiveStream while in execution will print logs that now have this prefix
`[AS-xx]`
where xx stand for an ID of a CAdaptiveStream class

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
while investigating on freeze problems, i used this on my local code
allow to have less headaches while debugging
valuable help in distinguishing which stream has problems
more useful by adding custom LOG points for local testing

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on this simple example on download "finish" logs there are AS prefixes
in relation to first 3 line "Created AdaptiveStream..."
```
2023-04-11 19:43:45.091 T:2000    debug <general>: AddOnLog: inputstream.adaptive: Created AdaptiveStream [AS-0] with adaptation set ID: "", stream type: video
2023-04-11 19:43:45.091 T:2000    debug <general>: AddOnLog: inputstream.adaptive: Created AdaptiveStream [AS-1] with adaptation set ID: "", stream type: audio
2023-04-11 19:43:45.091 T:2000    debug <general>: AddOnLog: inputstream.adaptive: Created AdaptiveStream [AS-2] with adaptation set ID: "", stream type: subtitle
2023-04-11 19:43:45.092 T:2000    debug <general>: AddOnLog: inputstream.adaptive: GetCapabilities()
2023-04-11 19:43:45.106 T:2000     info <general>: Creating Demuxer
2023-04-11 19:43:45.106 T:2000    debug <general>: AddOnLog: inputstream.adaptive: GetStreamIds()
2023-04-11 19:43:45.106 T:2000    debug <general>: AddOnLog: inputstream.adaptive: GetStream(1001)
2023-04-11 19:43:45.107 T:2000    debug <general>: AddOnLog: inputstream.adaptive: GetStream(1002)
2023-04-11 19:43:45.107 T:2000    debug <general>: AddOnLog: inputstream.adaptive: GetStream(1003)
2023-04-11 19:43:45.107 T:2000    debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1001 with codec_id 27
2023-04-11 19:43:45.107 T:2000    debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1002 with codec_id 86018
2023-04-11 19:43:45.107 T:2000    debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1003 with codec_id 94226
2023-04-11 19:43:47.001 T:20064   debug <general>: AddOnLog: inputstream.adaptive: [AS-0] Download finished: https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps_1280x720_4000k/bbb_30fps_1280x720_4000k_1.m4v (downloaded 1019520 byte, speed 2912914.00 byte/s)
2023-04-11 19:43:47.003 T:18192   debug <general>: CDVDVideoCodecFFmpeg - Updated codec: ff-h264-d3d11va
2023-04-11 19:43:47.007 T:20064   debug <general>: CurlFile::XFILE::CCurlFile::Open - <https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps_1280x720_4000k/bbb_30fps_1280x720_4000k_2.m4v>
2023-04-11 19:43:47.024 T:18192   debug <general>: CRenderManager::Configure - change configuration. 1280x720. display: 1280x720. framerate: 30.00.
2023-04-11 19:43:47.024 T:7344    debug <general>: AddOnLog: inputstream.adaptive: [AS-1] Download finished: https://dash.akamaized.net/akamai/bbb_30fps/bbb_a64k/bbb_a64k_3.m4a (downloaded 33405 byte, speed 710744.00 byte/s)
2023-04-11 19:43:47.028 T:7344    debug <general>: CurlFile::XFILE::CCurlFile::Open - <https://dash.akamaized.net/akamai/bbb_30fps/bbb_a64k/bbb_a64k_4.m4a>
```



## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
