### PR TITLE
Improvements/fixes to code misuses

### DIFF
--- a/lib/jni/jni/jutils/jutils-details.hpp
+++ b/lib/jni/jni/jutils/jutils-details.hpp
@@ -163,6 +163,12 @@ struct jcast_helper<jhstring, std::string>
     static jhstring cast(const std::string &v);
 };
 
+template<>
+struct jcast_helper<jhbyteArray, std::vector<uint8_t>>
+{
+    static jhbyteArray cast(const std::vector<uint8_t>& v);
+};
+
 template <>
 struct jcast_helper<jhbyteArray, std::vector<char> >
 {

--- a/lib/jni/jni/jutils/jutils.cpp
+++ b/lib/jni/jni/jutils/jutils.cpp
@@ -45,6 +45,23 @@ jhstring jcast_helper<jhstring, std::string>::cast(const std::string &s)
     return jhstring(ret);
 }
 
+jhbyteArray jcast_helper<jhbyteArray, std::vector<uint8_t>>::cast(const std::vector<uint8_t>& s)
+{
+    JNIEnv* env = xbmc_jnienv();
+    jbyteArray ret = NULL;
+    if (!s.empty())
+    {
+      char* pArray;
+      ret = env->NewByteArray(s.size());
+      if ((pArray = (char*)env->GetPrimitiveArrayCritical(ret, NULL)))
+      {
+        memcpy(pArray, s.data(), s.size());
+        env->ReleasePrimitiveArrayCritical(ret, pArray, 0);
+      }
+    }
+    return jhbyteArray(ret);
+}
+
 jhbyteArray jcast_helper<jhbyteArray, std::vector<char> >::cast(const std::vector<char> &s)
 {
   JNIEnv *env = xbmc_jnienv();

--- a/lib/jni/jni/src/MediaDrm.cpp
+++ b/lib/jni/jni/src/MediaDrm.cpp
@@ -94,9 +94,12 @@ void CJNIMediaDrm::setPropertyByteArray(const std::string &propertyName, const s
     jcast<jhstring>(propertyName), jcast<jhbyteArray, std::vector<char> >(value));
 }
 
