### PR TITLE
[backport][AdaptiveTree] Stop manifest updates before class deconstruction

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -98,6 +98,8 @@ CSession::~CSession()
   m_streams.clear();
   DisposeDecrypter();
 
+  m_adaptiveTree->Uninitialize();
+
   delete m_adaptiveTree;
   m_adaptiveTree = nullptr;
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -814,6 +814,11 @@ bool AdaptiveStream::ensureSegment()
   {
     // wait until worker is ready for new segment
     std::unique_lock<std::mutex> lck(thread_data_->mutex_dl_);
+
+    // check if it has been stopped in the meantime (e.g. playback stop)
+    if (state_ == STOPPED)
+      return false;
+
     // lock live segment updates
     std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(tree_.GetTreeUpdMutex());
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -535,6 +535,11 @@ public:
    */
   virtual void Configure(const UTILS::PROPERTIES::KodiProperties& kodiProps);
 
+  /*!
+   * \brief Performs operations to stop running process and release resources.
+   */
+  virtual void Uninitialize();
+
   virtual bool open(const std::string& url) = 0;
   virtual bool open(const std::string& url, std::map<std::string, std::string> additionalHeaders) = 0;
 
@@ -638,6 +643,9 @@ public:
 
     // \brief As "std::mutex" unlock, but resume the manifest updates (support std::lock_guard).
     void unlock() { Resume(); }
+
+    // \brief Stop performing new updates.
+    void Stop();
 
   private:
     void Worker();

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -31,6 +31,7 @@ protected:
 
   void TearDown() override
   {
+    tree->Uninitialize();
     testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -30,6 +30,7 @@ protected:
 
   void TearDown() override
   {
+    tree->Uninitialize();
     testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -31,6 +31,7 @@ protected:
 
   void TearDown() override
   {
+    tree->Uninitialize();
     testHelper::effectiveUrl.clear();
     delete tree;
     tree = nullptr;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
backport of #1382
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
