### PR TITLE
[AdaptiveTree] First rework to cleanup segment code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(ADP_SOURCES
 	src/common/Representation.cpp
 	src/common/ReprSelector.cpp
 	src/common/Segment.cpp
+	src/common/SegmentBase.cpp
 	src/common/SegmentList.cpp
 	src/common/SegTemplate.cpp
 	src/parser/CodecParser.cpp
@@ -103,6 +104,7 @@ set(ADP_HEADERS
 	src/common/Representation.h
 	src/common/ReprSelector.h
 	src/common/Segment.h
+	src/common/SegmentBase.h
 	src/common/SegmentList.h
 	src/common/SegTemplate.h
 	src/parser/CodecParser.h

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1004,7 +1004,7 @@ AP4_Movie* CSession::PrepareStream(CStream* stream, bool& needRefetch)
   }
 
   if (repr->GetContainerType() == ContainerType::MP4 && !repr->HasInitPrefixed() &&
-      !repr->HasInitialization())
+      !repr->HasInitSegment())
   {
     //We'll create a Movie out of the things we got from manifest file
     //note: movie will be deleted in destructor of stream->input_file_

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -64,6 +64,7 @@ void PLAYLIST::CAdaptationSet::CopyHLSData(const CAdaptationSet* other)
     m_representations.push_back(std::move(rep));
   }
 
+  m_baseUrl = other->m_baseUrl;
   m_streamType = other->m_streamType;
   m_duration = other->m_duration;
   m_startPts = other->m_startPts;

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -107,7 +107,7 @@ class AdaptiveStream;
     {
       std::string buffer;
       PLAYLIST::CSegment segment;
-      uint64_t segment_number{0}; // SEGMENT_NO_NUMBER is initialization segment!
+      uint64_t segment_number{0};
       PLAYLIST::CRepresentation* rep{nullptr};
     };
     std::vector<SEGMENTBUFFER*> segment_buffers_;
@@ -156,7 +156,6 @@ class AdaptiveStream;
     bool PrepareNextDownload(DownloadInfo& downloadInfo);
     bool PrepareDownload(const PLAYLIST::CRepresentation* rep,
                          const PLAYLIST::CSegment& seg,
-                         const uint64_t segNum,
                          DownloadInfo& downloadInfo);
 
     void ResetSegment(const PLAYLIST::CSegment* segment);
@@ -174,7 +173,7 @@ class AdaptiveStream;
 
     int SecondsSinceUpdate() const;
     static void ReplacePlaceholder(std::string& url, const std::string placeholder, uint64_t value);
-    bool ResolveSegmentBase(PLAYLIST::CRepresentation* rep, bool stopWorker);
+    bool ResolveSegmentBase(PLAYLIST::CRepresentation* rep);
 
     struct THREADDATA
     {

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -91,9 +91,6 @@ namespace adaptive
       period->DecrasePSSHSetUsageCount(segment.pssh_set_);
     }
 
-    if (repr->HasInitialization() && repr->HasSegmentsUrl())
-      repr->initialization_.url.clear();
-
     repr->SegmentTimeline().Clear();
     repr->current_segment_ = nullptr;
   }

