### PR TITLE
[AdaptiveTree] Rework of manifest update params

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay"
+    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/Session.h
+++ b/src/Session.h
@@ -220,7 +220,7 @@ public:
   /*! \brief Report if the current content is dynamic/live
    *  \return True if live, false if VOD
    */
-  bool IsLive() const { return m_adaptiveTree->has_timeshift_buffer_; };
+  bool IsLive() const { return m_adaptiveTree->IsLive(); };
 
   /*! \brief Get the type of manifest being played
    *  \return ManifestType - MPD/ISM/HLS

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -42,7 +42,7 @@ namespace adaptive
   void AdaptiveTree::Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps,
                                CHOOSER::IRepresentationChooser* reprChooser,
                                std::string_view supportedKeySystem,
-                               std::string_view manifestUpdateParam)
+                               std::string_view manifestUpdParams)
   {
     m_reprChooser = reprChooser;
     m_supportedKeySystem = supportedKeySystem;
@@ -56,7 +56,7 @@ namespace adaptive
 
     m_manifestParams = kodiProps.m_manifestParams;
     m_manifestHeaders = kodiProps.m_manifestHeaders;
-    m_manifestUpdateParam = manifestUpdateParam;
+    m_manifestUpdParams = manifestUpdParams;
 
     // Convenience way to share common addon settings we avoid
     // calling the API many times to improve parsing performance
@@ -81,7 +81,7 @@ namespace adaptive
     LOG::Log(LOGINFO,
              "Manifest successfully parsed (Periods: %zu, Streams in first period: %zu, Type: %s)",
              m_periods.size(), m_currentPeriod->GetAdaptationSets().size(),
-             has_timeshift_buffer_ ? "live" : "VOD");
+             m_isLive ? "live" : "VOD");
   }
 
   void AdaptiveTree::FreeSegments(CPeriod* period, CRepresentation* repr)
@@ -106,7 +106,7 @@ namespace adaptive
                                          uint32_t fragmentDuration,
                                          uint32_t movie_timescale)
   {
-    if (!has_timeshift_buffer_ || HasManifestUpdates() || repr->HasSegmentsUrl())
+    if (!m_isLive || HasManifestUpdates() || repr->HasSegmentsUrl())
       return;
 
     // Check if its the last frame we watch

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -319,7 +319,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
         if (STRING::CompareNoCase(tagValue, "VOD"))
         {
           m_refreshPlayList = false;
-          has_timeshift_buffer_ = false;
+          m_isLive = false;
         }
       }
       else if (tagName == "#EXT-X-TARGETDURATION")
@@ -546,7 +546,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
       else if (tagName == "#EXT-X-ENDLIST")
       {
         m_refreshPlayList = false;
-        has_timeshift_buffer_ = false;
+        m_isLive = false;
       }
     }
 
@@ -593,7 +593,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
       for (auto& p : m_periods)
       {
         totalTimeSecs += p->GetDuration() / p->GetTimescale();
-        if (!has_timeshift_buffer_ && !m_refreshPlayList)
+        if (!m_isLive && !m_refreshPlayList)
         {
           auto& adpSet = p->GetAdaptationSets()[adpSetPos];
           adpSet->GetRepresentations()[reprPos]->m_isDownloaded = true;
@@ -603,7 +603,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
     else
     {
       totalTimeSecs = rep->GetDuration() / rep->GetTimescale();
-      if (!has_timeshift_buffer_ && !m_refreshPlayList)
+      if (!m_isLive && !m_refreshPlayList)
       {
         rep->m_isDownloaded = true;
       }
@@ -1083,8 +1083,7 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
   m_extGroups.clear();
 
   // Set Live as default
-  has_timeshift_buffer_ = true;
-  m_manifestUpdateParam = "full";
+  m_isLive = true;
 
   m_periods.push_back(std::move(period));
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -77,7 +77,7 @@ bool adaptive::CSmoothTree::ParseManifest(const std::string& data)
 
   if (STRING::CompareNoCase(XML::GetAttrib(nodeSSM, "IsLive"), "true"))
   {
-    has_timeshift_buffer_ = true;
+    m_isLive = true;
     stream_start_ = UTILS::GetTimestamp();
     available_time_ = stream_start_;
   }

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -13,6 +13,8 @@
 std::string testHelper::testFile;
 std::string testHelper::effectiveUrl;
 std::vector<std::string> testHelper::downloadList;
+std::condition_variable DASHTestTree::s_cvDashManifestUpd;
+std::mutex DASHTestTree::s_mutexDashManifestUpd;
 
 bool testHelper::LoadFile(std::string path, std::string& data)
 {
@@ -54,6 +56,9 @@ bool testHelper::DownloadFile(std::string_view url,
                   const std::vector<std::string>& respHeaders,
                   UTILS::CURL::HTTPResponse& resp)
 {
+  if (testHelper::testFile.empty())
+    return false;
+
   bool ret = LoadFile(testHelper::testFile, resp.data);
 
   if (!ret)
@@ -157,11 +162,49 @@ void AESDecrypter::ivFromSequence(uint8_t* buffer, uint64_t sid){}
 
 bool AESDecrypter::RenewLicense(const std::string& pluginUrl){return false;}
 
+void DASHTestTree::RefreshLiveSegments()
+{
+  if (m_isManifestUpdSingleRun)
+    m_updateInterval = ~0U; // Prevent the execution of new manifest updates after this
+
+  CDashTree::RefreshLiveSegments();
+
+  m_isManifestUpdReady = true;
+  s_cvDashManifestUpd.notify_all();
+}
+
+void DASHTestTree::StartManifestUpdate()
+{
+  // Overriding interval to speed up execution
+  m_updateInterval = 1;
+  m_isManifestUpdSingleRun = true;
+  StartUpdateThread();
+}
+
+void DASHTestTree::WaitManifestUpdate(std::string& url)
+{
+  std::unique_lock<std::mutex> lock(s_mutexDashManifestUpd);
+  if (s_cvDashManifestUpd.wait_for(lock, std::chrono::milliseconds(1000),
+                                   [&] { return m_isManifestUpdReady; }) == false)
+  {
+    LOG::LogF(LOGFATAL, "Too much time elapsed to wait for manifest update");
+  }
+  else
+  {
+    url = m_manifestUpdUrl;
+    m_manifestUpdUrl.clear();
+  }
+  m_isManifestUpdReady = false;
+  m_isManifestUpdSingleRun = false;
+}
+
 bool DASHTestTree::DownloadManifestUpd(std::string_view url,
                                        const std::map<std::string, std::string>& reqHeaders,
                                        const std::vector<std::string>& respHeaders,
                                        UTILS::CURL::HTTPResponse& resp)
 {
+  m_manifestUpdUrl = url.data();
+
   if (testHelper::DownloadFile(url, reqHeaders, respHeaders, resp))
   {
     return true;

--- a/src/utils/PropertiesUtils.cpp
+++ b/src/utils/PropertiesUtils.cpp
@@ -27,9 +27,10 @@ constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_fl
 constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate";
 
 constexpr std::string_view PROP_MANIFEST_TYPE = "inputstream.adaptive.manifest_type"; //! @todo: deprecated, to be removed on next Kodi release
-constexpr std::string_view PROP_MANIFEST_UPD_PARAM = "inputstream.adaptive.manifest_update_parameter";
+constexpr std::string_view PROP_MANIFEST_UPD_PARAM = "inputstream.adaptive.manifest_update_parameter"; //! @todo: deprecated, to be removed on next Kodi release
 constexpr std::string_view PROP_MANIFEST_PARAMS = "inputstream.adaptive.manifest_params";
 constexpr std::string_view PROP_MANIFEST_HEADERS = "inputstream.adaptive.manifest_headers";
+constexpr std::string_view PROP_MANIFEST_UPD_PARAMS = "inputstream.adaptive.manifest_upd_params";
 
 constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_params";
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
@@ -101,9 +102,29 @@ KodiProperties UTILS::PROPERTIES::ParseKodiProperties(
       else
         LOG::LogF(LOGERROR, "Manifest type \"%s\" is not supported", prop.second.c_str());
     }
-    else if (prop.first == PROP_MANIFEST_UPD_PARAM)
+    else if (prop.first == PROP_MANIFEST_UPD_PARAM) //! @todo: deprecated, to be removed on next Kodi release
     {
-      props.m_manifestUpdateParam = prop.second;
+      LOG::Log(
+          LOGWARNING,
+          "Warning \"inputstream.adaptive.manifest_update_parameter\" property is deprecated and"
+          " will be removed next Kodi version, use \"inputstream.adaptive.manifest_upd_params\""
+          " instead.\nSee Wiki integration page for more details.");
+      if (prop.second == "full")
+      {
+        LOG::Log(LOGERROR, "The parameter \"full\" is no longer supported. For problems with live "
+                           "streaming contents please open an Issue to the GitHub repository.");
+      }
+      else
+        props.m_manifestUpdateParam = prop.second;
+    }
+    else if (prop.first == PROP_MANIFEST_UPD_PARAMS)
+    {
+      // Should not happen that an add-on try to force the old "full" parameter value
+      // of PROP_MANIFEST_UPD_PARAM here but better verify it, in the future this can be removed
+      if (prop.second == "full")
+        LOG::Log(LOGERROR, "The parameter \"full\" is not supported.");
+      else
+        props.m_manifestUpdParams = prop.second;
     }
     else if (prop.first == PROP_MANIFEST_PARAMS)
     {

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -42,9 +42,11 @@ struct KodiProperties
   bool m_isLicenseForceSecureDecoder{false};
   std::string m_serverCertificate;
   ManifestType m_manifestType{ManifestType::UNKNOWN};
-  // Can be used to force enable manifest updates,
-  // and optionally to set a specific url parameter
-  std::string m_manifestUpdateParam;
+  std::string m_manifestUpdateParam; // Deprecated
+  // HTTP parameters used to download manifest updates
+  // Dash manifest have the optional support of placeholder $START_NUMBER$ to allow set the segment
+  // start number to a parameter e.g. ?start_seq=$START_NUMBER$ become ?start_seq=10
+  std::string m_manifestUpdParams;
   // HTTP parameters used to download manifests
   std::string m_manifestParams;
   // HTTP headers used to download manifests


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After reading DASH specs for "MPD update" the "type" tag must be present in the MPD to distinguish LIVE and VOD content,
so i made the decision to remove the "full" parameter of `inputstream.adaptive.manifest_update_parameter` then cleanup and rework related variables, now if a MPD is declared dynamic we always enable manifest updates.

the old `inputstream.adaptive.manifest_update_parameter` property is now deprecated and replaced by
`inputstream.adaptive.manifest_upd_params` that has the same meaning, but
- ofc no "full" parameter support
- can be used to always add parameters to the manifest update url 
- property name renamed to have a consistent name with the other properties
I do not know if there are any other video services that use it except youtube

breaking change because "full" behaviour is removed,
@glennguy if you have some other live MPDs to test try play them

in the `DASHTreeTest` i have introduced a way to make manifest update tests which can be expanded as needs see `updateParameterLiveSegmentStartNumber`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Followup of PR #1267 to finish wip changes

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
from what i understand there can be two main cases for live:
1) regular live stream declared type=dynamic
2) live content but shown as on-demand, its declared type=static with availabilityStartTime tag value and "live" to profiles tag
3) regular live that when ends, it still accessible as VOD https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#timing-mpd-updates-theend, im a bit unsure that this is currently handled idk

tests for points above:
1) tested couple of sample dash live and facebook live
2) https://dash.akamaized.net/envivio/EnvivioDash3/manifest.mpd
3) atm i dont have a test stream, in theory FB live become LIVE to VOD when live ends, i notices in some occasions that some problem happens, but atm i cant confirm that its really related

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the Wiki documentation
- [x] I have updated the documentation accordingly
