### PR TITLE
[Cleanup] Use vector uint8_t to store data

### DIFF
--- a/src/Iaes_decrypter.h
+++ b/src/Iaes_decrypter.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 class IAESDecrypter
 {
@@ -21,7 +22,7 @@ public:
   virtual void decrypt(const AP4_UI08* aes_key,
                        const AP4_UI08* aes_iv,
                        const AP4_UI08* src,
-                       std::string& dst,
+                       std::vector<uint8_t>& dst,
                        size_t dstOffset,
                        size_t& dataSize,
                        bool lastChunk) = 0;

--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -15,7 +15,7 @@
 void AESDecrypter::decrypt(const AP4_UI08* aes_key,
                            const AP4_UI08* aes_iv,
                            const AP4_UI08* src,
-                           std::string& dst,
+                           std::vector<uint8_t>& dst,
                            size_t dstOffset,
                            size_t& dataSize,
                            bool lastChunk)

--- a/src/aes_decrypter.h
+++ b/src/aes_decrypter.h
@@ -13,6 +13,7 @@
 #include <bento4/Ap4Types.h>
 
 #include <string>
+#include <vector>
 
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "test/KodiStubs.h"
@@ -29,7 +30,7 @@ public:
   void decrypt(const AP4_UI08* aes_key,
                const AP4_UI08* aes_iv,
                const AP4_UI08* src,
-               std::string& dst,
+               std::vector<uint8_t>& dst,
                size_t dstOffset,
                size_t& dataSize,
                bool lastChunk);

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -89,7 +89,8 @@ class AdaptiveStream;
     bool StreamChanged() { return stream_changed_; }
 
   protected:
-    virtual bool parseIndexRange(PLAYLIST::CRepresentation* rep, const std::string& buffer);
+    virtual bool parseIndexRange(PLAYLIST::CRepresentation* rep,
+                                 const std::vector<uint8_t>& buffer);
 
     virtual void SetLastUpdated(const std::chrono::system_clock::time_point tm) {}
     std::chrono::time_point<std::chrono::system_clock> lastUpdated_;
@@ -105,7 +106,7 @@ class AdaptiveStream;
 
     struct SEGMENTBUFFER
     {
-      std::string buffer;
+      std::vector<uint8_t> buffer;
       PLAYLIST::CSegment segment;
       uint64_t segment_number{0};
       PLAYLIST::CRepresentation* rep{nullptr};
@@ -132,7 +133,7 @@ class AdaptiveStream;
     * \param data[OUT] The downloaded data
     * \return Return true if success, otherwise false
     */
-    virtual bool Download(const DownloadInfo& downloadInfo, std::string& data);
+    virtual bool Download(const DownloadInfo& downloadInfo, std::vector<uint8_t>& data);
 
    /*!
     * \brief Download a segment file in chunks, the data could be also decrypted by the manifest parser,
@@ -151,7 +152,7 @@ class AdaptiveStream;
     *                  will be stored to the segment buffer and could be decrypted by the manifest parser.
     * \return Return true if success, otherwise false
     */
-    bool DownloadImpl(const DownloadInfo& downloadInfo, std::string* data);
+    bool DownloadImpl(const DownloadInfo& downloadInfo, std::vector<uint8_t>* data);
 
     bool PrepareNextDownload(DownloadInfo& downloadInfo);
     bool PrepareDownload(const PLAYLIST::CRepresentation* rep,

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -174,13 +174,13 @@ namespace adaptive
   void AdaptiveTree::OnDataArrived(uint64_t segNum,
                                    uint16_t psshSet,
                                    uint8_t iv[16],
-                                   const char* srcData,
+                                   const uint8_t* srcData,
                                    size_t srcDataSize,
-                                   std::string& segBuffer,
+                                   std::vector<uint8_t>& segBuffer,
                                    size_t segBufferSize,
                                    bool isLastChunk)
   {
-    segBuffer.append(srcData, srcDataSize);
+    segBuffer.insert(segBuffer.end(), srcData, srcData + srcDataSize);
   }
 
   uint16_t AdaptiveTree::InsertPsshSet(PLAYLIST::StreamType streamType,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -118,9 +118,9 @@ public:
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
                              uint8_t iv[16],
-                             const char* srcData,
+                             const uint8_t* srcData,
                              size_t srcDataSize,
-                             std::string& segBuffer,
+                             std::vector<uint8_t>& segBuffer,
                              size_t segBufferSize,
                              bool isLastChunk);
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -617,9 +617,9 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
 void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
                                        uint16_t psshSet,
                                        uint8_t iv[16],
-                                       const char* srcData,
+                                       const uint8_t* srcData,
                                        size_t srcDataSize,
-                                       std::string& segBuffer,
+                                       std::vector<uint8_t>& segBuffer,
                                        size_t segBufferSize,
                                        bool isLastChunk)
 {
@@ -682,7 +682,7 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
     }
     if (pssh.defaultKID_ == "0")
     {
-      segBuffer.insert(segBufferSize, srcDataSize, 0);
+      segBuffer.resize(segBufferSize + srcDataSize, 0);
       return;
     }
     else if (!segBufferSize)
@@ -696,7 +696,7 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
       }
     }
 
