### PR TITLE
[HLSTree] Reworked EXT-X-STREAM-INF parsing

### DIFF
--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -10,6 +10,7 @@
 
 #include "Representation.h"
 #include "../utils/StringUtils.h"
+#include "../utils/Utils.h"
 
 #include <algorithm> // any_of
 
@@ -155,4 +156,28 @@ bool PLAYLIST::CAdaptationSet::Compare(const std::unique_ptr<CAdaptationSet>& le
   }
 
   return false;
+}
+
+PLAYLIST::CAdaptationSet* PLAYLIST::CAdaptationSet::FindByCodec(
+    std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, std::string codec)
+{
+  auto itAdpSet = std::find_if(adpSets.cbegin(), adpSets.cend(),
+                               [&codec](const std::unique_ptr<CAdaptationSet>& item)
+                               { return CODEC::Contains(item->GetCodecs(), codec); });
+  if (itAdpSet != adpSets.cend())
+    return (*itAdpSet).get();
+
+  return nullptr;
+}
+
+CAdaptationSet* PLAYLIST::CAdaptationSet::FindMergeable(
+    std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, CAdaptationSet* adpSet)
+{
+  auto itAdpSet = std::find_if(adpSets.cbegin(), adpSets.cend(),
+                               [&adpSet](const std::unique_ptr<CAdaptationSet>& item)
+                               { return item->IsMergeable(adpSet); });
+  if (itAdpSet != adpSets.cend())
+    return (*itAdpSet).get();
+
+  return nullptr;
 }

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -23,6 +23,11 @@ void PLAYLIST::CAdaptationSet::AddCodecs(std::string_view codecs)
   m_codecs.insert(list.begin(), list.end());
 }
 
