### PR TITLE
[HLSTree] Fix wrong saved manifest child filename

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1161,7 +1161,7 @@ void adaptive::CHLSTree::SaveManifest(PLAYLIST::CAdaptationSet* adpSet,
   std::string fileNameSuffix = "master";
   if (adpSet)
   {
-    fileNameSuffix += "child-";
+    fileNameSuffix = "child-";
     fileNameSuffix += StreamTypeToString(adpSet->GetStreamType());
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix wrong saved manifest child filename
was resulting ad `masterchild` instead of `child`
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
