### PR TITLE
Implement set audio profile from demuxer

### DIFF
--- a/lib/mpegts/ES_AAC.h
+++ b/lib/mpegts/ES_AAC.h
@@ -17,6 +17,7 @@ namespace TSDemux
   class ES_AAC : public ElementaryStream
   {
   private:
+    int m_codecProfile; // Refer to PROFILE enum
     int         m_SampleRate;
     int         m_Channels;
     int         m_BitRate;
@@ -36,6 +37,16 @@ namespace TSDemux
     uint32_t LATMGetValue(CBitstream *bs) { return bs->readBits(bs->readBits(2) * 8); }
 
   public:
+    enum PROFILE
+    {
+      PROFILE_NONE,
+      PROFILE_MAIN,
+      PROFILE_LC,
+      PROFILE_SSR,
+      PROFILE_LTP,
+      PROFILE_UNKNOWN
+    };
+
     ES_AAC(uint16_t pes_pid);
     virtual ~ES_AAC();
 

--- a/lib/mpegts/elementaryStream.cpp
+++ b/lib/mpegts/elementaryStream.cpp
@@ -267,14 +267,20 @@ bool ElementaryStream::SetVideoInformation(int FpsScale, int FpsRate, int Height
   return ret;
 }
 
-bool ElementaryStream::SetAudioInformation(int Channels, int SampleRate, int BitRate, int BitsPerSample, int BlockAlign)
+bool ElementaryStream::SetAudioInformation(int Channels,
+                                           int SampleRate,
+                                           int BitRate,
+                                           int BitsPerSample,
+                                           int BlockAlign,
+                                           int codecProfile /* = 0 */)
 {
   bool ret = false;
   if ((stream_info.channels != Channels) ||
       (stream_info.sample_rate != SampleRate) ||
       (stream_info.block_align != BlockAlign) ||
       (stream_info.bit_rate != BitRate) ||
-      (stream_info.bits_per_sample != BitsPerSample))
+      (stream_info.bits_per_sample != BitsPerSample) ||
+      (stream_info.codecProfile != codecProfile))
     ret = true;
 
   stream_info.channels          = Channels;
@@ -282,6 +288,7 @@ bool ElementaryStream::SetAudioInformation(int Channels, int SampleRate, int Bit
   stream_info.block_align       = BlockAlign;
   stream_info.bit_rate          = BitRate;
   stream_info.bits_per_sample   = BitsPerSample;
+  stream_info.codecProfile = codecProfile;
 
   has_stream_info = true;
   return ret;

--- a/lib/mpegts/elementaryStream.h
+++ b/lib/mpegts/elementaryStream.h
@@ -49,6 +49,7 @@ namespace TSDemux
     char                  language[4];
     int                   composition_id;
     int                   ancillary_id;
+    int codecProfile;
     int                   fps_scale;
     int                   fps_rate;
     int                   height;
@@ -105,7 +106,7 @@ namespace TSDemux
     void ResetStreamPacket(STREAM_PKT* pkt);
     uint64_t Rescale(uint64_t a, uint64_t b, uint64_t c);
     bool SetVideoInformation(int FpsScale, int FpsRate, int Height, int Width, float Aspect, bool Interlaced);
-    bool SetAudioInformation(int Channels, int SampleRate, int BitRate, int BitsPerSample, int BlockAlign);
+    bool SetAudioInformation(int Channels, int SampleRate, int BitRate, int BitsPerSample, int BlockAlign, int codecProfile = 0);
 
     size_t es_alloc_init;         ///< Initial allocation of memory for buffer
     unsigned char* es_buf;        ///< The Pointer to buffer

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1609,9 +1609,13 @@ AP4_Movie* CSession::CreateMovieAtom(CStream* stream)
     }
     else
     {
-      LOG::LogF(LOGWARNING,
-                "Created sample desciption atom of unknown type, codec \"%s\" is not handled",
-                stream->m_info.GetCodecName().c_str());
+      // Codecs like audio types, will have unknown SampleDescription, because to create an appropriate
+      // audio SampleDescription atom require different code rework. This means also that CFragmentedSampleReader
+      // will use a generic CodecHandler instead of AudioCodecHandler, because will be not able do determine the codec
+      LOG::LogF(
+          LOGDEBUG,
+          "Created sample description atom of unknown type for codec \"%s\" because unhandled",
+          stream->m_info.GetCodecName().c_str());
       sampleDesc = new AP4_SampleDescription(AP4_SampleDescription::TYPE_UNKNOWN, 0, 0);
     }
 

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -978,8 +978,13 @@ void CSession::UpdateStream(CStream& stream)
       stream.m_info.SetCodecName(CODEC::NAME_DTS);
     else if (CODEC::Contains(codecs, CODEC::FOURCC_AC_3, codecStr))
       stream.m_info.SetCodecName(CODEC::NAME_AC3);
-    else if (CODEC::Contains(codecs, CODEC::FOURCC_EC_3, codecStr))
+    else if (CODEC::Contains(codecs, CODEC::NAME_EAC3_JOC, codecStr) ||
+             CODEC::Contains(codecs, CODEC::FOURCC_EC_3, codecStr))
+    {
+      // In the above condition above is checked NAME_EAC3_JOC as first,
+      // in order to get the codec string to signal DD+ Atmos in to the SetCodecInternalName
       stream.m_info.SetCodecName(CODEC::NAME_EAC3);
+    }
     else if (CODEC::Contains(codecs, CODEC::FOURCC_OPUS, codecStr))
       stream.m_info.SetCodecName(CODEC::NAME_OPUS);
     else if (CODEC::Contains(codecs, CODEC::FOURCC_VORB, codecStr) || // Find "vorb" and "vorbis" case
@@ -1010,6 +1015,7 @@ void CSession::UpdateStream(CStream& stream)
     }
   }
 
