### PR TITLE
[AdaptiveTree] Move update thread start to PostOpen

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -73,6 +73,8 @@ namespace adaptive
       m_liveDelay = kodiProps.m_liveDelay;
     else if (m_liveDelay < 16)
       m_liveDelay = 16;
+
+    StartUpdateThread();
   }
 
   void AdaptiveTree::FreeSegments(CPeriod* period, CRepresentation* repr)

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -121,7 +121,6 @@ bool adaptive::CDashTree::open(const std::string& url,
   m_currentPeriod = m_periods[0].get();
 
   SortTree();
-  StartUpdateThread();
 
   return true;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
With current architecture in DASH we are always starting the update thread on the 'update tree' that is only used to extract information for our 'main' tree. Update tree only has a very short lifespan but the suspicion is that update tree is destroyed before the thread has started - update thread possibly then goes on to spawn its own update thread.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To fix issues reported on data corruption/memory exhaustion/buffering such as in #1260

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against live DASH streams, no issues, memory usage stays consistent.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