+void PLAYLIST::CAdaptationSet::AddCodecs(const std::set<std::string>& codecs)
+{
+  m_codecs.insert(codecs.begin(), codecs.end());
+}
+
 bool PLAYLIST::CAdaptationSet::ContainsCodec(std::string_view codec)
 {
   if (std::any_of(m_codecs.begin(), m_codecs.end(),
@@ -86,18 +91,7 @@ bool PLAYLIST::CAdaptationSet::IsMergeable(const CAdaptationSet* other) const
   if (m_streamType != other->m_streamType)
     return false;
 
-  if (m_streamType == StreamType::VIDEO)
-  {
-    if (m_group == other->m_group &&
-        std::find(m_switchingIds.begin(), m_switchingIds.end(), other->m_id) !=
-            m_switchingIds.end() &&
-        std::find(other->m_switchingIds.begin(), other->m_switchingIds.end(), m_id) !=
-            other->m_switchingIds.end())
-    {
-      return true;
-    }
-  }
-  else if (m_streamType == StreamType::AUDIO)
+  if (m_streamType == StreamType::AUDIO)
   {
     if (m_id == other->m_id && m_startPts == other->m_startPts &&
         m_startNumber == other->m_startNumber && m_duration == other->m_duration &&
@@ -106,6 +100,46 @@ bool PLAYLIST::CAdaptationSet::IsMergeable(const CAdaptationSet* other) const
         m_isOriginal == other->m_isOriginal && m_isForced == other->m_isForced &&
         m_isImpaired == other->m_isImpaired && m_mimeType == other->m_mimeType &&
         m_audioChannels == other->m_audioChannels && m_codecs == other->m_codecs)
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool PLAYLIST::CAdaptationSet::CompareSwitchingId(const CAdaptationSet* other) const
+{
+  if (m_streamType != other->m_streamType || m_switchingIds.empty())
+    return false;
+
+  if (m_streamType == StreamType::VIDEO)
+  {
+    if (m_group == other->m_group &&
+        std::find(m_switchingIds.cbegin(), m_switchingIds.cend(), other->m_id) !=
+            m_switchingIds.cend() &&
+        std::find(other->m_switchingIds.cbegin(), other->m_switchingIds.cend(), m_id) !=
+            other->m_switchingIds.cend())
+    {
+      //! @todo: we have no way to determine supported codecs by hardware in use
+      //! and can broken playback, we allow same codec only
+      for (std::string codec : m_codecs)
+      {
+        codec = codec.substr(0, codec.find('.')); // Get fourcc only
+        if (CODEC::IsVideo(codec) && CODEC::Contains(other->m_codecs, codec))
+        {
+          return true;
+        }
+      }
+    }
+  }
+  else if (m_streamType == StreamType::AUDIO)
+  {
+    if (m_language == other->m_language && m_group == other->m_group &&
+        std::find(m_switchingIds.cbegin(), m_switchingIds.cend(), other->m_id) !=
+            m_switchingIds.cend() &&
+        std::find(other->m_switchingIds.cbegin(), other->m_switchingIds.cend(), m_id) !=
+            other->m_switchingIds.cend())
     {
       return true;
     }

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -109,6 +109,24 @@ public:
   static bool Compare(const std::unique_ptr<CAdaptationSet>& left,
                       const std::unique_ptr<CAdaptationSet>& right);
 
+  /*!
+   * \brief Find an adaptation set by codec string.
+   * \param adpSets The adaptation set list where to search
+   * \param codec The codec string
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindByCodec(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                                     std::string codec);
+
+  /*!
+   * \brief Find a mergeable adaptation set by comparing properties.
+   * \param adpSets The adaptation set list where to search
+   * \param adpSet The adaptation set to be compared
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindMergeable(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                                       CAdaptationSet* adpSet);
+
 protected:
   std::vector<std::unique_ptr<CRepresentation>> m_representations;
 

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -65,6 +65,11 @@ public:
   void AddCodecs(std::string_view codecs);
   const std::set<std::string>& GetCodecs() { return m_codecs; }
 
+  /*!
+   * \brief Add codec strings
+   */
+  void AddCodecs(const std::set<std::string>& codecs);
+
   StreamType GetStreamType() const { return m_streamType; }
   void SetStreamType(StreamType streamType) { m_streamType = streamType; }
 
@@ -105,6 +110,14 @@ public:
   void CopyHLSData(const CAdaptationSet* other);
 
   bool IsMergeable(const CAdaptationSet* other) const;
+
+  /*!
+   * \brief Determine if an adaptation set is switchable with another one,
+   *        as urn:mpeg:dash:adaptation-set-switching:2016 scheme
+   * \param adpSets The adaptation set to compare
+   * \return True if switchable, otherwise false
+   */
+  bool CompareSwitchingId(const CAdaptationSet* other) const;
 
   static bool Compare(const std::unique_ptr<CAdaptationSet>& left,
                       const std::unique_ptr<CAdaptationSet>& right);

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -80,6 +80,8 @@ protected:
    */
   size_t EstimateSegmentsCount(uint64_t duration, uint32_t timescale, uint64_t totalTimeSecs = 0);
 
+  void MergeAdpSets();
+
   /*!
    * \brief Download manifest update, overridable method for test project
    */

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -167,8 +167,6 @@ bool adaptive::CHLSTree::Open(std::string_view url,
 
   m_currentPeriod = m_periods[0].get();
 
-  // SortTree();
-
   return true;
 }
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -80,6 +80,11 @@ protected:
   PLAYLIST::EncryptionType ProcessEncryption(std::string_view baseUrl,
                                              std::map<std::string, std::string>& attribs);
 
+  bool ParseMediaGroup(std::unique_ptr<PLAYLIST::CAdaptationSet>& adpSet,
+                       std::unique_ptr<PLAYLIST::CRepresentation>& repr,
+                       std::map<std::string, std::string> attribs,
+                       const std::string& codecStr);
+
   virtual void SaveManifest(PLAYLIST::CAdaptationSet* adpSet,
                             const std::string& data,
                             std::string_view info);
@@ -87,28 +92,6 @@ protected:
   std::unique_ptr<IAESDecrypter> m_decrypter;
 
 private:
-  struct ExtGroup
-  {
-    std::string m_codecs;
-    std::vector<std::unique_ptr<PLAYLIST::CAdaptationSet>> m_adpSets;
-
-    // Apply codecs to the first representation of each adaptation set
-    void SetCodecs(std::string_view codecs)
-    {
-      if (m_codecs.empty()) // Update only one time
-      {
-        m_codecs = codecs;
-        for (auto& adpSet : m_adpSets)
-        {
-          auto& repr = adpSet->GetRepresentations()[0];
-          repr->AddCodecs(codecs);
-          adpSet->AddCodecs(codecs);
-        }
-      }
-    };
-  };
-
-  std::map<std::string, ExtGroup> m_extGroups;
   uint8_t m_segmentIntervalSec = 4;
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -47,7 +47,6 @@ bool adaptive::CSmoothTree::Open(std::string_view url,
   m_currentPeriod = m_periods[0].get();
 
   CreateSegmentTimeline();
-  SortTree();
 
   return true;
 }

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -67,7 +67,7 @@ protected:
       LOG::Log(LOGERROR, "Cannot open \"%s\" HLS manifest.", url.c_str());
       exit(1);
     }
-
+    tree->PostOpen(m_kodiProps);
     tree->m_currentAdpSet = tree->m_periods[0]->GetAdaptationSets()[0].get();
     tree->m_currentRepr = tree->m_currentAdpSet->GetRepresentations()[0].get();
   }

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -62,6 +62,7 @@ protected:
       LOG::Log(LOGERROR, "Cannot open \"%s\" Smooth Streaming manifest.", url.c_str());
       exit(1);
     }
+    tree->PostOpen(m_kodiProps);
   }
 
   SmoothTestTree* tree;

--- a/src/test/manifests/mpd/adaptation_set_merge.mpd
+++ b/src/test/manifests/mpd/adaptation_set_merge.mpd
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+A sample manifest from amazon VOD, showing two uncommon cases:
+1) apparently identical audio adp sets with same language can be listed, for example language code "es", but one "es" language is different, can only be distinguished from audioTrackId (es-419)
+2) multiple identical audio adp sets with same language and codec can be listed, the only differences are ContentProtection and base url
+-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" majorVersion="1" mediaPresentationDuration="PT54M14.208S" minBufferTime="PT10S" minorVersion="0" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" revision="3" type="static" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd">
+  <Period duration="PT54M14.208S">
+    <AdaptationSet contentType="video" group="2" maxBandwidth="1500000" maxHeight="540" maxWidth="960" mimeType="video/mp4" minBandwidth="100000" par="16:9" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation aspectRatio="16:9" bandwidth="100000" codecPrivateData="00000001674D4016E430323B7FE01C001C2D4040405000000300100000030328F162D9A00000000168E978FC80" codecs="avc1.4D4016" frameRate="25" height="224" id="video=100000" sar="224:225" scanType="progressive" width="400">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_1.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1616"/>
+          <SegmentURL mediaRange="12329-41573"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="150000" codecPrivateData="00000001674D4016E4301004B602D4040405000003000100000300328F162D9A0000000168E9786F20" codecs="avc1.4D4016" frameRate="25" height="288" id="video=150000" sar="1:1" scanType="progressive" width="512">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_2.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1596"/>
+          <SegmentURL mediaRange="12309-58829"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="300000" codecPrivateData="00000001674D401EE4301405FF2E02D4040405000003000100000300328F162D9A0000000168E978BC80" codecs="avc1.4D401E" frameRate="25" height="360" id="video=300000" sar="1:1" scanType="progressive" width="640">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_3.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-58883"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="501000" codecPrivateData="00000001674D401EE43016067F780B50101014000003000400000300CA3C58B6680000000168E978FC80" codecs="avc1.4D401E" frameRate="25" height="396" id="video=501000" sar="1:1" scanType="progressive" width="704">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_4.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-69353"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="800000" codecPrivateData="00000001674D401EE43016067F780B50101014000003000400000300CA3C58B6680000000168E9785F20" codecs="avc1.4D401E" frameRate="25" height="396" id="video=800000" sar="1:1" scanType="progressive" width="704">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_5.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-80923"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="1001000" codecPrivateData="00000001674D401FE4301E022FDE02D4040405000003000100000300328F18319A0000000168E9784F20" codecs="avc1.4D401F" frameRate="25" height="540" id="video=1001000" sar="1:1" scanType="progressive" width="960">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_6.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-104880"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="1500000" codecPrivateData="00000001674D401FE4301E022FDE02D4040405000003000100000300328F18319A0000000168E9786F20" codecs="avc1.4D401F" frameRate="25" height="540" id="video=1500000" sar="1:1" scanType="progressive" width="960">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_7.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-127633"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="100">
+        <S d="452"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="ja-jp_dialog_0" contentType="audio" group="1" lang="ja" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="48000" bandwidth="128000" codecs="mp4a.40.2" id="audio_ja-JP_3=128000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_117.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-54754"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="48000">
+        <S d="96256"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-419_dialog_0" contentType="audio" group="1" lang="es" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="48000" bandwidth="128000" codecs="mp4a.40.2" id="audio_es-419_3=128000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_127.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-54759"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="48000">
+        <S d="96256"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-es_dialog_0" contentType="audio" group="1" lang="es" maxBandwidth="32000" mimeType="audio/mp4" minBandwidth="20000" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="24000" bandwidth="20000" codecs="mp4a.40.29" id="audio_es-ES=20000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_17.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1532"/>
+          <SegmentURL mediaRange="21089-27026"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation audioSamplingRate="24000" bandwidth="32000" codecs="mp4a.40.29" id="audio_es-ES=32000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_39.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1532"/>
+          <SegmentURL mediaRange="21089-29970"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="24000">
+        <S d="48128"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-es_dialog_0" contentType="audio" group="1" lang="es" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="24000" bandwidth="64000" codecs="mp4a.40.5" id="audio_es-ES_1=64000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_83.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1530"/>
+          <SegmentURL mediaRange="21087-38133"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="24000">
+        <S d="48128"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-es_dialog_0" contentType="audio" group="1" lang="es" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="F34B9742-51DB-4C24-B3AF-9FA742A34BAD" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AUQBwAGQATAA4ADkAdABSAEoARQB5AHoAcgA1ACsAbgBRAHEATgBMAHIAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBjAG8AMgBaAGQAQQBIADgAZgBkAGMAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEPNLl0JR20wks6+fp0KjS60aBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="24000" bandwidth="64000" codecs="mp4a.40.5" id="audio_es-ES_1=64000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_84.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1530"/>
+          <SegmentURL mediaRange="21087-38133"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="24000">
+        <S d="48128"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="en-gb_dialog_0" contentType="audio" group="1" lang="en" maxBandwidth="192000" mimeType="audio/mp4" minBandwidth="96000" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="F34B9742-51DB-4C24-B3AF-9FA742A34BAD" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AUQBwAGQATAA4ADkAdABSAEoARQB5AHoAcgA1ACsAbgBRAHEATgBMAHIAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBjAG8AMgBaAGQAQQBIADgAZgBkAGMAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEPNLl0JR20wks6+fp0KjS60aBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="48000" bandwidth="96000" codecs="mp4a.40.2" id="audio_en-GB_3=96000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_108.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-46737"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation audioSamplingRate="48000" bandwidth="128000" codecs="mp4a.40.2" id="audio_en-GB_3=128000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_120.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-54757"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation audioSamplingRate="48000" bandwidth="192000" codecs="mp4a.40.2" id="audio_en-GB_3=192000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_172.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-70801"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="48000">
+        <S d="96256"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/src/test/manifests/mpd/adaptation_set_switching.mpd
+++ b/src/test/manifests/mpd/adaptation_set_switching.mpd
@@ -1,53 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MPD _xmlns:ns2="http://www.w3.org/1999/xlink" mediaPresentationDuration="PT1H45M47.904S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_xmlns="xmlns">
   <Period duration="PT1H45M47.904S">
