### PR TITLE
Fix compilation warnings in contexpr

### DIFF
--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -38,54 +38,54 @@ uint64_t GetTimestamp();
 
 namespace CODEC
 {
-constexpr char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
+constexpr const char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
 
 // IMPORTANT: Codec names must match the ffmpeg library definition
 // https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/codec_desc.c
 
 // Video definitions
 
-constexpr char* NAME_MPEG1 = "mpeg1video";
-constexpr char* NAME_MPEG2 = "mpeg2video";
-constexpr char* NAME_MPEG4 = "mpeg4"; // MPEG-4 part 2
-constexpr char* NAME_VC1 = "vc1"; // SMPTE VC-1
-constexpr char* NAME_H264 = "h264"; // MPEG-4 AVC
-constexpr char* NAME_HEVC = "hevc";
-constexpr char* NAME_VP9 = "vp9";
-constexpr char* NAME_AV1 = "av1";
+constexpr const char* NAME_MPEG1 = "mpeg1video";
+constexpr const char* NAME_MPEG2 = "mpeg2video";
+constexpr const char* NAME_MPEG4 = "mpeg4"; // MPEG-4 part 2
+constexpr const char* NAME_VC1 = "vc1"; // SMPTE VC-1
+constexpr const char* NAME_H264 = "h264"; // MPEG-4 AVC
+constexpr const char* NAME_HEVC = "hevc";
+constexpr const char* NAME_VP9 = "vp9";
+constexpr const char* NAME_AV1 = "av1";
 
 constexpr std::array VIDEO_NAME_LIST = {NAME_MPEG1, NAME_MPEG2, NAME_MPEG4, NAME_VC1,
                                         NAME_H264,  NAME_HEVC,  NAME_VP9,   NAME_AV1};
 
 // Audio definitions
 
-constexpr char* NAME_AAC = "aac";
-constexpr char* NAME_DTS = "dts";
-constexpr char* NAME_AC3 = "ac3";
-constexpr char* NAME_EAC3 = "eac3"; // Enhanced AC-3
-constexpr char* NAME_OPUS = "opus";
-constexpr char* NAME_VORBIS = "vorbis";
+constexpr const char* NAME_AAC = "aac";
+constexpr const char* NAME_DTS = "dts";
+constexpr const char* NAME_AC3 = "ac3";
+constexpr const char* NAME_EAC3 = "eac3"; // Enhanced AC-3
+constexpr const char* NAME_OPUS = "opus";
+constexpr const char* NAME_VORBIS = "vorbis";
 
 constexpr std::array AUDIO_NAME_LIST = {NAME_AAC,  NAME_DTS,  NAME_AC3,
                                         NAME_EAC3, NAME_OPUS, NAME_VORBIS};
 
 // Subtitles definitions
 
-constexpr char* NAME_SRT = "srt";
-constexpr char* NAME_WEBVTT = "webvtt";
-constexpr char* NAME_TTML = "ttml";
+constexpr const char* NAME_SRT = "srt";
+constexpr const char* NAME_WEBVTT = "webvtt";
+constexpr const char* NAME_TTML = "ttml";
 
 // Fourcc video definitions
 
-constexpr char* FOURCC_H264 = "h264"; // MPEG-4 AVC
-constexpr char* FOURCC_AVC_ = "avc"; // Generic prefix for all avc* fourcc, e.g. avc1, avcb
-constexpr char* FOURCC_VP09 = "vp09"; // VP9
-constexpr char* FOURCC_AV01 = "av01"; // AV1
-constexpr char* FOURCC_HEVC = "hevc";
-constexpr char* FOURCC_HVC1 = "hvc1"; // HEVC Dolby vision
-constexpr char* FOURCC_DVH1 = "dvh1"; // HEVC Dolby vision, hvc1 variant
-constexpr char* FOURCC_HEV1 = "hev1"; // HEVC Dolby vision
-constexpr char* FOURCC_DVHE = "dvhe"; // HEVC Dolby vision, hev1 variant
+constexpr const char* FOURCC_H264 = "h264"; // MPEG-4 AVC
+constexpr const char* FOURCC_AVC_ = "avc"; // Generic prefix for all avc* fourcc, e.g. avc1, avcb
+constexpr const char* FOURCC_VP09 = "vp09"; // VP9
+constexpr const char* FOURCC_AV01 = "av01"; // AV1
+constexpr const char* FOURCC_HEVC = "hevc";
+constexpr const char* FOURCC_HVC1 = "hvc1"; // HEVC Dolby vision
+constexpr const char* FOURCC_DVH1 = "dvh1"; // HEVC Dolby vision, hvc1 variant
+constexpr const char* FOURCC_HEV1 = "hev1"; // HEVC Dolby vision
+constexpr const char* FOURCC_DVHE = "dvhe"; // HEVC Dolby vision, hev1 variant
 
 constexpr std::array VIDEO_FOURCC_LIST = {FOURCC_H264,   FOURCC_AVC_,  FOURCC_VP09,   FOURCC_AV01,
                                           FOURCC_HEVC,   FOURCC_HVC1,  FOURCC_DVH1,   FOURCC_HEV1,
@@ -93,20 +93,20 @@ constexpr std::array VIDEO_FOURCC_LIST = {FOURCC_H264,   FOURCC_AVC_,  FOURCC_VP
 
 // Fourcc audio definitions
 
-constexpr char* FOURCC_MP4A = "mp4a";
-constexpr char* FOURCC_AAC_ = "aac"; // Generic prefix for all aac* fourcc, e.g. aac, aacl, aacp
-constexpr char* FOURCC_AACL = "aacl";
-constexpr char* FOURCC_AC_3 = "ac-3";
-constexpr char* FOURCC_EC_3 = "ec-3"; // Enhanced AC-3
-constexpr char* FOURCC_OPUS = "opus";
-constexpr char* FOURCC_VORB = "vorb"; // Vorbis
-constexpr char* FOURCC_VORB1 = "vor1"; // Vorbis 1
-constexpr char* FOURCC_VORB1P = "vo1+"; // Vorbis 1+
-constexpr char* FOURCC_VORB2 = "vor2"; // Vorbis 2
-constexpr char* FOURCC_VORB2P = "vo2+"; // Vorbis 2+
-constexpr char* FOURCC_VORB3 = "vor3"; // Vorbis 3
-constexpr char* FOURCC_VORB3P = "vo3+"; // Vorbis 3+
-constexpr char* FOURCC_DTS_ = "dts"; // Generic prefix for all dts* fourcc, e.g. dtsx
+constexpr const char* FOURCC_MP4A = "mp4a";
+constexpr const char* FOURCC_AAC_ = "aac"; // Generic prefix for all aac* fourcc, e.g. aac, aacl...
+constexpr const char* FOURCC_AACL = "aacl";
+constexpr const char* FOURCC_AC_3 = "ac-3";
+constexpr const char* FOURCC_EC_3 = "ec-3"; // Enhanced AC-3
+constexpr const char* FOURCC_OPUS = "opus";
+constexpr const char* FOURCC_VORB = "vorb"; // Vorbis
+constexpr const char* FOURCC_VORB1 = "vor1"; // Vorbis 1
+constexpr const char* FOURCC_VORB1P = "vo1+"; // Vorbis 1+
+constexpr const char* FOURCC_VORB2 = "vor2"; // Vorbis 2
+constexpr const char* FOURCC_VORB2P = "vo2+"; // Vorbis 2+
+constexpr const char* FOURCC_VORB3 = "vor3"; // Vorbis 3
+constexpr const char* FOURCC_VORB3P = "vo3+"; // Vorbis 3+
+constexpr const char* FOURCC_DTS_ = "dts"; // Generic prefix for all dts* fourcc, e.g. dtsx
 
 constexpr std::array AUDIO_FOURCC_LIST = {FOURCC_MP4A, FOURCC_AAC_, FOURCC_AACL,
                                           FOURCC_AC_3, FOURCC_EC_3, FOURCC_OPUS, FOURCC_VORB, FOURCC_VORB1,
@@ -115,12 +115,12 @@ constexpr std::array AUDIO_FOURCC_LIST = {FOURCC_MP4A, FOURCC_AAC_, FOURCC_AACL,
 
 // Fourcc subtitles definitions
 
-constexpr char* FOURCC_WVTT = "wvtt"; // WebVTT
-constexpr char* FOURCC_TTML = "ttml";
+constexpr const char* FOURCC_WVTT = "wvtt"; // WebVTT
+constexpr const char* FOURCC_TTML = "ttml";
 // TTML variant for XML type
 // In the complete codec description can be presented with or without name and profile
 // for example "stpp.ttml.im1t", or only "stpp"
-constexpr char* FOURCC_STPP = "stpp";
+constexpr const char* FOURCC_STPP = "stpp";
 
 constexpr std::array SUBTITLES_FOURCC_LIST = {FOURCC_WVTT, FOURCC_TTML, FOURCC_STPP};
 


### PR DESCRIPTION
## Description
Small fix, I've seen it when compiling:

```
/home/user/inputstream.adaptive/src/utils/Utils.h:41:32: 
warning: ISO C++11 does not allow conversion from string literal to 'char *const' [-Wwritable-strings]
constexpr char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
...
```

Since C++11 the string literal is const char*

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
