### PR TITLE
Improvements/fixes to code misuses

### DIFF
--- a/src/Iaes_decrypter.h
+++ b/src/Iaes_decrypter.h
@@ -19,7 +19,7 @@ class IAESDecrypter
 public:
   virtual ~IAESDecrypter() {};
 
-  virtual void decrypt(const AP4_UI08* aes_key,
+  virtual void decrypt(const std::vector<uint8_t>& aes_key,
                        const AP4_UI08* aes_iv,
                        const AP4_UI08* src,
                        std::vector<uint8_t>& dst,

--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -12,7 +12,7 @@
 #include <kodi/Filesystem.h>
 #include <vector>
 
-void AESDecrypter::decrypt(const AP4_UI08* aes_key,
+void AESDecrypter::decrypt(const std::vector<uint8_t>& aes_key,
                            const AP4_UI08* aes_iv,
                            const AP4_UI08* src,
                            std::vector<uint8_t>& dst,
@@ -22,13 +22,8 @@ void AESDecrypter::decrypt(const AP4_UI08* aes_key,
 {
   AP4_BlockCipher* cbc_d_block_cipher;
   AP4_DefaultBlockCipherFactory::Instance.CreateCipher(
-    AP4_BlockCipher::AES_128,
-    AP4_BlockCipher::DECRYPT,
-    AP4_BlockCipher::CBC,
-    NULL,
-    aes_key,
-    16,
-    cbc_d_block_cipher);
+      AP4_BlockCipher::AES_128, AP4_BlockCipher::DECRYPT, AP4_BlockCipher::CBC, NULL,
+      aes_key.data(), static_cast<AP4_Size>(aes_key.size()), cbc_d_block_cipher);
 
   AP4_CbcStreamCipher cbcStreamCipher{cbc_d_block_cipher};
   cbcStreamCipher.SetIV(aes_iv);

--- a/src/aes_decrypter.h
+++ b/src/aes_decrypter.h
@@ -27,7 +27,7 @@ public:
   AESDecrypter(const std::string& licenseKey) : m_licenseKey(licenseKey){};
   virtual ~AESDecrypter() = default;
 
-  void decrypt(const AP4_UI08* aes_key,
+  void decrypt(const std::vector<uint8_t>& aes_key,
                const AP4_UI08* aes_iv,
                const AP4_UI08* src,
                std::vector<uint8_t>& dst,

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -10,8 +10,10 @@
 
 #include "utils/CryptoUtils.h"
 
+#include <cstdint>
 #include <stdexcept>
 #include <string_view>
+#include <vector>
 
 #include <bento4/Ap4.h>
 
@@ -23,7 +25,7 @@ public:
   /*! \brief Add a Key ID to the current session
    *  \param keyId The KID
    */
-  virtual void AddKeyId(std::string_view keyId)
+  virtual void AddKeyId(const std::vector<uint8_t>& keyId)
   {
     throw std::logic_error("AddKeyId method not implemented.");
   };
@@ -31,13 +33,13 @@ public:
   /*! \brief Set a Key ID as default
    *  \param keyId The KID
    */
-  virtual void SetDefaultKeyId(std::string_view keyId)
+  virtual void SetDefaultKeyId(const std::vector<uint8_t>& keyId)
   {
     throw std::logic_error("SetDefaultKeyId method not implemented.");
   };
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 poolId,
-                                     const AP4_UI08* key,
+                                     const std::vector<uint8_t>& key,
                                      const AP4_UI08 nalLengthSize,
                                      AP4_DataBuffer& annexbSpsPps,
                                      AP4_UI32 flags,

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -121,18 +121,43 @@ namespace adaptive
   uint16_t AdaptiveTree::InsertPsshSet(PLAYLIST::StreamType streamType,
                                        PLAYLIST::CPeriod* period,
                                        PLAYLIST::CAdaptationSet* adp,
-                                       std::string_view pssh,
-                                       std::string_view defaultKID,
-                                       std::string_view iv /* = "" */)
+                                       const std::vector<uint8_t>& pssh,
+                                       const std::vector<uint8_t>& defaultKid,
+                                       bool needsExtractPssh /* = false */)
   {
-    if (!pssh.empty())
+    return InsertPsshSetImpl(streamType, period, adp, pssh, defaultKid, "", "", needsExtractPssh);
+  }
+
+  uint16_t AdaptiveTree::InsertPsshSet(PLAYLIST::StreamType streamType,
+                                       PLAYLIST::CPeriod* period,
+                                       PLAYLIST::CAdaptationSet* adp,
+                                       const std::vector<uint8_t>& pssh,
+                                       const std::vector<uint8_t>& defaultKid,
+                                       std::string_view kidUrl,
+                                       std::string_view iv)
+  {
+    return InsertPsshSetImpl(streamType, period, adp, pssh, defaultKid, kidUrl, iv, false);
+  }
+
+  uint16_t AdaptiveTree::InsertPsshSetImpl(PLAYLIST::StreamType streamType,
+                                           PLAYLIST::CPeriod* period,
+                                           PLAYLIST::CAdaptationSet* adp,
+                                           const std::vector<uint8_t>& pssh,
+                                           const std::vector<uint8_t>& defaultKID,
+                                           std::string_view kidUrl,
+                                           std::string_view iv,
+                                           bool needsExtractPssh)
+  {
+    if (!pssh.empty() || !kidUrl.empty())
     {
       CPeriod::PSSHSet psshSet;
       psshSet.pssh_ = pssh;
       psshSet.defaultKID_ = defaultKID;
+      psshSet.m_kidUrl = kidUrl;
       psshSet.iv = iv;
       psshSet.m_cryptoMode = m_cryptoMode;
       psshSet.adaptation_set_ = adp;
+      psshSet.m_needsExtractPssh = needsExtractPssh;
 
       if (streamType == StreamType::VIDEO)
         psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -174,13 +174,20 @@ public:
   {
   }
 
-  // Insert a PSSHSet to the specified Period and return the position
   uint16_t InsertPsshSet(PLAYLIST::StreamType streamType,
                          PLAYLIST::CPeriod* period,
                          PLAYLIST::CAdaptationSet* adp,
-                         std::string_view pssh,
-                         std::string_view defaultKID,
-                         std::string_view iv = "");
+                         const std::vector<uint8_t>& pssh,
+                         const std::vector<uint8_t>& defaultKid,
+                         bool needsExtractPssh = false);
+
+  uint16_t InsertPsshSet(PLAYLIST::StreamType streamType,
+                         PLAYLIST::CPeriod* period,
+                         PLAYLIST::CAdaptationSet* adp,
+                         const std::vector<uint8_t>& pssh,
+                         const std::vector<uint8_t>& defaultKid,
+                         std::string_view kidUrl,
+                         std::string_view iv);
 
   PLAYLIST::CAdaptationSet* GetAdaptationSet(size_t pos) const
   {
@@ -282,6 +289,16 @@ public:
   std::string_view GetLicenseUrl() { return m_licenseUrl; }
 
 protected:
+  // Insert a PSSHSet to the specified Period and return the position
+  uint16_t InsertPsshSetImpl(PLAYLIST::StreamType streamType,
+                             PLAYLIST::CPeriod* period,
+                             PLAYLIST::CAdaptationSet* adp,
+                             const std::vector<uint8_t>& pssh,
+                             const std::vector<uint8_t>& defaultKID,
+                             std::string_view kidUrl,
+                             std::string_view iv,
+                             bool needsExtractPssh);
+
   /*!
    * \brief Save manifest data to a file for debugging purpose.
    * \param fileNameSuffix Suffix to add to the filename generated.

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -94,13 +94,17 @@ public:
     // Custom comparator for std::find
     bool operator==(const PSSHSet& other) const
     {
-      return m_usageCount == 0 || (media_ == other.media_ && pssh_ == other.pssh_ &&
-                                   defaultKID_ == other.defaultKID_ && iv == other.iv);
+      return m_usageCount == 0 ||
+             (m_kidUrl.empty() && media_ == other.media_ && pssh_ == other.pssh_ &&
+              defaultKID_ == other.defaultKID_ && iv == other.iv) ||
+             (!m_kidUrl.empty() && m_kidUrl == other.m_kidUrl);
     }
 
     //! @todo: create getter/setters
-    std::string pssh_;
-    std::string defaultKID_;
+    bool m_needsExtractPssh{false}; // Its required to extract PSSH from the file
+    std::vector<uint8_t> pssh_;
+    std::string m_kidUrl; // Url where get the KID
+    std::vector<uint8_t> defaultKID_;
     std::string iv;
     uint32_t media_{0};
     // Specify how many times the same PSSH is used between AdaptationSets or Representations

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -87,7 +87,7 @@ public:
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
       AP4_DataBuffer& pssh,
       const char* optionalKeyParameter,
-      std::string_view defaultKeyId,
+      const std::vector<uint8_t>& defaultKeyId,
       bool skipSessionMessage,
       CryptoMode cryptoMode) = 0;
 
@@ -105,7 +105,7 @@ public:
    * \param caps The capabilities object to be populated
    */
   virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                               const uint8_t* keyId,
+                               const std::vector<uint8_t>& keyId,
                                uint32_t media,
                                IDecrypter::DecrypterCapabilites& caps) = 0;
 
@@ -116,7 +116,7 @@ public:
    * \return True if the KeyID has a license otherwise false
    */
   virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                             const uint8_t* keyId) = 0;
+                             const std::vector<uint8_t>& keyId) = 0;
 
   /**
    * \brief Check if the decrypter has been initialised (OpenDRMSystem called)

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -32,13 +32,15 @@ public:
   // methods
   CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
                                AP4_DataBuffer& pssh,
-                               std::string_view defaultKeyId,
+                               const std::vector<uint8_t>& defaultKeyId,
                                bool skipSessionMessage,
                                CryptoMode cryptoMode,
                                CWVDecrypter* host);
   virtual ~CWVCencSingleSampleDecrypter();
 
-  void GetCapabilities(const uint8_t* key, uint32_t media, IDecrypter::DecrypterCapabilites& caps);
+  void GetCapabilities(const std::vector<uint8_t>& key,
+                       uint32_t media,
+                       IDecrypter::DecrypterCapabilites& caps);
   virtual const char* GetSessionId() override;
   void CloseSessionId();
   AP4_DataBuffer GetChallengeData();
@@ -46,10 +48,10 @@ public:
   void SetSession(const char* session, uint32_t sessionSize, const uint8_t* data, size_t dataSize);
 
   void AddSessionKey(const uint8_t* data, size_t dataSize, uint32_t status);
-  bool HasKeyId(const uint8_t* keyid);
+  bool HasKeyId(const std::vector<uint8_t>& keyid);
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 poolId,
-                                     const AP4_UI08* key,
+                                     const std::vector<uint8_t>& key,
                                      const AP4_UI08 nalLengthSize,
                                      AP4_DataBuffer& annexbSpsPps,
                                      AP4_UI32 flags,
@@ -80,8 +82,8 @@ public:
   VIDEOCODEC_RETVAL VideoFrameDataToPicture(kodi::addon::CInstanceVideoCodec* codecInstance,
                                             VIDEOCODEC_PICTURE* picture);
   void ResetVideo();
-  void SetDefaultKeyId(std::string_view keyId) override;
-  void AddKeyId(std::string_view keyId) override;
+  void SetDefaultKeyId(const std::vector<uint8_t>& keyId) override;
+  void AddKeyId(const std::vector<uint8_t>& keyId) override;
 
 private:
   void CheckLicenseRenewal();
@@ -91,11 +93,11 @@ private:
   std::string m_strSession;
   AP4_DataBuffer m_pssh;
   AP4_DataBuffer m_challenge;
-  std::string m_defaultKeyId;
+  std::vector<uint8_t> m_defaultKeyId;
   struct WVSKEY
   {
     bool operator==(WVSKEY const& other) const { return m_keyId == other.m_keyId; };
-    std::string m_keyId;
+    std::vector<uint8_t> m_keyId;
     cdm::KeyStatus status;
   };
   std::vector<WVSKEY> m_keys;
@@ -109,14 +111,14 @@ private:
 
   struct FINFO
   {
-    const AP4_UI08* m_key;
+    std::vector<uint8_t> m_key;
     AP4_UI08 m_nalLengthSize;
     AP4_UI16 m_decrypterFlags;
     AP4_DataBuffer m_annexbSpsPps;
     CryptoInfo m_cryptoInfo;
   };
   std::vector<FINFO> m_fragmentPool;
-  void LogDecryptError(const cdm::Status status, const AP4_UI08* key);
+  void LogDecryptError(const cdm::Status status, const std::vector<uint8_t>& key);
   void SetCdmSubsamples(std::vector<cdm::SubsampleEntry>& subsamples, bool isCbc);
   void RepackSubsampleData(AP4_DataBuffer& dataIn,
                            AP4_DataBuffer& dataOut,

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -96,7 +96,7 @@ bool CWVDecrypter::OpenDRMSystem(const char* licenseURL,
 Adaptive_CencSingleSampleDecrypter* CWVDecrypter::CreateSingleSampleDecrypter(
     AP4_DataBuffer& pssh,
     const char* optionalKeyParameter,
-    std::string_view defaultKeyId,
+    const std::vector<uint8_t>& defaultKeyId,
     bool skipSessionMessage,
     CryptoMode cryptoMode)
 {
@@ -121,7 +121,7 @@ void CWVDecrypter::DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypt
 }
 
 void CWVDecrypter::GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                                   const uint8_t* keyId,
+                                   const std::vector<uint8_t>& keyId,
                                    uint32_t media,
                                    IDecrypter::DecrypterCapabilites& caps)
 {
@@ -135,7 +135,7 @@ void CWVDecrypter::GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter
 }
 
 bool CWVDecrypter::HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                                 const uint8_t* keyId)
+                                 const std::vector<uint8_t>& keyId)
 {
   if (decrypter)
     return static_cast<CWVCencSingleSampleDecrypter*>(decrypter)->HasKeyId(keyId);

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -34,16 +34,16 @@ public:
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
       AP4_DataBuffer& pssh,
       const char* optionalKeyParameter,
-      std::string_view defaultKeyId,
+      const std::vector<uint8_t>& defaultKeyId,
       bool skipSessionMessage,
       CryptoMode cryptoMode) override;
   virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override;
   virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                               const uint8_t* keyId,
+                               const std::vector<uint8_t>& keyId,
                                uint32_t media,
                                IDecrypter::DecrypterCapabilites& caps) override;
   virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                             const uint8_t* keyId) override;
+                             const std::vector<uint8_t>& keyId) override;
   virtual bool IsInitialised() override { return m_WVCdmAdapter != nullptr; }
   virtual std::string GetChallengeB64Data(Adaptive_CencSingleSampleDecrypter* decrypter) override;
   virtual bool OpenVideoDecoder(Adaptive_CencSingleSampleDecrypter* decrypter,

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -74,7 +74,9 @@ protected:
 
   void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate* segTpl);
 
-  bool ParseTagContentProtection(pugi::xml_node nodeCP, std::string& pssh, std::string& kid);
+  bool ParseTagContentProtection(pugi::xml_node nodeCP,
+                                 std::vector<uint8_t>& pssh,
+                                 std::vector<uint8_t>& kid);
 
   bool ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 
@@ -126,8 +128,8 @@ protected:
   {
     std::string idUri;
     std::string value;
-    std::string kid;
-    std::string pssh;
+    std::vector<uint8_t> kid;
+    std::vector<uint8_t> pssh;
   };
 };
 } // namespace adaptive

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -262,7 +262,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
             period->SetEncryptionState(EncryptionState::ENCRYPTED_SUPPORTED);
 
             rep->m_psshSetPos = InsertPsshSet(adp->GetStreamType(), period, adp, m_currentPssh,
-                                              m_currentDefaultKID, m_currentIV);
+                                              m_currentDefaultKID, m_currentKidUrl, m_currentIV);
             if (period->GetPSSHSets()[rep->GetPsshSetPos()].m_usageCount == 1 ||
                 prepareStatus == PrepareRepStatus::DRMCHANGED)
             {
@@ -410,7 +410,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
           if (psshSetPos == PSSHSET_POS_DEFAULT)
           {
             psshSetPos = InsertPsshSet(StreamType::NOTYPE, period, adp, m_currentPssh,
-                                       m_currentDefaultKID, m_currentIV);
+                                       m_currentDefaultKID, m_currentKidUrl, m_currentIV);
             newSegment->pssh_set_ = psshSetPos;
           }
           else
@@ -506,7 +506,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
         if (currentEncryptionType == EncryptionType::WIDEVINE)
         {
           rep->m_psshSetPos = InsertPsshSet(adp->GetStreamType(), period, adp, m_currentPssh,
-                                            m_currentDefaultKID, m_currentIV);
+                                            m_currentDefaultKID, m_currentKidUrl, m_currentIV);
           period->SetEncryptionState(EncryptionState::ENCRYPTED_SUPPORTED);
         }
 
@@ -639,13 +639,13 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
     //Encrypted media, decrypt it
     if (pssh.defaultKID_.empty())
     {
-      //First look if we already have this URL resolved
-      for (auto itPsshSet = m_currentPeriod->GetPSSHSets().begin();
-           itPsshSet != m_currentPeriod->GetPSSHSets().end(); itPsshSet++)
+      // First look if we already have this URL resolved
+      for (const CPeriod::PSSHSet& psshSet : m_currentPeriod->GetPSSHSets())
       {
-        if (itPsshSet->pssh_ == pssh.pssh_ && !itPsshSet->defaultKID_.empty())
+        if (!psshSet.defaultKID_.empty() && psshSet.pssh_ == pssh.pssh_ ||
+            (!psshSet.m_kidUrl.empty() && psshSet.m_kidUrl == pssh.m_kidUrl))
         {
-          pssh.defaultKID_ = itPsshSet->defaultKID_;
+          pssh.defaultKID_ = psshSet.defaultKID_;
           break;
         }
       }
@@ -655,7 +655,7 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
       RETRY:
         std::map<std::string, std::string> headers;
         std::vector<std::string> keyParts = STRING::SplitToVec(m_decrypter->getLicenseKey(), '|');
-        std::string url = pssh.pssh_.c_str();
+        std::string url = pssh.m_kidUrl;
 
         if (keyParts.size() > 0)
         {
@@ -668,18 +668,23 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
 
         if (DownloadKey(url, headers, {}, resp))
         {
-          pssh.defaultKID_ = resp.data;
+          //! @todo: change DownloadKey and CURL methods to provide directly uint8_t data
+          pssh.defaultKID_.assign(resp.data.begin(), resp.data.end());
         }
-        else if (pssh.defaultKID_ != "0")
+        else if (pssh.defaultKID_.size() != 1)
         {
-          pssh.defaultKID_ = "0";
+          //! @todo: RenewLicense (addon) callback is not wiki documented, there are addons that could use this?
+          //!        currently fall here when the above download fail, there is no a better behaviour to avoid to do a broken download?
+          //!        the defaultKID_ is forced set with a single "0" instead of 16 chars without explanations
+          pssh.defaultKID_.clear();
+          pssh.defaultKID_.push_back('0');
           if (keyParts.size() >= 5 && !keyParts[4].empty() &&
               m_decrypter->RenewLicense(keyParts[4]))
             goto RETRY;
         }
       }
     }
-    if (pssh.defaultKID_ == "0")
+    if (pssh.defaultKID_.size() == 1 && pssh.defaultKID_.front() == '0')
     {
       segBuffer.resize(segBufferSize + srcDataSize, 0);
       return;
@@ -698,9 +703,8 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
     // Decrypter needs preallocated data
     segBuffer.resize(segBufferSize + srcDataSize);
 
-    m_decrypter->decrypt(reinterpret_cast<const uint8_t*>(pssh.defaultKID_.data()), iv,
-                         reinterpret_cast<const AP4_UI08*>(srcData), segBuffer, segBufferSize,
-                         srcDataSize, isLastChunk);
+    m_decrypter->decrypt(pssh.defaultKID_, iv, reinterpret_cast<const AP4_UI08*>(srcData),
+                         segBuffer, segBufferSize, srcDataSize, isLastChunk);
     if (srcDataSize >= 16)
       memcpy(iv, srcData + (srcDataSize - 16), 16);
   }
@@ -826,9 +830,9 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
   // AES-128
   if (encryptMethod == "AES-128" && !attribs["URI"].empty())
   {
-    m_currentPssh = attribs["URI"];
-    if (URL::IsUrlRelative(m_currentPssh))
-      m_currentPssh = URL::Join(baseUrl.data(), m_currentPssh);
+    m_currentKidUrl = attribs["URI"];
+    if (URL::IsUrlRelative(m_currentKidUrl))
+      m_currentKidUrl = URL::Join(baseUrl.data(), m_currentKidUrl);
 
     m_currentIV = m_decrypter->convertIV(attribs["IV"]);
 
@@ -844,6 +848,7 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
     {
       std::string keyid = attribs["KEYID"].substr(2);
       const char* defaultKID = keyid.c_str();
+      m_currentDefaultKID.clear();
       m_currentDefaultKID.resize(16);
       for (unsigned int i(0); i < 16; ++i)
       {
@@ -854,7 +859,11 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
       }
     }
 
-    m_currentPssh = attribs["URI"].substr(23);
+    m_currentPssh = ConvertDataUriToBytes(attribs["URI"]);
+    /*
+    *! @TODO: Following commented code dont take in account of possible pssh data and skip pssh parsing
+    *         needed appropriate method to parse wv pssh
+    * 
     // Try to get KID from pssh, we assume len+'pssh'+version(0)+systemid+lenkid+kid
     if (m_currentDefaultKID.empty() && m_currentPssh.size() == 68)
     {
@@ -862,6 +871,7 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
       if (decPssh.size() == 50)
         m_currentDefaultKID = decPssh.substr(34, 16);
     }
+    */
     if (encryptMethod == "SAMPLE-AES-CTR")
       m_cryptoMode = CryptoMode::AES_CTR;
     else if (encryptMethod == "SAMPLE-AES")
@@ -878,6 +888,35 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
   }
 
   return EncryptionType::UNKNOWN;
+}
+
+std::vector<uint8_t> adaptive::CHLSTree::ConvertDataUriToBytes(std::string_view uri)
+{
+  // Uri data format: "data:[media type][;attribute=value][;base64],<data>"
+  std::vector<std::string> colonSplit = STRING::SplitToVec(uri, ':');
+  if (colonSplit.size() == 2 && colonSplit[0] == "data")
+  {
+    std::vector<std::string> semiColonSplit = STRING::SplitToVec(colonSplit[1], ';');
+    if (semiColonSplit.size() > 0)
+    {
+      std::vector<std::string> comSplit = STRING::SplitToVec(semiColonSplit.back(), ',');
+      if (comSplit.size() == 2)
+      {
+        const bool isBase64 = comSplit[0] == "base64";
+        const std::string data = comSplit[1];
+        if (isBase64)
+        {
+          //return BASE64::DecodeStrToUint8(data);
+          return STRING::ToVecUint8(data);
+        }
+        else //!@TODO
+        {
+        }
+      }
+    }
+  }
+  // todo: log uri not supported?
+  return {};
 }
 
 bool adaptive::CHLSTree::ParseRenditon(const Rendition& r,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -125,6 +125,8 @@ protected:
   PLAYLIST::EncryptionType ProcessEncryption(std::string_view baseUrl,
                                              std::map<std::string, std::string>& attribs);
 
+  std::vector<uint8_t> ConvertDataUriToBytes(std::string_view uri);
+
   /*!
    * \brief Parse a rendition and set the data to the AdaptationSet and Representation.
    * \param r The rendition
@@ -181,8 +183,9 @@ private:
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;
 
-  std::string m_currentPssh; // Last processed encryption URI
-  std::string m_currentDefaultKID; // Last processed encryption KID
+  std::vector<uint8_t> m_currentPssh; // Last processed encryption URI
+  std::vector<uint8_t> m_currentDefaultKID; // Last processed encryption KID
+  std::string m_currentKidUrl; // Last processed encryption KID URI
   std::string m_currentIV; // Last processed encryption IV
 };
 

--- a/src/parser/PRProtectionParser.cpp
+++ b/src/parser/PRProtectionParser.cpp
@@ -33,12 +33,12 @@ bool adaptive::PRProtectionParser::ParseHeader(std::string_view prHeader)
   if (prHeader.empty())
     return false;
 
-  std::string headerData = BASE64::Decode(prHeader);
+  std::vector<uint8_t> headerData = BASE64::DecodeStrToUint8(prHeader.data());
   m_PSSH = headerData;
 
   // Parse header object data
   CCharArrayParser charParser;
-  charParser.Reset(headerData.c_str(), static_cast<int>(headerData.size()));
+  charParser.Reset(headerData.data(), static_cast<int>(headerData.size()));
 
   if (!charParser.SkipChars(4))
   {
@@ -139,7 +139,7 @@ bool adaptive::PRProtectionParser::ParseHeader(std::string_view prHeader)
 
   if (!kidBase64.empty())
   {
-    std::string kid = BASE64::Decode(kidBase64);
+    std::vector<uint8_t> kid = BASE64::DecodeStrToUint8(kidBase64);
     if (kid.size() == 16)
     {
       m_KID = ConvertKIDtoWVKID(kid);

--- a/src/parser/PRProtectionParser.h
+++ b/src/parser/PRProtectionParser.h
@@ -38,14 +38,14 @@ public:
    */
   bool HasProtection() const { return !m_PSSH.empty(); }
 
-  std::string_view GetKID() const { return m_KID; }
+  std::vector<uint8_t> GetKID() const { return m_KID; }
   std::string_view GetLicenseURL() const { return m_licenseURL; }
-  std::string_view GetPSSH() const { return m_PSSH; }
+  std::vector<uint8_t> GetPSSH() const { return m_PSSH; }
 
 private:
-  std::string m_KID;
+  std::vector<uint8_t> m_KID;
   std::string m_licenseURL;
-  std::string m_PSSH;
+  std::vector<uint8_t> m_PSSH;
 };
 
 } // namespace adaptive

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -53,14 +53,14 @@ CFragmentedSampleReader::CFragmentedSampleReader(AP4_ByteStream* input,
         (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
     {
       AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
-      if (tenc)
-        m_defaultKey = tenc->GetDefaultKid();
+      if (tenc && tenc->GetDefaultKid())
+        m_defaultKey.assign(tenc->GetDefaultKid(), tenc->GetDefaultKid() + 16);
       else
       {
         AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(
             AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
-        if (piff)
-          m_defaultKey = piff->GetDefaultKid();
+        if (piff && piff->GetDefaultKid())
+          m_defaultKey.assign(piff->GetDefaultKid(), piff->GetDefaultKid() + 16);
       }
     }
   }
@@ -492,7 +492,7 @@ void CFragmentedSampleReader::ParseTrafTfrf(AP4_UuidAtom* uuidAtom)
 {
   const AP4_DataBuffer& buf{AP4_DYNAMIC_CAST(AP4_UnknownUuidAtom, uuidAtom)->GetData()};
   CCharArrayParser parser;
-  parser.Reset(reinterpret_cast<const char*>(buf.GetData()), static_cast<int>(buf.GetDataSize()));
+  parser.Reset(buf.GetData(), static_cast<int>(buf.GetDataSize()));
 
   if (parser.CharsLeft() < 5)
   {

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -81,7 +81,7 @@ private:
   AP4_DataBuffer m_encrypted;
   AP4_DataBuffer m_sampleData;
   CodecHandler* m_codecHandler{nullptr};
-  const AP4_UI08* m_defaultKey{nullptr};
+  std::vector<uint8_t> m_defaultKey;
   AP4_ProtectedSampleDescription* m_protectedDesc{nullptr};
   Adaptive_CencSingleSampleDecrypter* m_singleSampleDecryptor;
   CAdaptiveCencSampleDecrypter* m_decrypter{nullptr};

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -395,11 +395,13 @@ TEST_F(DASHTreeTest, CalculatePsshDefaultKid)
 {
   OpenTestFile("mpd/pssh_default_kid.mpd");
 
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].pssh_, "ABCDEFGH");
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].defaultKID_.length(), 16);
+  const uint8_t* pssh1 = reinterpret_cast<const uint8_t*>("ABCDEFGH");
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].pssh_.data(), pssh1);
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].defaultKID_.size(), 16);
 
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].pssh_, "HGFEDCBA");
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].defaultKID_.length(), 16);
+  const uint8_t* pssh2 = reinterpret_cast<const uint8_t*>("HGFEDCBA");
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].pssh_.data(), pssh2);
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].defaultKID_.size(), 16);
 }
 
 TEST_F(DASHTreeAdaptiveStreamTest, subtitles)

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -204,9 +204,9 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
       "hls/ts_aes_keyuriwithslash_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
