### PR TITLE
[AdaptiveStream] Fix tree mutex deadlock

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include <algorithm>
+// #include <cassert>
 #include <chrono>
 #include <stdlib.h>
 #include <string.h>
@@ -31,7 +32,7 @@ using namespace UTILS;
 namespace adaptive
 {
   AdaptiveTree::AdaptiveTree(CHOOSER::IRepresentationChooser* reprChooser)
-    : m_reprChooser(reprChooser)
+  : m_reprChooser(reprChooser)
   {
   }
 
@@ -41,20 +42,6 @@ namespace adaptive
     m_manifestHeaders = left.m_manifestHeaders;
     m_settings = left.m_settings;
     m_supportedKeySystem = left.m_supportedKeySystem;
-  }
-
-  AdaptiveTree::~AdaptiveTree()
-  {
-    has_timeshift_buffer_ = false;
-    if (updateThread_)
-    {
-      {
-        std::lock_guard<std::mutex> lck(updateMutex_);
-        updateVar_.notify_one();
-      }
-      updateThread_->join();
-      delete updateThread_;
-    }
   }
 
   void AdaptiveTree::Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps)
@@ -99,7 +86,7 @@ namespace adaptive
                                          uint32_t fragmentDuration,
                                          uint32_t movie_timescale)
   {
-    if (!has_timeshift_buffer_ || HasUpdateThread() || repr->HasSegmentsUrl())
+    if (!has_timeshift_buffer_ || HasManifestUpdates() || repr->HasSegmentsUrl())
       return;
 
     // Check if its the last frame we watch
@@ -279,33 +266,10 @@ namespace adaptive
     }
   }
 
-  void AdaptiveTree::RefreshUpdateThread()
-  {
-    if (HasUpdateThread())
-    {
-      std::lock_guard<std::mutex> lck(updateMutex_);
-      updateVar_.notify_one();
-    }
-  }
-
   void AdaptiveTree::StartUpdateThread()
   {
-    if (!updateThread_ && ~updateInterval_ && has_timeshift_buffer_ && !m_manifestUpdateParam.empty())
-      updateThread_ = new std::thread(&AdaptiveTree::SegmentUpdateWorker, this);
-  }
-
-  void AdaptiveTree::SegmentUpdateWorker()
-  {
-    std::unique_lock<std::mutex> updLck(updateMutex_);
-    while (~updateInterval_ && has_timeshift_buffer_)
-    {
-      if (updateVar_.wait_for(updLck, std::chrono::milliseconds(updateInterval_)) == std::cv_status::timeout)
-      {
-        std::lock_guard<std::mutex> lck(treeMutex_);
-        lastUpdated_ = std::chrono::system_clock::now();
-        RefreshLiveSegments();
-      }
-    }
+    if (HasManifestUpdates())
+      m_updThread.Initialize(this);
   }
 
   bool AdaptiveTree::DownloadManifest(std::string url,
@@ -454,4 +418,66 @@ namespace adaptive
     }
   }
 
-} // namespace
+  AdaptiveTree::TreeUpdateThread::~TreeUpdateThread()
+  {
+    // assert(m_waitQueue == 0); // Debug only, missing resume
+    m_threadStop = true;
+
+    if (m_updateThread)
+    {
+      m_cvUpdInterval.notify_all(); // Unlock possible waiting
+
+      if (m_updateThread->joinable())
+        m_updateThread->join();
+
+      delete m_updateThread;
+      m_updateThread = nullptr;
+    }
+  }
+
+  void AdaptiveTree::TreeUpdateThread::Initialize(AdaptiveTree* tree)
+  {
+    if (!m_updateThread)
+    {
+      m_tree = tree;
+      m_updateThread = new std::thread(&TreeUpdateThread::Worker, this);
+    }
+  }
+
+  void AdaptiveTree::TreeUpdateThread::Worker()
+  {
+    std::unique_lock<std::mutex> updLck(m_updMutex);
+
+    while (~m_tree->m_updateInterval && !m_threadStop)
+    {
+      if (m_cvUpdInterval.wait_for(updLck, std::chrono::milliseconds(m_tree->m_updateInterval)) ==
+          std::cv_status::timeout)
+      {
+        updLck.unlock();
+        // If paused, wait until last "Resume" will be called
+        std::unique_lock<std::mutex> lckWait(m_waitMutex);
+        m_cvWait.wait(lckWait, [&] { return m_waitQueue == 0; });
+
+        updLck.lock();
+        m_tree->RefreshLiveSegments();
+      }
+    }
+  }
+
+  void AdaptiveTree::TreeUpdateThread::Pause()
+  {
+    // If an update is already in progress the wait until its finished
+    std::lock_guard<std::mutex> updLck{m_updMutex};
+    m_waitQueue++;
+  }
+
+  void AdaptiveTree::TreeUpdateThread::Resume()
+  {
+    // assert(m_waitQueue != 0); // Debug only, resume without any pause
+    m_waitQueue--;
+    // If there are no more pauses, unblock the update thread
+    if (m_waitQueue == 0)
+      m_cvWait.notify_all();
+  }
+
+  } // namespace adaptive


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
commit https://github.com/xbmc/inputstream.adaptive/commit/181d600ef22527a0c8456dd8b4c99e86c2cd4fb8
has removed `lckTree.unlock();` from `AdaptiveStream::seek_time` method
what happens is:
1) AdaptiveStream::seek_time -> lock tree
2) after call ResetCurrentSegment that call StopWorker
3) meatime a download can be in progress
4) if a download in in progress call AdaptiveStream::write_data
5) AdaptiveStream::write_data call HLS `OnDataArrived` overrided method
6) deadlock

the code after the `lckTree.unlock();` that i have add seem not needs the tree lock but 
i could be wrong @glennguy can you try make a double check?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Video seek can cause a/v freeze

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
akmai HLS sample stream

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
