### PR TITLE
[HLSTree] Reworked multivariant playlist parser

### DIFF
--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -10,6 +10,7 @@
 
 #include "Representation.h"
 #include "../utils/StringUtils.h"
+#include "../utils/Utils.h"
 
 #include <algorithm> // any_of
 
@@ -155,4 +156,28 @@ bool PLAYLIST::CAdaptationSet::Compare(const std::unique_ptr<CAdaptationSet>& le
   }
 
   return false;
+}
+
+PLAYLIST::CAdaptationSet* PLAYLIST::CAdaptationSet::FindByCodec(
+    std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, std::string codec)
+{
+  auto itAdpSet = std::find_if(adpSets.cbegin(), adpSets.cend(),
+                               [&codec](const std::unique_ptr<CAdaptationSet>& item)
+                               { return CODEC::Contains(item->GetCodecs(), codec); });
+  if (itAdpSet != adpSets.cend())
+    return (*itAdpSet).get();
+
+  return nullptr;
+}
+
+CAdaptationSet* PLAYLIST::CAdaptationSet::FindMergeable(
+    std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, CAdaptationSet* adpSet)
+{
+  auto itAdpSet = std::find_if(adpSets.cbegin(), adpSets.cend(),
+                               [&adpSet](const std::unique_ptr<CAdaptationSet>& item)
+                               { return item->IsMergeable(adpSet); });
+  if (itAdpSet != adpSets.cend())
+    return (*itAdpSet).get();
+
+  return nullptr;
 }

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -23,6 +23,11 @@ void PLAYLIST::CAdaptationSet::AddCodecs(std::string_view codecs)
   m_codecs.insert(list.begin(), list.end());
 }
 