-CJNIMediaDrmKeyRequest CJNIMediaDrm::getKeyRequest(const std::vector<char> &scope, 
-  const std::vector<char> &init, const std::string &mimeType, int keyType,
-  const std::map<std::string, std::string> &optionalParameters) const
+CJNIMediaDrmKeyRequest CJNIMediaDrm::getKeyRequest(
+    const std::vector<char>& scope,
+    const std::vector<uint8_t>& init,
+    const std::string& mimeType,
+    int keyType,
+    const std::map<std::string, std::string>& optionalParameters) const
 {
   JNIEnv *env = xbmc_jnienv();
 
@@ -107,7 +110,7 @@ CJNIMediaDrmKeyRequest CJNIMediaDrm::getKeyRequest(const std::vector<char> &scop
   CJNIMediaDrmKeyRequest result =
     call_method<jhobject>(m_object,
       "getKeyRequest", "([B[BLjava/lang/String;ILjava/util/HashMap;)Landroid/media/MediaDrm$KeyRequest;",
-      jcast<jhbyteArray, std::vector<char> >(scope), jcast<jhbyteArray, std::vector<char> >(init),
+      jcast<jhbyteArray, std::vector<char>>(scope), jcast<jhbyteArray, std::vector<uint8_t>>(init),
       jcast<jhstring>(mimeType), keyType, hashMap.get_raw());
 
   return result;

--- a/lib/jni/jni/src/MediaDrm.h
+++ b/lib/jni/jni/src/MediaDrm.h
@@ -47,7 +47,7 @@ public:
   void setPropertyByteArray(const std::string &propertyName, const std::vector<char> &value) const;
 
   CJNIMediaDrmKeyRequest getKeyRequest(const std::vector<char> &scope,
-    const std::vector<char> &init, const std::string &mimeType, int keyType,
+    const std::vector<uint8_t> &init, const std::string &mimeType, int keyType,
     const std::map<std::string, std::string> &optionalParameters) const;
   std::vector<char> provideKeyResponse(const std::vector<char> &scope, const std::vector<char> &response) const;
 

--- a/src/Session.h
+++ b/src/Session.h
@@ -10,6 +10,7 @@
 
 #include "Stream.h"
 #include "common/AdaptiveStream.h"
+#include "common/Period.h"
 #include "decrypters/IDecrypter.h"
 #include "utils/PropertiesUtils.h"
 
@@ -363,6 +364,10 @@ protected:
   /*! \brief Destroy the decrypter module instance
    */
   void DisposeDecrypter();
+
+  bool ExtractStreamProtectionData(PLAYLIST::CPeriod::PSSHSet& sessionPsshset,
+                                   AP4_DataBuffer& init_data,
+                                   std::string keySystem);
 
 private:
   const UTILS::PROPERTIES::KodiProperties m_kodiProps;

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -12,6 +12,7 @@
 
 #include <stdexcept>
 #include <string_view>
+#include <vector>
 
 #include <bento4/Ap4.h>
 
@@ -37,7 +38,7 @@ public:
   };
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 poolId,
-                                     const AP4_UI08* key,
+                                     const std::vector<uint8_t>& keyId,
                                      const AP4_UI08 nalLengthSize,
                                      AP4_DataBuffer& annexbSpsPps,
                                      AP4_UI32 flags,

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -121,15 +121,17 @@ namespace adaptive
   uint16_t AdaptiveTree::InsertPsshSet(PLAYLIST::StreamType streamType,
                                        PLAYLIST::CPeriod* period,
                                        PLAYLIST::CAdaptationSet* adp,
-                                       std::string_view pssh,
+                                       const std::vector<uint8_t>& pssh,
                                        std::string_view defaultKID,
+                                       std::string_view kidUrl /* = "" */,
                                        std::string_view iv /* = "" */)
   {
-    if (!pssh.empty())
+    if (!pssh.empty() || !kidUrl.empty())
     {
       CPeriod::PSSHSet psshSet;
       psshSet.pssh_ = pssh;
       psshSet.defaultKID_ = defaultKID;
+      psshSet.m_kidUrl = kidUrl;
       psshSet.iv = iv;
       psshSet.m_cryptoMode = m_cryptoMode;
       psshSet.adaptation_set_ = adp;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -178,8 +178,9 @@ public:
   uint16_t InsertPsshSet(PLAYLIST::StreamType streamType,
                          PLAYLIST::CPeriod* period,
                          PLAYLIST::CAdaptationSet* adp,
-                         std::string_view pssh,
+                         const std::vector<uint8_t>& pssh,
                          std::string_view defaultKID,
+                         std::string_view kidUrl = "",
                          std::string_view iv = "");
 
   PLAYLIST::CAdaptationSet* GetAdaptationSet(size_t pos) const

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -27,8 +27,6 @@ namespace PLAYLIST
 constexpr uint16_t PSSHSET_POS_DEFAULT = 0;
 // Marker for not valid psshset position
 constexpr uint16_t PSSHSET_POS_INVALID = std::numeric_limits<uint16_t>::max();
-// Marker to try extract the PSSH from the file, or to try use a custom PSSH license data provided
-constexpr std::string_view PSSH_FROM_FILE = "FILE";
 // Marker for not set/not found segment position
 constexpr size_t SEGMENT_NO_POS = std::numeric_limits<size_t>::max();
 // Marker for not set/not found segment number

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -47,17 +47,24 @@ uint16_t PLAYLIST::CPeriod::InsertPSSHSet(PSSHSet* psshSet)
 {
   if (psshSet)
   {
-    // Find the psshSet by skipping the first one of the list (empty)
-    // note that PSSHSet struct has a custom comparator for std::find
-    auto itPssh = std::find(m_psshSets.begin() + 1, m_psshSets.end(), *psshSet);
+    auto itPssh = m_psshSets.end();
 
-    if (itPssh == m_psshSets.end())
-      itPssh = m_psshSets.insert(m_psshSets.end(), *psshSet);
-    else // Found
+    if (psshSet->m_kidUrl.empty())
     {
-      // If the existing is not used replace it with current one
-      if (itPssh->m_usageCount == 0)
-        *itPssh = *psshSet;
+      // Find the psshSet by skipping the first one of the list (for unencrypted streams)
+      // note that PSSHSet struct has a custom comparator for std::find
+      itPssh = std::find(m_psshSets.begin() + 1, m_psshSets.end(), *psshSet);
+    }
+
+    if (itPssh != m_psshSets.end() && itPssh->m_usageCount == 0)
+    {
+      // If the existing psshSet is not used, replace it with the new one
+      *itPssh = *psshSet;
+    }
+    else
+    {
+      // Add a new PsshSet
+      itPssh = m_psshSets.insert(m_psshSets.end(), *psshSet);
     }
 
     itPssh->m_usageCount++;

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -99,7 +99,8 @@ public:
     }
 
     //! @todo: create getter/setters
-    std::string pssh_;
+    std::vector<uint8_t> pssh_; // Data as bytes (not base64)
+    std::string m_kidUrl; // Url where get the KID
     std::string defaultKID_;
     std::string iv;
     uint32_t media_{0};

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -86,7 +86,7 @@ public:
    */
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
       AP4_DataBuffer& pssh,
-      const char* optionalKeyParameter,
+      std::string_view optionalKeyParameter,
       std::string_view defaultKeyId,
       bool skipSessionMessage,
       CryptoMode cryptoMode) = 0;
@@ -105,7 +105,7 @@ public:
    * \param caps The capabilities object to be populated
    */
   virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                               const uint8_t* keyId,
+                               std::string_view keyId,
                                uint32_t media,
                                IDecrypter::DecrypterCapabilites& caps) = 0;
 
@@ -116,7 +116,7 @@ public:
    * \return True if the KeyID has a license otherwise false
    */
   virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                             const uint8_t* keyId) = 0;
+                             std::string_view keyId) = 0;
 
   /**
    * \brief Check if the decrypter has been initialised (OpenDRMSystem called)

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -38,7 +38,9 @@ public:
                                CWVDecrypter* host);
   virtual ~CWVCencSingleSampleDecrypter();
 
-  void GetCapabilities(const uint8_t* key, uint32_t media, IDecrypter::DecrypterCapabilites& caps);
+  void GetCapabilities(std::string_view keyId,
+                       uint32_t media,
+                       IDecrypter::DecrypterCapabilites& caps);
   virtual const char* GetSessionId() override;
   void CloseSessionId();
   AP4_DataBuffer GetChallengeData();
@@ -46,10 +48,10 @@ public:
   void SetSession(const char* session, uint32_t sessionSize, const uint8_t* data, size_t dataSize);
 
   void AddSessionKey(const uint8_t* data, size_t dataSize, uint32_t status);
-  bool HasKeyId(const uint8_t* keyid);
+  bool HasKeyId(std::string_view keyid);
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 poolId,
-                                     const AP4_UI08* key,
+                                     const std::vector<uint8_t>& keyId,
                                      const AP4_UI08 nalLengthSize,
                                      AP4_DataBuffer& annexbSpsPps,
                                      AP4_UI32 flags,
@@ -109,14 +111,14 @@ private:
 
   struct FINFO
   {
-    const AP4_UI08* m_key;
+    std::vector<uint8_t> m_key;
     AP4_UI08 m_nalLengthSize;
     AP4_UI16 m_decrypterFlags;
     AP4_DataBuffer m_annexbSpsPps;
     CryptoInfo m_cryptoInfo;
   };
   std::vector<FINFO> m_fragmentPool;
-  void LogDecryptError(const cdm::Status status, const AP4_UI08* key);
+  void LogDecryptError(const cdm::Status status, const std::vector<uint8_t>& keyId);
   void SetCdmSubsamples(std::vector<cdm::SubsampleEntry>& subsamples, bool isCbc);
   void RepackSubsampleData(AP4_DataBuffer& dataIn,
                            AP4_DataBuffer& dataOut,

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -95,7 +95,7 @@ bool CWVDecrypter::OpenDRMSystem(const char* licenseURL,
 
 Adaptive_CencSingleSampleDecrypter* CWVDecrypter::CreateSingleSampleDecrypter(
     AP4_DataBuffer& pssh,
-    const char* optionalKeyParameter,
+    std::string_view optionalKeyParameter,
     std::string_view defaultKeyId,
     bool skipSessionMessage,
     CryptoMode cryptoMode)
@@ -121,7 +121,7 @@ void CWVDecrypter::DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypt
 }
 
 void CWVDecrypter::GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                                   const uint8_t* keyId,
+                                   std::string_view keyId,
                                    uint32_t media,
                                    IDecrypter::DecrypterCapabilites& caps)
 {
@@ -135,7 +135,7 @@ void CWVDecrypter::GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter
 }
 
 bool CWVDecrypter::HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                                 const uint8_t* keyId)
+                                 std::string_view keyId)
 {
   if (decrypter)
     return static_cast<CWVCencSingleSampleDecrypter*>(decrypter)->HasKeyId(keyId);

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -33,17 +33,17 @@ public:
                              const uint8_t config) override;
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
       AP4_DataBuffer& pssh,
-      const char* optionalKeyParameter,
+      std::string_view optionalKeyParameter,
       std::string_view defaultKeyId,
       bool skipSessionMessage,
       CryptoMode cryptoMode) override;
   virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override;
   virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                               const uint8_t* keyId,
+                               std::string_view keyId,
                                uint32_t media,
                                IDecrypter::DecrypterCapabilites& caps) override;
   virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                             const uint8_t* keyId) override;
+                             std::string_view keyId) override;
   virtual bool IsInitialised() override { return m_WVCdmAdapter != nullptr; }
   virtual std::string GetChallengeB64Data(Adaptive_CencSingleSampleDecrypter* decrypter) override;
   virtual bool OpenVideoDecoder(Adaptive_CencSingleSampleDecrypter* decrypter,

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.h
@@ -11,6 +11,7 @@
 #include "common/AdaptiveCencSampleDecrypter.h"
 
 #include <map>
+#include <string_view>
 
 #include <bento4/Ap4.h>
 
@@ -22,20 +23,20 @@ class ATTR_DLL_LOCAL CWVCencSingleSampleDecrypterA : public Adaptive_CencSingleS
 public:
   // methods
   CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm,
-                               AP4_DataBuffer& pssh,
-                               const char* optionalKeyParameter,
-                               std::string_view defaultKeyId,
-                               CWVDecrypterA* host);
+                                AP4_DataBuffer& pssh,
+                                std::string_view optionalKeyParameter,
+                                std::string_view defaultKeyId,
+                                CWVDecrypterA* host);
   virtual ~CWVCencSingleSampleDecrypterA();
 
   bool StartSession(bool skipSessionMessage) { return KeyUpdateRequest(true, skipSessionMessage); };
   const std::vector<char>& GetSessionIdRaw() { return m_sessionId; };
   virtual const char* GetSessionId() override;
   std::vector<char> GetChallengeData();
-  virtual bool HasLicenseKey(const uint8_t* keyId);
+  virtual bool HasLicenseKey(std::string_view keyId);
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 poolId,
-                                     const AP4_UI08* key,
+                                     const std::vector<uint8_t>& keyId,
                                      const AP4_UI08 nalLengthSize,
                                      AP4_DataBuffer& annexbSpsPps,
                                      AP4_UI32 flags,
@@ -60,7 +61,7 @@ public:
       // array of <subsample_count> integers. NULL if subsample_count is 0
       const AP4_UI32* bytesOfEncryptedData) override;
 
-  void GetCapabilities(const uint8_t* keyId,
+  void GetCapabilities(std::string_view keyId,
                        uint32_t media,
                        DRM::IDecrypter::DecrypterCapabilites& caps);
 
@@ -73,8 +74,8 @@ private:
   bool SendSessionMessage(const std::vector<char>& keyRequestData);
 
   CWVCdmAdapterA& m_mediaDrm;
-  std::vector<char> m_pssh;
-  std::vector<char> m_initialPssh;
+  std::vector<uint8_t> m_pssh;
+  std::vector<uint8_t> m_initialPssh;
   std::map<std::string, std::string> m_optParams;
   CWVDecrypterA* m_host;
 
@@ -90,7 +91,7 @@ private:
 
   struct FINFO
   {
-    const AP4_UI08* m_key;
+    std::vector<uint8_t> m_key;
     AP4_UI08 m_nalLengthSize;
     AP4_UI16 m_decrypterFlags;
     AP4_DataBuffer m_annexbSpsPps;

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -141,7 +141,7 @@ bool CWVDecrypterA::OpenDRMSystem(const char* licenseURL,
 
 Adaptive_CencSingleSampleDecrypter* CWVDecrypterA::CreateSingleSampleDecrypter(
     AP4_DataBuffer& pssh,
-    const char* optionalKeyParameter,
+    std::string_view optionalKeyParameter,
     std::string_view defaultKeyId,
     bool skipSessionMessage,
     CryptoMode cryptoMode)
@@ -178,9 +178,9 @@ void CWVDecrypterA::DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecryp
 }
 
 void CWVDecrypterA::GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                                   const uint8_t* keyId,
-                                   uint32_t media,
-                                   IDecrypter::DecrypterCapabilites& caps)
+                                    std::string_view keyId,
+                                    uint32_t media,
+                                    IDecrypter::DecrypterCapabilites& caps)
 {
   if (decrypter)
     static_cast<CWVCencSingleSampleDecrypterA*>(decrypter)->GetCapabilities(keyId, media, caps);
@@ -189,7 +189,7 @@ void CWVDecrypterA::GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypte
 }
 
 bool CWVDecrypterA::HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                                 const uint8_t* keyId)
+                                  std::string_view keyId)
 {
   if (decrypter)
     return static_cast<CWVCencSingleSampleDecrypterA*>(decrypter)->HasLicenseKey(keyId);
@@ -201,9 +201,8 @@ std::string CWVDecrypterA::GetChallengeB64Data(Adaptive_CencSingleSampleDecrypte
   if (!decrypter)
     return "";
 
-  std::vector<char> challengeData =
-      static_cast<CWVCencSingleSampleDecrypterA*>(decrypter)->GetChallengeData();
-  return BASE64::Encode(challengeData.data(), challengeData.size());
+  const std::vector<char> data = static_cast<CWVCencSingleSampleDecrypterA*>(decrypter)->GetChallengeData();
+  return BASE64::Encode(data);
 }
 
 void CWVDecrypterA::OnMediaDrmEvent(const CJNIMediaDrm& mediaDrm,

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -89,7 +89,7 @@ public:
 
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
       AP4_DataBuffer& pssh,
-      const char* optionalKeyParameter,
+      std::string_view optionalKeyParameter,
       std::string_view defaultKeyId,
       bool skipSessionMessage,
       CryptoMode cryptoMode) override;
@@ -97,12 +97,12 @@ public:
   virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override;
 
   virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
-                               const uint8_t* keyId,
+                               std::string_view keyId,
                                uint32_t media,
                                IDecrypter::DecrypterCapabilites& caps) override;
 
   virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
-                             const uint8_t* keyId) override;
+                             std::string_view keyId) override;
 
   virtual std::string GetChallengeB64Data(Adaptive_CencSingleSampleDecrypter* decrypter) override;
 

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -74,7 +74,9 @@ protected:
 
   void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate* segTpl);
 
-  bool ParseTagContentProtection(pugi::xml_node nodeCP, std::string& pssh, std::string& kid);
+  bool ParseTagContentProtection(pugi::xml_node nodeCP,
+                                 std::vector<uint8_t>& pssh,
+                                 std::string& kid);
 
   bool ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -125,6 +125,8 @@ protected:
   PLAYLIST::EncryptionType ProcessEncryption(std::string_view baseUrl,
                                              std::map<std::string, std::string>& attribs);
 
+  bool GetUriByteData(std::string_view uri, std::vector<uint8_t>& data);
+
   /*!
    * \brief Parse a rendition and set the data to the AdaptationSet and Representation.
    * \param r The rendition
@@ -181,8 +183,9 @@ private:
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;
 
-  std::string m_currentPssh; // Last processed encryption URI
+  std::vector<uint8_t> m_currentPssh; // Last processed encryption PSSH from URI
   std::string m_currentDefaultKID; // Last processed encryption KID
+  std::string m_currentKidUrl; // Last processed encryption KID URI
   std::string m_currentIV; // Last processed encryption IV
 };
 

--- a/src/parser/PRProtectionParser.h
+++ b/src/parser/PRProtectionParser.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "test/KodiStubs.h"
@@ -40,12 +41,31 @@ public:
 
   std::string_view GetKID() const { return m_KID; }
   std::string_view GetLicenseURL() const { return m_licenseURL; }
-  std::string_view GetPSSH() const { return m_PSSH; }
+  std::vector<uint8_t> GetPSSH() const { return m_PSSH; }
 
 private:
   std::string m_KID;
   std::string m_licenseURL;
-  std::string m_PSSH;
+  std::vector<uint8_t> m_PSSH;
+};
+
+// \brief Parse PSSH data format (ref. https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html#common-system)
+class ATTR_DLL_LOCAL CPsshParser
+{
+public:
+  bool Parse(const std::vector<uint8_t>& data);
+
+  const std::vector<uint8_t>& GetSystemId() const { return m_systemId; }
+  const std::vector<std::string>& GetKeyIds() const { return m_keyIds; }
+  const std::vector<uint8_t>& GetData() const { return m_data; }
+
+private:
+  const uint8_t m_boxTypePssh[4]{'p', 's', 's', 'h'};
+  uint8_t m_version{0};
+  uint32_t m_flags{0};
+  std::vector<uint8_t> m_systemId;
+  std::vector<std::string> m_keyIds;
+  std::vector<uint8_t> m_data;
 };
 
 } // namespace adaptive

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -53,14 +53,14 @@ CFragmentedSampleReader::CFragmentedSampleReader(AP4_ByteStream* input,
         (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
     {
       AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
-      if (tenc)
-        m_defaultKey = tenc->GetDefaultKid();
+      if (tenc && tenc->GetDefaultKid())
+        m_defaultKey.assign(tenc->GetDefaultKid(), tenc->GetDefaultKid() + 16);
       else
       {
         AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(
             AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
-        if (piff)
-          m_defaultKey = piff->GetDefaultKid();
+        if (piff && piff->GetDefaultKid())
+          m_defaultKey.assign(piff->GetDefaultKid(), piff->GetDefaultKid() + 16);
       }
     }
   }
@@ -492,7 +492,7 @@ void CFragmentedSampleReader::ParseTrafTfrf(AP4_UuidAtom* uuidAtom)
 {
   const AP4_DataBuffer& buf{AP4_DYNAMIC_CAST(AP4_UnknownUuidAtom, uuidAtom)->GetData()};
   CCharArrayParser parser;
-  parser.Reset(reinterpret_cast<const char*>(buf.GetData()), static_cast<int>(buf.GetDataSize()));
+  parser.Reset(buf.GetData(), buf.GetDataSize());
 
   if (parser.CharsLeft() < 5)
   {

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -81,7 +81,7 @@ private:
   AP4_DataBuffer m_encrypted;
   AP4_DataBuffer m_sampleData;
   CodecHandler* m_codecHandler{nullptr};
-  const AP4_UI08* m_defaultKey{nullptr};
+  std::vector<uint8_t> m_defaultKey;
   AP4_ProtectedSampleDescription* m_protectedDesc{nullptr};
   Adaptive_CencSingleSampleDecrypter* m_singleSampleDecryptor;
   CAdaptiveCencSampleDecrypter* m_decrypter{nullptr};

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -8,6 +8,7 @@
 
 #include "TestHelper.h"
 
+#include "../utils/Base64Utils.h"
 #include "../utils/PropertiesUtils.h"
 #include "../utils/UrlUtils.h"
 #include "../utils/Utils.h"
@@ -395,11 +396,13 @@ TEST_F(DASHTreeTest, CalculatePsshDefaultKid)
 {
   OpenTestFile("mpd/pssh_default_kid.mpd");
 
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].pssh_, "ABCDEFGH");
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].defaultKID_.length(), 16);
+  const std::vector<uint8_t> pssh1 = BASE64::Decode("AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQblodJidXR9eARuql0dNLWg==");
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].pssh_, pssh1);
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].defaultKID_.size(), 16);
 
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].pssh_, "HGFEDCBA");
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].defaultKID_.length(), 16);
+  const std::vector<uint8_t> pssh2 = BASE64::Decode("AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQnrQFDeRLSAKTLifXUIPiZg==");
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].pssh_, pssh2);
+  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].defaultKID_.size(), 16);
 }
 
 TEST_F(DASHTreeAdaptiveStreamTest, subtitles)

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -204,9 +204,9 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
       "hls/ts_aes_keyuriwithslash_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
@@ -220,10 +220,9 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod,
       tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url,
-            "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
@@ -235,8 +234,7 @@ TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].pssh_,
-            "https://foo.bar/hls/key/key.php?stream=stream_name");
+  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelative)
@@ -247,9 +245,9 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
       "hls/ts_aes_keyurirelative_stream_0.m3u8",
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
@@ -265,9 +263,9 @@ TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
       tree->m_currentPeriod,
       tree->m_currentAdpSet, tree->m_currentRepr);
 
-  std::string pssh_url = tree->m_currentPeriod->GetPSSHSets()[1].pssh_;
   EXPECT_EQ(res, PLAYLIST::PrepareRepStatus::OK);
-  EXPECT_EQ(pssh_url, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
+  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, PtsSetInMultiPeriod)

--- a/src/test/manifests/mpd/pssh_default_kid.mpd
+++ b/src/test/manifests/mpd/pssh_default_kid.mpd
@@ -11,7 +11,7 @@
       </Representation>
       <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_="urn:mpeg:cenc:2013" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" _:default_KID="0101f49e-117c-ec8e-d606-27d7cb46ae38"/>
       <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
-        <pssh xmlns="urn:mpeg:cenc:2013">ABCDEFGH</pssh>
+        <pssh xmlns="urn:mpeg:cenc:2013">AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQblodJidXR9eARuql0dNLWg==</pssh>
       </ContentProtection>
     </AdaptationSet>
     <AdaptationSet id="1" contentType="video">
@@ -24,7 +24,7 @@
       </Representation>
       <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_="urn:mpeg:cenc:2013" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="01004b6f-0835-b807-9098-c070dc30a6c7"/>
       <ContentProtection xmlns="urn:mpeg:dash:schema:mpd:2011" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
-        <cenc:pssh xmlns="urn:mpeg:cenc:2013">HGFEDCBA</cenc:pssh>
+        <cenc:pssh xmlns="urn:mpeg:cenc:2013">AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQnrQFDeRLSAKTLifXUIPiZg==</cenc:pssh>
       </ContentProtection>
     </AdaptationSet>
   </Period>

--- a/src/utils/Base64Utils.cpp
+++ b/src/utils/Base64Utils.cpp
@@ -41,7 +41,7 @@ constexpr unsigned char BASE64_TABLE[] = {
 // clang-format on
 } // namespace
 
-void UTILS::BASE64::Encode(const char* input, const size_t length, std::string& output)
+void UTILS::BASE64::Encode(const uint8_t* input, const size_t length, std::string& output)
 {
   if (input == nullptr || length == 0)
     return;
@@ -74,33 +74,35 @@ void UTILS::BASE64::Encode(const char* input, const size_t length, std::string& 
   }
 }
 
-std::string UTILS::BASE64::Encode(const unsigned char* input, const size_t length)
-{
-  std::string output;
-  Encode(reinterpret_cast<const char*>(input), length, output);
-  return output;
-}
-
-std::string UTILS::BASE64::Encode(const char* input, const size_t length)
+std::string UTILS::BASE64::Encode(const uint8_t* input, const size_t length)
 {
   std::string output;
   Encode(input, length, output);
   return output;
 }
 
-void UTILS::BASE64::Encode(const std::string& input, std::string& output)
-{
-  Encode(input.c_str(), input.size(), output);
-}
-
-std::string UTILS::BASE64::Encode(const std::string& input)
+std::string UTILS::BASE64::Encode(const std::vector<uint8_t>& input)
 {
   std::string output;
-  Encode(input, output);
+  Encode(input.data(), input.size(), output);
   return output;
 }
 
-void UTILS::BASE64::Decode(const char* input, const size_t length, std::string& output)
+std::string UTILS::BASE64::Encode(const std::vector<char>& input)
+{
+  std::string output;
+  Encode(reinterpret_cast<const uint8_t*>(input.data()), input.size(), output);
+  return output;
+}
+
+std::string UTILS::BASE64::Encode(const std::string& inputStr)
+{
+  std::string output;
+  Encode(reinterpret_cast<const uint8_t*>(inputStr.data()), inputStr.size(), output);
+  return output;
+}
+
+void UTILS::BASE64::Decode(const char* input, const size_t length, std::vector<uint8_t>& output)
 {
   if (!input)
     return;
@@ -185,21 +187,16 @@ void UTILS::BASE64::Decode(const char* input, const size_t length, std::string& 
   }
 }
 
-std::string UTILS::BASE64::Decode(const char* input, const size_t length)
+std::vector<uint8_t> UTILS::BASE64::Decode(std::string_view input)
 {
-  std::string output;
-  Decode(input, length, output);
-  return output;
+  std::vector<uint8_t> data;
+  Decode(input.data(), input.size(), data);
+  return data;
 }
 
-void UTILS::BASE64::Decode(std::string_view input, std::string& output)
+std::string UTILS::BASE64::DecodeToStr(std::string_view input)
 {
+  std::vector<uint8_t> output;
   Decode(input.data(), input.size(), output);
-}
-
-std::string UTILS::BASE64::Decode(std::string_view input)
-{
-  std::string output;
-  Decode(input.data(), input.size(), output);
-  return output;
+  return {output.begin(), output.end()};
 }

--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -8,23 +8,25 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace UTILS
 {
 namespace BASE64
 {
 
-void Encode(const char* input, const size_t length, std::string& output);
-std::string Encode(const unsigned char* input, const size_t length);
-std::string Encode(const char* input, const size_t length);
-void Encode(const std::string& input, std::string& output);
+void Encode(const uint8_t* input, const size_t length, std::string& output);
+std::string Encode(const uint8_t* input, const size_t length);
+std::string Encode(const std::vector<uint8_t>& input);
+std::string Encode(const std::vector<char>& input);
 std::string Encode(const std::string& input);
-void Decode(const char* input, const size_t length, std::string& output);
-std::string Decode(const char* input, const size_t length);
-void Decode(std::string_view input, std::string& output);
-std::string Decode(std::string_view input);
+
+void Decode(const char* input, const size_t length, std::vector<uint8_t>& output);
+std::vector<uint8_t> Decode(std::string_view input);
+std::string DecodeToStr(std::string_view input);
 
 } // namespace BASE64
 } // namespace UTILS

--- a/src/utils/CharArrayParser.h
+++ b/src/utils/CharArrayParser.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace UTILS
 {
@@ -33,31 +34,31 @@ public:
    * \param data The data
    * \param limit The limit of length of the data
    */
