### PR TITLE
[DASH] parse encryption scheme value

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1344,6 +1344,13 @@ bool adaptive::CDashTree::ParseTagContentProtection(pugi::xml_node nodeParent,
       xml_attribute attrKID = XML::FirstAttributeNoPrefix(nodeCP, "default_KID");
       if (attrKID)
         defaultKID = attrKID.value();
+
+      // get crypto mode if available
+      std::string_view protectionValue = XML::GetAttrib(nodeCP, "value");
+      if (protectionValue == "cenc")
+        m_cryptoMode = CryptoMode::AES_CTR;
+      else if (protectionValue == "cbcs")
+        m_cryptoMode = CryptoMode::AES_CBC;
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After the revert to single widevine session changes, it exposes a problem with the CDM that was the reason I originally went that way. It wasn't picked up in the change because I tested on a different source.

When setting up decryption and `GetCapabilities` is called in wvdecrypter the encryption mode in the CDM is set to cenc by default. This isn't an issue of itself when testing the license against dummy data but the CDM seems to not be able to handle changing modes once this first decryption is done. Of note, for some reason the CDM is fine with this scenario if there are 2 sessions??? Starting off at cenc and then changing to cbcs in the case of my old test stream will currently end up with decryption failing. When testing the single session PR, I used a live CMAF stream that was HLS - HLS is already set up to determine cenc/cbcs based on the `METHOD` value in the key. This PR gives the same capability for DASH streams. 

Example tag:
`<ContentProtection value="cbcs" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="30303030-3030-3030-3030-303030303030"/>`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes broken playback in DASH cbcs streams

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://proxy.uat.widevine.com/proxy?provider=widevine_test||R{SSM}|
https://storage.googleapis.com/wvmedia/cbcs/h264/tears/tears_aes_cbcs.mpd
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
