### PR TITLE
[backport] include missing <cstdint> to support gcc-13

### DIFF
--- a/src/Iaes_decrypter.h
+++ b/src/Iaes_decrypter.h
@@ -10,6 +10,7 @@
 
 #include <bento4/Ap4Types.h>
 
+#include <cstdint>
 #include <string>
 
 class IAESDecrypter

--- a/src/SSD_dll.h
+++ b/src/SSD_dll.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <stdarg.h> // va_list, va_start, va_arg, va_end
 #include <string_view>
 

--- a/src/utils/FileUtils.h
+++ b/src/utils/FileUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
Upstream: https://github.com/xbmc/inputstream.adaptive/commit/7b5c284e63c1d6327db7551a0646cffcbaf9410f
[Bernd: backported from Omega branch]

## Description
include missing cstdint header to support gcc-13, backported from https://github.com/xbmc/inputstream.adaptive/pull/1240

## Motivation and context
Fix build with gcc-13

## How has this been tested?
build-tested with gcc-13

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