-  void Reset(const char* data, int limit);
+  void Reset(const uint8_t* data, size_t limit);
 
   /*!
    * \brief Return the number of chars yet to be read
    */
-  int CharsLeft();
+  size_t CharsLeft();
 
   /*!
    * \brief Returns the current offset in the array
    */
-  int GetPosition();
+  size_t GetPosition();
 
   /*!
    * \brief Set the reading offset in the array
    * \param position The new offset position
    * \return True if success, otherwise false
    */
-  bool SetPosition(int position);
+  bool SetPosition(size_t position);
 
   /*!
    * \brief Skip a specified number of chars
    * \param nChars The number of chars
    * \return True if success, otherwise false
    */
-  bool SkipChars(int nChars);
+  bool SkipChars(size_t nChars);
 
   /*!
    * \brief Reads the next unsigned char (it is assumed that the caller has
@@ -107,7 +108,7 @@ public:
    * \param length The length to be read
    * \return The string value
    */
-  std::string ReadNextString(int length);
+  std::string ReadNextString(size_t length);
 
   /*!
    * \brief Reads the next chars array of specified length (it is assumed that
@@ -116,29 +117,24 @@ public:
    * \param data[OUT] The data read
    * \return True if success, otherwise false
    */
-  bool ReadNextArray(int length, char* data);
-
-  /*!
-   * \brief Reads a line of text.
-   * A line is considered to be terminated by any one of a carriage return ('\\r'),
-   * a line feed ('\\n'), or a carriage return followed by a line feed ('\\r\\n'),
-   * this method discards leading UTF-8 byte order marks, if present.
-   * \param line [OUT] The line read without line-termination characters
-   * \return True if read, otherwise false if the end of the data has already
-   *         been reached
-   */
-  bool ReadNextLine(std::string& line);
+  bool ReadNextArray(size_t length, std::vector<uint8_t>& data);
 
   /*!
    * \brief Get the current data
    * \return The char pointer to the current data
    */