-    <!-- 3 below should merge -->
+    <!-- 4 below should merge, despite id 6 has different codec -->
     <AdaptationSet id="0" group="0" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation id="1" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
-      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1,2"/>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1,2,6"/>
     </AdaptationSet>
     <AdaptationSet id="1" group="0" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation id="2" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
-      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,2"/>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,2,6"/>
     </AdaptationSet>
     <AdaptationSet id="2" group="0" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation id="3" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
-      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1"/>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1,6"/>
+    </AdaptationSet>
+    <AdaptationSet id="6" group="0" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="4" bandwidth="1474186" codecs="hev1.2.4.L93.90" frameRate="60/2" height="720" sar="1:1" width="1280" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1,2"/>
     </AdaptationSet>
 
     <!-- 2 below should merge -->
     <AdaptationSet id="0" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="4" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
+      <Representation id="5" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1"/>
     </AdaptationSet>
     <AdaptationSet id="1" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="5" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
+      <Representation id="6" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0"/>
     </AdaptationSet>
 
     <!-- Wont merge as id 99 doesnt exist -->
     <AdaptationSet id="2" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="6" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <Representation id="7" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="99"/>
     </AdaptationSet>
 
     <!-- Wont merge as id 1 doesnt list my id -->
     <AdaptationSet id="2" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="7" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <Representation id="8" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1"/>
     </AdaptationSet>
 
     <!-- Wont merge as no adaptation-set-switching -->
     <AdaptationSet id="3" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="8" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <Representation id="9" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
     </AdaptationSet>
   </Period>
 </MPD>

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -401,6 +401,21 @@ bool UTILS::CODEC::IsAudio(std::string_view codec)
   return false;
 }
 
