### PR TITLE
[Session] Do not check GetInformation on GetNextSample

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1209,9 +1209,6 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
         }
       }
     }
-
-    if (isStarted && streamReader->GetInformation(stream->m_info))
-      m_changed = true;
   }
 
   if (waiting)
@@ -1222,8 +1219,6 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
   {
     CheckFragmentDuration(*res);
     ISampleReader* sr{res->GetReader()};
-    if (sr->GetInformation(res->m_info))
-      m_changed = true;
 
     if (sr->PTS() != STREAM_NOPTS_VALUE)
       m_elapsedTime = PTSToElapsed(sr->PTS()) + GetChapterStartTime();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
While in playback imo there should be no reasons to run `GetInformation` to verify changes during playback

the properties set in to `InputstreamInfo` (also metadata) that are checked by `GetInformation` methods for example here
https://github.com/xbmc/inputstream.adaptive/blob/Omega/src/WebmReader.cpp#L106-L149
if changed while in playback are ignored from kodi
kodi check these properties value only when get/open a stream `GetStream`
or when VP are resetted by DEMUX_SPECIALID_STREAMCHANGE that is too much expensive

now the question is why do this?
we carry this (removed) old code from the initial commit of the project and i suspect that this is a workaround for something that is not explained or was a old workaround

i tried two tests
1) with adaptive stream i changed quality while in playback in automatic way (test switching) and manually by using GUI, no regressions
2) with adaptive stream i changed video codec manually by using GUI, no regressions

maybe we can switch to a representation with different video codec "without know it" at that point? ~this is the only point that could be need to investigate better~ 
EDIT: This is the code that allow to send DEMUX_SPECIALID_STREAMCHANGE to kodi when the representation change
https://github.com/xbmc/inputstream.adaptive/blob/21.1.0-Omega/src/common/AdaptiveStream.cpp#L808-L814
so in any case it cover all cases

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~try to~ fix #1197

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
read above

~however need to be tested with am@zon~
Tested with am@zon 4k HDR works without produce DEMUX_SPECIALID_STREAMCHANGE in the log, and then resolved video stuttering problem

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
