### PR TITLE
[Widevine] Improvements to DRM storage folder

### DIFF
--- a/lib/cdm/cdm/media/cdm/cdm_adapter.h
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.h
@@ -269,6 +269,7 @@ public:
 
 private:
   std::string base_path_;
+  std::string m_filepath;
   cdm::FileIOClient* client_;
   FILE *file_descriptor_;
   uint8_t *data_buffer_;

--- a/src/decrypters/CMakeLists.txt
+++ b/src/decrypters/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES
   DrmFactory.cpp
+  Helpers.cpp
 )
 
 set(HEADERS
   DrmFactory.h
+  Helpers.h
   IDecrypter.h
 )
 

--- a/src/decrypters/Helpers.cpp
+++ b/src/decrypters/Helpers.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Helpers.h"
+
+#include "utils/DigestMD5Utils.h"
+#include "utils/StringUtils.h"
+#include "utils/UrlUtils.h"
+
+using namespace UTILS;
+
+std::string DRM::GenerateUrlDomainHash(std::string_view url)
+{
+  std::string baseDomain = URL::GetBaseDomain(url.data());
+  // If we are behind a proxy we fall always in to the same domain e.g. "http://localhost/"
+  // but we have to differentiate the results based on the service of the add-on hosting the proxy
+  // to avoid possible collisions, so we include the first directory path after the domain name
+  // e.g. http://localhost:1234/addonservicename/other_dir/get_license?id=xyz
+  // domain will result: http://localhost/addonservicename/
+  if (STRING::Contains(baseDomain, "127.0.0.1") || STRING::Contains(baseDomain, "localhost"))
+  {
+    const size_t domainStartPos = url.find("://") + 3;
+    const size_t pathStartPos = url.find_first_of('/', domainStartPos);
+    if (pathStartPos != std::string::npos)
+    {
+      // Try get the first directory path name
+      const size_t nextSlashPos = url.find_first_of('/', pathStartPos + 1);
+      size_t length = std::string::npos;
+      if (nextSlashPos != std::string::npos)
+      {
+        length = nextSlashPos - pathStartPos;
+        baseDomain += url.substr(pathStartPos, length);
+      }
+    }
+  }
+
+  // Generate hash of domain name
+  DIGEST::MD5 md5;
+  md5.Update(baseDomain.c_str(), static_cast<uint32_t>(baseDomain.size()));
+  md5.Finalize();
+  return md5.HexDigest();
+}

--- a/src/decrypters/Helpers.h
+++ b/src/decrypters/Helpers.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace DRM
+{
+
+/*!
+ * \brief Generate an hash by using the base domain of an URL.
+ * \param url An URL
+ * \return The hash of a base domain URL
+ */
+std::string GenerateUrlDomainHash(std::string_view url);
+
+}; // namespace DRM

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -358,7 +358,7 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
           // Try find the container type on the representation according to the file extension
           std::string url = URL::RemoveParameters(line);
           // Remove domain on absolute url, to not confuse top-level domain as extension
-          url = url.substr(URL::GetDomainUrl(url).size());
+          url = url.substr(URL::GetBaseDomain(url).size());
 
           std::string extension;
           size_t extPos = url.rfind('.');

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -35,7 +35,7 @@ protected:
 TEST_F(UtilsTest, DetermineBaseDomain)
 {
   std::string url = "https://foo.bar/mpd/test.mpd";
-  EXPECT_EQ(URL::GetDomainUrl(url), "https://foo.bar");
+  EXPECT_EQ(URL::GetBaseDomain(url), "https://foo.bar");
 }
 
 TEST_F(UtilsTest, JoinUrls)

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -34,8 +34,17 @@ protected:
 
 TEST_F(UtilsTest, DetermineBaseDomain)
 {
-  std::string url = "https://foo.bar/mpd/test.mpd";
-  EXPECT_EQ(URL::GetBaseDomain(url), "https://foo.bar");
+  std::string url = "https://www.foo.bar/mpd/test.mpd";
+  EXPECT_EQ(URL::GetBaseDomain(url), "https://www.foo.bar");
+
+  url = "https://www.foo.bar/mpd/test.mpd?ping=pong";
+  EXPECT_EQ(URL::GetBaseDomain(url), "https://www.foo.bar");
+
+  url = "https://www.foo.bar:1234";
+  EXPECT_EQ(URL::GetBaseDomain(url), "https://www.foo.bar");
+
+  url = "https://www.foo.bar:1234/mpd/test.mpd?ping=pong";
+  EXPECT_EQ(URL::GetBaseDomain(url), "https://www.foo.bar");
 }
 
 TEST_F(UtilsTest, JoinUrls)

--- a/src/utils/FileUtils.cpp
+++ b/src/utils/FileUtils.cpp
@@ -41,15 +41,13 @@ std::string UTILS::FILESYS::PathCombine(std::string path, std::string filePath)
   if (path.empty())
     return filePath;
 
-  const char separator = path[1] == ':' && std::isalpha(path[0]) ? '\\' : '/';
-
-  if (path.back() == separator)
+  if (path.back() == SEPARATOR)
     path.pop_back();
 
-  if (filePath.front() == separator)
+  if (filePath.front() == SEPARATOR)
     filePath.erase(0, 1);
 