+bool UTILS::CODEC::IsVideo(std::string_view codec)
+{
+  for (const auto fourcc : CODEC::VIDEO_FOURCC_LIST)
+  {
+    if (STRING::Contains(codec, fourcc))
+      return true;
+  }
+  for (const auto name : CODEC::VIDEO_NAME_LIST)
+  {
+    if (STRING::Contains(codec, name))
+      return true;
+  }
+  return false;
+}
+
 bool UTILS::CODEC::IsSubtitleFourCC(std::string_view codec)
 {
   for (const auto fourcc : CODEC::SUBTITLES_FOURCC_LIST)

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -54,6 +54,9 @@ constexpr char* NAME_HEVC = "hevc";
 constexpr char* NAME_VP9 = "vp9";
 constexpr char* NAME_AV1 = "av1";
 
+constexpr std::array VIDEO_NAME_LIST = {NAME_MPEG1, NAME_MPEG2, NAME_MPEG4, NAME_VC1,
+                                        NAME_H264,  NAME_HEVC,  NAME_VP9,   NAME_AV1};
+
 // Audio definitions
 
 constexpr char* NAME_AAC = "aac";
@@ -83,6 +86,10 @@ constexpr char* FOURCC_HVC1 = "hvc1"; // HEVC Dolby vision
 constexpr char* FOURCC_DVH1 = "dvh1"; // HEVC Dolby vision, hvc1 variant
 constexpr char* FOURCC_HEV1 = "hev1"; // HEVC Dolby vision
 constexpr char* FOURCC_DVHE = "dvhe"; // HEVC Dolby vision, hev1 variant
+
+constexpr std::array VIDEO_FOURCC_LIST = {FOURCC_H264,   FOURCC_AVC_,  FOURCC_VP09,   FOURCC_AV01,
+                                          FOURCC_HEVC,   FOURCC_HVC1,  FOURCC_DVH1,   FOURCC_HEV1,
+                                          FOURCC_DVHE};
 
 // Fourcc audio definitions
 
@@ -167,6 +174,13 @@ std::string GetVideoDesc(const std::set<std::string>& list);
  * \return True if it is audio type, otherwise false
  */
 bool IsAudio(std::string_view codec);
+
+/*!
+ * \brief Determines if the codec string is of type video, regardless of whether it is a name or fourcc.
+ * \param codec The codec string
+ * \return True if it is video type, otherwise false
+ */
+bool IsVideo(std::string_view codec);
 
 /*!
  * \brief Determines if the codec string contains a fourcc of type subtitles.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
While testing i found over time old HLS parsing problems not solved yet:
- On manifest with multi-codec video streams the representations mixes all codecs together, this was causing problems with the "Ask quality" stream selector (show mixed codecs) and adaptive streaming, because each adaptation set must have a single codec type as dash specs
- With manifests that have EXT-X-STREAM-INF variants with video streams but also variants with only audio (without video), these variants was wrongly added as a video stream causing broken playback on all sense, this can be confirmed by using "Ask quality" stream selector where wrong video streams are shown with lack of metadata

Related to this will be fixed #1259 since now EXT-X-STREAM-INF variants with only audio are now correctly handled

Has been full removed the `ExtGroup` struct because media groups are now parsed when required by variants itself

~Since merge adaptation sets with a separate method should not needed anymore, has been removed in full the merging code on `AdaptiveTree::SortTree`
This also revert/remove the code to `urn:mpeg:dash:adaptation-set-switching:2016` introduced by PR #694~
EDIT: After some more investigations i choosed to reintroduce "adaptation sets merging" method but for dash only, the reason behind is due to amazon manifests that appears to have uncommon adaptation sets with same data, for this reason i have add a new test case `AdaptionSetMerge` so to not forgot in future this peculiarity.
`AdaptiveTree::SortTree` method now does exactly what it describes and does not merge adpsets,
the adaptation set merging code that include also `urn:mpeg:dash:adaptation-set-switching:2016` introduced by PR #694 has been moved to a separate method in dash parser, but i am somewhat puzzled as to how it was implemented because:
- wipe out adaptation sets data
- for example on this manifest [SwitchingManifestExample.txt](https://github.com/xbmc/inputstream.adaptive/files/12194881/SwitchingManifestExample.txt) there are different protection levels i may be wrong but it would be good to keep this and other possible different data

Moving this code i have also limited the merging code to adaptation sets with same codec, currently mixing more codecs to the same adaptation set can cause broken playback, because we have no way to determine supported codecs in advance and also currently there is no way to fallback if playback dont works with a specific codec

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hoh-subs.ism/.m3u8

and HLS audio stream from
https://stream.rtl.lu/live/hls/radio/rtllx

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
