### PR TITLE
[AdaptiveStream] Fix sidx/init parsing

### DIFF
--- a/src/Session.h
+++ b/src/Session.h
@@ -92,10 +92,8 @@ public:
   /*! \brief Update stream's InputstreamInfo
    *  \param stream The stream to prepare
    *  \param needRefetch [OUT] Set to true if stream info has changed
-   *  \return The Movie box if the stream container is MP4 and a valid MOOV
-   *        box is found, otherwise nullptr
    */
-  AP4_Movie* PrepareStream(CStream* stream, bool& needRefetch);
+  void PrepareStream(CStream* stream, bool& needRefetch);
 
 
   /*! \brief Get a stream by index (starting at 1)
@@ -332,6 +330,13 @@ public:
    *  \param adStream The adaptive stream on which the stream has changed
    */
   void OnStreamChange(adaptive::AdaptiveStream* adStream) override;
+
+  /*!
+   * \brief Create a Movie (MOOV) atom from scratch based on manifest info.
+   * \param stream The stream where to get the info
+   * \return The Movie atom if success, otherwise nullptr
+   */
+  AP4_Movie* CreateMovieAtom(CStream* stream);
 
 protected:
   /*!

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -91,6 +91,13 @@ class AdaptiveStream;
 
     void OnTFRFatom(uint64_t ts, uint64_t duration, uint32_t mediaTimescale) override;
 
+    /*!
+    * \brief Some streaming manifest types can be required to create the Movie (MOOV) atom
+    *        because its not provided with the stream.
+    * \return True if its required to create Movie (MOOV) atom, otherwise false
+    */
+    bool IsRequiredCreateMovieAtom();
+
   protected:
     virtual bool parseIndexRange(PLAYLIST::CRepresentation* rep,
                                  const std::vector<uint8_t>& buffer);
@@ -177,7 +184,7 @@ class AdaptiveStream;
 
     int SecondsSinceUpdate() const;
     static void ReplacePlaceholder(std::string& url, const std::string placeholder, uint64_t value);
