### PR TITLE
[DASHTree] Allow content protection without systemid urn

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -466,7 +466,7 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
 
       CPeriod::PSSHSet& sessionPsshset = m_adaptiveTree->m_currentPeriod->GetPSSHSets()[ses];
 
-      if (sessionPsshset.pssh_ == "FILE")
+      if (sessionPsshset.pssh_ == PSSH_FROM_FILE)
       {
         LOG::Log(LOGDEBUG, "Searching PSSH data in FILE");
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1408,15 +1408,14 @@ bool adaptive::CDashTree::ParseTagContentProtection(pugi::xml_node nodeParent,
 
   if (commonPssh.empty() && !playReadyPro.empty())
   {
-    currentPssh = PSSH_FROM_FILE;
-
     PRProtectionParser parser;
     if (parser.ParseHeader(playReadyPro))
       currentDefaultKID = parser.GetKID();
   }
   else
   {
-    currentPssh = commonPssh;
+    if (!commonPssh.empty())
+      currentPssh = commonPssh;
 
     if ((isUrnSchemeFound || isUrnProtectionFound) && defaultKID && std::strlen(defaultKID) == 36)
     {

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1433,7 +1433,7 @@ bool adaptive::CDashTree::ParseTagContentProtection(pugi::xml_node nodeParent,
     }
   }
 
-  return isUrnSchemeFound;
+  return isUrnSchemeFound || isUrnProtectionFound;
 }
 
 uint32_t adaptive::CDashTree::ParseAudioChannelConfig(pugi::xml_node node)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
in the ContentProtection specify system id urn is not mandatory a mistake from the refactor

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
reported on slack
manifest used: [MPDmanifest.txt](https://github.com/xbmc/inputstream.adaptive/files/11610050/MPDmanifest.txt)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
just test parse the manifest

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