@@ -220,10 +220,9 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod,
       tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url,
-            "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
@@ -235,7 +234,7 @@ TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].pssh_,
+  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl,
             "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
@@ -247,9 +246,9 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
       "hls/ts_aes_keyurirelative_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
@@ -265,9 +264,9 @@ TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
       tree->m_currentPeriod,
       tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, PtsSetInMultiPeriod)

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -141,7 +141,7 @@ bool TestAdaptiveStream::Download(const DownloadInfo& downloadInfo, std::vector<
   return true;
 }
 
-void AESDecrypter::decrypt(const AP4_UI08* aes_key,
+void AESDecrypter::decrypt(const std::vector<uint8_t>& aes_key,
                            const AP4_UI08* aes_iv,
                            const AP4_UI08* src,
                            std::vector<uint8_t>& dst,

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -83,7 +83,7 @@ public:
   AESDecrypter(const std::string& licenseKey) : m_licenseKey(licenseKey){};
   virtual ~AESDecrypter() = default;
 
-  void decrypt(const AP4_UI08* aes_key,
+  void decrypt(const std::vector<uint8_t>& aes_key,
                const AP4_UI08* aes_iv,
                const AP4_UI08* src,
                std::vector<uint8_t>& dst,

--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace UTILS
 {
@@ -21,6 +23,11 @@ std::string Encode(const unsigned char* input, const size_t length);
 std::string Encode(const char* input, const size_t length);
 void Encode(const std::string& input, std::string& output);
 std::string Encode(const std::string& input);
+
+std::vector<uint8_t> DecodeStrToUint8(const std::string& input);
+std::vector<uint8_t> DecodeToUint8(const std::vector<uint8_t>& input);
+void DecodeData(const uint8_t* input, const size_t length, std::vector<uint8_t>& output);
+
 void Decode(const char* input, const size_t length, std::string& output);
 std::string Decode(const char* input, const size_t length);
 void Decode(std::string_view input, std::string& output);

--- a/src/utils/CharArrayParser.cpp
+++ b/src/utils/CharArrayParser.cpp
@@ -19,7 +19,7 @@ void UTILS::CCharArrayParser::Reset()
   m_position = 0;
 }
 
-void UTILS::CCharArrayParser::Reset(const char* data, int limit)
+void UTILS::CCharArrayParser::Reset(const uint8_t* data, int limit)
 {
   m_data = data;
   m_limit = limit;
@@ -152,14 +152,14 @@ std::string UTILS::CCharArrayParser::ReadNextString(int length)
     LOG::LogF(LOGERROR, "{} - No data to read");
     return "";
   }
-  std::string str(m_data + m_position, length);
+  std::string str(reinterpret_cast<const char*>(m_data + m_position), length);
   m_position += length;
   if (m_position > m_limit)
     LOG::LogF(LOGERROR, "{} - Position out of range");
   return str;
 }
 
-bool UTILS::CCharArrayParser::ReadNextArray(int length, char* data)
+bool UTILS::CCharArrayParser::ReadNextArray(int length, std::vector<uint8_t>& data)
 {
   if (!m_data)
   {
@@ -171,8 +171,7 @@ bool UTILS::CCharArrayParser::ReadNextArray(int length, char* data)
     LOG::LogF(LOGERROR, "{} - Position out of range");
     return false;
   }
-  std::strncpy(data, m_data + m_position, length);
-  data[length] = '\0';
+  data.insert(data.end(), m_data + m_position, m_data + m_position + length);
   return true;
 }
 
@@ -202,7 +201,7 @@ bool UTILS::CCharArrayParser::ReadNextLine(std::string& line)
     m_position += 3;
   }
 
-  line.assign(m_data + m_position, lineLimit - m_position);
+  line.assign(reinterpret_cast<const char*>(m_data + m_position), lineLimit - m_position);
   m_position = lineLimit;
 
   if (m_data[m_position] == '\r')

--- a/src/utils/CharArrayParser.h
+++ b/src/utils/CharArrayParser.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace UTILS
 {
@@ -33,7 +34,7 @@ public:
    * \param data The data
    * \param limit The limit of length of the data
    */
-  void Reset(const char* data, int limit);
+  void Reset(const uint8_t* data, int limit);
 
   /*!
    * \brief Return the number of chars yet to be read
@@ -116,7 +117,7 @@ public:
    * \param data[OUT] The data read
    * \return True if success, otherwise false
    */
-  bool ReadNextArray(int length, char* data);
+  bool ReadNextArray(int length, std::vector<uint8_t>& data);
 
   /*!
    * \brief Reads a line of text.
@@ -133,10 +134,10 @@ public:
    * \brief Get the current data
    * \return The char pointer to the current data
    */
-  const char* GetData() { return m_data; };
+  const uint8_t* GetData() { return m_data; };
 
 private:
-  const char* m_data{nullptr};
+  const uint8_t* m_data{nullptr};
   int m_position{0};
   int m_limit{0};
 };

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -273,3 +273,10 @@ uint32_t UTILS::STRING::HexStrToUint(std::string_view hexValue)
   ss >> val;
   return val;
 }
+
+std::vector<uint8_t> UTILS::STRING::ToVecUint8(std::string_view str)
+{
+  std::vector<uint8_t> val;
+  val.assign(str.begin(), str.end());
+  return val;
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -180,5 +180,7 @@ std::string ToLower(std::string str);
  */
 uint32_t HexStrToUint(std::string_view hexValue);
 
+std::vector<uint8_t> ToVecUint8(std::string_view str);
+
 } // namespace STRING
 } // namespace UTILS

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -208,32 +208,32 @@ std::string UTILS::AvcToAnnexb(const std::string& avc)
   return std::string(reinterpret_cast<char*>(buffer), buffer_size);
 }
 
