### PR TITLE
[AdaptiveTree] Fix pointer move and reintroduced audioTrackId

### DIFF
--- a/src/common/CommonAttribs.h
+++ b/src/common/CommonAttribs.h
@@ -59,6 +59,7 @@ public:
   void SetAudioChannels(uint32_t audioChannels) { m_audioChannels = audioChannels; }
 
 protected:
+  CCommonAttribs* m_parentCommonAttributes{nullptr};
   std::string m_mimeType;
   std::optional<ContainerType> m_containerType;
   int m_resHeight{0};
@@ -68,9 +69,6 @@ protected:
   uint32_t m_frameRateScale{0};
   uint32_t m_sampleRate{0};
   uint32_t m_audioChannels{0};
-
-private:
-  CCommonAttribs* m_parentCommonAttributes{nullptr};
 };
 
 } // namespace PLAYLIST

--- a/src/common/CommonSegAttribs.h
+++ b/src/common/CommonSegAttribs.h
@@ -27,10 +27,8 @@ public:
   bool HasSegmentList();
 
 protected:
-  std::optional<CSegmentList> m_segmentList;
-
-private:
   CCommonSegAttribs* m_parentCommonSegAttribs{nullptr};
+  std::optional<CSegmentList> m_segmentList;
 };
 
 } // namespace PLAYLIST

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -40,6 +40,18 @@ public:
   }
   ~CRepresentation() {}
 
+  /*!
+   * \brief Set the parent AdaptationSet class, it may be necessary to allow methods to obtain
+   *        the data of some common attributes from the parent when the representation is missing data.
+   *        To be used if you plan to set or move a representation to an AdptationSet or a different one.
+   * \param parent[OPT] The parent AdaptationSet to link
+   */
+  void SetParent(CAdaptationSet* parent = nullptr)
+  {
+    CCommonSegAttribs::m_parentCommonSegAttribs = parent;
+    CCommonAttribs::m_parentCommonAttributes = parent;
+  }
+
   // Share AdaptationSet common attribs
   static std::unique_ptr<CRepresentation> MakeUniquePtr(CAdaptationSet* parent = nullptr)
   {

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -355,7 +355,11 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
 
   adpSet->SegmentTimelineDuration() = period->SegmentTimelineDuration();
 
-  adpSet->SetId(XML::GetAttrib(nodeAdp, "id"));
+  std::string id;
+  // "audioTrackId" tag is amazon VOD specific, since dont use the standard "id" tag
+  // this helps to avoid merging adpSets (done with AdaptiveTree::SortTree) for some limit cases
+  if (XML::QueryAttrib(nodeAdp, "id", id) || XML::QueryAttrib(nodeAdp, "audioTrackId", id))
+    adpSet->SetId(id);
 
   std::string contentType;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
With recent reworks in the AdaptiveTree::SortTree the std::move used to move all representations from an adpSet to another one was working correctly but since the "starting" adpSet will be at the end deleted, the representations still have members that point to the deleted adpSet, and this was causing the crash

I have add a "todo" note to AdaptiveTree::SortTree because i am a bit concerned about this "merge", i suspect that this is wrong thing to do since adpsets may have different data in childrens (e.g. dash xml) and on others manifests may be not useful to do,
if you have some details please specify them because the purpose of the merge is not completely clear and git history dont provide clear details

For dash case i have reintroduced `audioTrackId`, this is specific am@zon case only, since we "merge" adpSets the only way to distinguish limit cases are by using the `audioTrackId`, in case we remove or rework the adpSet "merge" behaviour, we can also consider to remove again the `audioTrackId` parsing.
An example is on the attached mpd where there are two audio streams with same "lang" code `es`, but declared with different region code on audioTrackId.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Final fixes for #1197
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Played am@zon 4k hdr streams

Example mpd for audioTrackId: [manifest_1685902687.txt](https://github.com/xbmc/inputstream.adaptive/files/11649211/manifest_1685902687.txt)


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
