### PR TITLE
[HLSTree] Fixes for parser regressions

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -98,7 +98,7 @@ bool adaptive::CDashTree::Open(std::string_view url,
 
   m_manifestRespHeaders = headers;
   manifest_url_ = url;
-  base_url_ = URL::RemoveParameters(url.data());
+  base_url_ = URL::GetUrlPath(url.data());
 
   if (!ParseManifest(data))
     return false;
@@ -1514,7 +1514,7 @@ void adaptive::CDashTree::RefreshLiveSegments()
   {
     manifestUrl = manifest_url_;
     if (!manifestParams.empty())
-      manifestUrl = URL::RemoveParameters(manifestUrl, false);
+      manifestUrl = URL::RemoveParameters(manifestUrl);
   }
   else
     manifestUrl = location_;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -151,7 +151,7 @@ bool adaptive::CHLSTree::Open(std::string_view url,
   SaveManifest(nullptr, data, url);
 
   manifest_url_ = url;
-  base_url_ = URL::RemoveParameters(url.data());
+  base_url_ = URL::GetUrlPath(url.data());
 
   if (!ParseManifest(data))
   {
@@ -205,7 +205,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
 
     SaveManifest(adp, resp.data, manifestUrl);
 
-    rep->SetBaseUrl(URL::RemoveParameters(resp.effectiveUrl));
+    rep->SetBaseUrl(URL::GetUrlPath(resp.effectiveUrl));
 
     EncryptionType currentEncryptionType = EncryptionType::CLEAR;
 
@@ -354,7 +354,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
         if (rep->GetContainerType() == ContainerType::NOTYPE)
         {
           // Try find the container type on the representation according to the file extension
-          std::string url = URL::RemoveParameters(line, false);
+          std::string url = URL::RemoveParameters(line);
           // Remove domain on absolute url, to not confuse top-level domain as extension
           url = url.substr(URL::GetDomainUrl(url).size());
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -489,11 +489,17 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
           m_periods.push_back(std::move(newPeriod));
         }
         else
+        {
+          // Period(s) already created by a previously downloaded manifest child
           period = m_periods[discontCount].get();
+        }
 
         newStartNumber += rep->SegmentTimeline().GetSize();
         adp = period->GetAdaptationSets()[adpSetPos].get();
-        rep = adp->GetRepresentations()[reprPos].get();
+        // When we switch to a repr of another period we need to set current base url
+        CRepresentation* switchRep = adp->GetRepresentations()[reprPos].get();
+        switchRep->SetBaseUrl(rep->GetBaseUrl());
+        rep = switchRep;
 
         currentSegStartPts = 0;
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -79,6 +79,7 @@ protected:
     std::string m_characteristics;
     std::string m_uri;
     int m_features{REND_FEATURE_NONE};
+    bool m_isUriDuplicate{false}; // Another rendition have same uri
   };
 
   // \brief Usually refer to an EXT-X-STREAM-INF tag
@@ -91,6 +92,7 @@ protected:
     std::string m_groupIdAudio;
     std::string m_groupIdSubtitles;
     std::string m_uri;
+    bool m_isUriDuplicate{false}; // Another variant have same uri
   };
 
   struct MultivariantPlaylist

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -33,7 +33,7 @@ bool adaptive::CSmoothTree::Open(std::string_view url,
   SaveManifest("", data, "");
 
   manifest_url_ = url;
-  base_url_ = URL::RemoveParameters(url.data());
+  base_url_ = URL::GetUrlPath(url.data());
 
   if (!ParseManifest(data))
     return false;

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -164,18 +164,32 @@ std::string UTILS::URL::GetParameters(std::string& url) {
   return "";
 }
 
-std::string UTILS::URL::RemoveParameters(std::string url, bool removeFilenameParam /* = true */)
+std::string UTILS::URL::RemoveParameters(std::string url)
 {
   size_t paramsPos = url.find('?');
   if (paramsPos != std::string::npos)
     url.resize(paramsPos);
 
-  if (removeFilenameParam)
+  return url;
+}
+
+std::string UTILS::URL::GetUrlPath(std::string url)
+{
+  if (url.empty())
+    return url;
+
+  size_t paramsPos = url.find('?');
+  if (paramsPos != std::string::npos)
+    url.resize(paramsPos);
+
+  // The part of the base url after last / is not a directory so will not be taken into account
+  if (url.back() != '/')
   {
-    size_t slashPos = url.find_last_of('/');
-    if (slashPos != std::string::npos && slashPos != (url.find("://") + 2))
-      url.resize(slashPos + 1);
+    size_t slashPos = url.rfind("/");
+    if (slashPos > url.find("://") + 3)
+      url.erase(slashPos + 1);
   }
+
   return url;
 }
 

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -53,13 +53,20 @@ std::string GetParametersFromPlaceholder(std::string& url, std::string_view plac
  */
 std::string GetParameters(std::string& url);
 
-/*! \brief Remove URL parameters e.g. "?q=something"
- *  \param url An URL
- *  \param removeFilenameParam If true remove the last URL level if it
- *   contains a filename with extension
- *  \return The URL without parameters
+/*!
+ * \brief Remove URL parameters e.g. "?q=something"
+ * \param url An URL
+ * \return The URL without parameters
  */
-std::string RemoveParameters(std::string url, bool removeFilenameParam = true);
+std::string RemoveParameters(std::string url);
+
+/*!
+ * \brief Get the url path, by removing file part and parameters
+ *        e.g. https://sample.com/part1/part2?test become https://sample.com/part1/
+ * \param url An URL
+ * \return The URL path
+ */
+std::string GetUrlPath(std::string url);
 
 /*! \brief Append a string of parameters to an URL with/without pre-existents params
  *  \param url URL where append the parameters


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The current RemoveParameters method can be misleading and can delete required url parts
so cleaned up method by removing "filename" variable,
and then created an appropriate method to get url path

HLS D+ manifest case has shown another time some things that has not been taken in account after recent parser rework

First thing, multiple variants with same uri, was added more times as representation
```
#EXT-X-STREAM-INF:BANDWIDTH=4275411,AVERAGE-BANDWIDTH=2392560,CODECS="hvc1.2.4.H120.90,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=24,VIDEO-RANGE=PQ,HDCP-LEVEL=TYPE-1,CHARACTERISTICS="com.dss.ctr.uhd",AUDIO="aac-128k",SUBTITLES="sub-main"
r/composite_2700k_CENC_CTR_UHD_HDR_HDR10_762ff663-9d08-497e-af6f-21855fff2eb5_b256a1e9-dd8d-4b19-b9cd-07b6a00b6567.m3u8

#EXT-X-STREAM-INF:BANDWIDTH=4404008,AVERAGE-BANDWIDTH=2521689,CODECS="hvc1.2.4.H120.90,ec-3,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=24,VIDEO-RANGE=PQ,HDCP-LEVEL=TYPE-1,CHARACTERISTICS="com.dss.ctr.uhd",AUDIO="eac-3",SUBTITLES="sub-main"
r/composite_2700k_CENC_CTR_UHD_HDR_HDR10_762ff663-9d08-497e-af6f-21855fff2eb5_b256a1e9-dd8d-4b19-b9cd-07b6a00b6567.m3u8
```

Second thing, on renditions there may exists multile renditions with same identical properties but different GROUP-ID
and we should not add them more times
```
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="atmos",NAME="Deutsch",LANGUAGE="de",AUTOSELECT=YES,CHANNELS="6",URI="r/composite_256k_ec-3_de_PRIMARY_a39c570a-3c46-4db6-b42f-751c28f17566_10310d0e-3231-46ca-8ec4-822aec4d1f6b.m3u8"

#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="eac-3",NAME="Deutsch",LANGUAGE="de",AUTOSELECT=YES,CHANNELS="6",URI="r/composite_256k_ec-3_de_PRIMARY_a39c570a-3c46-4db6-b42f-751c28f17566_10310d0e-3231-46ca-8ec4-822aec4d1f6b.m3u8"
```

The last one when we parse a child manifest that have multiple EXT-X-DISCONTINUITY was missing add base url to representations of switched period, and was causing bad download url address

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1335 #1366

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i wait user feedback as confirm
i tested some random dash/hls/ss

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
