### PR TITLE
[DASHTree] Dont force rounding segment count

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -19,6 +19,7 @@
 #include "pugixml.hpp"
 
 #include <algorithm> // max
+#include <cmath>
 #include <cstdio> // sscanf
 #include <numeric> // accumulate
 #include <string>
@@ -1037,7 +1038,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
         double lengthSecs =
             static_cast<double>(segTemplate->GetDuration()) / segTemplate->GetTimescale();
         segmentsCount =
-            static_cast<size_t>(static_cast<double>(reprTotalTimeSecs) / lengthSecs + 1);
+            static_cast<size_t>(std::ceil(static_cast<double>(reprTotalTimeSecs) / lengthSecs));
       }
 
       if (segmentsCount < 65536) // SIDX atom is limited to 65535 references (fragments)

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -244,9 +244,9 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithPTO)
 
   auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
 
-  EXPECT_EQ(segments.GetSize(), 451);
+  EXPECT_EQ(segments.GetSize(), 450);
   EXPECT_EQ(segments.Get(0)->range_end_, 404305525);
-  EXPECT_EQ(segments.Get(450)->range_end_, 404305975);
+  EXPECT_EQ(segments.Get(449)->range_end_, 404305974);
 }
 
 TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithOldPublishTime)
@@ -257,9 +257,9 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithOldPub
 
   auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
 
-  EXPECT_EQ(segments.GetSize(), 31);
+  EXPECT_EQ(segments.GetSize(), 30);
   EXPECT_EQ(segments.Get(0)->range_end_, 603272);
-  EXPECT_EQ(segments.Get(30)->range_end_, 603302);
+  EXPECT_EQ(segments.Get(29)->range_end_, 603301);
 }
 
 TEST_F(DASHTreeTest, CalculateCorrectFpsScaleFromAdaptionSet)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
the calculation of segment count was forced rounded by always add +1
attached sample stream show that we are generating a surplus segment that on playback try download without success because not existent

looking at similar calculation of exoplayer their use ceil to round the result value
https://github.com/google/ExoPlayer/blob/ac9d5337b2b51a855f3c33f3b126d9ef921ebc69/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java#L459-L463

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i was trying play following sample stream
https://ftp.itec.aau.at/datasets/mmsys18/testing/Beauty_4sec/multi-codec.mpd
that show different playback weirdness that make me think there are more little bugs to check, eg.:
- fails to download last segment but playback result broken, at differents points of playback!? I would expect to playback until the last downloaded segment despite the last segment is broken (could be due to the AdaptiveStream worker that stop operations at first broken segment)
- fails to download last segment but sometime reach the end of duration, but playback continues without stop...
- after this PR fix, playback works but when reach the end of video duration, the kodi GUI progress time bar go to "0" then stop

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://ftp.itec.aau.at/datasets/mmsys18/testing/Beauty_4sec/multi-codec.mpd
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
