### PR TITLE
[Properties] Add license_url/license_url_append properties

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay"
+    listitemprops="license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -21,6 +21,15 @@ namespace
 // clang-format off
 constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type";
 constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key";
+// PROP_LICENSE_URL and PROP_LICENSE_URL_APPEND has been added as workaround for Kodi PVR API bug
+// where limit property values to max 1024 chars, if exceeds the string is truncated.
+// Since some services provide license urls that exceeds 1024 chars,
+// PROP_LICENSE_KEY dont have enough space also because include other parameters
+// so we provide two properties allow set an url split into two 1024-character parts
+// see: https://github.com/xbmc/xbmc/issues/23903#issuecomment-1755264854
+// this problem should be fixed on Kodi 22
+constexpr std::string_view PROP_LICENSE_URL = "inputstream.adaptive.license_url";
+constexpr std::string_view PROP_LICENSE_URL_APPEND = "inputstream.adaptive.license_url_append";
 constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data";
 constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags";
 constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate";
@@ -49,6 +58,8 @@ constexpr std::string_view PROP_CHOOSER_RES_SECURE_MAX = "inputstream.adaptive.c
 
 ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std::string>& props)
 {
+  std::string licenseUrl;
+
   for (const auto& prop : props)
   {
     bool logPropValRedacted{false};
@@ -60,6 +71,17 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
     else if (prop.first == PROP_LICENSE_KEY)
     {
       m_licenseKey = prop.second;
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_LICENSE_URL)
+    {
+      // If PROP_LICENSE_URL_APPEND is parsed before this one, we need to append it
+      licenseUrl = prop.second + licenseUrl;
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_LICENSE_URL_APPEND)
+    {
+      licenseUrl += prop.second;
       logPropValRedacted = true;
     }
     else if (prop.first == PROP_LICENSE_DATA)
@@ -188,5 +210,15 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
 
     LOG::Log(LOGDEBUG, "Property found \"%s\" value: %s", prop.first.c_str(),
              logPropValRedacted ? "[redacted]" : prop.second.c_str());
+  }
+
+  if (!licenseUrl.empty())
+  {
+    // PROP_LICENSE_URL replace the license url contained into PROP_LICENSE_KEY
+    const size_t pipePos = m_licenseKey.find('|');
+    if (pipePos == std::string::npos)
+      m_licenseKey = licenseUrl;
+    else
+      m_licenseKey.replace(0, pipePos, licenseUrl);
   }
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR add
`inputstream.adaptive.license_url`
`inputstream.adaptive.license_url_append`
an exclusive workaround for PVR binary add-ons

these new properties has same valence of
_[license server URL]_ template field of `inputstream.adaptive.license_key` property

when a value is set on both, the `license_url_append` value will be appended to `license_url` value

the resulting value will replace _[license server URL]_ template field of `inputstream.adaptive.license_key`
also in case the `license_key` has a license url specified.
I choose to not allow the use both at same time to specify the url, to try to avoid confusions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kodi PVR API has a bug that limit all strings to max 1024 chars
so on each property that exceeds the limit the string is truncated and so ISA get broken property values and the playback fails

this usually is not a big problem because not often exceeds 1024 chars but
`inputstream.adaptive.license_key` property can contains concatenated data,
and when also the url is very long broken will result in a truncated url or license configuration

this solution is intended for Kodi 20 and 21
because also for Kodi 21 case we are not in time to fix kodi PVR API, a real fix will be delayed to future Kodi 22

Ref. Issues:
https://github.com/xbmc/xbmc/issues/23903
https://github.com/xbmc/inputstream.adaptive/issues/1248

**Appropriate changes to PVR binary addons are needed in order to use this workaround,**
atm im aware that Kodi PVR iptvsimple addon use it, so need the changes for Kodi 20/21,
the change is quite simple, instead to set the license url string to the `inputstream.adaptive.license_key` use
`inputstream.adaptive.license_url`
`inputstream.adaptive.license_url_append`
by taking care to split the url in two parts of 1024 chars (max url length of 2048 chars, that in any case should be a common limit used on webbrowsers)

**e.g. before:**
license_key: `http://www.xyz.com/license/...[other chars].../itsverylong/|Content-Type=application/octet-stream|R{SSM}|R`
**after:**
license_key: `|Content-Type=application/octet-stream|R{SSM}|R` (note that need to start with a pipe `|`)
license_url: `http://www.xyz.com/license/...` (split/limit the string to 1024)
license_url_append: `.../itsverylong/` (set here the remaining url chars)


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
~needed feedbacks~ user confirmed work

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