+  // Internal codec name can be used by Kodi to detect the codec name to be shown in the GUI track list
   stream.m_info.SetCodecInternalName(codecStr);
 }
 

--- a/src/TSReader.cpp
+++ b/src/TSReader.cpp
@@ -9,6 +9,7 @@
 #include "TSReader.h"
 
 #include "../lib/mpegts/debug.h"
+#include "../lib/mpegts/ES_AAC.h"
 #include "utils/log.h"
 #include "utils/Utils.h"
 
@@ -169,6 +170,26 @@ bool TSReader::GetInformation(kodi::addon::InputstreamInfo& info)
     if (info.GetCodecName() != codecName)
     {
       info.SetCodecName(codecName);
+      isChanged = true;
+    }
+
+    STREAMCODEC_PROFILE codecProfile{CodecProfileUnknown};
+    if (codecName == CODEC::NAME_AAC)
+    {
+      int tsCodecProfile = tsInfo.m_stream->stream_info.codecProfile;
+      if (tsCodecProfile == TSDemux::ES_AAC::PROFILE_MAIN)
+        codecProfile = AACCodecProfileMAIN;
+      else if (tsCodecProfile == TSDemux::ES_AAC::PROFILE_LC)
+        codecProfile = AACCodecProfileLOW;
+      else if (tsCodecProfile == TSDemux::ES_AAC::PROFILE_SSR)
+        codecProfile = AACCodecProfileSSR;
+      else if (tsCodecProfile == TSDemux::ES_AAC::PROFILE_LTP)
+        codecProfile = AACCodecProfileLTP;
+    }
+
+    if (codecProfile != CodecProfileUnknown && info.GetCodecProfile() != codecProfile)
+    {
+      info.SetCodecProfile(codecProfile);
       isChanged = true;
     }
 

--- a/src/codechandler/AudioCodecHandler.cpp
+++ b/src/codechandler/AudioCodecHandler.cpp
@@ -10,6 +10,8 @@
 
 #include "../utils/Utils.h"
 
+#include <bento4/Ap4Mp4AudioInfo.h>
+
 using namespace UTILS;
 
 AudioCodecHandler::AudioCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd)
