### PR TITLE
Cleanup/fixes to codec names / fourcc

### DIFF
--- a/src/TSReader.cpp
+++ b/src/TSReader.cpp
@@ -10,10 +10,13 @@
 
 #include "../lib/mpegts/debug.h"
 #include "utils/log.h"
+#include "utils/Utils.h"
 
 #include <stdlib.h>
 
 #include <bento4/Ap4ByteStream.h>
+
+using namespace UTILS;
 
 namespace
 {
@@ -104,9 +107,13 @@ bool TSReader::StartStreaming(AP4_UI32 typeMask)
 
 bool TSReader::GetInformation(kodi::addon::InputstreamInfo& info)
 {
-  static const char* STREAMTYPEMAP[] = {
-    "unk", "mpeg1", "mpeg2", "mpeg1", "mpeg2", "aac", "aac", "aac", "h264", "hevc", "ac3", "eac3", "unk", "srt", "mpeg4", "vc1", "unk", "unk", "unk"
-  };
+  // Keep it in sync with TSDemux::STREAM_TYPE
+  static const char* STREAMTYPEMAP[19] = {
+      CODEC::NAME_UNKNOWN, CODEC::NAME_MPEG1, CODEC::NAME_MPEG2,  CODEC::NAME_MPEG1,
+      CODEC::NAME_MPEG2,   CODEC::NAME_AAC,   CODEC::NAME_AAC,    CODEC::NAME_AAC,
+      CODEC::NAME_H264,    CODEC::NAME_HEVC,  CODEC::NAME_AC3,    CODEC::NAME_EAC3,
+      CODEC::NAME_UNKNOWN, CODEC::NAME_SRT,   CODEC::NAME_MPEG4,  CODEC::NAME_VC1,
+      CODEC::NAME_UNKNOWN, CODEC::NAME_DTS,   CODEC::NAME_UNKNOWN};
 
   for (auto &tsInfo : m_streamInfos)
   {

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -93,7 +93,7 @@ PLAYLIST::CRepresentation* CRepresentationChooserAskQuality::GetNextRepresentati
         CRepresentation* repr = (*itRep).get();
 
         std::string entryName{kodi::addon::GetLocalizedString(30232)};
-        STRING::ReplaceFirst(entryName, "{codec}", GetVideoCodecDesc(repr->GetFirstCodec()));
+        STRING::ReplaceFirst(entryName, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
 
         float fps{static_cast<float>(repr->GetFrameRate())};
         if (fps > 0 && repr->GetFrameRateScale() > 0)

--- a/src/common/Representation.cpp
+++ b/src/common/Representation.cpp
@@ -10,8 +10,6 @@
 
 #include "../utils/StringUtils.h"
 
-#include <algorithm> // any_of, find_if
-
 using namespace PLAYLIST;
 using namespace UTILS;
 
@@ -24,30 +22,6 @@ void PLAYLIST::CRepresentation::AddCodecs(std::string_view codecs)
 void PLAYLIST::CRepresentation::AddCodecs(const std::set<std::string>& codecs)
 {
   m_codecs.insert(codecs.begin(), codecs.end());
-}
-
-bool PLAYLIST::CRepresentation::ContainsCodec(std::string_view codec) const
-{
-  if (std::any_of(m_codecs.begin(), m_codecs.end(),
-                  [codec](const std::string_view name) { return STRING::Contains(name, codec); }))
-  {
-    return true;
-  }
-  return false;
-}
-
-bool PLAYLIST::CRepresentation::ContainsCodec(std::string_view codec, std::string& codecStr) const
-{
-  auto itCodec =
-      std::find_if(m_codecs.begin(), m_codecs.end(),
-                   [codec](const std::string_view name) { return STRING::Contains(name, codec); });
-  if (itCodec != m_codecs.end())
-  {
-    codecStr = *itCodec;
-    return true;
-  }
-  codecStr.clear();
-  return false;
 }
 
 void PLAYLIST::CRepresentation::CopyHLSData(const CRepresentation* other)

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -68,16 +68,27 @@ public:
   std::string GetBaseUrl() const { return m_baseUrl; }
   void SetBaseUrl(std::string_view baseUrl) { m_baseUrl = baseUrl; }
 
+  /*!
+   * \brief Add a codec string
+   */
   void AddCodecs(std::string_view codecs);
-  void AddCodecs(const std::set<std::string>& codecs);
-  std::set<std::string> GetCodecs() const { return m_codecs; }
-  const std::set<std::string>& GetCodecs() { return m_codecs; }
-  std::string GetFirstCodec() const { return m_codecs.empty() ? "" : *m_codecs.begin(); }
 
-  // Check if a codec exists, convenient function to check within of strings
-  // e.g find "ttml" return true also when there is a "stpp.ttml.im1t" codec name
-  bool ContainsCodec(std::string_view codec) const;
-  bool ContainsCodec(std::string_view codec, std::string& codecStr) const;
+  /*!
+   * \brief Add codec string
+   */
+  void AddCodecs(const std::set<std::string>& codecs);
+
+  /*!
+   * \brief Get codec list, a common rule for a codec string among manifest types is the use
+   *        of fourcc codes, but codec string can contains other info as ISO BMFF (RFC 6381) format
+   */
+  std::set<std::string> GetCodecs() const { return m_codecs; }
+
+  /*!
+   * \brief Get codec list, a common rule for a codec string among manifest types is the use
+   *        of fourcc codes, but codec string can contains other info as ISO BMFF (RFC 6381) format
+   */
+  const std::set<std::string>& GetCodecs() { return m_codecs; }
 
   // ISA custom attribute
   std::string& GetCodecPrivateData() { return m_codecPrivateData; }

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -682,9 +682,10 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   if (adpSet->GetStreamType() == StreamType::NOTYPE)
   {
     StreamType streamType = DetectStreamType("", repr->GetMimeType());
-
-    if (streamType == StreamType::NOTYPE &&
-        (repr->ContainsCodec("wvtt") || (repr->ContainsCodec("ttml"))))
+    const auto& codecs = repr->GetCodecs();
+    if (streamType == StreamType::NOTYPE && (CODEC::Contains(codecs, CODEC::FOURCC_WVTT) ||
+                                             CODEC::Contains(codecs, CODEC::FOURCC_TTML) ||
+                                             CODEC::Contains(codecs, CODEC::FOURCC_STPP)))
     {
       streamType = StreamType::SUBTITLE;
     }
@@ -694,8 +695,10 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   // Set properties for subtitles types
   if (repr->GetMimeType() != "application/mp4") // Handle text type only, not ISOBMFF format
   {
+    const auto& codecs = repr->GetCodecs();
     if (repr->GetMimeType() == "application/ttml+xml" || repr->GetMimeType() == "text/vtt" ||
-        repr->ContainsCodec("wvtt") || repr->ContainsCodec("ttml"))
+        CODEC::Contains(codecs, CODEC::FOURCC_WVTT) ||
+        CODEC::Contains(codecs, CODEC::FOURCC_TTML) || CODEC::Contains(codecs, CODEC::FOURCC_STPP))
     {
       if (adpSet->SegmentTimelineDuration().IsEmpty())
         repr->SetIsSubtitleFileStream(true); // Treat as single subtitle file

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -111,22 +111,23 @@ std::string GetAudioCodec(std::string_view codecs)
   // The codec search must follow exactly the following order, this is currently the best workaround
   // to make multi-channel audio formats work, but since CODECS attribute is unreliable
   // this workaround can still cause playback problems
-  if (codecs.find("ec-3") != std::string::npos)
-    return "ec-3";
-  else if (codecs.find("ac-3") != std::string::npos)
-    return "ac-3";
+  if (codecs.find(CODEC::FOURCC_EC_3) != std::string::npos)
+    return CODEC::FOURCC_EC_3;
+  else if (codecs.find(CODEC::FOURCC_AC_3) != std::string::npos)
+    return CODEC::FOURCC_AC_3;
   else
-    return "aac";
+    return CODEC::FOURCC_MP4A;
 }
 // \brief Workaround to get audio codec from representation codecs list
 std::string GetAudioCodec(const PLAYLIST::CRepresentation* repr)
 {
-  if (repr->ContainsCodec("ec-3"))
-    return "ec-3";
-  else if (repr->ContainsCodec("ac-3"))
-    return "ac-3";
+  const auto& codecs = repr->GetCodecs();
+  if (CODEC::Contains(codecs, CODEC::FOURCC_EC_3))
+    return CODEC::FOURCC_EC_3;
+  else if (CODEC::Contains(codecs, CODEC::FOURCC_AC_3))
+    return CODEC::FOURCC_AC_3;
   else
-    return "aac";
+    return CODEC::FOURCC_MP4A;
 }
 
 } // unnamed namespace
@@ -1012,7 +1013,7 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
     repr->SetTimescale(1000000);
 
     // Try to get the codecs from first representation
-    std::string codec = "aac";
+    std::string codec = CODEC::FOURCC_MP4A;
     auto& adpSets = period->GetAdaptationSets();
     if (!adpSets.empty())
     {

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -278,13 +278,17 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
   std::string codecPrivateData;
   if (XML::QueryAttrib(nodeQI, "CodecPrivateData", codecPrivateData))
   {
-    if (repr->ContainsCodec("hev"))
+    const auto& codecs = repr->GetCodecs();
+    if (CODEC::Contains(codecs, CODEC::FOURCC_HEVC) ||
+        CODEC::Contains(codecs, CODEC::FOURCC_HEV1) || CODEC::Contains(codecs, CODEC::FOURCC_HVC1))
+    {
       repr->SetCodecPrivateData(AnnexbToHvcc(codecPrivateData.c_str()));
+    }
     else
       repr->SetCodecPrivateData(AnnexbToAvc(codecPrivateData.c_str()));
   }
 
-  if (repr->ContainsCodec("aacl") && repr->GetCodecPrivateData().empty())
+  if (CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_AACL) && repr->GetCodecPrivateData().empty())
   {
     uint16_t esds = 0x1010;
     uint16_t sidx = 4;

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -17,6 +17,9 @@
 #include "../codechandler/VP9CodecHandler.h"
 #include "../codechandler/WebVTTCodecHandler.h"
 #include "../utils/log.h"
+#include "../utils/Utils.h"
+
+using namespace UTILS;
 
 namespace
 {
@@ -245,19 +248,19 @@ bool CFragmentedSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
       case AP4_OTI_MPEG2_AAC_AUDIO_MAIN:
       case AP4_OTI_MPEG2_AAC_AUDIO_LC:
       case AP4_OTI_MPEG2_AAC_AUDIO_SSRP:
-        info.SetCodecName("aac");
+        info.SetCodecName(CODEC::NAME_AAC);
         break;
       case AP4_OTI_DTS_AUDIO:
       case AP4_OTI_DTS_HIRES_AUDIO:
       case AP4_OTI_DTS_MASTER_AUDIO:
       case AP4_OTI_DTS_EXPRESS_AUDIO:
-        info.SetCodecName("dca");
+        info.SetCodecName(CODEC::NAME_DTS);
         break;
       case AP4_OTI_AC3_AUDIO:
-        info.SetCodecName("ac3");
+        info.SetCodecName(CODEC::NAME_AC3);
         break;
       case AP4_OTI_EAC3_AUDIO:
-        info.SetCodecName("eac3");
+        info.SetCodecName(CODEC::NAME_EAC3);
         break;
     }
   }

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -10,8 +10,11 @@
 
 #include "../utils/PropertiesUtils.h"
 #include "../utils/UrlUtils.h"
+#include "../utils/Utils.h"
 
 #include <gtest/gtest.h>
+
+using namespace UTILS;
 
 class DASHTreeTest : public ::testing::Test
 {
@@ -405,47 +408,47 @@ TEST_F(DASHTreeAdaptiveStreamTest, subtitles)
 
   EXPECT_EQ(adpSets[1]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[1]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_TTML), true);
 
   EXPECT_EQ(adpSets[2]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[2]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_TTML), true);
 
   EXPECT_EQ(adpSets[3]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[3]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[3]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[3]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_TTML), true);
 
   EXPECT_EQ(adpSets[4]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[4]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[4]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[4]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_TTML), true);
 
   EXPECT_EQ(adpSets[5]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[5]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[5]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[5]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_WVTT), true);
 
   EXPECT_EQ(adpSets[6]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[6]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[6]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[6]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_WVTT), true);
 
   EXPECT_EQ(adpSets[7]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[7]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[7]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[7]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_WVTT), true);
 
   EXPECT_EQ(adpSets[8]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[8]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[8]->GetRepresentations()[0]->ContainsCodec("wvtt"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[8]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_WVTT), true);
 
   EXPECT_EQ(adpSets[9]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[9]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[9]->GetRepresentations()[0]->ContainsCodec("my_codec"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[9]->GetRepresentations()[0]->GetCodecs(), "my_codec"), true);
 
   EXPECT_EQ(adpSets[10]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(adpSets[10]->GetRepresentations()[0]->IsSubtitleFileStream(), true);
-  EXPECT_EQ(adpSets[10]->GetRepresentations()[0]->ContainsCodec("ttml"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[10]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_TTML), true);
 
   EXPECT_EQ(adpSets[11]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(STR(adpSets[11]->GetRepresentations()[0]->GetMimeType()), "application/mp4");
-  EXPECT_EQ(adpSets[11]->GetRepresentations()[0]->ContainsCodec("stpp"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[11]->GetRepresentations()[0]->GetCodecs(), CODEC::FOURCC_STPP), true);
 
   SetTestStream(NewStream(adpSets[11].get()));
   testStream->start_stream();
@@ -455,7 +458,7 @@ TEST_F(DASHTreeAdaptiveStreamTest, subtitles)
 
   EXPECT_EQ(adpSets[12]->GetStreamType(), PLAYLIST::StreamType::SUBTITLE);
   EXPECT_EQ(STR(adpSets[12]->GetMimeType()), "application/mp4");
-  EXPECT_EQ(adpSets[12]->GetRepresentations()[0]->ContainsCodec("stpp.ttml.im1t"), true);
+  EXPECT_EQ(CODEC::Contains(adpSets[12]->GetRepresentations()[0]->GetCodecs(), "stpp.ttml.im1t"), true);
 
   SetTestStream(NewStream(adpSets[12].get()));
   testStream->start_stream();

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <ctime> // time
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -29,30 +30,119 @@ bool CreateISMlicense(std::string_view key,
 void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std::string& header);
 
 /*!
- * \brief Get video codec description from a codec name
- * \param codecName The codec name
- * \return The codec description, otherwise empty if unsupported
- */
-std::string GetVideoCodecDesc(std::string_view codecName);
-
-/*!
  * \brief Get the current timestamp
  * \return The timestamp in milliseconds
  */
 uint64_t GetTimestamp();
 
+namespace CODEC
+{
+constexpr char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
+
+// IMPORTANT: Codec names must match the ffmpeg library definition
+// https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/codec_desc.c
+
+// Video definitions
+
+constexpr char* NAME_MPEG1 = "mpeg1video";
+constexpr char* NAME_MPEG2 = "mpeg2video";
+constexpr char* NAME_MPEG4 = "mpeg4"; // MPEG-4 part 2
+constexpr char* NAME_VC1 = "vc1"; // SMPTE VC-1
+constexpr char* NAME_H264 = "h264"; // MPEG-4 AVC
+constexpr char* NAME_HEVC = "hevc";
+constexpr char* NAME_VP9 = "vp9";
+constexpr char* NAME_AV1 = "av1";
+
+// Audio definitions
+
+constexpr char* NAME_AAC = "aac";
+constexpr char* NAME_DTS = "dts";
+constexpr char* NAME_AC3 = "ac3";
+constexpr char* NAME_EAC3 = "eac3"; // Enhanced AC-3
+constexpr char* NAME_OPUS = "opus";
+constexpr char* NAME_VORBIS = "vorbis";
+
+// Subtitles definitions
+
+constexpr char* NAME_SRT = "srt";
+constexpr char* NAME_WEBVTT = "webvtt";
+constexpr char* NAME_TTML = "ttml";
+
+// Fourcc video definitions
+
+constexpr char* FOURCC_H264 = "h264"; // MPEG-4 AVC
+constexpr char* FOURCC_AVC_ = "avc"; // Generic prefix for all avc* fourcc, e.g. avc1, avcb
+constexpr char* FOURCC_VP09 = "vp09"; // VP9
+constexpr char* FOURCC_AV01 = "av01"; // AV1
+constexpr char* FOURCC_HEVC = "hevc";
+constexpr char* FOURCC_HVC1 = "hvc1"; // HEVC Dolby vision
+constexpr char* FOURCC_DVH1 = "dvh1"; // HEVC Dolby vision, hvc1 variant
+constexpr char* FOURCC_HEV1 = "hev1"; // HEVC Dolby vision
+constexpr char* FOURCC_DVHE = "dvhe"; // HEVC Dolby vision, hev1 variant
+
+// Fourcc audio definitions
+
+constexpr char* FOURCC_MP4A = "mp4a";
+constexpr char* FOURCC_AAC_ = "aac"; // Generic prefix for all aac* fourcc, e.g. aac, aacl, aacp
+constexpr char* FOURCC_AACL = "aacl";
+constexpr char* FOURCC_AC_3 = "ac-3";
+constexpr char* FOURCC_EC_3 = "ec-3"; // Enhanced AC-3
+constexpr char* FOURCC_OPUS = "opus";
+constexpr char* FOURCC_VORB = "vorb"; // Vorbis
+constexpr char* FOURCC_VORB1 = "vor1"; // Vorbis 1
+constexpr char* FOURCC_VORB1P = "vo1+"; // Vorbis 1+
+constexpr char* FOURCC_VORB2 = "vor2"; // Vorbis 2
+constexpr char* FOURCC_VORB2P = "vo2+"; // Vorbis 2+
+constexpr char* FOURCC_VORB3 = "vor3"; // Vorbis 3
+constexpr char* FOURCC_VORB3P = "vo3+"; // Vorbis 3+
+constexpr char* FOURCC_DTS_ = "dts"; // Generic prefix for all dts* fourcc, e.g. dtsx
+
+// Fourcc subtitles definitions
+
+constexpr char* FOURCC_WVTT = "wvtt"; // WebVTT
+constexpr char* FOURCC_TTML = "ttml";
+// TTML variant for XML type
+// In the complete codec description can be presented with or without name and profile
+// for example "stpp.ttml.im1t", or only "stpp"
+constexpr char* FOURCC_STPP = "stpp";
+
 /*!
  * \brief Make a FourCC code as unsigned integer value
- * \param c1 The first FourCC char
- * \param c2 The second FourCC char
- * \param c3 The third FourCC char
- * \param c4 The fourth FourCC char
+ * \param fourcc The FourCC code (4 chars)
  * \return The FourCC as unsigned integer value
  */
-constexpr uint32_t MakeFourCC(char c1, char c2, char c3, char c4)
+constexpr uint32_t MakeFourCC(const char* fourcc)
 {
-  return ((static_cast<uint32_t>(c1)) | (static_cast<uint32_t>(c2) << 8) |
-    (static_cast<uint32_t>(c3) << 16) | (static_cast<uint32_t>(c4) << 24));
+  return ((static_cast<uint32_t>(fourcc[0])) | (static_cast<uint32_t>(fourcc[1]) << 8) |
+          (static_cast<uint32_t>(fourcc[2]) << 16) | (static_cast<uint32_t>(fourcc[3]) << 24));
+}
+
+/*!
+ * \brief Check if a codec string exists in the list, convenient function to check within of strings
+ *        e.g find "ttml" return true also when there is a "stpp.ttml.im1t" codec string
+ * \param list The list of codecs
+ * \param codec The codec string to find
+ * \return True if found, otherwise false
+ */
+bool Contains(const std::set<std::string>& list, std::string_view codec);
+
+/*!
+ * \brief Checks whether the codec string exists within a list entry,
+ *        e.g check for "ttml" will return true also when there is a "stpp.ttml.im1t" codec string
+ * \param list The list of codecs
+ * \param codec The codec string to find
+ * \param codecStr[OUT] Return the original codec string if found, otherwise empty string
+ * \return True if found, otherwise false
+ */
+bool Contains(const std::set<std::string>& list, std::string_view codec, std::string& codecStr);
+
+/*!
+ * \brief Get the description of the video codec contained in the list
+ * \param list The list of codecs
+ * \return The video codec description, otherwise empty if unsupported
+ */
+std::string GetVideoDesc(const std::set<std::string>& list);
+
 }
 
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The main thing is that i distinguished the names of the ffmpeg codecs from the fourcc codec codes
now grouped in the header utils there are no more definitions at random throughout the code

To be sure i verified supported codecs/fourcc from following specs:
https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices-appendixes
https://dashif.org/codecs/video/
https://dashif.org/codecs/audio/
https://learn.microsoft.com/en-us/iis/extensions/smooth-streaming-client/qualitylevel-attributes
https://learn.microsoft.com/en-us/previous-versions/media-services/previous/media-services-specifications-ms-sstr-amendment-hevc

Doing this i have found / fixed following things:
- add missing `hev1` fourcc
- changed wrong `dca` codec name (at least i have not found it on ffmpeg code) with `dts`
- add missing DTS corrispondence to TSReader codec map
- add support to `aacp` (aac+ on smoothstreaming)
- fix get codec description bug (mentioned below) that can happens for two reasons, 1) the `std::set` dont keep sort order, 2) HLS CODECS property may be reversed values, these cause that "GetFirstCodec" method fail to get description
- add some missing vorbis fourcc

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was testing stream on #1303 and i found that when you use "Ask quality" stream selection
in the video GUI stream list the VP9 text was missing due to a bug, so i have cleanup whole codecs things

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
some random vod and stream on #1303

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