-  const char* GetData() { return m_data; };
+  const uint8_t* GetData() { return m_data; };
+
+  /*!
+   * \brief Get the data from current position
+   * \return The char pointer from the current data position
+   */
+  const uint8_t* GetDataPos() { return m_data + m_position; }
 
 private:
-  const char* m_data{nullptr};
-  int m_position{0};
-  int m_limit{0};
+  const uint8_t* m_data{nullptr};
+  size_t m_position{0};
+  size_t m_limit{0};
 };
 
 } // namespace UTILS

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -273,3 +273,21 @@ uint32_t UTILS::STRING::HexStrToUint(std::string_view hexValue)
   ss >> val;
   return val;
 }
+
+std::vector<uint8_t> UTILS::STRING::ToVecUint8(std::string_view str)
+{
+  std::vector<uint8_t> val;
+  val.assign(str.begin(), str.end());
+  return val;
+}
+
+std::string UTILS::STRING::ToHexadecimal(std::string_view str)
+{
+  std::ostringstream ss;
+  ss << std::hex;
+  for (unsigned char ch : str)
+  {
+    ss << std::setw(2) << std::setfill('0') << static_cast<unsigned long>(ch);
+  }
+  return ss.str();
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -180,5 +180,21 @@ std::string ToLower(std::string str);
  */
 uint32_t HexStrToUint(std::string_view hexValue);
 
+/*!
+ * \brief Convert a string in to a vector of uint8_t
+ * \param str The string to be converted
+ * \return The converted data
+ */
+std::vector<uint8_t> ToVecUint8(std::string_view str);
+
+/*!
+ * \brief Convert each character in the string to its hexadecimal
+ *        representation and return the concatenated result.
+ *        Example: "abc" -> "616263"
+ * \param str The string to be converted
+ * \return The string on its hexadecimal representation
+ */
+std::string ToHexadecimal(std::string_view str);
+
 } // namespace STRING
 } // namespace UTILS

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -243,7 +243,7 @@ bool UTILS::CreateISMlicense(std::string_view key,
     return false;
   }
 