-  return path + separator + filePath;
+  return path + SEPARATOR + filePath;
 }
 
 std::string UTILS::FILESYS::GetAddonUserPath()

--- a/src/utils/FileUtils.h
+++ b/src/utils/FileUtils.h
@@ -16,6 +16,11 @@ namespace UTILS
 {
 namespace FILESYS
 {
+#ifdef WIN32
+constexpr char SEPARATOR = '\\';
+#else
+constexpr char SEPARATOR = '/';
+#endif
 
 /*!
  * \brief Save the data into a file

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -209,7 +209,7 @@ void UTILS::URL::AppendParameters(std::string& url, std::string params)
   url += params;
 }
 
-std::string UTILS::URL::GetDomainUrl(std::string url)
+std::string UTILS::URL::GetBaseDomain(std::string url)
 {
   if (IsUrlAbsolute(url))
   {
@@ -269,7 +269,7 @@ std::string UTILS::URL::Join(std::string baseUrl, std::string relativeUrl)
   {
     skipRemovingSegs = false;
     relativeUrl.erase(0, 1);
-    std::string domain = GetDomainUrl(baseUrl);
+    std::string domain = GetBaseDomain(baseUrl);
     if (!domain.empty())
       baseUrl = domain + "/";
   }

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -213,17 +213,22 @@ std::string UTILS::URL::GetDomainUrl(std::string url)
 {
   if (IsUrlAbsolute(url))
   {
-    size_t paramsPos = url.find('?');
+    const size_t paramsPos = url.find('?');
     if (paramsPos != std::string::npos)
-      url = url.substr(0, paramsPos);
+      url.erase(paramsPos);
 
-    size_t slashPos = url.find_first_of('/', url.find("://") + 3);
-    if (slashPos != std::string::npos)
-      url = url.substr(0, slashPos);
-
-    if (url.back() == '/')
-      url.pop_back();
-
+    const size_t domainStartPos = url.find("://") + 3;
+    // Try remove url port number and path
+    const size_t port = url.find_first_of(':', domainStartPos);
+    if (port != std::string::npos)
+      url.erase(port);
+    else
+    {
+      // Try remove the path
+      const size_t slashPos = url.find_first_of('/', domainStartPos);
+      if (slashPos != std::string::npos)
+        url.erase(slashPos);
+    }
     return url;
   }
   return "";

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -74,11 +74,11 @@ std::string GetUrlPath(std::string url);
  */
 void AppendParameters(std::string& url, std::string params);
 
-/*! \brief Get the domain URL from an URL
+/*! \brief Get the base domain of an URL
  *  \param url An URL
- *  \return The domain URL if found, otherwise empty string
+ *  \return The base domain URL if found, otherwise empty string
  */
-std::string GetDomainUrl(std::string url);
+std::string GetBaseDomain(std::string url);
 
 /*! 
  * \brief Combine two URLs as per RFC 3986 specification.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR avoid the creation of empty folders under kodi `.../CDM/widevine/` folder for no reasons, and so create the folder when CDM library have to write files only.

### Changes
**before:**
A new folder was "often" created under CDM/widevine for no reasons,
the directory names was the result of a conversion of the license domain in to hex values, that may lead to very long folder names.

**now:**
when the CDM library have to write persistent data to disk a new folder will be created, otherwise no operations will be done to disk.
Has been also changed how the directory names are generated,
now are the result of MD5 hash of the license domain, i choosen to change it because the previous hex conversion was/can cause too long folder names of about 360 chars imo not really a good thing, instead by using MD5 hash we are sure that the folder name has a fixed length

i don't worry much about previously stored data that may be lost with this change due to different folder name, must not cause any problem.

Instead, i would not know how to determine when to delete these files once saved to disk, ATM i dont know how to know the lifetime.

The addons that use a proxy for the license now they are no longer storage "killers", since the port number specified in to the URL is now excluded from the domain name.
In addition there is another problem now somewhat solved, since with a proxy the domain name is "localhost" due to this all addons will have the same domain, and then fall always in to same cdm storage folder, as workaround, the name of the first directory that appears after the domain name will be appended to the domain, for example:

license url: `http://localhost:1234/myaddonname/service/get_license?id=xyz`
will result as: `http://localhost/myaddonname/` <<<< we can ensure appropriate folder by add the first folder name
where previously was resulting as: `http://localhost:1234`

The last fix is regards CDM file management interface, currently when CDM open a file for an operation, the filename was appended always to the path that could potentially result in a wrong file path, now fixed

wiki updated https://github.com/xbmc/inputstream.adaptive/wiki/How-to-provide-custom-manifest-and-license

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
after last code cleanups i was looking at decrypter code i noticed a code that i was suspecting that was creating directories for not clear reasons, by checking on my devices i found that the kodi `.../CDM/widevine/` folder contains about 500 directories! almost all empty, so there is a problem

moreover addons that host a proxy on their service become storage "killers",
since they provide a license url with port number (e.g. `http://127.0.0.1:64954`)
currently this cause that each time the port number change, the license domain change, and a new folder will be created each time, filling up the device of folders that are never deleted because the CDM folder is external and the only way is a manual delete or a full CDM removal

~depends on other opened PR1395 that must be merged as first, after that need a rebase~

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No empty folders on kodi `.../CDM/widevine/` folder when you play a widevine video

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