--- a/src/common/AdaptiveUtils.cpp
+++ b/src/common/AdaptiveUtils.cpp
@@ -31,8 +31,8 @@ std::string_view PLAYLIST::StreamTypeToString(const StreamType streamType)
 bool PLAYLIST::ParseRangeRFC(std::string_view range, uint64_t& start, uint64_t& end)
 {
   //! @todo: must be reworked as https://httpwg.org/specs/rfc7233.html
-  uint64_t startVal;
-  uint64_t endVal;
+  uint64_t startVal{0};
+  uint64_t endVal{0};
   if (std::sscanf(range.data(), "%" SCNu64 "-%" SCNu64, &startVal, &endVal) > 0)
   {
     start = startVal;

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -35,6 +35,8 @@ constexpr size_t SEGMENT_NO_POS = std::numeric_limits<size_t>::max();
 constexpr uint64_t SEGMENT_NO_NUMBER = std::numeric_limits<uint64_t>::max();
 // Marker for undefined timestamp value
 constexpr uint64_t NO_PTS_VALUE = std::numeric_limits<uint64_t>::max();
+// Marker for undefined value
+constexpr uint64_t NO_VALUE = std::numeric_limits<uint64_t>::max();
 
 enum class EncryptionState
 {

--- a/src/common/Representation.cpp
+++ b/src/common/Representation.cpp
@@ -52,10 +52,10 @@ bool PLAYLIST::CRepresentation::ContainsCodec(std::string_view codec, std::strin
 
 void PLAYLIST::CRepresentation::CopyHLSData(const CRepresentation* other)
 {
-  m_url = other->m_url;
   m_id = other->m_id;
   m_codecs = other->m_codecs;
   m_codecPrivateData = other->m_codecPrivateData;
+  m_baseUrl = other->m_baseUrl;
   m_sourceUrl = other->m_sourceUrl;
   m_bandwidth = other->m_bandwidth;
   m_sampleRate = other->m_sampleRate;
@@ -71,10 +71,10 @@ void PLAYLIST::CRepresentation::CopyHLSData(const CRepresentation* other)
   timescale_ext_ = other->timescale_ext_;
   timescale_int_ = other->timescale_int_;
 
-  m_hasInitialization = other->m_hasInitialization;
   m_isIncludedStream = other->m_isIncludedStream;
   m_hasSegmentsUrl = other->m_hasSegmentsUrl;
   m_isEnabled = other->m_isEnabled;
   m_isWaitForSegment = other->m_isWaitForSegment;
   m_isDownloaded = other->m_isDownloaded;
+  m_initSegment = other->m_initSegment;
 }

--- a/src/common/SegTemplate.h
+++ b/src/common/SegTemplate.h
@@ -20,6 +20,9 @@
 
 namespace PLAYLIST
 {
+// Forward
+class CSegment;
+
 // SegmentTemplate class provide segment template data
 // of class itself or when not set of the parent class (if any).
 class ATTR_DLL_LOCAL CSegmentTemplate
@@ -28,15 +31,13 @@ public:
   CSegmentTemplate(CSegmentTemplate* parent = nullptr);
   ~CSegmentTemplate() {}
 
-  std::string_view GetInitialization() const;
+  std::string GetInitialization() const;
   void SetInitialization(std::string_view init) { m_initialization = init; }
 
-  std::string_view GetMedia() const;
-  void SetMedia(std::string_view media) { m_media = media; }
+  bool HasInitialization() const { return !GetInitialization().empty(); }
 
-  // Same content of "GetMedia" method but with placeholder $RepresentationID$ and $Bandwidth$ filled
-  std::string_view GetMediaUrl() const;
-  void SetMediaUrl(std::string_view mediaUrl) { m_mediaUrl = mediaUrl; }
+  std::string GetMedia() const;
+  void SetMedia(std::string_view media) { m_media = media; }
 
   uint32_t GetTimescale() const;
   void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
@@ -48,11 +49,20 @@ public:
   void SetStartNumber(uint64_t startNumber) { m_startNumber = startNumber; }
 
   bool HasVariableTime() const;
+  
+  CSegment MakeInitSegment();
+
+  std::string FormatUrl(const std::string url,
+                        const std::string id,
+                        const uint32_t bandwidth,
+                        const uint64_t number,
+                        const uint64_t time);
 
 private:
+  void FormatIdentifier(std::string& identifier, const uint64_t value);
+
   std::string m_initialization;
   std::string m_media;
-  std::string m_mediaUrl;
   std::optional<uint32_t> m_timescale;
   std::optional<uint32_t> m_duration;
   std::optional<uint64_t> m_startNumber;

--- a/src/common/Segment.cpp
+++ b/src/common/Segment.cpp
@@ -7,14 +7,3 @@
  */
 
 #include "Segment.h"
-#include "AdaptiveUtils.h"
-
-#include "kodi/tools/StringUtils.h"
-
-using namespace PLAYLIST;
-using namespace kodi::tools;
-
-void PLAYLIST::CSegment::Copy(const CSegment* src)
-{
-  *this = *src;
-}

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -28,21 +28,29 @@ public:
   CSegment() {}
   ~CSegment(){}
 
-  static constexpr uint64_t NO_RANGE_VALUE = std::numeric_limits<uint64_t>::max();
-
   //! @todo: create getters/setters
-  //! its possible add a way to determinate if range is set
 
-  //Either byterange start or timestamp or NO_RANGE_VALUE
-  uint64_t range_begin_ = NO_RANGE_VALUE;
-  //Either byterange end or sequence_id if range_begin is NO_RANGE_VALUE
-  uint64_t range_end_ = NO_RANGE_VALUE;
+  // Byte range start
+  uint64_t range_begin_ = NO_VALUE;
+  // Byte range end
+  uint64_t range_end_ = NO_VALUE;
   std::string url;
   uint64_t startPTS_ = NO_PTS_VALUE;
   uint64_t m_duration = 0; // If available gives the media duration of a segment (depends on type of stream e.g. HLS)
   uint16_t pssh_set_ = PSSHSET_POS_DEFAULT;
 
-  void Copy(const CSegment* src);
+  uint64_t m_time{0};
+  uint64_t m_number{0};
+
+  /*!
+   * \brief Determines if it is an initialization segment.
+   * \return True if it is an initialization segment, otherwise false for media segment.
+   */
+  bool IsInitialization() const { return m_isInitialization; }
+  void SetIsInitialization(bool isInitialization) { m_isInitialization = isInitialization; }
+
+private:
+  bool m_isInitialization{false};
 };
 
-} // namespace adaptive
+} // namespace PLAYLIST

--- a/src/common/SegmentBase.cpp
+++ b/src/common/SegmentBase.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SegmentBase.h"
+
+#include "AdaptiveUtils.h"
+#include "Segment.h"
+
+using namespace PLAYLIST;
+
+void PLAYLIST::CSegmentBase::SetIndexRange(std::string_view indexRange)
+{
+  if (!ParseRangeRFC(indexRange, m_indexRangeBegin, m_indexRangeEnd))
+    LOG::LogF(LOGERROR, "Failed to parse \"indexrange\" attribute");
+}
+
+void PLAYLIST::CSegmentBase::SetInitRange(std::string_view range)
+{
+  if (!ParseRangeRFC(range, m_initRangeBegin, m_initRangeEnd))
+    LOG::LogF(LOGERROR, "Failed to parse initialization \"range\" attribute");
+}
+
+CSegment PLAYLIST::CSegmentBase::MakeIndexSegment()
+{
+  CSegment seg;
+  seg.range_begin_ = m_indexRangeBegin;
+  seg.range_end_ = m_indexRangeEnd;
+  return seg;
+}
+
+CSegment PLAYLIST::CSegmentBase::MakeInitSegment()
+{
+  CSegment seg;
+  seg.SetIsInitialization(true);
+  seg.startPTS_ = 0;
+  if (HasInitialization())
+  {
+    seg.range_begin_ = m_initRangeBegin;
+    seg.range_end_ = m_initRangeEnd;
+  }
+  else
+    LOG::LogF(LOGWARNING,
+              "The \"range\" attribute is missing in the SegmentBase initialization tag");
+
+  return seg;
+}

--- a/src/common/SegmentBase.h
+++ b/src/common/SegmentBase.h
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AdaptiveUtils.h"
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "../test/KodiStubs.h"
+#else
+#include <kodi/AddonBase.h>
+#endif
+
+#include <string_view>
+
+namespace PLAYLIST
+{
+// Forward
+class CSegment;
+
+class ATTR_DLL_LOCAL CSegmentBase
+{
+public:
+  CSegmentBase() = default;
+  ~CSegmentBase() = default;
+
+  void SetIndexRange(std::string_view indexRange);
+  void SetInitRange(std::string_view range);
+
+  void SetIndexRangeBegin(uint64_t value) { m_indexRangeBegin = value; }
+  void SetIndexRangeEnd(uint64_t value) { m_indexRangeEnd = value; }
+
+  uint64_t GetIndexRangeBegin() { return m_indexRangeBegin; }
+  uint64_t GetIndexRangeEnd() { return m_indexRangeEnd; }
+
+  void SetIsRangeExact(bool isRangeExact) { m_isRangeExact = isRangeExact; }
+
+  void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
+  uint32_t GetTimescale() { return m_timescale; }
+
+  bool HasInitialization() { return m_initRangeBegin != NO_VALUE && m_initRangeEnd != NO_VALUE; }
+
+  CSegment MakeIndexSegment();
+  CSegment MakeInitSegment();
+
+private:
+  uint64_t m_indexRangeBegin{0};
+  uint64_t m_indexRangeEnd{0};
+
+  uint64_t m_initRangeBegin{NO_VALUE};
+  uint64_t m_initRangeEnd{NO_VALUE};
+  
+  uint32_t m_timescale{0};
+  bool m_isRangeExact{false};
+};
+
+} // namespace PLAYLIST

--- a/src/common/SegmentList.cpp
+++ b/src/common/SegmentList.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SegmentList.h"
+#include "Segment.h"
 
 using namespace PLAYLIST;
 
@@ -36,4 +37,21 @@ uint64_t PLAYLIST::CSegmentList::GetPresTimeOffset() const
   if (m_ptsOffset > 0 || !m_parentSegList)
     return m_ptsOffset;
   return m_parentSegList->GetPresTimeOffset();
+}
+
+void PLAYLIST::CSegmentList::SetInitRange(std::string_view range)
+{
+  if (!ParseRangeRFC(range, m_initRangeBegin, m_initRangeEnd))
+    LOG::LogF(LOGERROR, "Failed to parse \"range\" attribute");
+}
+
+CSegment PLAYLIST::CSegmentList::MakeInitSegment()
+{
+  CSegment seg;
+  seg.SetIsInitialization(true);
+  seg.startPTS_ = 0;
+  seg.range_begin_ = m_initRangeBegin;
+  seg.range_end_ = m_initRangeEnd;
+  seg.url = m_initSourceUrl;
+  return seg;
 }

--- a/src/common/SegmentList.h
+++ b/src/common/SegmentList.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "AdaptiveUtils.h"
+
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "../test/KodiStubs.h"
 #else
@@ -19,6 +21,8 @@
 
 namespace PLAYLIST
 {
+// Forward
+class CSegment;
 
 class ATTR_DLL_LOCAL CSegmentList
 {
@@ -38,11 +42,20 @@ public:
   uint64_t GetPresTimeOffset() const;
   void SetPresTimeOffset(uint64_t ptsOffset) { m_ptsOffset = ptsOffset; }
 
+  void SetInitSourceUrl(std::string_view url) { m_initSourceUrl = url; }
+
+  void SetInitRange(std::string_view range);
+  bool HasInitialization() { return m_initRangeBegin != NO_VALUE && m_initRangeEnd != NO_VALUE; }
+  CSegment MakeInitSegment();
+
 private:
   uint64_t m_startNumber{0};
   uint64_t m_duration{0};
   uint32_t m_timescale{0};
   uint64_t m_ptsOffset{0};
+  uint64_t m_initRangeBegin = NO_VALUE;
+  uint64_t m_initRangeEnd = NO_VALUE;
+  std::string m_initSourceUrl;
 
   CSegmentList* m_parentSegList{nullptr};
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (rep->IsSubtitleFileStream())
   {
     stream->SetReader(std::make_unique<CSubtitleSampleReader>(
-        rep->GetUrl(), streamid, stream->m_info.GetCodecInternalName()));
+        rep->GetBaseUrl(), streamid, stream->m_info.GetCodecInternalName()));
     return stream->GetReader()->GetInformation(stream->m_info);
   }
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -250,7 +250,7 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
 {
   std::unique_ptr<CRepresentation> repr = CRepresentation::MakeUniquePtr(adpSet);
 
-  repr->SetUrl(adpSet->GetBaseUrl());
+  repr->SetBaseUrl(adpSet->GetBaseUrl());
   repr->SetTimescale(timescale);
 
   repr->SetId(XML::GetAttrib(nodeQI, "Index"));
@@ -321,13 +321,12 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
 
   CSegmentTemplate segTpl;
 
-  segTpl.SetMedia(repr->GetUrl());
-  std::string mediaUrl = repr->GetUrl();
-
+  std::string mediaUrl = repr->GetBaseUrl();
+  // Convert markers to DASH template identification tag
   STRING::ReplaceFirst(mediaUrl, "{start time}", "$Time$");
-  STRING::ReplaceFirst(mediaUrl, "{bitrate}", std::to_string(repr->GetBandwidth()));
+  STRING::ReplaceFirst(mediaUrl, "{bitrate}", "$Bandwidth$");
 
-  segTpl.SetMediaUrl(mediaUrl);
+  segTpl.SetMedia(mediaUrl);
 
   repr->SetSegmentTemplate(segTpl);
 
@@ -341,8 +340,8 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
   {
     CSegment seg;
     seg.startPTS_ = nextStartPts;
-    seg.range_begin_ = nextStartPts + base_time_;
-    seg.range_end_ = index;
+    seg.m_time = nextStartPts + base_time_;
+    seg.m_number = index;
 
     repr->SegmentTimeline().GetData().emplace_back(seg);
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${BINARY}
     ../common/Representation.cpp
     ../common/ReprSelector.cpp
     ../common/Segment.cpp
+    ../common/SegmentBase.cpp
     ../common/SegmentList.cpp
     ../common/SegTemplate.cpp
     ../oscompat.cpp


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is a first PR to start cleanup all code related to segments which is all so messy and barely readable

Some main changes:
- The `CSegment` `range_begin_` `range_end_` now contains the exact data, and is no longer crazily mixed with PTS and numbering
- Has been removed the `segNum` code hack in the `AdaptiveStream::PrepareDownload`
- Has been removed the hackish way of `SEGMENTBUFFER::segment_number` to detect initialization segment by using `~`
- The weird use of `CRepresentation::initialization_` with separate statement `m_hasInitialization` has been removed
- Now the `AdaptiveStream::PrepareDownload` is responsable to build the url where download the segment and there is no more scattered code with parsers
- `CSegmentTemplate` now have the old called "placeholder replace" in its place with appropriate implementation to format template identifiers

Note 1: i have add `m_time` and `m_number` to `CSegment` in temporary way, the reason is that the existing old code couples the timeline with the segments, this should usually be separated, to do so will require many more changes to the code and will not be addressed here

Note 2: `CSegment` `m_time` looks almost equal to `startPTS_`, maybe is possible merge both members (separate PR?)

Note 3: Most of Dash tests in the TestDASHTree.cpp has been readapted for the new changes, since the tests wants know the final url from segment template we need to run "stream test" to generate and get the segments urls used for downloads

~Note 4: There is some HLS code stuff in the HLSTree.cpp that needs a double check by someonelse, looks to changed/commented code~ restored propagation across new periods of init segment  

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A first attempt to solve some old code hacks
and fix #1129

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

DASH: tested couple of LIVE samples, and some VOD samples
HLS: tested akmai local test (chapters), LIVE RAI, LA7

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
