### PR TITLE
[AdaptiveTree] Some cleanups after refactor

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -423,7 +423,7 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
     std::string licenseKey{m_kodiProps.m_licenseKey};
 
     if (licenseKey.empty())
-      licenseKey = m_adaptiveTree->license_url_;
+      licenseKey = m_adaptiveTree->GetLicenseUrl();
 
     LOG::Log(LOGDEBUG, "Entering encryption section");
 

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -78,7 +78,6 @@ void PLAYLIST::CAdaptationSet::CopyHLSData(const CAdaptationSet* other)
   m_id = other->m_id;
   m_group = other->m_group;
   m_codecs = other->m_codecs;
-  m_audioTrackId = other->m_audioTrackId;
   m_name = other->m_name;
 }
 
@@ -106,8 +105,7 @@ bool PLAYLIST::CAdaptationSet::IsMergeable(const CAdaptationSet* other) const
         m_baseUrl == other->m_baseUrl && m_isDefault == other->m_isDefault &&
         m_isOriginal == other->m_isOriginal && m_isForced == other->m_isForced &&
         m_isImpaired == other->m_isImpaired && m_mimeType == other->m_mimeType &&
-        m_audioTrackId == other->m_audioTrackId && m_audioChannels == other->m_audioChannels &&
-        m_codecs == other->m_codecs)
+        m_audioChannels == other->m_audioChannels && m_codecs == other->m_codecs)
     {
       return true;
     }
@@ -127,9 +125,6 @@ bool PLAYLIST::CAdaptationSet::Compare(const std::unique_ptr<CAdaptationSet>& le
 
   if (left->m_streamType == StreamType::AUDIO)
   {
-    if (left->m_audioTrackId != right->m_audioTrackId)
-      return left->m_audioTrackId < right->m_audioTrackId;
-
     if (left->m_name != right->m_name)
       return left->m_name < right->m_name;
 

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -102,10 +102,6 @@ public:
   bool IsForced() const { return m_isForced; }
   void SetIsForced(bool isForced) { m_isForced = isForced; }
 
-  //! @todo: undocumented, used to distingish audio streams on mergeable method? could be removed?
-  std::string GetAudioTrackId() const { return m_audioTrackId; }
-  void SetAudioTrackId(std::string_view audioTrackId) { m_audioTrackId = audioTrackId; }
-
   void CopyHLSData(const CAdaptationSet* other);
 
   bool IsMergeable(const CAdaptationSet* other) const;
@@ -139,7 +135,6 @@ protected:
   bool m_isOriginal{false};
   bool m_isDefault{false};
   bool m_isForced{false};
-  std::string m_audioTrackId;
 };
 
 } // namespace PLAYLIST

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -256,12 +256,6 @@ namespace adaptive
       {
         std::sort(adpSet->GetRepresentations().begin(), adpSet->GetRepresentations().end(),
                   CRepresentation::CompareBandwidth);
-
-        //! @todo: move set scaling out of SortTree
-        for (auto& repr : adpSet->GetRepresentations())
-        {
-          repr->SetScaling();
-        }
       }
     }
   }

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -64,7 +64,6 @@ public:
 
   std::string manifest_url_;
   std::string base_url_;
-  std::string effective_url_;
   std::string m_manifestUpdateParam;
 
   std::optional<uint32_t> initial_sequence_; // HLS only

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -78,7 +79,6 @@ public:
   std::string location_;
 
   CryptoMode m_cryptoMode{CryptoMode::NONE};
-  std::string license_url_; // SmoothTree only
 
   AdaptiveTree(CHOOSER::IRepresentationChooser* reprChooser);
   AdaptiveTree(const AdaptiveTree& left);
@@ -230,6 +230,12 @@ public:
    */
   TreeUpdateThread& GetTreeUpdMutex() { return m_updThread; };
 
