### PR TITLE
[TSReader] Add code to debug TSDemux library

### DIFF
--- a/src/TSReader.cpp
+++ b/src/TSReader.cpp
@@ -7,12 +7,49 @@
  */
 
 #include "TSReader.h"
-#include <bento4/Ap4ByteStream.h>
+
+#include "../lib/mpegts/debug.h"
+#include "utils/log.h"
+
 #include <stdlib.h>
+
+#include <bento4/Ap4ByteStream.h>
+
+namespace
+{
+void DebugLog(int level, char* msg)
+{
+  if (msg[std::strlen(msg) - 1] == '\n')
+    msg[std::strlen(msg) - 1] = '\0';
+
+  switch (level)
+  {
+    case DEMUX_DBG_ERROR:
+      LOG::Log(LOGERROR, msg);
+      break;
+    case DEMUX_DBG_WARN:
+      LOG::Log(LOGWARNING, msg);
+      break;
+    case DEMUX_DBG_INFO:
+      LOG::Log(LOGINFO, msg);
+      break;
+    case DEMUX_DBG_DEBUG:
+      [[fallthrough]];
+    case DEMUX_DBG_PARSE:
+      LOG::Log(LOGDEBUG, msg);
+      break;
+    default:
+      break;
+  }
+}
+} // unnamed namespace
 
 TSReader::TSReader(AP4_ByteStream* stream, uint32_t requiredMask)
   : m_stream(stream), m_requiredMask(requiredMask), m_typeMask(0), m_startPts{STREAM_NOPTS_VALUE}
 {
+  // Uncomment to debug TSDemux library
+  // TSDemux::DBGAll();
+  // TSDemux::SetDBGMsgCallback(DebugLog);
 }
 
 bool TSReader::Initialize()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add easy way to debug TSDemux library

i have not add an expert setting to enable/disable i think its not a frequent case that its needed
but if you think it is appropriate let me know and i will add also the new debug setting

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
we have some opened issues that needs debug the library
having this code here makes things faster

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
log example
```
2023-06-24 16:13:36.595 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::configure_ts: packet size is 188
2023-06-24 16:13:36.595 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::parse_ts_psi: new PAT version 0
2023-06-24 16:13:36.596 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::clear_pmt
2023-06-24 16:13:36.596 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::parse_ts_psi: PAT version 0: new PMT 01e0 channel 1
2023-06-24 16:13:36.596 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::parse_ts_psi: PAT version 0: register PMT 01e0 channel 1
2023-06-24 16:13:36.596 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::parse_ts_psi: PMT(01e0) version 0
2023-06-24 16:13:36.596 T:6368    debug <general>: AddOnLog: inputstream.adaptive: (TSDemux)TSDemux::AVContext::clear_pes(1)
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
