### PR TITLE
Fix ways to update manifest and intervals

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -782,7 +782,7 @@ bool AdaptiveStream::ensureSegment()
     // lock live segment updates
     std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(tree_.GetTreeUpdMutex());
 
-    if (tree_.HasManifestUpdates() && SecondsSinceUpdate() > 1)
+    if (tree_.HasManifestUpdatesSegs() && SecondsSinceUpdate() > 1)
     {
       tree_.RefreshSegments(current_period_, current_adp_, current_rep_, current_adp_->GetStreamType());
       lastUpdated_ = std::chrono::system_clock::now();
@@ -926,7 +926,8 @@ bool AdaptiveStream::ensureSegment()
         return false;
       }
     }
-    else if (tree_.HasManifestUpdates() && current_period_ == tree_.m_periods.back().get())
+    else if ((tree_.HasManifestUpdates() || tree_.HasManifestUpdatesSegs()) &&
+             current_period_ == tree_.m_periods.back().get())
     {
       if (!current_rep_->IsWaitForSegment())
       {
@@ -1179,7 +1180,7 @@ bool AdaptiveStream::seek_time(double seek_seconds, bool preceeding, bool& needR
 
 bool AdaptiveStream::waitingForSegment(bool checkTime) const
 {
-  if (tree_.HasManifestUpdates() && state_ == RUNNING)
+  if ((tree_.HasManifestUpdates() || tree_.HasManifestUpdatesSegs()) && state_ == RUNNING)
   {
     std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(tree_.GetTreeUpdMutex());
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -164,9 +164,18 @@ public:
    */
   bool IsLive() const { return m_isLive; }
 
+  /*!
+   * \brief Determines if a live manifest needs updates when new segments are requested
+   */
+  bool HasManifestUpdatesSegs() const { return m_isLive && m_updateInterval == 0; }
+
+  /*!
+   * \brief Determines if a live manifest needs updates that are handled automatically
+   *        by using time intervals
+   */
   bool HasManifestUpdates() const
   {
-    return m_isLive && ~m_updateInterval && m_updateInterval > 0;
+    return m_isLive && m_updateInterval != PLAYLIST::NO_VALUE && m_updateInterval > 0;
   }
 
   const std::chrono::time_point<std::chrono::system_clock> GetLastUpdated() const { return lastUpdated_; };
@@ -255,7 +264,11 @@ protected:
   bool m_isLive{false};
   virtual void StartUpdateThread();
   virtual void RefreshLiveSegments() { lastUpdated_ = std::chrono::system_clock::now(); }
-  std::atomic<uint32_t> m_updateInterval{~0U};
+
+  // Manifest update interval in ms,
+  // Non-zero value: refresh interval starting from the moment mpd download was initiated
+  // Value 0: refresh each time we need to make new segments
+  std::atomic<uint64_t> m_updateInterval{PLAYLIST::NO_VALUE};
   TreeUpdateThread m_updThread;
   std::atomic<std::chrono::time_point<std::chrono::system_clock>> lastUpdated_{std::chrono::system_clock::now()};
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -144,6 +144,11 @@ bool adaptive::CDashTree::ParseManifest(const std::string& data)
   if (!locationText.empty() && URL::IsValidUrl(locationText.data()))
     location_ = locationText;
 
+  // Parse <MPD> <UTCTiming> tags
+  //! @todo: needed implementation
+  if (nodeMPD.child("UTCTiming"))
+    LOG::LogF(LOGWARNING, "The <UTCTiming> tag element is not supported so playback problems may occur.");
+
   // Parse <MPD> <BaseURL> tag (just first, multi BaseURL not supported yet)
   std::string mpdUrl = base_url_;
   std::string baseUrl = nodeMPD.child("BaseURL").child_value();
@@ -228,13 +233,8 @@ void adaptive::CDashTree::ParseTagMPDAttribs(pugi::xml_node nodeMPD)
   std::string minimumUpdatePeriodStr;
   if (XML::QueryAttrib(nodeMPD, "minimumUpdatePeriod", minimumUpdatePeriodStr))
   {
-    double duration = XML::ParseDuration(minimumUpdatePeriodStr) * 1500;
-    // 0S minimumUpdatePeriod = refresh after every segment
-    // We already do that so lets set our minimum updateInterval to 30s
-    if (duration == 0)
-      duration = 30000;
-
-    m_updateInterval = static_cast<uint32_t>(duration);
+    double duration = XML::ParseDuration(minimumUpdatePeriodStr) * 1000;
+    m_updateInterval = static_cast<uint64_t>(duration);
   }
 
   if (mediaPresDuration == 0)

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -107,7 +107,6 @@ private:
   };
 
   std::map<std::string, ExtGroup> m_extGroups;
-  bool m_refreshPlayList = true;
   uint8_t m_segmentIntervalSec = 4;
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -380,13 +380,9 @@ TEST_F(DASHTreeTest, updateParameterLiveSegmentStartNumber)
 {
   OpenTestFile("mpd/segtimeline_live_pd.mpd", "https://foo.bar/dash.mpd?foo=bar&baz=qux", {},
                "?start_seq=$START_NUMBER$");
-  // Clear testFile to not download the same file as manifest update or will cause mess,
-  // the manifest update operation is just to verify the manifest update url
-  testHelper::testFile.clear();
 
-  tree->StartManifestUpdate();
-  std::string manifestUpdUrl;
-  tree->WaitManifestUpdate(manifestUpdUrl);
+  // The manifest file is not specified because we need only to check the url
+  std::string manifestUpdUrl = tree->RunManifestUpdate("");
   EXPECT_EQ(manifestUpdUrl, "https://foo.bar/dash.mpd?start_seq=487063");
 }
 
@@ -583,21 +579,14 @@ TEST_F(DASHTreeAdaptiveStreamTest, CalculateReprensentationBaseURLMultiple)
 TEST_F(DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline)
 {
   OpenTestFile("mpd/bad_segtimeline_1.mpd", "https://foo.bar/placeholders.mpd");
-  SetTestStream(NewStream(tree->m_currentPeriod->GetAdaptationSets()[1].get()));
-  testStream->start_stream();
 
-  ReadSegments(testStream, 16, 1);
-
-  testHelper::testFile = "mpd/bad_segtimeline_2.mpd";
-  ReadSegments(testStream, 16, 1);
+  tree->RunManifestUpdate("mpd/bad_segtimeline_2.mpd");
   EXPECT_EQ(tree->m_currentPeriod->GetAdaptationSets()[1]->GetRepresentations()[0]->GetStartNumber(), 3);
 
-  testHelper::testFile = "mpd/bad_segtimeline_3.mpd";
-  ReadSegments(testStream, 16, 1);
+  tree->RunManifestUpdate("mpd/bad_segtimeline_3.mpd");
   EXPECT_EQ(tree->m_currentPeriod->GetAdaptationSets()[1]->GetRepresentations()[0]->GetStartNumber(), 4);
 
-  testHelper::testFile = "mpd/bad_segtimeline_4.mpd";
-  ReadSegments(testStream, 16, 1);
+  tree->RunManifestUpdate("mpd/bad_segtimeline_4.mpd");
   EXPECT_EQ(tree->m_currentPeriod->GetAdaptationSets()[1]->GetRepresentations()[0]->GetStartNumber(), 5);
 }
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -165,7 +165,7 @@ bool AESDecrypter::RenewLicense(const std::string& pluginUrl){return false;}
 void DASHTestTree::RefreshLiveSegments()
 {
   if (m_isManifestUpdSingleRun)
-    m_updateInterval = ~0U; // Prevent the execution of new manifest updates after this
+    m_updateInterval = PLAYLIST::NO_VALUE; // Prevent the execution of new manifest updates after this
 
   CDashTree::RefreshLiveSegments();
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -13,8 +13,6 @@
 std::string testHelper::testFile;
 std::string testHelper::effectiveUrl;
 std::vector<std::string> testHelper::downloadList;
-std::condition_variable DASHTestTree::s_cvDashManifestUpd;
-std::mutex DASHTestTree::s_mutexDashManifestUpd;
 
 bool testHelper::LoadFile(std::string path, std::string& data)
 {
@@ -162,40 +160,12 @@ void AESDecrypter::ivFromSequence(uint8_t* buffer, uint64_t sid){}
 
 bool AESDecrypter::RenewLicense(const std::string& pluginUrl){return false;}
 
-void DASHTestTree::RefreshLiveSegments()
+std::string DASHTestTree::RunManifestUpdate(std::string manifestUpdFile)
 {
-  if (m_isManifestUpdSingleRun)
-    m_updateInterval = PLAYLIST::NO_VALUE; // Prevent the execution of new manifest updates after this
-
-  CDashTree::RefreshLiveSegments();
-
-  m_isManifestUpdReady = true;
-  s_cvDashManifestUpd.notify_all();
-}
-
-void DASHTestTree::StartManifestUpdate()
-{
-  // Overriding interval to speed up execution
-  m_updateInterval = 1;
-  m_isManifestUpdSingleRun = true;
-  StartUpdateThread();
-}
-
-void DASHTestTree::WaitManifestUpdate(std::string& url)
-{
-  std::unique_lock<std::mutex> lock(s_mutexDashManifestUpd);
-  if (s_cvDashManifestUpd.wait_for(lock, std::chrono::milliseconds(1000),
-                                   [&] { return m_isManifestUpdReady; }) == false)
-  {
-    LOG::LogF(LOGFATAL, "Too much time elapsed to wait for manifest update");
-  }
-  else
-  {
-    url = m_manifestUpdUrl;
-    m_manifestUpdUrl.clear();
-  }
-  m_isManifestUpdReady = false;
-  m_isManifestUpdSingleRun = false;
+  m_manifestUpdUrl.clear();
+  testHelper::testFile = manifestUpdFile;
+  RefreshLiveSegments();
+  return m_manifestUpdUrl;
 }
 
 bool DASHTestTree::DownloadManifestUpd(std::string_view url,

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -109,19 +109,11 @@ public:
   void SetLastUpdated(const std::chrono::system_clock::time_point tm) { lastUpdated_ = tm; }
   std::chrono::system_clock::time_point GetNowTimeChrono() { return m_mock_time_chrono; };
 
-  virtual void RefreshLiveSegments() override;
-
   /*!
-   * \brief Start a manifest update, will be executed a single update,
-   *        mandatory use WaitGetManifestUpdate method to wait the response data
+   * \brief Run manually a manifest update with the specified file
+   * \return The url used to make the manifest request
    */
-  void StartManifestUpdate();
-
-  /*!
-   * \brief Wait the data response of a manifest update
-   * \param url[OUT] Provides the url used to the manifest request
-   */
-  void WaitManifestUpdate(std::string& url);
+  std::string RunManifestUpdate(std::string manifestUpdFile);
 
 private:
   bool DownloadManifestUpd(std::string_view url,
@@ -134,12 +126,7 @@ private:
   uint64_t m_mockTime = 10000000L;
   std::chrono::system_clock::time_point m_mock_time_chrono = std::chrono::system_clock::now();
 
-  bool m_isManifestUpdSingleRun{false};
   std::string m_manifestUpdUrl; // Temporarily stores the url where to request the manifest update
-  bool m_isManifestUpdReady{false}; // Security check for the variable_condition
-
-  static std::condition_variable s_cvDashManifestUpd;
-  static std::mutex s_mutexDashManifestUpd;
 };
 
 class HLSTestTree : public adaptive::CHLSTree


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After recent rework/cleanup with PR #1288 critical issues were highlighted in the current implementation of the manifest update code, where mainly our existing code use bad timing intervals, dont manage correctly manifest updates (for DASH use cases) and also can mixes update types resulting download too much times same file

This is a fast fixup to allow at least find a kind of solution with existing code without introduce a big expensive rework

whats done:
`AdaptiveTree::m_updateInterval` has three meaning as dash specs:
> A nonzero value for MPD@minimumUpdatePeriod defines the [MPD validity duration](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#mpd-validity-duration) of the present snapshot of the [MPD](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#mpd), starting from the moment its download was initiated. This allows the service to provide regular updates to the [MPD](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#mpd) while limiting the refresh interval to avoid overload.
> 
> The value 0 for MPD@minimumUpdatePeriod indicates that the [MPD](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#mpd) has no validity after the moment it is retrieved. In such a situation, the client SHALL acquire a new [MPD](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#mpd) whenever it wants to make new [media segments](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#media-segment) available (no "natural" state changes will occur due to passage of time).
> 
> Absence of the MPD@minimumUpdatePeriod attribute indicates an infinite validity (the [MPD](https://dashif-documents.azurewebsites.net/Guidelines-TimingModel/master/Guidelines-TimingModel.html#mpd) will never be updated).

this allow distinguish what type of manifest update is needed then and then use or not the update thread

what missing for an appropriate manifest update (require future reworks):
- Timing interval used in the update thread should be dynamic, so we have the need to implement a method that allow to change the interval value, two reasons:
   - for HLS case the best should be take the last segment duration time and use that "time" value to download the next manifest update
   - for HLS case in the case the downloaded manifest dont contains changes on segments, take the last segment duration time divide time in half, and use that time to download the next manifest update (after restore the right timing)
- implement for DASH `UTCTiming` tags support is required to synchronise manifest updates

i will add a link to what said above to project roadmap

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live tests only

- Dash
LA7
Facebook
https://livesim.dashif.org/livesim/segtimeline_1/testpic_2s/Manifest.mpd
https://livesim.dashif.org/livesim/periods_20/testpic_2s/Manifest.mpd
https://livesim.dashif.org/livesim/ato_10/testpic_2s/Manifest.mpd

- HLS
RAI
dailymotion

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