-    // Decrypter needs preallocated string data
+    // Decrypter needs preallocated data
     segBuffer.resize(segBufferSize + srcDataSize);
 
     m_decrypter->decrypt(reinterpret_cast<const uint8_t*>(pssh.defaultKID_.data()), iv,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -45,9 +45,9 @@ public:
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
                              uint8_t iv[16],
-                             const char* srcData,
+                             const uint8_t* srcData,
                              size_t srcDataSize,
-                             std::string& segBuffer,
+                             std::vector<uint8_t>& segBuffer,
                              size_t segBufferSize,
                              bool isLastChunk) override;
 

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -89,11 +89,11 @@ bool TestAdaptiveStream::DownloadSegment(const DownloadInfo& downloadInfo)
   if (downloadInfo.m_url.empty())
     return false;
 
-  std::string& segmentBuffer = downloadInfo.m_segmentBuffer->buffer;
+  std::vector<uint8_t>& segmentBuffer = downloadInfo.m_segmentBuffer->buffer;
   std::stringstream sampleData("Sixteen bytes!!!");
 
   const size_t bufferSize = 8;
-  char bufferData[bufferSize];
+  uint8_t bufferData[bufferSize];
   size_t totalByteRead = 0;
 
   sampleData.clear();
@@ -108,7 +108,7 @@ bool TestAdaptiveStream::DownloadSegment(const DownloadInfo& downloadInfo)
       if (state_ == STOPPED)
         break;
 
-      sampleData.read(bufferData, bufferSize);
+      sampleData.read(reinterpret_cast<char*>(bufferData), bufferSize);
       size_t bytesRead = sampleData.gcount();
 
       if (bytesRead == 0) // EOF
@@ -134,16 +134,17 @@ bool TestAdaptiveStream::DownloadSegment(const DownloadInfo& downloadInfo)
   return true;
 }
 
-bool TestAdaptiveStream::Download(const DownloadInfo& downloadInfo, std::string& data)
+bool TestAdaptiveStream::Download(const DownloadInfo& downloadInfo, std::vector<uint8_t>& data)
 {
-  data = "Sixteen bytes!!!";
+  const char* dataStr = "Sixteen bytes!!!";
+  data.insert(data.end(), dataStr, dataStr + 16);
   return true;
 }
 
 void AESDecrypter::decrypt(const AP4_UI08* aes_key,
                            const AP4_UI08* aes_iv,
                            const AP4_UI08* src,
-                           std::string& dst,
+                           std::vector<uint8_t>& dst,
                            size_t dstOffset,
                            size_t& dataSize,
                            bool lastChunk)

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -75,7 +75,7 @@ public:
   virtual bool DownloadSegment(const DownloadInfo& downloadInfo) override;
 
 protected:
-  virtual bool Download(const DownloadInfo& downloadInfo, std::string& data) override;
+  virtual bool Download(const DownloadInfo& downloadInfo, std::vector<uint8_t>& data) override;
 };
 
 class AESDecrypter : public IAESDecrypter
@@ -87,7 +87,7 @@ public:
   void decrypt(const AP4_UI08* aes_key,
                const AP4_UI08* aes_iv,
                const AP4_UI08* src,
-               std::string& dst,
+               std::vector<uint8_t>& dst,
                size_t dstOffset,
                size_t& dataSize,
                bool lastChunk);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Replace std::string with std::vector of uint8_t to store data
it should be more secure for data continuity that grow

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
