### PR TITLE
[PropertiesUtils] Add streams_config property

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|streams_config"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -798,13 +798,10 @@ void CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
       stream.m_info.SetStreamType(INPUTSTREAM_TYPE_AUDIO);
       if (adp->IsImpaired())
         flags |= INPUTSTREAM_FLAG_VISUAL_IMPAIRED;
+      if (adp->IsOriginal())
+        flags |= INPUTSTREAM_FLAG_ORIGINAL;
       if (adp->IsDefault())
         flags |= INPUTSTREAM_FLAG_DEFAULT;
-      if (adp->IsOriginal() || (!m_kodiProps.m_audioLanguageOrig.empty() &&
-                                adp->GetLanguage() == m_kodiProps.m_audioLanguageOrig))
-      {
-        flags |= INPUTSTREAM_FLAG_ORIGINAL;
-      }
       break;
     }
     case StreamType::SUBTITLE:

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -157,3 +157,24 @@ bool PLAYLIST::CAdaptationSet::Compare(const std::unique_ptr<CAdaptationSet>& le
 
   return false;
 }
+
+std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator PLAYLIST::CAdaptationSet::
+    FindAudioAdpSet(const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                    const std::string langCode,
+                    bool isPreferStereo,
+                    bool filterImpaired)
+{
+  for (auto& itAdpSet = adpSets.cbegin(); itAdpSet != adpSets.cend(); itAdpSet++)
+  {
+    auto adpSet = itAdpSet->get();
+    if (adpSet->GetStreamType() == StreamType::AUDIO &&
+        STRING::CompareNoCase(adpSet->GetLanguage(), langCode) &&
+        (isPreferStereo ? adpSet->GetRepresentations()[0]->GetAudioChannels() <= 2
+                        : adpSet->GetRepresentations()[0]->GetAudioChannels() > 2) &&
+        adpSet->IsImpaired() == filterImpaired)
+    {
+      return itAdpSet;
+    }
+  }
+  return adpSets.end();
+}

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -109,6 +109,12 @@ public:
   static bool Compare(const std::unique_ptr<CAdaptationSet>& left,
                       const std::unique_ptr<CAdaptationSet>& right);
 
+  static std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator FindAudioAdpSet(
+      const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+      const std::string langCode,
+      bool isPreferStereo,
+      bool filterImpaired = false);
+
 protected:
   std::vector<std::unique_ptr<CRepresentation>> m_representations;
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -254,6 +254,12 @@ protected:
                             const std::string& data,
                             std::string_view info);
 
+  /*!
+   * \brief Apply fixes and overrides to audio/subtitles stream flags.
+   * \param kodiProps The Kodi properties
+   */
+  void FixStreamsFlags(const UTILS::PROPERTIES::KodiProperties& kodiProps);
+
   void SortTree();
 
   // Live segment update section

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -376,6 +376,8 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
         adpSet->SetIsForced(true);
       else if (value == "main")
         adpSet->SetIsDefault(true);
+      else if (value == "caption" || value == "alternate" || value == "commentary")
+        adpSet->SetIsImpaired(true);
     }
   }
 
@@ -388,7 +390,7 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
 
     if (schemeIdUri == "urn:mpeg:dash:role:2011")
     {
-      if (value == "caption")
+      if (STRING::StartsWith(value, "caption")) // caption or captions
         adpSet->SetIsImpaired(true);
     }
   }

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -34,7 +34,9 @@ constexpr std::string_view PROP_MANIFEST_HEADERS = "inputstream.adaptive.manifes
 constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_params";
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 
-constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
+constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language"; //! @todo: deprecated, to be removed on next Kodi release
+constexpr std::string_view PROP_STREAMS_CONFIG = "inputstream.adaptive.streams_config";
+
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay";
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
@@ -121,9 +123,29 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
     {
       ParseHeaderString(props.m_streamHeaders, prop.second);
     }