+void PLAYLIST::CAdaptationSet::AddCodecs(const std::set<std::string>& codecs)
+{
+  m_codecs.insert(codecs.begin(), codecs.end());
+}
+
 bool PLAYLIST::CAdaptationSet::ContainsCodec(std::string_view codec)
 {
   if (std::any_of(m_codecs.begin(), m_codecs.end(),
@@ -86,18 +91,7 @@ bool PLAYLIST::CAdaptationSet::IsMergeable(const CAdaptationSet* other) const
   if (m_streamType != other->m_streamType)
     return false;
 
-  if (m_streamType == StreamType::VIDEO)
-  {
-    if (m_group == other->m_group &&
-        std::find(m_switchingIds.begin(), m_switchingIds.end(), other->m_id) !=
-            m_switchingIds.end() &&
-        std::find(other->m_switchingIds.begin(), other->m_switchingIds.end(), m_id) !=
-            other->m_switchingIds.end())
-    {
-      return true;
-    }
-  }
-  else if (m_streamType == StreamType::AUDIO)
+  if (m_streamType == StreamType::AUDIO)
   {
     if (m_id == other->m_id && m_startPts == other->m_startPts &&
         m_startNumber == other->m_startNumber && m_duration == other->m_duration &&
@@ -106,6 +100,46 @@ bool PLAYLIST::CAdaptationSet::IsMergeable(const CAdaptationSet* other) const
         m_isOriginal == other->m_isOriginal && m_isForced == other->m_isForced &&
         m_isImpaired == other->m_isImpaired && m_mimeType == other->m_mimeType &&
         m_audioChannels == other->m_audioChannels && m_codecs == other->m_codecs)
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool PLAYLIST::CAdaptationSet::CompareSwitchingId(const CAdaptationSet* other) const
+{
+  if (m_streamType != other->m_streamType || m_switchingIds.empty())
+    return false;
+
+  if (m_streamType == StreamType::VIDEO)
+  {
+    if (m_group == other->m_group &&
+        std::find(m_switchingIds.cbegin(), m_switchingIds.cend(), other->m_id) !=
+            m_switchingIds.cend() &&
+        std::find(other->m_switchingIds.cbegin(), other->m_switchingIds.cend(), m_id) !=
+            other->m_switchingIds.cend())
+    {
+      //! @todo: we have no way to determine supported codecs by hardware in use
+      //! and can broken playback, we allow same codec only
+      for (std::string codec : m_codecs)
+      {
+        codec = codec.substr(0, codec.find('.')); // Get fourcc only
+        if (CODEC::IsVideo(codec) && CODEC::Contains(other->m_codecs, codec))
+        {
+          return true;
+        }
+      }
+    }
+  }
+  else if (m_streamType == StreamType::AUDIO)
+  {
+    if (m_language == other->m_language && m_group == other->m_group &&
+        std::find(m_switchingIds.cbegin(), m_switchingIds.cend(), other->m_id) !=
+            m_switchingIds.cend() &&
+        std::find(other->m_switchingIds.cbegin(), other->m_switchingIds.cend(), m_id) !=
+            other->m_switchingIds.cend())
     {
       return true;
     }

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -109,6 +109,24 @@ public:
   static bool Compare(const std::unique_ptr<CAdaptationSet>& left,
                       const std::unique_ptr<CAdaptationSet>& right);
 
+  /*!
+   * \brief Find an adaptation set by codec string.
+   * \param adpSets The adaptation set list where to search
+   * \param codec The codec string
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindByCodec(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                                     std::string codec);
+
+  /*!
+   * \brief Find a mergeable adaptation set by comparing properties.
+   * \param adpSets The adaptation set list where to search
+   * \param adpSet The adaptation set to be compared
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindMergeable(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                                       CAdaptationSet* adpSet);
+
 protected:
   std::vector<std::unique_ptr<CRepresentation>> m_representations;
 

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -65,6 +65,11 @@ public:
   void AddCodecs(std::string_view codecs);
   const std::set<std::string>& GetCodecs() { return m_codecs; }
 
+  /*!
+   * \brief Add codec strings
+   */
+  void AddCodecs(const std::set<std::string>& codecs);
+
   StreamType GetStreamType() const { return m_streamType; }
   void SetStreamType(StreamType streamType) { m_streamType = streamType; }
 
@@ -105,6 +110,14 @@ public:
   void CopyHLSData(const CAdaptationSet* other);
 
   bool IsMergeable(const CAdaptationSet* other) const;
+
+  /*!
+   * \brief Determine if an adaptation set is switchable with another one,
+   *        as urn:mpeg:dash:adaptation-set-switching:2016 scheme
+   * \param adpSets The adaptation set to compare
+   * \return True if switchable, otherwise false
+   */
+  bool CompareSwitchingId(const CAdaptationSet* other) const;
 
   static bool Compare(const std::unique_ptr<CAdaptationSet>& left,
                       const std::unique_ptr<CAdaptationSet>& right);

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -80,6 +80,8 @@ protected:
    */
   size_t EstimateSegmentsCount(uint64_t duration, uint32_t timescale, uint64_t totalTimeSecs = 0);
 
+  void MergeAdpSets();
+
   /*!
    * \brief Download manifest update, overridable method for test project
    */

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -167,8 +167,6 @@ bool adaptive::CHLSTree::Open(std::string_view url,
 
   m_currentPeriod = m_periods[0].get();
 
-  // SortTree();
-
   return true;
 }
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -114,7 +114,19 @@ std::string GetAudioCodec(std::string_view codecs)
     if (CODEC::IsAudio(codecStr))
       return codecStr;
   }
-  return codecs.data();
+  return "";
+}
+
+// \brief Get the video codec string from CODECS attribute list
+std::string GetVideoCodec(std::string_view codecs)
+{
+  const std::vector<std::string> list = STRING::SplitToVec(codecs, ',');
+  for (const std::string& codecStr : list)
+  {
+    if (CODEC::IsVideo(codecStr))
+      return codecStr;
+  }
+  return "";
 }
 } // unnamed namespace
 
@@ -155,7 +167,7 @@ bool adaptive::CHLSTree::Open(std::string_view url,
 
   m_currentPeriod = m_periods[0].get();
 
-  SortTree();
+  // SortTree();
 
   return true;
 }
@@ -745,289 +757,32 @@ void adaptive::CHLSTree::RefreshLiveSegments()
 
 bool adaptive::CHLSTree::ParseManifest(const std::string& data)
 {
-  // Parse master playlist
-
-  bool isExtM3Uformat{false};
-
-  // Determine if is needed create a dummy audio representation for audio stream embedded on video stream
-  bool createDummyAudioRepr{false};
-
-  std::unique_ptr<CPeriod> period = CPeriod::MakeUniquePtr();
-  period->SetTimescale(1000000);
-
-  std::stringstream streamData{data};
-
-  for (std::string line; STRING::GetLine(streamData, line);)
-  {
-    // Keep track of current line pos, can be used to go back to previous line
-    // if we move forward within the loop code
-    std::streampos currentStreamPos = streamData.tellg();
-
-    std::string tagName;
-    std::string tagValue;
-    ParseTagNameValue(line, tagName, tagValue);
-
-    // Find the extended M3U file initialization tag
-    if (!isExtM3Uformat)
-    {
-      if (tagName == "#EXTM3U")
-        isExtM3Uformat = true;
-      continue;
-    }
-
-    if (tagName == "#EXT-X-MEDIA")
-    {
-      auto attribs = ParseTagAttributes(tagValue);
-
-      StreamType streamType = StreamType::NOTYPE;
-      if (attribs["TYPE"] == "AUDIO")
-        streamType = StreamType::AUDIO;
-      else if (attribs["TYPE"] == "SUBTITLES")
-        streamType = StreamType::SUBTITLE;
-      else
-        continue;
-
-      // Create or get existing group id
-      ExtGroup& group = m_extGroups[attribs["GROUP-ID"]];
-
-      auto adpSet = CAdaptationSet::MakeUniquePtr(period.get());
-      auto repr = CRepresentation::MakeUniquePtr(adpSet.get());
-
-      adpSet->SetStreamType(streamType);
-      adpSet->SetLanguage(attribs["LANGUAGE"].empty() ? "unk" : attribs["LANGUAGE"]);
-      adpSet->SetName(attribs["NAME"]);
-      adpSet->SetIsDefault(attribs["DEFAULT"] == "YES");
-      adpSet->SetIsForced(attribs["FORCED"] == "YES");
-
-      if (STRING::KeyExists(attribs, "CHARACTERISTICS"))
-      {
-        std::string ch = attribs["CHARACTERISTICS"];
-        if (STRING::Contains(ch, "public.accessibility.transcribes-spoken-dialog") ||
-            STRING::Contains(ch, "public.accessibility.describes-music-and-sound") ||
-            STRING::Contains(ch, "public.accessibility.describes-video"))
-        {
-          adpSet->SetIsImpaired(true);
-        }
-      }
-
-      repr->AddCodecs(group.m_codecs);
-      repr->SetTimescale(1000000);
-
-      if (STRING::KeyExists(attribs, "URI"))
-      {
-        std::string uri = attribs["URI"];
-        if (URL::IsUrlRelative(uri))
-          uri = URL::Join(base_url_, uri);
-
-        repr->SetSourceUrl(uri);
-
-        if (streamType == StreamType::SUBTITLE)
-        {
-          // default to WebVTT
-          repr->AddCodecs("wvtt");
-        }
-      }
-      else
-      {
-        repr->SetIsIncludedStream(true);
-        period->m_includedStreamType |= 1U << static_cast<int>(streamType);
-      }
-
-      if (streamType == StreamType::AUDIO)
-      {
-        repr->SetAudioChannels(STRING::ToUint32(attribs["CHANNELS"], 2));
-        // Copy channels to adpset to help AdaptiveTree::SortTree() on adpsets merging
-        adpSet->SetAudioChannels(repr->GetAudioChannels());
-      }
-
-      repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-      repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
-
-      repr->SetScaling();
-
-      // Add the representation/adaptation set to the group
-      adpSet->AddRepresentation(repr);
-      group.m_adpSets.push_back(std::move(adpSet));
-    }
-    else if (tagName == "#EXT-X-STREAM-INF")
-    {
-      //! @todo: If CODECS value is not present, get StreamReps from stream program section
-      // #EXT-X-STREAM-INF:BANDWIDTH=263851,CODECS="mp4a.40.2, avc1.4d400d",RESOLUTION=416x234,AUDIO="bipbop_audio",SUBTITLES="subs"
-
-      auto attribs = ParseTagAttributes(tagValue);
-
-      if (!STRING::KeyExists(attribs, "BANDWIDTH"))
-      {
-        LOG::LogF(LOGERROR, "Skipped EXT-X-STREAM-INF due to to missing bandwidth attribute (%s)",
-                  tagValue.c_str());
-        continue;
-      }
-
-      if (period->GetAdaptationSets().empty())
-      {
-        auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
-        newAdpSet->SetStreamType(StreamType::VIDEO);
-        period->AddAdaptationSet(newAdpSet);
-      }
-
-      CAdaptationSet* adpSet = period->GetAdaptationSets()[0].get();
-
-      auto repr = CRepresentation::MakeUniquePtr(adpSet);
-      repr->SetTimescale(1000000);
-
-      if (STRING::KeyExists(attribs, "CODECS"))
-        repr->AddCodecs(attribs["CODECS"]);
-      else
-      {
-        LOG::LogF(LOGDEBUG, "Missing CODECS attribute, fallback to h264");
-        repr->AddCodecs("h264");
-      }
-
-      repr->SetBandwidth(STRING::ToUint32(attribs["BANDWIDTH"]));
-
-      if (STRING::KeyExists(attribs, "RESOLUTION"))
-      {
-        int resWidth{0};
-        int resHeight{0};
-        ParseResolution(resWidth, resHeight, attribs["RESOLUTION"]);
-        repr->SetResWidth(resWidth);
-        repr->SetResHeight(resHeight);
-      }
-
-      if (STRING::KeyExists(attribs, "AUDIO"))
-      {
-        // Set codecs to the representations of audio group
-        m_extGroups[attribs["AUDIO"]].SetCodecs(GetAudioCodec(attribs["CODECS"]));
-      }
-      else
-      {
-        // We assume audio is included
-        period->m_includedStreamType |= 1U << static_cast<int>(StreamType::AUDIO);
-        createDummyAudioRepr = true;
-      }
-
-      if (STRING::KeyExists(attribs, "FRAME-RATE"))
-      {
-        double frameRate = STRING::ToFloat(attribs["FRAME-RATE"]);
-        if (frameRate == 0)
-        {
-          LOG::LogF(LOGWARNING, "Wrong FRAME-RATE attribute, fallback to 60 fps");
-          frameRate = 60.0f;
-        }
-        repr->SetFrameRate(static_cast<uint32_t>(frameRate * 1000));
-        repr->SetFrameRateScale(1000);
-      }
-
-      repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-      repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
-
-      repr->SetScaling();
-
-      // Try read on the next stream line, to get the playlist URL address
-      if (STRING::GetLine(streamData, line) && !line.empty() && line[0] != '#')
-      {
-        std::string url = line;
-        if (URL::IsUrlRelative(url))
-          url = URL::Join(base_url_, url);
-
-        // Ensure that we do not add duplicate URLs / representations
-        auto itRepr = std::find_if(
-            adpSet->GetRepresentations().begin(), adpSet->GetRepresentations().end(),
-            [&url](const std::unique_ptr<CRepresentation>& r) { return r->GetSourceUrl() == url; });
-
-        if (itRepr == adpSet->GetRepresentations().end())
-        {
-          repr->SetSourceUrl(url);
-          adpSet->AddRepresentation(repr);
-        }
-      }
-      else
-      {
-        // Malformed line, rollback stream to previous line position
-        streamData.seekg(currentStreamPos);
-      }
-    }
-    else if (tagName == "#EXTINF")
-    {
-      // This is a media playlist (not a master playlist with multi-bitrate playlist)
-
-      //! @todo: here we are add some fake data, and we are downloading two times the same manifest
-      //! because the current parser code is splitted on two parts and managed from different code,
-      //! to solve this situation a rework is needed, where we can have a seletable parsing method
-      auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
-      newAdpSet->SetStreamType(StreamType::VIDEO);
-
-      auto repr = CRepresentation::MakeUniquePtr(newAdpSet.get());
-      repr->SetTimescale(1000000);
-      repr->SetSourceUrl(manifest_url_);
-      repr->AddCodecs(CODEC::FOURCC_H264);
-
-      repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-      repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
-
-      repr->SetScaling();
-
-      newAdpSet->AddRepresentation(repr);
-      period->AddAdaptationSet(newAdpSet);
-
-      // We assume audio is included
-      period->m_includedStreamType |= 1U << static_cast<int>(StreamType::AUDIO);
-      createDummyAudioRepr = true;
-      break;
-    }
-    else if (tagName == "#EXT-X-SESSION-KEY")
-    {
-      auto attribs = ParseTagAttributes(tagValue);
-
-      switch (ProcessEncryption(base_url_, attribs))
-      {
-        case EncryptionType::NOT_SUPPORTED:
-          return false;
-        case EncryptionType::AES128:
-        case EncryptionType::WIDEVINE:
-          // #EXT-X-SESSION-KEY is meant for preparing DRM without
-          // loading sub-playlist. As long our workflow is serial, we
-          // don't profite and therefore do not any action.
-          break;
-        case EncryptionType::UNKNOWN:
-          LOG::LogF(LOGWARNING, "Unknown encryption type");
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
-  if (!isExtM3Uformat)
+  if (data.find("#EXTM3U") == std::string::npos)
   {
     LOG::LogF(LOGERROR, "Non-compliant HLS manifest, #EXTM3U tag not found.");
     return false;
   }
 
-  if (createDummyAudioRepr)
+  if (data.find("#EXTINF") == std::string::npos)
   {
-    // We may need to create the Default / Dummy audio representation
+    if (!ParseMultivariantPlaylist(data))
+      return false;
+  }
+  else // Media playlist
+  {
+    //! @todo: we are downloading two times the same manifest
+    //! media playlist parsing code could be reused
+    
+    std::unique_ptr<CPeriod> period = CPeriod::MakeUniquePtr();
+    period->SetTimescale(1000000);
 
     auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
-    newAdpSet->SetStreamType(StreamType::AUDIO);
-    newAdpSet->SetContainerType(ContainerType::MP4);
-    newAdpSet->SetLanguage("unk"); // Unknown
+    newAdpSet->SetStreamType(StreamType::VIDEO);
 
     auto repr = CRepresentation::MakeUniquePtr(newAdpSet.get());
     repr->SetTimescale(1000000);
-
-    // Try to get the codecs from first representation
-    std::set<std::string> codecs{CODEC::FOURCC_MP4A};
-    auto& adpSets = period->GetAdaptationSets();
-    if (!adpSets.empty())
-    {
-      auto& reprs = adpSets[0]->GetRepresentations();
-      if (!reprs.empty())
-        codecs = reprs[0]->GetCodecs();
-    }
-    repr->AddCodecs(codecs);
-    repr->SetAudioChannels(2);
-    repr->SetIsIncludedStream(true);
+    repr->SetSourceUrl(manifest_url_);
+    repr->AddCodecs(CODEC::FOURCC_H264);
 
     repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
     repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
@@ -1036,22 +791,16 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
 
     newAdpSet->AddRepresentation(repr);
     period->AddAdaptationSet(newAdpSet);
-  }
 
-  // Add adaptation sets from groups
-  for (auto& group : m_extGroups)
-  {
-    for (auto& adpSet : group.second.m_adpSets)
-    {
-      period->AddAdaptationSet(adpSet);
-    }
+    // We assume audio is included
+    period->m_includedStreamType |= 1U << static_cast<int>(StreamType::AUDIO);
+    AddIncludedAudioStream(period, CODEC::FOURCC_MP4A);
+
+    m_periods.push_back(std::move(period));
   }
-  m_extGroups.clear();
 
   // Set Live as default
   m_isLive = true;
-
-  m_periods.push_back(std::move(period));
 
   return true;
 }
@@ -1126,6 +875,379 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
   return EncryptionType::UNKNOWN;
 }
 
+bool adaptive::CHLSTree::ParseRenditon(const Rendition& r,
+                                       std::unique_ptr<PLAYLIST::CAdaptationSet>& adpSet,
+                                       std::unique_ptr<PLAYLIST::CRepresentation>& repr)
+{
+  StreamType streamType = StreamType::NOTYPE;
+  if (r.m_type == "AUDIO")
+    streamType = StreamType::AUDIO;
+  else if (r.m_type == "SUBTITLES")
+    streamType = StreamType::SUBTITLE;
+  else // Not supported
+    return false;
+
+  adpSet->SetStreamType(streamType);
+  adpSet->SetLanguage(r.m_language.empty() ? "unk" : r.m_language);
+  adpSet->SetName(r.m_name);
+  adpSet->SetIsDefault(r.m_isDefault);
+  adpSet->SetIsForced(r.m_isForced);
+
+  if (!r.m_characteristics.empty())
+  {
+    if (STRING::Contains(r.m_characteristics, "public.accessibility.transcribes-spoken-dialog") ||
+        STRING::Contains(r.m_characteristics, "public.accessibility.describes-music-and-sound") ||
+        STRING::Contains(r.m_characteristics, "public.accessibility.describes-video"))
+    {
+      adpSet->SetIsImpaired(true);
+    }
+  }
+
+  repr->SetTimescale(1000000);
+
+  if (!r.m_uri.empty())
+  {
+    std::string uri = r.m_uri;
+    if (URL::IsUrlRelative(uri))
+      uri = URL::Join(base_url_, uri);
+
+    repr->SetSourceUrl(uri);
+  }
+
+  if (streamType == StreamType::AUDIO)
+  {
+    repr->SetAudioChannels(r.m_channels);
+    // Set channels in the adptation set to help distinguish it from other similar renditions
+    adpSet->SetAudioChannels(r.m_channels);
+  }
+
+  repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
+  repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
+
+  repr->SetScaling();
+
+  return true;
+}
+
+bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
+{
+  std::stringstream streamData{data};
+  MultivariantPlaylist pl;
+
+  // Parse text data
+
+  for (std::string line; STRING::GetLine(streamData, line);)
+  {
+    // Keep track of current line pos, can be used to go back to previous line
+    // if we move forward within the loop code
+    std::streampos currentStreamPos = streamData.tellg();
+
+    std::string tagName;
+    std::string tagValue;
+    ParseTagNameValue(line, tagName, tagValue);
+
+    if (tagName == "#EXT-X-MEDIA")
+    {
+      auto attribs = ParseTagAttributes(tagValue);
+
+      StreamType streamType = StreamType::NOTYPE;
+      if (attribs["TYPE"] == "AUDIO")
+        streamType = StreamType::AUDIO;
+      else if (attribs["TYPE"] == "SUBTITLES")
+        streamType = StreamType::SUBTITLE;
+      else
+        continue; // Skip, other types are not supported
+
+      Rendition rend;
+      rend.m_type = attribs["TYPE"];
+      rend.m_groupId = attribs["GROUP-ID"];
+      rend.m_name = attribs["NAME"];
+      rend.m_language = attribs["LANGUAGE"];
+      if (streamType == StreamType::AUDIO)
+        rend.m_channels = STRING::ToUint32(attribs["CHANNELS"]);
+      rend.m_isDefault = attribs["DEFAULT"] == "YES";
+      rend.m_isForced = attribs["FORCED"] == "YES";
+      rend.m_characteristics = attribs["CHARACTERISTICS"];
+      rend.m_uri = attribs["URI"];
+
+      if (streamType == StreamType::AUDIO)
+        pl.m_audioRenditions.emplace_back(rend);
+      else if (streamType == StreamType::SUBTITLE)
+        pl.m_subtitleRenditions.emplace_back(rend);
+    }
+    else if (tagName == "#EXT-X-STREAM-INF")
+    {
+      auto attribs = ParseTagAttributes(tagValue);
+
+      if (!STRING::KeyExists(attribs, "BANDWIDTH"))
+      {
+        LOG::LogF(LOGERROR, "Skipped EXT-X-STREAM-INF due to to missing bandwidth attribute (%s)",
+                  tagValue.c_str());
+        continue;
+      }
+
+      std::string uri;
+      // Try read on the next stream line, to get the playlist URL address
+      if (STRING::GetLine(streamData, line) && !line.empty() && line.front() != '#')
+        uri = line;
+      else
+      {
+        LOG::Log(LOGDEBUG, "Skipped EXT-X-STREAM-INF tag due to missing uri (%s)",
+                 tagValue.c_str());
+        streamData.seekg(currentStreamPos); // rollback stream to previous line position
+        continue;
+      }
+
+      Variant var;
+      var.m_bandwidth = STRING::ToUint32(attribs["BANDWIDTH"]);
+      var.m_codecs = attribs["CODECS"];
+      var.m_resolution = attribs["RESOLUTION"];
+      if (STRING::KeyExists(attribs, "FRAME-RATE"))
+      {
+        var.m_frameRate = STRING::ToFloat(attribs["FRAME-RATE"]);
+        if (var.m_frameRate == 0)
+          LOG::LogF(LOGWARNING, "Cannot get FRAME-RATE attribute");
+      }
+      var.m_groupIdAudio = attribs["AUDIO"];
+      var.m_groupIdSubtitles = attribs["SUBTITLES"];
+      var.m_uri = uri;
+
+      pl.m_variants.emplace_back(var);
+    }
+    else if (tagName == "#EXT-X-SESSION-KEY")
+    {
+      auto attribs = ParseTagAttributes(tagValue);
+
+      switch (ProcessEncryption(base_url_, attribs))
+      {
+        case EncryptionType::NOT_SUPPORTED:
+          return false;
+        case EncryptionType::AES128:
+        case EncryptionType::WIDEVINE:
+          // #EXT-X-SESSION-KEY is meant for preparing DRM without
+          // loading sub-playlist. As long our workflow is serial, we
+          // don't profite and therefore do not any action.
+          break;
+        case EncryptionType::UNKNOWN:
+          LOG::LogF(LOGWARNING, "Unknown encryption type");
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  // Create Period / Adaptation sets / Representations
+
+  std::unique_ptr<CPeriod> period = CPeriod::MakeUniquePtr();
+  period->SetTimescale(1000000);
+
+  // Add audio renditions (do not take in account variants references)
+  for (const Rendition& r : pl.m_audioRenditions)
+  {
+    auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
+    auto newRepr = CRepresentation::MakeUniquePtr(newAdpSet.get());
+
+    if (!ParseRenditon(r, newAdpSet, newRepr))
+      continue;
+
+    // Find the codec string from a variant that references it
+    const Variant* varFound = FindVariantByAudioGroupId(r.m_groupId, pl.m_variants);
+    std::string codecStr = CODEC::FOURCC_MP4A; // Fallback
+    if (varFound)
+      codecStr = GetAudioCodec(varFound->m_codecs);
+    else
+      LOG::LogF(LOGERROR, "Cannot find variant for AUDIO GROUP-ID: %s", r.m_groupId.c_str());
+
+    newRepr->AddCodecs(codecStr);
+    newAdpSet->AddCodecs(codecStr);
+
+    if (r.m_uri.empty()) // EXT-X-MEDIA without URI (audio included to video)
+    {
+      newRepr->SetIsIncludedStream(true);
+      period->m_includedStreamType |= 1U << static_cast<int>(StreamType::AUDIO);
+    }
+    // Ensure that we dont have already an existing adaptation set with same attributes,
+    // usually should happens only when we have more EXT-X-MEDIA without URI (audio included to video)
+    // and we need to keep just one
+    CAdaptationSet* foundAdpSet =
+        CAdaptationSet::FindMergeable(period->GetAdaptationSets(), newAdpSet.get());
+
+    if (foundAdpSet)
+    {
+      if (newRepr->IsIncludedStream())
+        continue; // Repr. with included audio already exists
+
+      newRepr->SetParent(foundAdpSet);
+      foundAdpSet->AddRepresentation(newRepr);
+    }
+    else
+    {
+      newAdpSet->AddRepresentation(newRepr);
+      period->AddAdaptationSet(newAdpSet);
+    }
+  }
+
+  // Add subtitles renditions (do not take in account variants references)
+  for (const Rendition& r : pl.m_subtitleRenditions)
+  {
+    auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
+    auto newRepr = CRepresentation::MakeUniquePtr(newAdpSet.get());
+
+    if (!ParseRenditon(r, newAdpSet, newRepr))
+      continue;
+    // Use WebVTT as default subtitle codec
+    newRepr->AddCodecs(CODEC::FOURCC_WVTT);
+    newAdpSet->AddCodecs(CODEC::FOURCC_WVTT);
+
+    newAdpSet->AddRepresentation(newRepr);
+    period->AddAdaptationSet(newAdpSet);
+  }
+
+  // Add variants
+  for (const Variant& var : pl.m_variants)
+  {
+    if (var.m_bandwidth == 0)
+      LOG::LogF(LOGWARNING, "Variant with malformed bandwidth attribute");
+
+    // Try determine the type of stream from codecs
+    StreamType streamType = StreamType::NOTYPE;
+    std::string codecVideo;
+    std::string codecAudio;
+
+    if (!var.m_codecs.empty())
+    {
+      codecVideo = GetVideoCodec(var.m_codecs);
+      codecAudio = GetAudioCodec(var.m_codecs);
+
+      if (!codecVideo.empty()) // Audio/Video stream
+        streamType = StreamType::VIDEO;
+      else if (!codecAudio.empty()) // Audio only stream
+        streamType = StreamType::AUDIO;
+    }
+    else
+    {
+      if (!var.m_resolution.empty())
+      {
+        LOG::LogF(
+            LOGDEBUG,
+            "CODECS attribute missing in the EXT-X-STREAM-INF variant, assumed as video stream");
+        streamType = StreamType::VIDEO;
+        codecVideo = CODEC::FOURCC_H264;
+        if (codecAudio.empty())
+          codecAudio = CODEC::FOURCC_MP4A;
+      }
+      else
+        LOG::LogF(LOGERROR, "The EXT-X-STREAM-INF variant does not have enough info to "
+                            "determine the stream type");
+    }
+
+    if (streamType == StreamType::AUDIO) // Audio only variant
+    {
+      auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
+      auto newRepr = CRepresentation::MakeUniquePtr(newAdpSet.get());
+      // Initialize a rendition with generic info
+      Rendition r;
+      r.m_channels = 2;
+      r.m_language = "unk";
+      r.m_type = "AUDIO";
+
+      if (!var.m_groupIdAudio.empty())
+      {
+        // Get info from the specified group id rendition
+        const Rendition* rFound = FindRenditionByGroupId(var.m_groupIdAudio, pl.m_audioRenditions);
+        if (rFound)
+          r = *rFound;
+        else
+          LOG::LogF(LOGWARNING, "Undefined GROUP-ID \"%s\" in EXT-X-STREAM-INF variant",
+                    var.m_groupIdAudio.c_str());
+      }
+
+      r.m_uri = var.m_uri;
+
+      if (!ParseRenditon(r, newAdpSet, newRepr))
+        continue;
+
+      newAdpSet->AddCodecs(codecAudio);
+      newRepr->AddCodecs(codecAudio);
+      newRepr->SetBandwidth(var.m_bandwidth);
+
+      // Check if it is mergeable with an existing adp set
+      CAdaptationSet* foundAdpSet =
+          CAdaptationSet::FindMergeable(period->GetAdaptationSets(), newAdpSet.get());
+      if (foundAdpSet)
+      {
+        newRepr->SetParent(foundAdpSet);
+        foundAdpSet->AddRepresentation(newRepr);
+      }
+      else
+      {
+        newAdpSet->AddRepresentation(newRepr);
+        period->AddAdaptationSet(newAdpSet);
+      }
+    }
+    else if (streamType == StreamType::VIDEO) // Video variant
+    {
+      if (var.m_groupIdAudio.empty())
+      {
+        // No audio group specified, we assume audio is included to video stream
+        period->m_includedStreamType |= 1U << static_cast<int>(StreamType::AUDIO);
+        AddIncludedAudioStream(period, codecAudio);
+      }
+
+      // We group all video representations by codec fourcc, similar to the DASH specs
+      std::string codecFourcc = codecVideo.substr(0, codecVideo.find('.'));
+      // Find existing adaptation set with same codec fourcc ...
+      CAdaptationSet* adpSet = CAdaptationSet::FindByCodec(period->GetAdaptationSets(), codecFourcc);
+      if (!adpSet) // ... or create a new one
+      {
+        auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
+        newAdpSet->SetStreamType(streamType);
+        newAdpSet->AddCodecs(codecFourcc);
+        adpSet = newAdpSet.get();
+        period->AddAdaptationSet(newAdpSet);
+      }
+
+      auto repr = CRepresentation::MakeUniquePtr(adpSet);
+      repr->SetTimescale(1000000);
+      repr->AddCodecs(codecVideo);
+      repr->SetBandwidth(var.m_bandwidth);
+
+      if (!var.m_resolution.empty())
+      {
+        int resWidth{0};
+        int resHeight{0};
+        ParseResolution(resWidth, resHeight, var.m_resolution);
+        repr->SetResWidth(resWidth);
+        repr->SetResHeight(resHeight);
+      }
+      if (var.m_frameRate != 0)
+      {
+        repr->SetFrameRate(static_cast<uint32_t>(var.m_frameRate * 1000));
+        repr->SetFrameRateScale(1000);
+      }
+
+      repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
+      repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
+      repr->SetScaling();
+
+      std::string uri = var.m_uri;
+      if (URL::IsUrlRelative(uri))
+        uri = URL::Join(base_url_, uri);
+
+      repr->SetSourceUrl(uri);
+      adpSet->AddRepresentation(repr);
+    }
+    else
+    {
+      LOG::LogF(LOGWARNING, "Cannot add EXT-X-STREAM-INF variant due to unhandled data");
+    }
+  }
+
+  m_periods.push_back(std::move(period));
+  return true;
+}
+
 void adaptive::CHLSTree::SaveManifest(PLAYLIST::CAdaptationSet* adpSet,
                                       const std::string& data,
                                       std::string_view info)
@@ -1141,4 +1263,51 @@ void adaptive::CHLSTree::SaveManifest(PLAYLIST::CAdaptationSet* adpSet,
   }
 
   AdaptiveTree::SaveManifest(fileNameSuffix, data, info);
+}
+
+void adaptive::CHLSTree::AddIncludedAudioStream(std::unique_ptr<PLAYLIST::CPeriod>& period, std::string codec)
+{
+  auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
+  newAdpSet->SetStreamType(StreamType::AUDIO);
+  newAdpSet->SetContainerType(ContainerType::MP4);
+  newAdpSet->SetLanguage("unk"); // Unknown
+
+  auto repr = CRepresentation::MakeUniquePtr(newAdpSet.get());
+  repr->SetTimescale(1000000);
+
+  repr->AddCodecs(codec);
+  repr->SetAudioChannels(2);
+  repr->SetIsIncludedStream(true);
+
+  repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
+  repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
+
+  repr->SetScaling();
+
+  newAdpSet->AddRepresentation(repr);
+  period->AddAdaptationSet(newAdpSet);
+}
+
+const adaptive::CHLSTree::Variant* adaptive::CHLSTree::FindVariantByAudioGroupId(
+    std::string groupId, std::vector<Variant>& variants) const
+{
+  auto itVar =
+      std::find_if(variants.cbegin(), variants.cend(),
+                   [&groupId](const Variant& item) { return item.m_groupIdAudio == groupId; });
+  if (itVar != variants.cend())
+    return &(*itVar);
+
+  return nullptr;
+}
+
+const adaptive::CHLSTree::Rendition* adaptive::CHLSTree::FindRenditionByGroupId(
+    std::string groupId, std::vector<adaptive::CHLSTree::Rendition>& renditions) const
+{
+  auto itRend =
+      std::find_if(renditions.cbegin(), renditions.cend(),
+                   [&groupId](const Rendition& item) { return item.m_groupId == groupId; });
+  if (itRend != renditions.cend())
+    return &(*itRend);
+
+  return nullptr;
 }

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -47,7 +47,6 @@ bool adaptive::CSmoothTree::Open(std::string_view url,
   m_currentPeriod = m_periods[0].get();
 
   CreateSegmentTimeline();
-  SortTree();
 
   return true;
 }

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -67,7 +67,7 @@ protected:
       LOG::Log(LOGERROR, "Cannot open \"%s\" HLS manifest.", url.c_str());
       exit(1);
     }
-
+    tree->PostOpen(m_kodiProps);
     tree->m_currentAdpSet = tree->m_periods[0]->GetAdaptationSets()[0].get();
     tree->m_currentRepr = tree->m_currentAdpSet->GetRepresentations()[0].get();
   }

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -62,6 +62,7 @@ protected:
       LOG::Log(LOGERROR, "Cannot open \"%s\" Smooth Streaming manifest.", url.c_str());
       exit(1);
     }
+    tree->PostOpen(m_kodiProps);
   }
 
   SmoothTestTree* tree;

--- a/src/test/manifests/mpd/adaptation_set_merge.mpd
+++ b/src/test/manifests/mpd/adaptation_set_merge.mpd
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+A sample manifest from amazon VOD, showing two uncommon cases:
+1) apparently identical audio adp sets with same language can be listed, for example language code "es", but one "es" language is different, can only be distinguished from audioTrackId (es-419)
+2) multiple identical audio adp sets with same language and codec can be listed, the only differences are ContentProtection and base url
+-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" majorVersion="1" mediaPresentationDuration="PT54M14.208S" minBufferTime="PT10S" minorVersion="0" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" revision="3" type="static" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd">
+  <Period duration="PT54M14.208S">
+    <AdaptationSet contentType="video" group="2" maxBandwidth="1500000" maxHeight="540" maxWidth="960" mimeType="video/mp4" minBandwidth="100000" par="16:9" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation aspectRatio="16:9" bandwidth="100000" codecPrivateData="00000001674D4016E430323B7FE01C001C2D4040405000000300100000030328F162D9A00000000168E978FC80" codecs="avc1.4D4016" frameRate="25" height="224" id="video=100000" sar="224:225" scanType="progressive" width="400">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_1.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1616"/>
+          <SegmentURL mediaRange="12329-41573"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="150000" codecPrivateData="00000001674D4016E4301004B602D4040405000003000100000300328F162D9A0000000168E9786F20" codecs="avc1.4D4016" frameRate="25" height="288" id="video=150000" sar="1:1" scanType="progressive" width="512">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_2.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1596"/>
+          <SegmentURL mediaRange="12309-58829"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="300000" codecPrivateData="00000001674D401EE4301405FF2E02D4040405000003000100000300328F162D9A0000000168E978BC80" codecs="avc1.4D401E" frameRate="25" height="360" id="video=300000" sar="1:1" scanType="progressive" width="640">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_3.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-58883"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="501000" codecPrivateData="00000001674D401EE43016067F780B50101014000003000400000300CA3C58B6680000000168E978FC80" codecs="avc1.4D401E" frameRate="25" height="396" id="video=501000" sar="1:1" scanType="progressive" width="704">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_4.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-69353"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="800000" codecPrivateData="00000001674D401EE43016067F780B50101014000003000400000300CA3C58B6680000000168E9785F20" codecs="avc1.4D401E" frameRate="25" height="396" id="video=800000" sar="1:1" scanType="progressive" width="704">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_5.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-80923"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="1001000" codecPrivateData="00000001674D401FE4301E022FDE02D4040405000003000100000300328F18319A0000000168E9784F20" codecs="avc1.4D401F" frameRate="25" height="540" id="video=1001000" sar="1:1" scanType="progressive" width="960">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_6.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-104880"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation aspectRatio="16:9" bandwidth="1500000" codecPrivateData="00000001674D401FE4301E022FDE02D4040405000003000100000300328F18319A0000000168E9786F20" codecs="avc1.4D401F" frameRate="25" height="540" id="video=1500000" sar="1:1" scanType="progressive" width="960">
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_video_7.mp4</BaseURL>
+        <SegmentList duration="365" timescale="100">
+          <Initialization range="0-1597"/>
+          <SegmentURL mediaRange="12310-127633"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="100">
+        <S d="452"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="ja-jp_dialog_0" contentType="audio" group="1" lang="ja" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="48000" bandwidth="128000" codecs="mp4a.40.2" id="audio_ja-JP_3=128000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_117.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-54754"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="48000">
+        <S d="96256"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-419_dialog_0" contentType="audio" group="1" lang="es" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="48000" bandwidth="128000" codecs="mp4a.40.2" id="audio_es-419_3=128000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_127.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-54759"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="48000">
+        <S d="96256"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-es_dialog_0" contentType="audio" group="1" lang="es" maxBandwidth="32000" mimeType="audio/mp4" minBandwidth="20000" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="24000" bandwidth="20000" codecs="mp4a.40.29" id="audio_es-ES=20000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_17.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1532"/>
+          <SegmentURL mediaRange="21089-27026"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation audioSamplingRate="24000" bandwidth="32000" codecs="mp4a.40.29" id="audio_es-ES=32000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_39.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1532"/>
+          <SegmentURL mediaRange="21089-29970"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="24000">
+        <S d="48128"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-es_dialog_0" contentType="audio" group="1" lang="es" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="16B2EE1A-C691-450E-A19C-84E40F8E6221" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4ARwB1ADYAeQBGAHAASABHAEQAawBXAGgAbgBJAFQAawBEADQANQBpAEkAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBQAFMARQBRAHEANQAwAEoAMwB3AGcAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEBay7hrGkUUOoZyE5A+OYiEaBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="24000" bandwidth="64000" codecs="mp4a.40.5" id="audio_es-ES_1=64000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_83.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1530"/>
+          <SegmentURL mediaRange="21087-38133"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="24000">
+        <S d="48128"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="es-es_dialog_0" contentType="audio" group="1" lang="es" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="F34B9742-51DB-4C24-B3AF-9FA742A34BAD" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AUQBwAGQATAA4ADkAdABSAEoARQB5AHoAcgA1ACsAbgBRAHEATgBMAHIAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBjAG8AMgBaAGQAQQBIADgAZgBkAGMAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEPNLl0JR20wks6+fp0KjS60aBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="24000" bandwidth="64000" codecs="mp4a.40.5" id="audio_es-ES_1=64000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_84.mp4</BaseURL>
+        <SegmentList duration="48000" timescale="24000">
+          <Initialization range="0-1530"/>
+          <SegmentURL mediaRange="21087-38133"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="24000">
+        <S d="48128"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+    <AdaptationSet audioTrackId="en-gb_dialog_0" contentType="audio" group="1" lang="en" maxBandwidth="192000" mimeType="audio/mp4" minBandwidth="96000" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+      <ContentProtection cenc:default_KID="F34B9742-51DB-4C24-B3AF-9FA742A34BAD" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
+      <ContentProtection schemeIdUri="urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95" value="MSPR 2.0">
+        <cenc:pssh>bAIAAAEAAQBiAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AUQBwAGQATAA4ADkAdABSAEoARQB5AHoAcgA1ACsAbgBRAHEATgBMAHIAUQA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBjAG8AMgBaAGQAQQBIADgAZgBkAGMAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAcwA6AC8ALwBwAHIAbABzAC4AYQB0AHYALQBwAHMALgBhAG0AYQB6AG8AbgAuAGMAbwBtAC8AYwBkAHAAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED">
+        <cenc:pssh>CAESEPNLl0JR20wks6+fp0KjS60aBmFtYXpvbiI1Y2lkOkZyTHVHc2FSUlE2aG5JVGtENDVpSVE9PSw4MHVYUWxIYlRDU3pyNStuUXFOTHJRPT0qAlNEMgA=</cenc:pssh>
+      </ContentProtection>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <Representation audioSamplingRate="48000" bandwidth="96000" codecs="mp4a.40.2" id="audio_en-GB_3=96000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_108.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-46737"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation audioSamplingRate="48000" bandwidth="128000" codecs="mp4a.40.2" id="audio_en-GB_3=128000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_120.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-54757"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <Representation audioSamplingRate="48000" bandwidth="192000" codecs="mp4a.40.2" id="audio_en-GB_3=192000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <BaseURL>697ce4af-7905-45fb-a910-89d8c6357c61_audio_172.mp4</BaseURL>
+        <SegmentList duration="96000" timescale="48000">
+          <Initialization range="0-1527"/>
+          <SegmentURL mediaRange="21084-70801"/>
+          <!-- Segments truncated -->
+        </SegmentList>
+      </Representation>
+      <SegmentDurations timescale="48000">
+        <S d="96256"/>
+        <!-- Segments truncated -->
+      </SegmentDurations>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/src/test/manifests/mpd/adaptation_set_switching.mpd
+++ b/src/test/manifests/mpd/adaptation_set_switching.mpd
@@ -1,53 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MPD _xmlns:ns2="http://www.w3.org/1999/xlink" mediaPresentationDuration="PT1H45M47.904S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_xmlns="xmlns">
   <Period duration="PT1H45M47.904S">
-    <!-- 3 below should merge -->
+    <!-- 4 below should merge, despite id 6 has different codec -->
     <AdaptationSet id="0" group="0" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation id="1" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
-      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1,2"/>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1,2,6"/>
     </AdaptationSet>
     <AdaptationSet id="1" group="0" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation id="2" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
-      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,2"/>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,2,6"/>
     </AdaptationSet>
     <AdaptationSet id="2" group="0" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
       <Representation id="3" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
-      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1"/>
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1,6"/>
+    </AdaptationSet>
+    <AdaptationSet id="6" group="0" contentType="video">
+      <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+      <Representation id="4" bandwidth="1474186" codecs="hev1.2.4.L93.90" frameRate="60/2" height="720" sar="1:1" width="1280" />
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0,1,2"/>
     </AdaptationSet>
 
     <!-- 2 below should merge -->
     <AdaptationSet id="0" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="4" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
+      <Representation id="5" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="720" sar="1:1" width="1080" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1"/>
     </AdaptationSet>
     <AdaptationSet id="1" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="5" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
+      <Representation id="6" bandwidth="1000000" codecs="avc1.64001e" frameRate="60/2" height="1080" sar="1:1" width="1920" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="0"/>
     </AdaptationSet>
 
     <!-- Wont merge as id 99 doesnt exist -->
     <AdaptationSet id="2" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="6" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <Representation id="7" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="99"/>
     </AdaptationSet>
 
     <!-- Wont merge as id 1 doesnt list my id -->
     <AdaptationSet id="2" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="7" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <Representation id="8" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="1"/>
     </AdaptationSet>
 
     <!-- Wont merge as no adaptation-set-switching -->
     <AdaptationSet id="3" group="1" contentType="video">
       <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
-      <Representation id="8" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
+      <Representation id="9" bandwidth="1000" codecs="avc1.64001e" frameRate="60/2" height="480" sar="1:1" width="720" />
     </AdaptationSet>
   </Period>
 </MPD>

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -401,6 +401,21 @@ bool UTILS::CODEC::IsAudio(std::string_view codec)
   return false;
 }
 