@@ -25,36 +27,12 @@ AudioCodecHandler::AudioCodecHandler(AP4_SampleDescription* sd) : CodecHandler(s
 
 bool AudioCodecHandler::GetInformation(kodi::addon::InputstreamInfo& info)
 {
+  if (!m_sampleDescription)
+    return false;
+
   bool isChanged{false};
-
-  if (m_sampleDescription->GetType() == AP4_SampleDescription::TYPE_MPEG)
-  {
-    std::string codecName;
-
-    switch (static_cast<AP4_MpegSampleDescription*>(m_sampleDescription)->GetObjectTypeId())
-    {
-      case AP4_OTI_MPEG4_AUDIO:
-      case AP4_OTI_MPEG2_AAC_AUDIO_MAIN:
-      case AP4_OTI_MPEG2_AAC_AUDIO_LC:
-      case AP4_OTI_MPEG2_AAC_AUDIO_SSRP:
-        codecName = CODEC::NAME_AAC;
-        break;
-      case AP4_OTI_DTS_AUDIO:
-      case AP4_OTI_DTS_HIRES_AUDIO:
-      case AP4_OTI_DTS_MASTER_AUDIO:
-      case AP4_OTI_DTS_EXPRESS_AUDIO:
-        codecName = CODEC::NAME_DTS;
-        break;
-      case AP4_OTI_AC3_AUDIO:
-        codecName = CODEC::NAME_AC3;
-        break;
-      case AP4_OTI_EAC3_AUDIO:
-        codecName = CODEC::NAME_EAC3;
-        break;
-    }
-    if (!codecName.empty())
-      isChanged = UpdateInfoCodecName(info, codecName.c_str());
-  }
+  std::string codecName;
+  STREAMCODEC_PROFILE codecProfile{CodecProfileUnknown};
 
   if (AP4_AudioSampleDescription* audioSd =
           AP4_DYNAMIC_CAST(AP4_AudioSampleDescription, m_sampleDescription))
@@ -78,5 +56,147 @@ bool AudioCodecHandler::GetInformation(kodi::addon::InputstreamInfo& info)
     }
   }
 
+  if (m_sampleDescription->GetType() == AP4_SampleDescription::TYPE_MPEG)
+  {
+    switch (static_cast<AP4_MpegSampleDescription*>(m_sampleDescription)->GetObjectTypeId())
+    {
+      case AP4_OTI_MPEG4_AUDIO:
+        codecName = CODEC::NAME_AAC;
+        codecProfile = static_cast<STREAMCODEC_PROFILE>(GetMpeg4AACProfile());
+        break;
+      case AP4_OTI_MPEG2_AAC_AUDIO_MAIN:
+        codecName = CODEC::NAME_AAC;
+        codecProfile = AACCodecProfileMAIN;
+        break;
+      case AP4_OTI_MPEG2_AAC_AUDIO_LC:
+        codecName = CODEC::NAME_AAC;
+        codecProfile = MPEG2AACCodecProfileLOW;
+        break;
+      case AP4_OTI_MPEG2_AAC_AUDIO_SSRP:
+        codecName = CODEC::NAME_AAC;
+        break;
+      case AP4_OTI_DTS_AUDIO:
+        codecName = CODEC::NAME_DTS;
+        codecProfile = DTSCodecProfile;
+        break;
+      case AP4_OTI_DTS_HIRES_AUDIO:
+        codecName = CODEC::NAME_DTS;
+        codecProfile = DTSCodecProfileHDHRA;
+        break;
+      case AP4_OTI_DTS_MASTER_AUDIO:
+        codecName = CODEC::NAME_DTS;
+        codecProfile = DTSCodecProfileHDMA;
+        break;
+      case AP4_OTI_DTS_EXPRESS_AUDIO:
+        codecName = CODEC::NAME_DTS;
+        codecProfile = DTSCodecProfileHDExpress;
+        break;
+      case AP4_OTI_AC3_AUDIO:
+        codecName = CODEC::NAME_AC3;
+        break;
+      case AP4_OTI_EAC3_AUDIO:
+      {
+        codecName = CODEC::NAME_EAC3;
+        AP4_Dec3Atom* dec3 = AP4_DYNAMIC_CAST(
+            AP4_Dec3Atom, m_sampleDescription->GetDetails().GetChild(AP4_ATOM_TYPE_DEC3));
+        if (dec3 && dec3->GetFlagEC3ExtensionTypeA() > 0)
+        {
+          codecProfile = DDPlusCodecProfileAtmos;
+          // The channels value should match the value of the complexity_index_type_a field
+          if (dec3->GetComplexityIndexTypeA() > 0 &&
+              dec3->GetComplexityIndexTypeA() != info.GetChannels())
+          {
+            info.SetChannels(dec3->GetComplexityIndexTypeA());
+            isChanged = true;
+          }
+        }
+        break;
+      }
+    }
+  }
+  else if (m_sampleDescription->GetType() == AP4_SampleDescription::TYPE_EAC3)
+  {
+    codecName = CODEC::NAME_EAC3;
+    AP4_Dec3Atom* dec3 = AP4_DYNAMIC_CAST(
+        AP4_Dec3Atom, m_sampleDescription->GetDetails().GetChild(AP4_ATOM_TYPE_DEC3));
+    if (dec3 && dec3->GetFlagEC3ExtensionTypeA() > 0)
+    {
+      codecProfile = DDPlusCodecProfileAtmos;
+      // The channels value should match the value of the complexity_index_type_a field
+      if (dec3->GetComplexityIndexTypeA() > 0 &&
+          dec3->GetComplexityIndexTypeA() != info.GetChannels())
+      {
+        info.SetChannels(dec3->GetComplexityIndexTypeA());
+        isChanged = true;
+      }
+    }
+  }
+  else if (m_sampleDescription->GetType() == AP4_SampleDescription::TYPE_AC3)
+  {
+    codecName = CODEC::NAME_AC3;
+  }
+
+  if (!codecName.empty())
+    isChanged = UpdateInfoCodecName(info, codecName.c_str());
+
+  if (codecProfile != CodecProfileUnknown && info.GetCodecProfile() != codecProfile)
+  {
+    info.SetCodecProfile(codecProfile);
+    isChanged = true;
+  }
+
   return isChanged;
