### PR TITLE
[DASHTree] Fixed license_data property use case

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -480,10 +480,10 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
 
       if (sessionPsshset.pssh_ == PSSH_FROM_FILE)
       {
-        LOG::Log(LOGDEBUG, "Searching PSSH data in FILE");
-
         if (m_kodiProps.m_licenseData.empty())
         {
+          LOG::Log(LOGDEBUG, "Searching for PSSH data in the stream file");
+
           auto initialRepr{m_reprChooser->GetRepresentation(sessionPsshset.adaptation_set_)};
 
           CStream stream{*m_adaptiveTree, sessionPsshset.adaptation_set_, initialRepr, m_kodiProps};
@@ -554,17 +554,16 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
           }
           stream.Disable();
         }
-        else if (!sessionPsshset.defaultKID_.empty())
+        else
         {
-          std::string licenseData = BASE64::Decode(m_kodiProps.m_licenseData);
-          // Replace KID placeholder, if any
-          STRING::ReplaceFirst(licenseData, "{KID}", sessionPsshset.defaultKID_);
+          // This can allow to initialize a DRM that could be also not specified
+          // as supported in the manifest (e.g. on DASH ContentProtection tags)
+          LOG::Log(LOGDEBUG, "Set init PSSH data provided by the license data property");
 
+          std::string licenseData = BASE64::Decode(m_kodiProps.m_licenseData);
           init_data.SetData(reinterpret_cast<const AP4_Byte*>(licenseData.c_str()),
                             static_cast<AP4_Size>(licenseData.size()));
         }
-        else
-          return false;
       }
       else
       {

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -27,7 +27,7 @@ namespace PLAYLIST
 constexpr uint16_t PSSHSET_POS_DEFAULT = 0;
 // Marker for not valid psshset position
 constexpr uint16_t PSSHSET_POS_INVALID = std::numeric_limits<uint16_t>::max();
-// Marker to extract the PSSH from the file
+// Marker to try extract the PSSH from the file, or to try use a custom PSSH license data provided
 constexpr std::string_view PSSH_FROM_FILE = "FILE";
 // Marker for not set/not found segment position
 constexpr size_t SEGMENT_NO_POS = std::numeric_limits<size_t>::max();

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -32,6 +32,11 @@ public:
   CDashTree() : AdaptiveTree() {}
   CDashTree(const CDashTree& left);
 
+  void Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps,
+                 CHOOSER::IRepresentationChooser* reprChooser,
+                 std::string_view supportedKeySystem,
+                 std::string_view manifestUpdParams);
+
   virtual TreeType GetTreeType() override { return TreeType::DASH; }
 
   virtual bool Open(std::string_view url,
@@ -56,8 +61,7 @@ protected:
   void ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST::CPeriod* period);
   void ParseTagRepresentation(pugi::xml_node nodeRepr,
                               PLAYLIST::CAdaptationSet* adpSet,
-                              PLAYLIST::CPeriod* period,
-                              bool& hasReprURN);
+                              PLAYLIST::CPeriod* period);
 
   uint64_t ParseTagSegmentTimeline(pugi::xml_node parentNode,
                                    PLAYLIST::CSpinCache<uint32_t>& SCTimeline,
@@ -70,10 +74,9 @@ protected:
 
   void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate* segTpl);
 
-  bool ParseTagContentProtection(pugi::xml_node nodeCP,
-                                 std::string& currentPssh,
-                                 std::string& currentDefaultKID,
-                                 bool& isSecureDecoderNeeded);
+  bool ParseTagContentProtection(pugi::xml_node nodeCP, std::string& pssh, std::string& kid);
+
+  bool ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 
   uint32_t ParseAudioChannelConfig(pugi::xml_node node);
 
@@ -116,5 +119,15 @@ protected:
 
   uint64_t m_minimumUpdatePeriod{0}; // in seconds
   bool m_allowInsertLiveSegments{false};
+  // Determines if a custom PSSH initialization license data is provided
+  bool m_isCustomInitPssh{false};
+
+  struct ProtectionScheme
+  {
+    std::string idUri;
+    std::string value;
+    std::string kid;
+    std::string pssh;
+  };
 };
 } // namespace adaptive

--- a/src/utils/PropertiesUtils.h
+++ b/src/utils/PropertiesUtils.h
@@ -37,6 +37,7 @@ struct KodiProperties
 {
   std::string m_licenseType;
   std::string m_licenseKey;
+  // Custom PSSH initialization license data
   std::string m_licenseData;
   bool m_isLicensePersistentStorage{false};
   bool m_isLicenseForceSecureDecoder{false};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
after the parsers refactor when `inputstream.adaptive.license_data` is set is not more considered for two problems
- On CSession::InitializeDRM the `else if (!sessionPsshset.defaultKID_.empty())` condition was never true because the KID was not parsed anymore, due to no match with ContentProtection's tags and supportedKeySystem
- After rework the dash parser dont take in account of this use case anymore, because since dont find a match for supportedKeySystem, set period as EncryptionState::ENCRYPTED, and not as EncryptionState::ENCRYPTED_SUPPORTED. Then fails to initialize the DRM

With this PR has been also removed the support to inject the kid by using `{KID}` placeholder in the custom PSSH data provided with the license_data property. The main reasons are, its a very specific use case that sniff the kid from PlayReady ContentProtection tag only (if found), its use its so difficult and prone to not working, his implementation its hacky and will probably cause difficulties in the future to introduce support for new ContentProtection cases currently not implemented.

Additional thing, while investiganting i also found that ContentProtection for PlayReady with following format is not working
because we taking in account of `mspr:pro` tag but not `pro` child tag, so it has been added
```
<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95">
	<cenc:pssh>...</cenc:pssh>
	<pro>...</pro>
</ContentProtection>
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~try~ fix #1372
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested by users in issue
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