-std::string UTILS::ConvertKIDtoWVKID(std::string_view kid)
+std::vector<uint8_t> UTILS::ConvertKIDtoWVKID(const std::vector<uint8_t>& kid)
 {
-  std::string remapped;
+  std::vector<uint8_t> remapped;
   static const size_t remap[16] = {3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15};
   for (size_t i{0}; i < 16; ++i)
   {
-    remapped += kid[remap[i]];
+    remapped.emplace_back(kid[remap[i]]);
   }
   return remapped;
 }
 
-std::string UTILS::ConvertKIDtoUUID(std::string_view kid)
+std::vector<uint8_t> UTILS::ConvertKIDtoUUID(const std::vector<uint8_t>& kid)
 {
   static char hexDigits[] = "0123456789abcdef";
-  std::string uuid;
+  std::vector<uint8_t> uuid;
   for (size_t i{0}; i < 16; ++i)
   {
     if (i == 4 || i == 6 || i == 8 || i == 10)
-      uuid += '-';
-    uuid += hexDigits[static_cast<uint8_t>(kid[i]) >> 4];
-    uuid += hexDigits[static_cast<uint8_t>(kid[i]) & 15];
+      uuid.emplace_back('-');
+    uuid.emplace_back(hexDigits[kid[i] >> 4]);
+    uuid.emplace_back(hexDigits[kid[i] & 15]);
   }
   return uuid;
 }
 