+}
+
+int AudioCodecHandler::GetMpeg4AACProfile()
+{
+  AP4_MpegAudioSampleDescription* mpegDesc =
+      AP4_DYNAMIC_CAST(AP4_MpegAudioSampleDescription, m_sampleDescription);
+  if (mpegDesc)
+  {
+    AP4_MpegAudioSampleDescription::Mpeg4AudioObjectType ot = mpegDesc->GetMpeg4AudioObjectType();
+    switch (ot)
+    {
+      case AP4_MPEG4_AUDIO_OBJECT_TYPE_AAC_MAIN:
+        return AACCodecProfileMAIN;
+        break;
+      case AP4_MPEG4_AUDIO_OBJECT_TYPE_AAC_LC:
+      {
+        const AP4_DataBuffer& dsi = mpegDesc->GetDecoderInfo();
+        if (dsi.GetDataSize() > 0)
+        {
+          AP4_Mp4AudioDecoderConfig decConfig;
+          AP4_Result result = decConfig.Parse(dsi.GetData(), dsi.GetDataSize());
+          if (AP4_SUCCEEDED(result))
+          {
+            if (decConfig.m_Extension.m_PsPresent)
+            {
+              return AACCodecProfileHEV2; // HE-AAC v2
+            }
+            else if (decConfig.m_Extension.m_SbrPresent)
+            {
+              return AACCodecProfileHE; // HE-AAC
+            }
+          }
+        }
+        return AACCodecProfileLOW;
+        break;
+      }
+      case AP4_MPEG4_AUDIO_OBJECT_TYPE_AAC_SSR:
+        return AACCodecProfileSSR;
+        break;
+      case AP4_MPEG4_AUDIO_OBJECT_TYPE_AAC_LTP:
+        return AACCodecProfileLTP;
+        break;
+      case AP4_MPEG4_AUDIO_OBJECT_TYPE_SBR:
+        return AACCodecProfileHE; // HE-AAC
+        break;
+      case AP4_MPEG4_AUDIO_OBJECT_TYPE_PS:
+        return AACCodecProfileHEV2; // HE-AAC v2
+        break;
+      default:
+        break;
+    }
+  }
+  return CodecProfileUnknown;
 }

--- a/src/codechandler/AudioCodecHandler.h
+++ b/src/codechandler/AudioCodecHandler.h
@@ -17,4 +17,7 @@ public:
   AudioCodecHandler(AP4_SampleDescription* sd);
 
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
+
+protected:
+  int GetMpeg4AACProfile();
 };