-    else if (prop.first == PROP_AUDIO_LANG_ORIG)
+    else if (prop.first == PROP_AUDIO_LANG_ORIG) //! @todo: deprecated, to be removed on next Kodi release
     {
-      props.m_audioLanguageOrig = prop.second;
+      LOG::Log(LOGWARNING,
+               "Warning \"inputstream.adaptive.original_audio_language\" property is deprecated "
+               "has been replaced by \"inputstream.adaptive.stream_audio_cfg\". "
+               "Please read Wiki \"Integration\" page to learn more about the new properties.");
+      props.m_audioLangOriginal = prop.second;
+    }
+    else if (prop.first == PROP_STREAMS_CONFIG)
+    {
+      auto values = STRING::ToMap(prop.second, '=', ';');
+
+      if (STRING::KeyExists(values, "audio_langcode_default"))
+        props.m_audioLangDefault = STRING::Trim(values["audio_langcode_default"]);
+      if (STRING::KeyExists(values, "audio_langcode_original"))
+        props.m_audioLangOriginal = STRING::Trim(values["audio_langcode_original"]);
+      if (STRING::KeyExists(values, "audio_prefer_stereo"))
+        props.m_audioPrefStereo = values["audio_prefer_stereo"] == "true";
+      if (STRING::KeyExists(values, "audio_prefer_type"))
+        props.m_audioPrefType = STRING::Trim(values["audio_prefer_type"]);
+
+      if (STRING::KeyExists(values, "subtitles_langcode_default"))
+        props.m_subtitleLangDefault = STRING::Trim(values["subtitles_langcode_default"]);
     }
     else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
     {

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -53,7 +53,21 @@ struct KodiProperties
   std::string m_streamParams;
   // HTTP headers used to download streams
   std::map<std::string, std::string> m_streamHeaders;
-  std::string m_audioLanguageOrig;
+
+  // Defines what type of audio tracks should be preferred for the "default" flag,
+  // accepted values are: original, impaired, or empty string.
+  // When empty: it try to set the flag to a regular language track or fallback to original language
+  std::string m_audioPrefType;
+  // Defines if stereo audio tracks are preferred over multichannels one,
+  // it depends from m_audioLangDefault
+  bool m_audioPrefStereo{false};
+  // Force audio streams with the specified language code to have the "default" flag
+  std::string m_audioLangDefault;
+  // Force audio streams with the specified language code to have the "original" flag
+  std::string m_audioLangOriginal;
+  // Force subtitle streams with the specified language code to have the "default" flag
+  std::string m_subtitleLangDefault;
+
   bool m_playTimeshiftBuffer{false};
   // Set a custom delay from live edge in seconds
   uint64_t m_liveDelay{0};

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -11,6 +11,7 @@
 #include "kodi/tools/StringUtils.h"
 
 #include <algorithm>
+#include <cctype> // isspace
 #include <charconv> // from_chars
 #include <cstdio>
 #include <cstring> // strstr
@@ -254,4 +255,57 @@ std::string UTILS::STRING::ToLower(std::string str)
 {
   StringUtils::ToLower(str);
   return str;
+}
+
+std::map<std::string_view, std::string_view> UTILS::STRING::ToMap(std::string_view str,
+                                                                  const char delimiter,
+                                                                  const char separator)
+{
+  std::map<std::string_view, std::string_view> mapped;
+
+  size_t keyPos = 0;
+  size_t keyEnd;
+  size_t valPos;
+  size_t valEnd;
+
+  while ((keyEnd = str.find(delimiter, keyPos)) != std::string::npos)
+  {
+    valPos = str.find_first_not_of(delimiter, keyEnd);
+    if (valPos == std::string::npos)
+      break;
+
+    valEnd = str.find(separator, valPos);
+    mapped.emplace(str.substr(keyPos, keyEnd - keyPos), str.substr(valPos, valEnd - valPos));
+
+    keyPos = valEnd;
+    if (keyPos != std::string::npos)
+      ++keyPos;
+  }
+
+  return mapped;
+}
+
+std::string_view UTILS::STRING::Trim(std::string_view str)
+{
+  auto left = str.begin();
+  while (left != str.end())
+  {
+    if (!std::isspace(*left))
+      break;
+
+    left++;
+  }
+
+  if (left == str.end())
+    return {};
+
+  auto right = str.end() - 1;
+  while (right > left && std::isspace(*right))
+  {
+    right--;
+  }
+
+  //! @todo: when we will switch to C++20 replace return code with:
+  //!   return {left, std::distance(left, right) + 1};
+  return str.substr(left - str.begin(), std::distance(left, right) + 1);
 }

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -163,6 +164,23 @@ bool GetLine(std::stringstream& ss, std::string& line);
  * \return The string in lowercase.
  */
 std::string ToLower(std::string str);
+
+/*!
+ * \brief Convert a string to a map.
+ * \param str The string to convert
+ * \param delimiter The character separating the key from the value
+ * \param separator The character separating more key/value pairs
+ * \return The mapped string.
+ */
+std::map<std::string_view, std::string_view> ToMap(std::string_view str,
+                                                   const char delimiter,
+                                                   const char separator);
+
+/*!
+ * \brief Trim a string with remove of not wanted spaces at begin and end of string.
+ * \return The changed string.
+ */
+std::string_view Trim(std::string_view str);
 
 } // namespace STRING
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR add a new property: `inputstream.adaptive.streams_config`
the name a bit generic to allow in future possibile new extensions of these configurations relative to streams without add new properties (if you want suggest a better naming say so)

the values are handled in similar way of a pair values (or something similar of python dict) as follow:
`key=value;`
more values are so concatenated:
`key=value;key2=value2;key3=value3;`

### `inputstream.adaptive.streams_config`
Supported configuration keys:
- `audio_langcode_default`: Set the "default" flag to the audio streams with specified language code (need to match the manifest)
- `audio_langcode_original`: Set the "original" flag to the audio streams with specified language code (need to match the manifest)
- `audio_prefer_stereo`: Can be set to `true` when you want prefeer stereo track as default instead of multichannels (it depends from audio_langcode_default and/or audio_langcode_original)
- `audio_prefer_type`: Can be set to `original` to prefer set default streams with original language, or `impaired` to prefer set default streams for impaired, otherwise left empty value for default behaviour.
- `subtitles_langcode_default`: Set the "default" flag to the subtitle streams with specified language code (need to match the manifest)

Example:
`audio_langcode_default=pt_br;audio_prefer_stereo=true`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Completed fix for #422 for DASH and in more general way,
after the recent parser rework i have improved the behaviour of  `AdaptationSet` tag ISA custom attributes:
`default`, `impaired`, `forced`, `original`
where now can be add and used to full override default manifest stream attributes,
the reason is that Kodi stream flags have not always have the same meaning of manifests attributes
and/or there are video services that dont follow exactly the specs and lead to wrong flags set to the audio/subtitle tracks

ofc add these custom ISA attributes needs to implement a proxy on a video add-on not so easy to do for novice devs but also expensive for low end devices, therefore this PR add two new properties that allow to set (and so override) the default stream language and original stream language in easy way

### HLS manifest note
This manifest type not always have appropriate language codes and also not always provide right number of audio channels in th metadata, therefore above configurations may fails, strictly depends on the service provider

### WIP - i will evaluate this part in the coming days:
i will need to make some more tests
use json for property values

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a sample dash

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