-bool UTILS::CreateISMlicense(std::string_view key,
+bool UTILS::CreateISMlicense(std::vector<uint8_t> key,
                              std::string_view licenseData,
                              std::vector<uint8_t>& initData)
 {
@@ -289,8 +289,8 @@ bool UTILS::CreateISMlicense(std::string_view key,
     std::memcpy(protoptr, kid, uuid - kid);
     protoptr += uuid - kid;
 
-    std::string uuidKid{ConvertKIDtoUUID(key)};
-    protoptr = reinterpret_cast<uint8_t*>(uuidKid.data());
+    std::vector<uint8_t> uuidKid = ConvertKIDtoUUID(key);
+    protoptr = uuidKid.data();
 
     size_t sizeleft = origLicenseSize - ((uuid - kid) + 6);
     std::memcpy(protoptr, uuid + 6, sizeleft);

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -23,9 +23,9 @@ namespace UTILS
 std::string AnnexbToHvcc(const char* b16Data);
 std::string AnnexbToAvc(const char* b16Data);
 std::string AvcToAnnexb(const std::string& avc);
-std::string ConvertKIDtoWVKID(std::string_view kid);
-std::string ConvertKIDtoUUID(std::string_view kid);
-bool CreateISMlicense(std::string_view key,
+std::vector<uint8_t> ConvertKIDtoWVKID(const std::vector<uint8_t>& kid);
+std::vector<uint8_t> ConvertKIDtoUUID(const std::vector<uint8_t>& kid);
+bool CreateISMlicense(std::vector<uint8_t> key,
                       std::string_view licenseData,
                       std::vector<uint8_t>& initData);
 void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std::string& header);

--- a/src/utils/XMLUtils.h
+++ b/src/utils/XMLUtils.h
@@ -12,6 +12,7 @@
 #include <limits>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace tinyxml2 // Forward
 {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Changes:
 **`CPeriod::PSSHSet` `pssh_` changed from std::string to vector of uint8_t**
For better data integrity pssh data type has been changed to vector of uint8_t, but this highlighted some variable hacks, some i already knew others discovered now. So `pssh_` variable content type was inconsistent, because can have a mix of types, like string of bytes or base64 string or a placeholder (to extract protection data from stream) this will drive one crazy to understand how and why a value is different and in what cases, because may lead to hidden bad behaviours.
To recap this, ISM set pssh as string of bytes, DASH/HLS as base64 string, and DASH can also set it by using the placeholder `PSSH_FROM_FILE`, and HLS also have a bad hack that set to pssh variable the KID url (see CHLSTree::ProcessEncryption for AES-128 case).

To solve this situation, `pssh_` variable now contains only bytes as uint8_t, and no base64 string allowed, to do so:
Pssh data are decoded while parsing manifest, then the data will be always bytes.
The placeholder `PSSH_FROM_FILE` has been removed, and replaced by add a `HasNoData` method in the `CPeriod::PSSHSet`.
For the HLS case with KID to PSSH hack, i have decoupled the KID url from pssh.

**HLS: implemented appropriate URI parsing**
URI attribute parsing of EXT-X-KEY tag lead to wrong data (as #660 issue), because we are assuming that URI always start with `URI="data:text/plain;base64,`, now i add a new `CHLSTree::ConvertDataUriToBytes` method that allow a better safe data extracting, this way has be converted from https://github.com/video-dev/hls.js/blob/v1.4.12/src/loader/level-key.ts#L120,
and could be useful in future to implement playready support

**HLS: implemented appropriate PSSH parsing**
i avoided use Bento4 because too much bento4 data types related
the old code: https://github.com/xbmc/inputstream.adaptive/blob/21.3.0-Omega/src/parser/HLSTree.cpp#L858-L864
its very limited and ignore versioning, ignore pssh that can containing keys+data
on git history there is nothing explained about this, if someone has some info please leave a comment

**Add CHLSTree todo for `RenewLicense` method call**
this not wiki documented, i dont know how test it atm, there are some implementation questions that i havent found answers, if someone has some info please leave a comment

`CCharArrayParser` has been changed to `uint8_t`, since all uses are of this type

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
initially i was investigating for #660 and i thought of handling pssh data as uint8_t "bytes" instead of std::string its more appropriate, but while doing this data type conversion i got stuck on some code misuses to be fixed

fix #660

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
HLS/DASH widevine
HLS AES128

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