+bool UTILS::CODEC::IsVideo(std::string_view codec)
+{
+  for (const auto fourcc : CODEC::VIDEO_FOURCC_LIST)
+  {
+    if (STRING::Contains(codec, fourcc))
+      return true;
+  }
+  for (const auto name : CODEC::VIDEO_NAME_LIST)
+  {
+    if (STRING::Contains(codec, name))
+      return true;
+  }
+  return false;
+}
+
 bool UTILS::CODEC::IsSubtitleFourCC(std::string_view codec)
 {
   for (const auto fourcc : CODEC::SUBTITLES_FOURCC_LIST)

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -54,6 +54,9 @@ constexpr char* NAME_HEVC = "hevc";
 constexpr char* NAME_VP9 = "vp9";
 constexpr char* NAME_AV1 = "av1";
 
+constexpr std::array VIDEO_NAME_LIST = {NAME_MPEG1, NAME_MPEG2, NAME_MPEG4, NAME_VC1,
+                                        NAME_H264,  NAME_HEVC,  NAME_VP9,   NAME_AV1};
+
 // Audio definitions
 
 constexpr char* NAME_AAC = "aac";
@@ -83,6 +86,10 @@ constexpr char* FOURCC_HVC1 = "hvc1"; // HEVC Dolby vision
 constexpr char* FOURCC_DVH1 = "dvh1"; // HEVC Dolby vision, hvc1 variant
 constexpr char* FOURCC_HEV1 = "hev1"; // HEVC Dolby vision
 constexpr char* FOURCC_DVHE = "dvhe"; // HEVC Dolby vision, hev1 variant
+
+constexpr std::array VIDEO_FOURCC_LIST = {FOURCC_H264,   FOURCC_AVC_,  FOURCC_VP09,   FOURCC_AV01,
+                                          FOURCC_HEVC,   FOURCC_HVC1,  FOURCC_DVH1,   FOURCC_HEV1,
+                                          FOURCC_DVHE};
 
 // Fourcc audio definitions
 
@@ -167,6 +174,13 @@ std::string GetVideoDesc(const std::set<std::string>& list);
  * \return True if it is audio type, otherwise false
  */
 bool IsAudio(std::string_view codec);
+
+/*!
+ * \brief Determines if the codec string is of type video, regardless of whether it is a name or fourcc.
+ * \param codec The codec string
+ * \return True if it is video type, otherwise false
+ */
+bool IsVideo(std::string_view codec);
 
 /*!
  * \brief Determines if the codec string contains a fourcc of type subtitles.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Superseed closed PR #1342 because i preferred rewrite part of the parser to solve in better way the parsing problem mentioned here https://github.com/xbmc/inputstream.adaptive/pull/1342#issuecomment-1661833649 

Problem solved:
- On manifest with multi-codec video streams we are creating adaptation sets with mixed codecs, this was causing problems with the "Ask quality" stream selector (show mixed codecs) and adaptive streaming, also because currently we cant know in advance what codecs are supported, as dash spec we should have when possible each adaptation set with a single codec
- On manifests that contains EXT-X-STREAM-INF audio variants, was wrongly added as a video streams causing broken playback, this can be shown by using "Ask quality" stream selector where wrong video streams are shown with lack of metadata
- On manifests that contains EXT-X-STREAM-INF audio only and no video streams, are unplayable

Other changes:
The HLS parser now dont have the needs of the "adaptation sets merging" that was inside the `AdaptiveTree::SortTree` method, so now has been reworked for dash case only, the reason behind is due to amazon manifests that appears to have uncommon adaptation sets with same data, for this reason i have add a new test case `AdaptionSetMerge` so to not forgot in future this peculiarity.

`AdaptiveTree::SortTree` method now does exactly what it describes and does not merge adpsets.

i am somewhat puzzled as to how "adaptation sets merging" was in the past implemented because:
- wipe out adaptation sets data
- for example on this manifest [SwitchingManifestExample.txt](https://github.com/xbmc/inputstream.adaptive/files/12194881/SwitchingManifestExample.txt) there are different protection levels i may be wrong but it would be good to keep this and other possible different data

Moving this code i have also limited the adaptation set merging with adaptation sets containing the same codec, currently mixing more codecs to the same adaptation set can cause broken playback, because we have no way to determine supported codecs in advance and also currently there is no way to fallback if playback dont works with a specific codec

fix #1259

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hoh-subs.ism/.m3u8
https://storage.googleapis.com/shaka-demo-assets/apple-advanced-stream-ts/master.m3u8

and HLS audio stream from
https://stream.rtl.lu/live/hls/radio/rtllx

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
