### PR TITLE
[FragmentedSampleReader] Fix memory leak in AP4_LinearReader::Process…

### DIFF
--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -421,13 +421,9 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
         // we assume unencrypted fragment here
         goto SUCCESS;
 
-      AP4_CencSampleDecrypter* decrypter = nullptr;
-      if (AP4_FAILED(result = AP4_CencSampleDecrypter::Create(sample_table, algorithm_id, 0, 0, 0,
-                                                              reset_iv, m_singleSampleDecryptor,
-                                                              decrypter)))
-      {
-        return result;
-      }
+      if (!m_singleSampleDecryptor)
+        return AP4_ERROR_INVALID_PARAMETERS;
+
       m_decrypter = new CAdaptiveCencSampleDecrypter(m_singleSampleDecryptor, sample_table);
 
       // Inform decrypter of pattern decryption (CBCS)


### PR DESCRIPTION
## Description
Fix a memory leak in CFragmentedSampleReader::ProcessMoof where there is a decrypter object is constructed via AP4_CencSampleDecrypter::Create but it is never deconstructed.

## Motivation and context
If I'm right the m_singleSampleDecryptor is always pointing to something at this point and after checking what the AP4_CencSampleDecrypter::Create actual does when m_singleSampleDecryptor exist is checking the IV length corresponding to the given cipher type and then construct the decrypter object what is not used.
I removed this checks because this should already been done for m_singleSampleDecryptor and the decrypter object isn't constructed anymore.
I guess this patch will not break anything. But if there is change that AP4_CencSingleSampleDecrypter::Create was called with m_singleSampleDecryptor == NULL then it look like it running into a down-casting of single_sample_decrypter in the Bento4 code before this patch.

## How has this been tested?
Running the 'make test' and check if I can still watch some content with widevine DRM.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
