### PR TITLE
[AdaptiveTree] Stop manifest updates before class deconstruction

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -76,6 +76,8 @@ CSession::~CSession()
   m_streams.clear();
   DisposeDecrypter();
 
+  m_adaptiveTree->Uninitialize();
+
   delete m_adaptiveTree;
   m_adaptiveTree = nullptr;
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -795,6 +795,11 @@ bool AdaptiveStream::ensureSegment()
   {
     // wait until worker is ready for new segment
     std::unique_lock<std::mutex> lck(thread_data_->mutex_dl_);
+
+    // check if it has been stopped in the meantime (e.g. playback stop)
+    if (state_ == STOPPED)
+      return false;
+
     // lock live segment updates
     std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(tree_.GetTreeUpdMutex());
 

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -68,6 +68,13 @@ namespace adaptive
         static_cast<uint32_t>(kodi::addon::GetSettingInt("MAXBUFFERDURATION"));
   }
 
+  void AdaptiveTree::Uninitialize()
+  {
+    // Stop the update thread before the tree class deconstruction otherwise derived classes
+    // will be destructed early, so while an update could be just started
+    m_updThread.Stop();
+  }
+
   void AdaptiveTree::PostOpen(const UTILS::PROPERTIES::KodiProperties& kodiProps)
   {
     SortTree();
@@ -198,13 +205,12 @@ namespace adaptive
   AdaptiveTree::TreeUpdateThread::~TreeUpdateThread()
   {
     // assert(m_waitQueue == 0); // Debug only, missing resume
+
+    // We assume that Stop() method has been called before the deconstruction
     m_threadStop = true;
 
     if (m_thread.joinable())
-    {
-      m_cvUpdInterval.notify_all(); // Unlock possible waiting
       m_thread.join();
-    }
   }
 
   void AdaptiveTree::TreeUpdateThread::Initialize(AdaptiveTree* tree)
@@ -229,6 +235,8 @@ namespace adaptive
         // If paused, wait until last "Resume" will be called
         std::unique_lock<std::mutex> lckWait(m_waitMutex);
         m_cvWait.wait(lckWait, [&] { return m_waitQueue == 0; });
+        if (m_threadStop)
+          break;
 
         updLck.lock();
         m_tree->RefreshLiveSegments();
@@ -250,6 +258,15 @@ namespace adaptive
     // If there are no more pauses, unblock the update thread
     if (m_waitQueue == 0)
       m_cvWait.notify_all();
+  }
+
+  void AdaptiveTree::TreeUpdateThread::Stop()
+  {
+    m_threadStop = true;
+    // If an update is already in progress wait until exit
+    std::lock_guard<std::mutex> updLck{m_updMutex};
+    m_cvUpdInterval.notify_all();
+    m_cvWait.notify_all();
   }
 
   } // namespace adaptive

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -100,6 +100,11 @@ public:
                          std::string_view manifestUpdParams);
 
   /*!
+   * \brief Performs operations to stop running process and release resources.
+   */
+  virtual void Uninitialize();
+
+  /*!
    * \brief Open manifest data for parsing.
    * \param url Effective url where the manifest is downloaded
    * \param headers Headers provided in the HTTP response
@@ -236,6 +241,9 @@ public:
 
     // \brief As "std::mutex" unlock, but resume the manifest updates (support std::lock_guard).
     void unlock() { Resume(); }
+
+    // \brief Stop performing new updates.
+    void Stop();
 
   private:
     void Worker();

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -27,6 +27,7 @@ protected:
 
   void TearDown() override
   {
+    tree->Uninitialize();
     testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -24,6 +24,7 @@ protected:
 
   void TearDown() override
   {
+    tree->Uninitialize();
     testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -25,6 +25,7 @@ protected:
 
   void TearDown() override
   {
+    tree->Uninitialize();
     testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
manifest updates was not appropriately stopped after tree deconstruction
then when an update happen while the tree object is deconstructed will cause a crash

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1362 (ISA side, still exist a kodi core bug that can make crashes)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
by chance i found that following mpd allowed me to reproduce the crashes locally
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/?specConform=true||R{SSM}|
https://d24rwxnt7vw9qb.cloudfront.net/v1/dash/e6d234965645b411ad572802b6c9d5a10799c9c1/All_Reference_Streams//6e16c26536564c2f9dbc5f725a820cff/index.mpd
```
(i hacked the mpd parser to skip encrypted streams because cause license problems)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