--- a/src/codechandler/CodecHandler.cpp
+++ b/src/codechandler/CodecHandler.cpp
@@ -52,7 +52,7 @@ bool CodecHandler::UpdateInfoCodecName(kodi::addon::InputstreamInfo& info, const
 
   AP4_String codecStr;
   m_sampleDescription->GetCodecString(codecStr);
-  if (codecStr.GetLength() > 0 && info.GetCodecInternalName() != codecStr.GetChars())
+  if (isChanged && codecStr.GetLength() > 0 && info.GetCodecInternalName() != codecStr.GetChars())
   {
     info.SetCodecInternalName(codecStr.GetChars());
     isChanged = true;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -980,6 +980,25 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   else if (adpSet->GetStreamType() == StreamType::AUDIO && repr->GetAudioChannels() == 0)
     repr->SetAudioChannels(2); // Fallback to 2 channels when no value is set
 
+  // Parse <SupplementalProperty> child tags
+  for (xml_node nodeSP : nodeRepr.children("SupplementalProperty"))
+  {
+    std::string_view schemeIdUri = XML::GetAttrib(nodeSP, "schemeIdUri");
+    std::string_view value = XML::GetAttrib(nodeSP, "value");
+
+    if (schemeIdUri == "tag:dolby.com,2018:dash:EC3_ExtensionType:2018")
+    {
+      if (value == "JOC")
+        repr->AddCodecs(CODEC::NAME_EAC3_JOC);
+    }
+    else if (schemeIdUri == "tag:dolby.com,2018:dash:EC3_ExtensionComplexityIndex:2018")
+    {
+      uint32_t channels = STRING::ToUint32(value);
+      if (channels > 0)
+        repr->SetAudioChannels(channels);
+    }
+  }
+
   // For subtitles that are not as ISOBMFF format and where there is no timeline for segments
   // we should treat them as a single subtitle file
   if (repr->GetContainerType() == ContainerType::TEXT && repr->GetMimeType() != "application/mp4" &&

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1343,18 +1343,48 @@ uint32_t adaptive::CDashTree::ParseAudioChannelConfig(pugi::xml_node node)
   std::string_view value = XML::GetAttrib(node, "value");
   uint32_t channels{0};
 
-  if (schemeIdUri == "urn:mpeg:dash:23003:3:audio_channel_configuration:2011" ||
-      schemeIdUri == "urn:mpeg:mpegB:cicp:ChannelConfiguration")
+  if (schemeIdUri == "urn:mpeg:dash:outputChannelPositionList:2012")
   {
+    // A space-separated list of speaker positions,
+    // the number of channels is the length of the list
+    return static_cast<uint32_t>(STRING::SplitToVec(value, ' ').size());
+  }
+  else if (schemeIdUri == "urn:mpeg:dash:23003:3:audio_channel_configuration:2011" ||
+           schemeIdUri == "urn:dts:dash:audio_channel_configuration:2012")
+  {
+    // The value is the number of channels
     channels = STRING::ToUint32(value);
   }
   else if (schemeIdUri == "urn:dolby:dash:audio_channel_configuration:2011" ||
            schemeIdUri == "tag:dolby.com,2014:dash:audio_channel_configuration:2011")
   {
-    if (value == "F801")
-      channels = 6;
-    else if (value == "FE01")
-      channels = 8;
+    // A hex-encoded 16-bit integer, each bit represents a channel
+    uint32_t hexVal = STRING::HexStrToUint(value);
+    uint32_t numBits{0};
+    while (hexVal)
+    {
+      if (hexVal & 1)
+      {
+        ++numBits;
+      }
+      hexVal = hexVal >> 1;
+    }
+    channels = numBits;
+  }
+  else if (schemeIdUri == "urn:mpeg:mpegB:cicp:ChannelConfiguration")
+  {
+    // Defined by https://dashif.org/identifiers/audio_source_metadata/
+    static const size_t mapSize = 21;
+    static const int channelCountMapping[mapSize]{
+        0,  1, 2, 3,  4, 5,  6,  8,  2,  3, /* 0--9 */
+        4,  7, 8, 24, 8, 12, 10, 12, 14, 12, /* 10--19 */
+        14, /* 20 */
+    };
+    uint32_t pos = STRING::ToUint32(value);
+    if (pos > 0 && pos < mapSize)
+    {
+      channels = channelCountMapping[pos];
+    }
   }
   if (channels == 0)
   {

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -917,6 +917,9 @@ bool adaptive::CHLSTree::ParseRenditon(const Rendition& r,
     repr->SetAudioChannels(r.m_channels);
     // Set channels in the adptation set to help distinguish it from other similar renditions
     adpSet->SetAudioChannels(r.m_channels);
+
+    if ((r.m_features & REND_FEATURE_EC3_JOC) == REND_FEATURE_EC3_JOC)
+      repr->AddCodecs(CODEC::NAME_EAC3_JOC);
   }
 
   repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
@@ -962,7 +965,11 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
       rend.m_name = attribs["NAME"];
       rend.m_language = attribs["LANGUAGE"];
       if (streamType == StreamType::AUDIO)
+      {
         rend.m_channels = STRING::ToUint32(attribs["CHANNELS"]);
+        if (STRING::Contains(attribs["CHANNELS"], "/JOC"))
+          rend.m_features |= REND_FEATURE_EC3_JOC;
+      }
       rend.m_isDefault = attribs["DEFAULT"] == "YES";
       rend.m_isForced = attribs["FORCED"] == "YES";
       rend.m_characteristics = attribs["CHARACTERISTICS"];

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -59,6 +59,13 @@ public:
                                PLAYLIST::StreamType type) override;
 
 protected:
+  // \brief Rendition features
+  enum REND_FEATURE
+  {
+    REND_FEATURE_NONE,
+    REND_FEATURE_EC3_JOC = 1 << 0
+  };
+
   // \brief Usually refer to an EXT-X-MEDIA tag
   struct Rendition
   {
@@ -71,6 +78,7 @@ protected:
     uint32_t m_channels{0};
     std::string m_characteristics;
     std::string m_uri;
+    int m_features{REND_FEATURE_NONE};
   };
 
   // \brief Usually refer to an EXT-X-STREAM-INF tag

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -264,3 +264,12 @@ std::string UTILS::STRING::ToLower(std::string str)
   StringUtils::ToLower(str);
   return str;
 }
+
+uint32_t UTILS::STRING::HexStrToUint(std::string_view hexValue)
+{
+  uint32_t val;
+  std::stringstream ss;
+  ss << std::hex << hexValue;
+  ss >> val;
+  return val;
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -173,5 +173,12 @@ bool GetLine(std::stringstream& ss, std::string& line);
  */
 std::string ToLower(std::string str);
 
+/*!
+ * \brief Convert a hex value as string to unsigned integer.
+ * \param hexValue The hex value as string to be converted
+ * \return The hex value if has success, otherwise 0.
+ */
+uint32_t HexStrToUint(std::string_view hexValue);
+
 } // namespace STRING
 } // namespace UTILS

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -40,6 +40,9 @@ namespace CODEC
 {
 constexpr const char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
 
+// Kodi internal codec name to signal DD+ Atmos ("joc"), not a ffmpeg definition
+constexpr const char* NAME_EAC3_JOC = "eac3-joc";
+
 // IMPORTANT: Codec names must match the ffmpeg library definition
 // https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/codec_desc.c
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The idea is use the "full codec string" (RFC 6381) to set the codec profile as hint from manifest data,
so that not influence decoders, then when start play the stream we set the right profile provided by demuxers.

fix #650

references used to implement Atmos signal as codec DD+ profile:
https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices-appendixes
https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Documentation/Content_Creation/SDM/help_files/topics/ddp_mpeg_dash_c_signal_atmos_in_isobmf_2.html

**Smooth streaming manifest case**
this manifest works differents and its more complex find a good solution due to handmade Movie Atoms,
so its use `CSession::CreateMovieAtom` to allow `CFragmentedSampleReader` to determinate codec type,
but currently create an appropriate audio SampleDescription require some code reworks and will not be considered here.
This means that for now smooth streaming cases there are no codec profiles.

**This PR depends from xbmc PR's:**
https://github.com/xbmc/xbmc/pull/23524
https://github.com/xbmc/xbmc/pull/23541

BEFORE
![immagine](https://github.com/xbmc/inputstream.adaptive/assets/3257156/af702579-d24c-467a-994a-5047d7ec2c49)
AFTER
![immagine](https://github.com/xbmc/inputstream.adaptive/assets/3257156/8d48b9cf-681f-46f8-866c-f530e3fcc4fb)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Set the missing audio profile and allow distinguish from kodi GUI audio track list the type of codec since multiple tracks could have same characteristics with same language, but different codec quality

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For HLS, following sample include most common audio codec types included atmos:
https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8

Smooth streaming, no changes, read note in description

DASH Atmos: https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.4.1/Test_Signals/muxed_streams/DASH/OnDemand_MPD/ChID_voices_1280x720p_25fps_h264_6ch_640kbps_ddp_joc.mpd

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