-    bool ResolveSegmentBase(PLAYLIST::CRepresentation* rep);
+    bool GenerateSidxSegments(PLAYLIST::CRepresentation* rep);
 
     struct THREADDATA
     {

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -9,6 +9,7 @@
 #include "AdaptiveTree.h"
 #include "Chooser.h"
 
+#include "../common/AdaptiveUtils.h"
 #include "../utils/FileUtils.h"
 #include "../utils/StringUtils.h"
 #include "../utils/UrlUtils.h"

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -37,9 +37,22 @@ namespace CHOOSER
 {
 class IRepresentationChooser;
 }
+namespace PLAYLIST
+{
+enum class TreeType;
+}
 
 namespace adaptive
 {
+
+// \brief Adaptive tree types
+enum class TreeType
+{
+  UNKNOWN,
+  DASH,
+  HLS,
+  SMOOTH_STREAMING
+};
 
 class ATTR_DLL_LOCAL AdaptiveTree
 {
@@ -73,6 +86,8 @@ public:
   AdaptiveTree() = default;
   AdaptiveTree(const AdaptiveTree& left);
   virtual ~AdaptiveTree() = default;
+
+  virtual TreeType GetTreeType() { return TreeType::UNKNOWN; }
 
   /*!
    * \brief Configure the adaptive tree.

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -136,9 +136,6 @@ public:
     m_isSubtitleFileStream = isSubtitleFileStream;
   }
 
-  bool HasInitPrefixed() const { return m_hasInitPrefixed; }
-  void SetHasInitPrefixed(bool hasInitPrefixed) { m_hasInitPrefixed = hasInitPrefixed; }
-
   // Currently used for HLS only
   bool IsPrepared() const { return m_isPrepared; }
   // Currently used for HLS only
@@ -289,7 +286,6 @@ protected:
   uint32_t m_timescale{0};
 
   bool m_isSubtitleFileStream{false};
-  bool m_hasInitPrefixed{false};
 
   bool m_isPrepared{false};
   bool m_isEnabled{false};

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -990,7 +990,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   }
 
   // Generate timeline segments
-  if (!repr->HasSegmentTimeline() && repr->HasSegmentTemplate())
+  if (repr->HasSegmentTemplate())
   {
     auto& segTemplate = repr->GetSegmentTemplate();
 
@@ -1071,27 +1071,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
                   "Cannot generate segments timeline, the segment count exceeds SIDX atom limit.");
       }
     }
-    else if (!repr->HasSegmentBase() && !repr->IsSubtitleFileStream())
-    {
-      //Let us try to extract the fragments out of SIDX atom
-      CSegmentBase segBase;
-      
-      segBase.SetIndexRangeBegin(0);
-      //! @todo: Explain the reason of these specific values
-      static const uint64_t indexRangeMax = 1024 * 200;
-      segBase.SetIndexRangeEnd(indexRangeMax);
-
-      repr->SetSegmentBase(segBase);
-    }
-  }
-
-  //! @todo: "init prefixed" behaviour is not so clear and may be invalidated by ResolveSegmentBase (?)
-  //! we need to investigate if we can move this check where its used by CSession::PrepareStream
-  //! and remove HasInitPrefixed statement
-  if (repr->HasInitSegment() && !repr->SegmentTimeline().IsEmpty())
-  {
-    // we assume that we have a MOOV atom included in each segment (max 100k = youtube)
-    repr->SetHasInitPrefixed(true);
   }
 
   // Sanitize period

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -32,6 +32,8 @@ public:
   CDashTree() : AdaptiveTree() {}
   CDashTree(const CDashTree& left);
 
+  virtual TreeType GetTreeType() override { return TreeType::DASH; }
+
   virtual bool Open(std::string_view url,
                     const std::map<std::string, std::string>& headers,
                     const std::string& data) override;

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -24,6 +24,8 @@ public:
   CHLSTree() : AdaptiveTree() {}
   virtual ~CHLSTree() {}
 
+  virtual TreeType GetTreeType() override { return TreeType::HLS; }
+
   CHLSTree(const CHLSTree& left);
 
   virtual CHLSTree* Clone() const override { return new CHLSTree{*this}; }

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -26,6 +26,8 @@ public:
   CSmoothTree() : AdaptiveTree() {}
   CSmoothTree(const CSmoothTree& left);
 
+  virtual TreeType GetTreeType() override { return TreeType::SMOOTH_STREAMING; }
+
   virtual bool Open(std::string_view url,
                     const std::map<std::string, std::string>& headers,
                     const std::string& data) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When i made the big parsers rework the `AdaptiveStream::ResolveSegmentBase` method confused me a lot
and also in how the `AdaptiveStream::parseIndexRange` was a bit mess implemented

Use case: on DASH parser when a representation has no SegmentTemplate, no SegmentBase, no Timeline and then only the BaseUrl
we was creating a fake SegmentBase just to have access to `AdaptiveStream::ResolveSegmentBase` method,
this (at least to me) was not clear from the old (<=Nexus) code flow and there should not be this odd workaround

so this PR rework `AdaptiveStream::parseIndexRange` in a more clear way, its funcitonality is unchanged, but just fixed
the creation of the initialization segment that i have broken with the parsers rework

`ResolveSegmentBase` method now has been now renamed with a more appropriate name

~**TODO:**
representation `HasInitPrefixed` code condition is causing a mess due to its weird unclear conditions
and wipe out the original MP4 stream MOOV atom because create a fake MOOV
https://github.com/xbmc/inputstream.adaptive/blob/21.1.3-Omega/src/Session.cpp#L1033-L1036~

UPDATE: "init prefixed" variable has been in the past implemented for SmoothStreaming manifest case, because with that protocol the MP4 provided dont contains the initialization segment (Movie (MOOV) atom), that is needed for bento4 to demux MP4 fragments, so look like that variable was used as workaround to avoid create the Movie atom with other manifest cases.
Now that condition has been full removed, reworked code to works for SmoothStreaming case only, so that not interfere with regular MP4 cases.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i found that n€tflix has broken audio on windows without passthru i finally understand what happens

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dash: N€tflix trailers, audio working tested on Windows without passthru and Android
Dash: https://dash.akamaized.net/dash264/TestCases/4b/qualcomm/1/ED_OnDemand_5SecSeg_Subtitles.mpd
Smoothstreaming to test "init prefixed" and Movie MOOV atom creation

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