+  /*!
+   * \brief Get the license URL, some DRM-encrypted manifests (e.g. SmoothStreaming) can provide it.
+   * \return The license URL if found, otherwise empty string.
+   */
+  std::string_view GetLicenseUrl() { return m_licenseUrl; }
+
 protected:
   /*!
    * \brief Download a file.
@@ -297,6 +303,8 @@ protected:
 
   // Provide the path where the manifests will be saved, if debug enabled
   std::string m_pathSaveManifest;
+
+  std::string m_licenseUrl;
 };
 
 } // namespace adaptive

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -78,9 +78,6 @@ public:
   std::string m_supportedKeySystem;
   std::string location_;
 
-  std::string current_pssh_; //! @todo: remove me
-  std::string current_defaultKID_; //! @todo: remove me
-  std::string current_iv_; //! @todo: remove me
   CryptoMode m_cryptoMode{CryptoMode::NONE};
   std::string license_url_; // SmoothTree only
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -688,20 +688,18 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
     return;
   }
 
-  // Sanitize AdaptationSet properties
-  //! @todo: sanitize need to be reworked and moved outside representation parser
-  if (adpSet->GetStreamType() != StreamType::SUBTITLE)
+  // If AdaptationSet tag dont provide any info to know the content type
+  // we attempt to determine it based on the content of the representation
+  if (adpSet->GetStreamType() == StreamType::NOTYPE)
   {
-    if (adpSet->GetStreamType() == StreamType::NOTYPE)
+    StreamType streamType = DetectStreamType("", repr->GetMimeType());
+
+    if (streamType == StreamType::NOTYPE &&
+        (repr->ContainsCodec("wvtt") || (repr->ContainsCodec("ttml"))))
     {
-      StreamType streamType = DetectStreamType("", repr->GetMimeType());
-
-      if (streamType == StreamType::NOTYPE &&
-          (repr->ContainsCodec("wvtt") || (repr->ContainsCodec("ttml"))))
-        streamType = StreamType::SUBTITLE;
-
-      adpSet->SetStreamType(streamType);
+      streamType = StreamType::SUBTITLE;
     }
+    adpSet->SetStreamType(streamType);
   }
 
   // Set properties for subtitles types

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1183,6 +1183,8 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   if (repr->GetStartNumber() > m_firstStartNumber)
     m_firstStartNumber = repr->GetStartNumber();
 
+  repr->SetScaling();
+
   adpSet->AddRepresentation(repr);
 }
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -437,8 +437,6 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
 
   adpSet->AddCodecs(XML::GetAttrib(nodeAdp, "codecs"));
 
-  adpSet->SetAudioTrackId(XML::GetAttrib(nodeAdp, "audioTrackId")); // ISA custom attribute
-
   // Following stream properties, can be used to override existing values
   std::string isImpaired;
   if (XML::QueryAttrib(nodeAdp, "impaired", isImpaired)) // ISA custom attribute

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -104,10 +104,9 @@ bool adaptive::CDashTree::open(const std::string& url,
 
   SaveManifest("", data, url);
 
-  effective_url_ = respHeaders.m_effectiveUrl;
   m_manifestRespHeaders = respHeaders;
 
-  if (!PreparePaths(effective_url_))
+  if (!PreparePaths(respHeaders.m_effectiveUrl))
     return false;
 
   if (!ParseManifest(data))

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -633,44 +633,8 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
     }
   }
 
-  if (adpSet->SegmentTimelineDuration().IsEmpty() && adpSet->HasSegmentTemplate() &&
-      !adpSet->GetSegmentTemplate()->GetMedia().empty())
-  {
-    for (auto& rep : adpSet->GetRepresentations())
-    {
-      if (rep->GetDuration() == 0 || rep->GetTimescale() == 0)
-      {
-        rep->SetDuration(adpSet->GetSegmentTemplate()->GetDuration());
-        rep->SetTimescale(adpSet->GetSegmentTemplate()->GetTimescale());
-      }
-    }
-  }
-  else if (!adpSet->SegmentTimelineDuration().IsEmpty())
-  {
-    // If representations are not timelined, we have to adjust startPTS in representation segments
-    for (auto& rep : adpSet->GetRepresentations())
-    {
-      if (rep->HasSegmentTimeline())
-        continue;
-
-      uint64_t startPts{0};
-      for (size_t i{0}; i < adpSet->SegmentTimelineDuration().GetSize(); i++)
-      {
-        auto adpSeg = adpSet->SegmentTimelineDuration().Get(i);
-        auto repSeg = rep->SegmentTimeline().Get(i);
-        if (repSeg && adpSeg)
-        {
-          repSeg->startPTS_ = startPts;
-          startPts += *adpSeg;
-        }
-      }
-      rep->nextPts_ = startPts;
-    }
-  }
-
   period->AddAdaptationSet(adpSet);
 }
-
 
 void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
                                                  PLAYLIST::CAdaptationSet* adpSet,

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -866,6 +866,8 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
       repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
       repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
 
+      repr->SetScaling();
+
       // Add the representation/adaptation set to the group
       adpSet->AddRepresentation(repr);
       group.m_adpSets.push_back(std::move(adpSet));
@@ -942,6 +944,8 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
       repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
       repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
 
+      repr->SetScaling();
+
       // Try read on the next stream line, to get the playlist URL address
       if (STRING::GetLine(streamData, line) && !line.empty() && line[0] != '#')
       {
@@ -978,6 +982,8 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
 
       repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
       repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
+
+      repr->SetScaling();
 
       newAdpSet->AddRepresentation(repr);
       period->AddAdaptationSet(newAdpSet);
@@ -1043,6 +1049,8 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
 
     repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
     repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
+
+    repr->SetScaling();
 
     newAdpSet->AddRepresentation(repr);
     period->AddAdaptationSet(newAdpSet);

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -157,9 +157,7 @@ bool adaptive::CHLSTree::open(const std::string& url,
 
   SaveManifest(nullptr, data, url);
 
-  effective_url_ = respHeaders.m_effectiveUrl;
-
-  if (!PreparePaths(effective_url_))
+  if (!PreparePaths(respHeaders.m_effectiveUrl))
     return false;
 
   if (!ParseManifest(data))
@@ -211,8 +209,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
 
     SaveManifest(adp, data, rep->GetSourceUrl());
 
-    effective_url_ = respHeaders.m_effectiveUrl;
-    std::string baseUrl = URL::RemoveParameters(effective_url_);
+    std::string baseUrl = URL::RemoveParameters(respHeaders.m_effectiveUrl);
 
     EncryptionType currentEncryptionType = EncryptionType::CLEAR;
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -90,6 +90,10 @@ private:
   uint8_t m_segmentIntervalSec = 4;
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;
+
+  std::string m_currentPssh; // Last processed encryption URI
+  std::string m_currentDefaultKID; // Last processed encryption KID
+  std::string m_currentIV; // Last processed encryption IV
 };
 
 } // namespace

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -116,7 +116,7 @@ bool adaptive::CSmoothTree::ParseManifest(std::string& data)
         if (protParser.ParseHeader(nodeProtHead.child_value()))
         {
           period->SetEncryptionState(EncryptionState::ENCRYPTED_SUPPORTED);
-          license_url_ = protParser.GetLicenseURL();
+          m_licenseUrl = protParser.GetLicenseURL();
         }
       }
       else

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -367,5 +367,7 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
   repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
   repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
 
+  repr->SetScaling();
+
   adpSet->AddRepresentation(repr);
 }

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -46,9 +46,7 @@ bool adaptive::CSmoothTree::open(const std::string& url,
   // We do not add "info" arg to SaveManifest or corrupt possible UTF16 data
   SaveManifest("", data, "");
 
-  effective_url_ = respHeaders.m_effectiveUrl;
-
-  if (!PreparePaths(effective_url_))
+  if (!PreparePaths(respHeaders.m_effectiveUrl))
     return false;
 
   if (!ParseManifest(data))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
I made separate commits to a better review

to pay attention on commit: `[DashTree] Removed dead code`
the part of code that concern:
`If representations are not timelined, we have to adjust startPTS in representation segments`
the code is self-excluding (noop), this come from old code of 7y ago i do not know why this is so but imo has never worked

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
remove some todo's

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
played a couple of sample streams and run tests
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
