### PR TITLE
[backport][Session] Fix possible timingStream nullptr access

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1154,7 +1154,7 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
       {
         // Once the start PTS has been acquired for the timing stream, set this value
         // to the other stream readers
-        if (stream.get() != timingStream &&
+        if (timingStream && stream.get() != timingStream &&
             timingStream->GetReader()->GetStartPTS() != STREAM_NOPTS_VALUE &&
             streamReader->GetStartPTS() == STREAM_NOPTS_VALUE)
         {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
backport of commit 05f0877adc5ead54b7fb45e398e997e7dbe79971 from omega branch

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
trying to fix #1185 that could be a possible cause
but i have no way to test it

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
