### PR TITLE
[AdaptiveTree] Fix buffer data for goolge tests

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -177,14 +177,12 @@ bool adaptive::AdaptiveStream::DownloadImpl(const DownloadInfo& downloadInfo,
             if (state_ == STOPPED)
               break;
 
-            std::string& segment_buffer = downloadInfo.m_segmentBuffer->buffer;
-            size_t insertPos(segment_buffer.size());
-            segment_buffer.resize(insertPos + bytesRead);
+            std::string& segmentBuffer = downloadInfo.m_segmentBuffer->buffer;
 
             tree_.OnDataArrived(downloadInfo.m_segmentBuffer->segment_number,
                                 downloadInfo.m_segmentBuffer->segment.pssh_set_, m_decrypterIv,
-                                reinterpret_cast<const uint8_t*>(bufferData.data()), segment_buffer,
-                                insertPos, bytesRead, isLastChunk);
+                                bufferData.data(), bytesRead, segmentBuffer, segmentBuffer.size(),
+                                isLastChunk);
           }
           thread_data_->signal_rw_.notify_all();
         }
@@ -983,6 +981,7 @@ NEXTSEGMENT:
     while (true)
     {
       uint32_t avail = segment_buffers_[0]->buffer.size() - segment_read_pos_;
+
       if (avail < bytesToRead && worker_processing_)
       {
         thread_data_->signal_rw_.wait(lckrw);

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -148,13 +148,13 @@ namespace adaptive
   void AdaptiveTree::OnDataArrived(uint64_t segNum,
                                    uint16_t psshSet,
                                    uint8_t iv[16],
-                                   const uint8_t* src,
-                                   std::string& dst,
-                                   size_t dstOffset,
-                                   size_t dataSize,
-                                   bool lastChunk)
+                                   const char* srcData,
+                                   size_t srcDataSize,
+                                   std::string& segBuffer,
+                                   size_t segBufferSize,
+                                   bool isLastChunk)
   {
-    memcpy(&dst[0] + dstOffset, src, dataSize);
+    segBuffer.append(srcData, srcDataSize);
   }
 
   uint16_t AdaptiveTree::InsertPsshSet(PLAYLIST::StreamType streamType,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -105,14 +105,16 @@ public:
   {
     return std::chrono::system_clock::now();
   }
+
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
                              uint8_t iv[16],
-                             const uint8_t* src,
-                             std::string& dst,
-                             size_t dstOffset,
-                             size_t dataSize,
-                             bool lastChunk);
+                             const char* srcData,
+                             size_t srcDataSize,
+                             std::string& segBuffer,
+                             size_t segBufferSize,
+                             bool isLastChunk);
+
   virtual void RefreshSegments(PLAYLIST::CPeriod* period,
                                PLAYLIST::CAdaptationSet* adp,
                                PLAYLIST::CRepresentation* rep,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -40,11 +40,11 @@ public:
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
                              uint8_t iv[16],
-                             const uint8_t* src,
-                             std::string& dst,
-                             size_t dstOffset,
-                             size_t dataSize,
-                             bool lastChunk) override;
+                             const char* srcData,
+                             size_t srcDataSize,
+                             std::string& segBuffer,
+                             size_t segBufferSize,
+                             bool isLastChunk) override;
 
   virtual void RefreshSegments(PLAYLIST::CPeriod* period,
                                PLAYLIST::CAdaptationSet* adp,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix buffer data for tests with related cleanups to `OnDataArrived`

the root of problem was that on `TestAdaptiveStream::DownloadSegment`
was missing the buffer `resize` then memcpy was failing
now i have semplified a bit

this fix the problem of the CI being blocked for hours

but another bug still exists that sometimes cause segmentation fault when running tests
the problem should always related to `AdaptiveStream::read` operations
but at the moment i have not found it

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes google tests would get stuck in an endless loop
in the `AdaptiveStream::read` because the data was corrupted and can never arrive

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run google test dozens of times
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
