### PR TITLE
Fixes for buffer and recent regressions

### DIFF
--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -174,11 +174,13 @@
         <setting id="ASSUREDBUFFERDURATION" type="integer" label="30200" help="30167">
           <level>1</level>
           <default>60</default>
+          <visible>false</visible> <!-- Working code disabled, rework needed -->
           <control type="edit" format="integer" />
         </setting>
         <setting id="MAXBUFFERDURATION" type="integer" label="30201" help="30167">
           <level>1</level>
           <default>120</default>
+          <visible>false</visible> <!-- Working code disabled, rework needed -->
           <control type="edit" format="integer" />
         </setting>
         <setting id="MEDIATYPE" type="integer" label="30112">

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -998,14 +998,14 @@ bool AdaptiveStream::seek(uint64_t const pos)
   // we seek only in the current segment
   if (state_ != STOPPED && pos >= absolute_position_ - segment_read_pos_)
   {
-    segment_read_pos_ = static_cast<uint32_t>(pos - (absolute_position_ - segment_read_pos_));
+    segment_read_pos_ = static_cast<size_t>(pos - (absolute_position_ - segment_read_pos_));
 
     while (segment_read_pos_ > segment_buffers_[0]->buffer.size() && worker_processing_)
       thread_data_->signal_rw_.wait(lckrw);
 
     if (segment_read_pos_ > segment_buffers_[0]->buffer.size())
     {
-      segment_read_pos_ = static_cast<uint32_t>(segment_buffers_[0]->buffer.size());
+      segment_read_pos_ = segment_buffers_[0]->buffer.size();
       return false;
     }
     absolute_position_ = pos;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -44,8 +44,6 @@ AdaptiveStream::AdaptiveStream(AdaptiveTree& tree,
     current_period_(tree_.m_currentPeriod),
     current_adp_(adp),
     current_rep_(initialRepr),
-    available_segment_buffers_(0),
-    valid_segment_buffers_(0),
     m_streamParams(kodiProps.m_streamParams),
     m_streamHeaders(kodiProps.m_streamHeaders),
     segment_read_pos_(0),
@@ -58,9 +56,7 @@ AdaptiveStream::AdaptiveStream(AdaptiveTree& tree,
     choose_rep_(choose_rep),
     rep_counter_(1),
     prev_rep_(0),
-    last_rep_(0),
-    assured_buffer_length_(5),
-    max_buffer_length_(10)
+    last_rep_(0)
 {
   current_rep_->current_segment_ = nullptr;
 
@@ -598,8 +594,16 @@ bool AdaptiveStream::start_stream()
   //! a fixed duration of 1 sec moreover these properties currently works for
   //! the DASH manifest with "SegmentTemplate" tags defined only,
   //! in all other type of manifest cases always fallback on hardcoded values
+  /*
+   * Adaptive/custom buffering code disabled
+   * currently cause a bad memory management especially for 4k content
+   * too much buffer length leads to filling the RAM and cause kodi to crash
+   * required to implement a way to determine the max length of the buffer 
+   * by taking in account also the device RAM
+   *
   assured_buffer_length_ = current_rep_->assured_buffer_duration_;
   max_buffer_length_ = current_rep_->max_buffer_duration_;
+
   if (current_rep_->HasSegmentTemplate())
   {
     const auto& segTemplate = current_rep_->GetSegmentTemplate();
@@ -608,6 +612,7 @@ bool AdaptiveStream::start_stream()
     max_buffer_length_ = std::ceil((max_buffer_length_ * segTemplate->GetTimescale()) /
                                    static_cast<float>(segTemplate->GetDuration()));
   }
+  */
   assured_buffer_length_  = assured_buffer_length_ <4 ? 4:assured_buffer_length_;//for incorrect settings input
   if(max_buffer_length_<=assured_buffer_length_)//for incorrect settings input
     max_buffer_length_=assured_buffer_length_+4u;

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -221,11 +221,11 @@ class AdaptiveStream;
     uint8_t m_decrypterIv[16];
 
     // number of segmentbuffers whith valid segment, always >= valid_segment_buffers_
-    size_t available_segment_buffers_;
+    size_t available_segment_buffers_{0};
     // number of segment_buffers which are downloaded / downloading
-    uint32_t assured_buffer_length_;
-    uint32_t max_buffer_length_; 
-    size_t valid_segment_buffers_;
+    uint32_t assured_buffer_length_{0};
+    uint32_t max_buffer_length_{0};
+    size_t valid_segment_buffers_{0};
     uint32_t rep_counter_;
     PLAYLIST::CRepresentation* prev_rep_; // used for rep_counter_
     PLAYLIST::CRepresentation* last_rep_; // used to align new live rep with old

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,7 +240,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   bool needRefetch = false; //Make sure that Kodi fetches changes
   stream->m_isEnabled = true;
 
-  const CRepresentation* rep = stream->m_adStream.getRepresentation();
+  CRepresentation* rep = stream->m_adStream.getRepresentation();
 
   // If we select a dummy (=inside video) stream, open the video part
   // Dummy streams will be never enabled, they will only enable / activate audio track.
@@ -302,12 +302,27 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     stream->SetReader(std::make_unique<CTSSampleReader>(
         stream->GetAdByteStream(), stream->m_info.GetStreamType(), streamid, mask));
 
-    if (!stream->GetReader()->Initialize())
+    if (stream->GetReader()->Initialize())
+    {
+      m_session->OnSegmentChanged(&stream->m_adStream);
+    }
+    else if (stream->m_adStream.GetStreamType() == StreamType::AUDIO)
+    {
+      // If TSSampleReader fail, try fallback to ADTS
+      //! @todo: we should have an appropriate file type check
+      //! e.g. with HLS we determine the container type from file extension
+      //! in the url address, but .ts file could have ADTS
+      LOG::LogF(LOGWARNING, "Cannot initialize TS sample reader, fallback to ADTS sample reader");
+      rep->SetContainerType(ContainerType::ADTS);
+
+      stream->GetAdByteStream()->Seek(0); // Seek because bytes are consumed from previous reader
+      stream->SetReader(std::make_unique<CADTSSampleReader>(stream->GetAdByteStream(), streamid));
+    }
+    else
     {
       stream->Disable();
       return false;
     }
-    m_session->OnSegmentChanged(&stream->m_adStream);
   }
   else if (reprContainerType == ContainerType::ADTS)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixes found from slack discussion

One of the problems of high memory occupation
is due to
https://github.com/xbmc/inputstream.adaptive/blob/21.1.2-Omega/src/common/AdaptiveStream.cpp#L617-L638
where we set:
assured_buffer_length_ to 60
max_buffer_length_ to 120

in the old code:
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/common/AdaptiveStream.cpp#L541-L550
instead set:
assured_buffer_length_ to 4
max_buffer_length_ to 8

this implies we have a very big buffer that require much memory so increase a lot until the end

i think it is better to completely disable this bad code that we have been dragging around for years
now we have almost stable memory occuped, ~but we can see about 100 mb increased on start~ (seem regular its debug vs release build)
there is a little memory that increase of about 1mb each time after some seconds that could require other investigations but could be a problem at kodi side (its present also on old isa version)

this bug also reveals another problem on buffering
when we put the playback on pause, we continue download segments where should be paused and resumed when playback will be resumed, this can be improved later, until now this problem was hidden because the buffer is short

Commit: Fallback to ADTS sample reader when TS initialization fails
fix the audio with youtube HLS manifests
where we have wrong container, use file extension is not reliable,
tested with HLS version of https://www.youtube.com/watch?v=Hf5enZVznC4

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1295

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