-  std::string decLicData = BASE64::Decode(licenseData);
+  std::string decLicData = BASE64::DecodeToStr(licenseData);
   size_t origLicenseSize = decLicData.size();
 
   const uint8_t* kid{reinterpret_cast<const uint8_t*>(std::strstr(decLicData.data(), "{KID}"))};
@@ -326,6 +326,16 @@ uint64_t UTILS::GetTimestamp()
   std::chrono::seconds unix_timestamp = std::chrono::seconds(std::time(NULL));
   using dCast = std::chrono::duration<std::uint64_t>;
   return std::chrono::duration_cast<dCast>(std::chrono::milliseconds(unix_timestamp)).count();
+}
+
+std::vector<uint8_t> UTILS::ZeroPadding(const std::vector<uint8_t>& data, const size_t padSize)
+{
+  if (data.size() >= padSize || data.empty())
+    return data;
+
+  std::vector<uint8_t> paddedData(padSize, 0);
+  std::copy(data.cbegin(), data.cend(), paddedData.begin() + (padSize - data.size()));
+  return paddedData;
 }
 
 std::string UTILS::CODEC::FourCCToString(const uint32_t fourcc)

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -36,6 +36,14 @@ void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std:
  */
 uint64_t GetTimestamp();
 
+/*!
+ * \brief Add zero-pad on the left side of data when the data size is less than pad size
+ * \param data The data
+ * \param padSize The length of padding
+ * \return The padded data
+ */
+std::vector<uint8_t> ZeroPadding(const std::vector<uint8_t>& data, const size_t padSize);
+
 namespace CODEC
 {
 constexpr const char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Changes:
 **`CPeriod::PSSHSet` `pssh_` changed from std::string to vector of uint8_t**
For better data integrity pssh data type has been changed to vector of uint8_t, but this highlighted some variable hacks, some i already knew others discovered now. So `pssh_` variable content type was inconsistent, because can have a mix of types, like string of bytes or base64 string or a placeholder (to extract protection data from stream) this will drive one crazy to understand how and why a value is different and in what cases, because may lead to hidden bad behaviours.
To recap this, ISM set pssh as string of bytes, DASH/HLS as base64 string, and DASH can also set it by using the placeholder `PSSH_FROM_FILE`, and HLS also have a bad hack that set to pssh variable the KID url (see CHLSTree::ProcessEncryption for AES-128 case).

To solve this situation, `pssh_` variable now contains only bytes as uint8_t, and no base64 string allowed, to do so:
Pssh data are decoded while parsing manifest, then the data will be always bytes.
The placeholder `PSSH_FROM_FILE` has been removed and reordered conditions that set the license init PSSH in `CSession::InitializeDRM` so to fallback to extract the pssh as last resort.
For the HLS case with KID url to PSSH hack, i have decoupled the KID url from pssh.

**HLS: implemented appropriate URI parsing for data format**
URI attribute parsing of EXT-X-KEY tag lead to wrong data (as #660 issue), because we are assuming that URI always start with `URI="data:text/plain;base64,`, now i add a new `CHLSTree::GetUriByteData` method that allow a better safe data extracting, this way has be converted from https://github.com/video-dev/hls.js/blob/v1.4.12/src/loader/level-key.ts#L120,
and could be useful in future to implement playready support

**HLS: for AES-128, add support to read KID from EXT-X-KEY URI with base64 data format**
for example
```
#EXT-X-KEY:METHOD=AES-128,URI="data:;base64,dKbarMNMRSmPPEXQ3dDCNA=="
#EXT-X-KEY:METHOD=AES-128,URI="data:application/octet-stream;base64,xtfhsRCnE3+t2bVKn+gLEQ==",IV=0x50f881b1f9598945878e60ccb139bb9c
```
but i havent found a workable sample stream to test this use case

**HLS: implemented appropriate PSSH parsing**
i avoided use Bento4 because too much bento4 data types related
the old code: https://github.com/xbmc/inputstream.adaptive/blob/21.3.0-Omega/src/parser/HLSTree.cpp#L858-L864
its very limited and ignore versioning, ignore pssh that can containing keys+data
on git history there is nothing explained about this, if someone has some info please leave a comment

**Add CHLSTree todo for `RenewLicense` method call**
this not wiki documented, i dont know how test it atm, there are some implementation questions that i havent found answers, if someone has some info please leave a comment

`CCharArrayParser` has been changed to `uint8_t`, since all uses are of this type

**Code changes to `CSession::InitializeDRM` method to set license init PSSH data**
To remove the placeholder `PSSH_FROM_FILE` and keep a similar behaviour to set the initial pssh, i have reordered all these conditions
https://github.com/xbmc/inputstream.adaptive/blob/21.3.0-Omega/src/Session.cpp#L418-L533
hoping there is no oversights the behaviour is similar, with these differences:
- `license_data` ISA prop if set, now can always override an existing pssh
- The `drmOptionalKeyParam` (previously named `optionalKeyParameter`) has been limited to "com.microsoft.playready" license type, this because its PlayReady specific DRM parameter and should be not set to others DRM's
- Since `PSSH_FROM_FILE` dont exist anymore, we try to extract the protection data from the stream as last resort
- I have add some _todo_'s comments, around `license_data` behaviour because that ISA property have multiple mixed purposes that i find messy and should be reworked/changed

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
initially i was investigating for #660 and i thought of handling pssh data as uint8_t "bytes" instead of std::string its more appropriate, but while doing this data type conversion i got stuck on some code misuses to be fixed

fix #660

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
HLS/DASH widevine
HLS AES128

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
