### PR TITLE
[wvdecrypter] Fix memory heap corruption

### DIFF
--- a/wvdecrypter/wvdecrypter_android.cpp
+++ b/wvdecrypter/wvdecrypter_android.cpp
@@ -1121,11 +1121,8 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
 
     if (fragInfo.nal_length_size_ && (!iv || bytes_of_cleartext_data[0] > 0))
     {
-      //Note that we assume that there is enough data in data_out to hold everything without reallocating.
-
       //check NAL / subsample
       const AP4_Byte *packet_in(data_in.GetData()), *packet_in_e(data_in.GetData() + data_in.GetDataSize());
-      AP4_Byte *packet_out(data_out.UseData() + data_out.GetDataSize());
       AP4_UI16 *clrb_out(iv ? reinterpret_cast<AP4_UI16*>(data_out.UseData() + sizeof(subsample_count)) : nullptr);
       unsigned int nalunitcount(0), nalunitsum(0), configSize(0);
 
@@ -1137,19 +1134,18 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
         //look if we have to inject sps / pps
         if (fragInfo.annexb_sps_pps_.GetDataSize() && (*packet_in & 0x1F) != 9 /*AVC_NAL_AUD*/)
         {
-          memcpy(packet_out, fragInfo.annexb_sps_pps_.GetData(), fragInfo.annexb_sps_pps_.GetDataSize());
-          packet_out += fragInfo.annexb_sps_pps_.GetDataSize();
+          data_out.AppendData(fragInfo.annexb_sps_pps_.GetData(),
+                              fragInfo.annexb_sps_pps_.GetDataSize());
           if (clrb_out) *clrb_out += fragInfo.annexb_sps_pps_.GetDataSize();
           configSize = fragInfo.annexb_sps_pps_.GetDataSize();
           fragInfo.annexb_sps_pps_.SetDataSize(0);
         }
 
-        //Anex-B Start pos
-        packet_out[0] = packet_out[1] = packet_out[2] = 0; packet_out[3] = 1;
-        packet_out += 4;
-        memcpy(packet_out, packet_in, nalsize);
+        // Annex-B Start pos
+        static AP4_Byte annexbStartCode[4] = {0x00, 0x00, 0x00, 0x01};
+        data_out.AppendData(annexbStartCode, 4);
+        data_out.AppendData(packet_in, nalsize);
         packet_in += nalsize;
-        packet_out += nalsize;
         if (clrb_out) *clrb_out += (4 - fragInfo.nal_length_size_);
         ++nalunitcount;
 
@@ -1188,7 +1184,6 @@ AP4_Result WV_CencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 pool_id,
                   fragInfo.nal_length_size_, (int)(packet_in_e - packet_in), subsample_count);
         return AP4_ERROR_NOT_SUPPORTED;
       }
-      data_out.SetDataSize(data_out.GetDataSize() + data_in.GetDataSize() + configSize + (4 - fragInfo.nal_length_size_) * nalunitcount);
     }
     else
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After PR #1310 when you play a Widevine encrypted content on a debug build kodi crash with a memory heap corruption
![immagine](https://github.com/xbmc/inputstream.adaptive/assets/3257156/a201747b-74e8-40d4-bd5a-9807dfd96809)

the reason seem to be on changed code that looks bad and unsafe,
the code take the mem pointer from data_out and store to packet_out, this to manually copy data by using `memcpy` seem to avoid use the bento4 object method `AppendData`

the size of buffer internally of the data_out object is assumed to be big enough to contains written data, but if not so?
weird thing can happens also because at the end is called `data_out.SetDataSize` to update the wrong object data size,
from what i understand SetDataSize not only update the container data size but can also reallocate the object buffer,
if this happens the reallocation copy the buffer data but based on initial data size and not on what we have written with `memcpy`, that could exceed the size...

I do not know if I have explained myself correctly anyway dont crash anymore

maybe in the past has been done so to try limit `SetDataSize` uses in the
`while (packet_in < packet_in_e)` loop, at least with h264 i get at max 4 loops only not big things

a test confermation would be appreciated

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
played n€tflix on windows, debug build
played n€tflix on android, but release build

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
