### PR TITLE
Fixes for live streaming

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -886,7 +886,7 @@ bool AdaptiveStream::ensureSegment()
       if (newRep->SegmentTimeline().IsEmpty() && newRep->HasSegmentBase())
         ResolveSegmentBase(newRep);
 
-      if (tree_.SecondsSinceRepUpdate(newRep) > 1)
+      if (!newRep->IsPrepared() && tree_.SecondsSinceRepUpdate(newRep) > 1)
       {
         tree_.prepareRepresentation(
           current_period_, current_adp_, newRep, tree_.IsLive());

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -150,11 +150,11 @@ namespace adaptive
     }
 
     segCopy.startPTS_ += fragmentDuration;
-    segCopy.range_begin_ += fragmentDuration;
-    segCopy.range_end_++;
+    segCopy.m_time += fragmentDuration;
+    segCopy.m_number++;
 
-    LOG::LogF(LOGDEBUG, "Insert live segment: pts: %llu range_end: %llu", segCopy.startPTS_,
-              segCopy.range_end_);
+    LOG::LogF(LOGDEBUG, "Insert live segment: pts: %llu number: %llu", segCopy.startPTS_,
+              segCopy.m_number);
 
     for (auto& repr : adpSet->GetRepresentations())
     {

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -621,7 +621,10 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
     }
   }
   else
+  {
+    entryRep->SetIsPrepared(true);
     StartUpdateThread();
+  }
 
   if (periodLost)
     m_periods.insert(m_periods.begin(), std::move(periodLost));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1) The first commit fix live segment inserts, that has been broken by #1292
can be tested by https://livesim.dashif.org/livesim/ato_10/testpic_2s/Manifest.mpd
where in that manifest the duration validity is very high but segments dont cover all the duration validity

2) The second commit fix the old problem where at each playback startup downloads twice times the HLS manifest childs
that you can see on saved manifest files that often appears doubled files like
`manifest_1687957471_child-video.txt`
`manifest_1687957471_child-video_1.txt`

on this last regards the use of `prepareRepresentation` method appears bit dispersive like an abuse of his use, more likely will require a rework (add note to project roadmap)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
im study how to fix manifest updates behaviour that is currently "broken" and i pushed these two fixes before continue on this
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
