### PR TITLE
[Session] Fix regression to extract PSSH/KID

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -450,7 +450,7 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
         initData = BASE64::Decode(m_kodiProps.m_licenseData);
       }
 
-      if (initData.size() == 0)
+      if (initData.empty())
       {
         if (!sessionPsshset.pssh_.empty())
         {
@@ -1516,7 +1516,9 @@ bool CSession::ExtractStreamProtectionData(PLAYLIST::CPeriod::PSSHSet& sessionPs
                                            std::vector<uint8_t>& initData,
                                            std::string keySystem)
 {
-  keySystem = STRING::ToHexadecimal(keySystem);
+  std::vector<uint8_t> keySystemBytes;
+  STRING::ToHexBytes(keySystem, keySystemBytes);
+
   auto initialRepr = m_reprChooser->GetRepresentation(sessionPsshset.adaptation_set_);
 
   CStream stream{*m_adaptiveTree, sessionPsshset.adaptation_set_, initialRepr, m_kodiProps};
@@ -1537,7 +1539,7 @@ bool CSession::ExtractStreamProtectionData(PLAYLIST::CPeriod::PSSHSet& sessionPs
 
   for (unsigned int i = 0; initData.size() == 0 && i < pssh.ItemCount(); i++)
   {
-    if (std::memcmp(pssh[i].GetSystemId(), keySystem.c_str(), 16) == 0)
+    if (std::memcmp(pssh[i].GetSystemId(), keySystemBytes.data(), 16) == 0)
     {
       const AP4_DataBuffer& dataBuf = pssh[i].GetData();
       initData.insert(initData.end(), dataBuf.GetData(), dataBuf.GetData() + dataBuf.GetDataSize());
@@ -1582,5 +1584,5 @@ bool CSession::ExtractStreamProtectionData(PLAYLIST::CPeriod::PSSHSet& sessionPs
   }
 
   stream.Disable();
-  return initData.size() > 0;
+  return !initData.empty();
 }

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -99,7 +99,7 @@ namespace adaptive
   {
     for (auto& segment : repr->SegmentTimeline().GetData())
     {
-      period->DecrasePSSHSetUsageCount(segment.pssh_set_);
+      period->DecreasePSSHSetUsageCount(segment.pssh_set_);
     }
 
     repr->SegmentTimeline().Clear();

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -126,29 +126,24 @@ namespace adaptive
                                        std::string_view kidUrl /* = "" */,
                                        std::string_view iv /* = "" */)
   {
-    if (!pssh.empty() || !kidUrl.empty())
-    {
-      CPeriod::PSSHSet psshSet;
-      psshSet.pssh_ = pssh;
-      psshSet.defaultKID_ = defaultKID;
-      psshSet.m_kidUrl = kidUrl;
-      psshSet.iv = iv;
-      psshSet.m_cryptoMode = m_cryptoMode;
-      psshSet.adaptation_set_ = adp;
+    CPeriod::PSSHSet psshSet;
+    psshSet.pssh_ = pssh;
+    psshSet.defaultKID_ = defaultKID;
+    psshSet.m_kidUrl = kidUrl;
+    psshSet.iv = iv;
+    psshSet.m_cryptoMode = m_cryptoMode;
+    psshSet.adaptation_set_ = adp;
 
-      if (streamType == StreamType::VIDEO)
-        psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO;
-      else if (streamType == StreamType::VIDEO_AUDIO)
-        psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO | CPeriod::PSSHSet::MEDIA_AUDIO;
-      else if (streamType == StreamType::AUDIO)
-        psshSet.media_ = CPeriod::PSSHSet::MEDIA_AUDIO;
-      else
-        psshSet.media_ = CPeriod::PSSHSet::MEDIA_UNSPECIFIED;
-
-      return period->InsertPSSHSet(&psshSet);
-    }
+    if (streamType == StreamType::VIDEO)
+      psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO;
+    else if (streamType == StreamType::VIDEO_AUDIO)
+      psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO | CPeriod::PSSHSet::MEDIA_AUDIO;
+    else if (streamType == StreamType::AUDIO)
+      psshSet.media_ = CPeriod::PSSHSet::MEDIA_AUDIO;
     else
-      return period->InsertPSSHSet(nullptr);
+      psshSet.media_ = CPeriod::PSSHSet::MEDIA_UNSPECIFIED;
+
+    return period->InsertPSSHSet(psshSet);
   }
 
   void AdaptiveTree::SortTree()

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -43,40 +43,31 @@ void PLAYLIST::CPeriod::CopyHLSData(const CPeriod* other)
   m_isSecureDecoderNeeded = other->m_isSecureDecoderNeeded;
 }
 
-uint16_t PLAYLIST::CPeriod::InsertPSSHSet(PSSHSet* psshSet)
+uint16_t PLAYLIST::CPeriod::InsertPSSHSet(const PSSHSet& psshSet)
 {
-  if (psshSet)
+  auto itPssh = m_psshSets.end();
+
+  if (psshSet.m_kidUrl.empty())
   {
-    auto itPssh = m_psshSets.end();
+    // Find the psshSet by skipping the first one of the list (for unencrypted streams)
+    // note that PSSHSet struct has a custom comparator for std::find
+    itPssh = std::find(m_psshSets.begin() + 1, m_psshSets.end(), psshSet);
+  }
 
-    if (psshSet->m_kidUrl.empty())
-    {
-      // Find the psshSet by skipping the first one of the list (for unencrypted streams)
-      // note that PSSHSet struct has a custom comparator for std::find
-      itPssh = std::find(m_psshSets.begin() + 1, m_psshSets.end(), *psshSet);
-    }
-
-    if (itPssh != m_psshSets.end() && itPssh->m_usageCount == 0)
-    {
-      // If the existing psshSet is not used, replace it with the new one
-      *itPssh = *psshSet;
-    }
-    else
-    {
-      // Add a new PsshSet
-      itPssh = m_psshSets.insert(m_psshSets.end(), *psshSet);
-    }
-
-    itPssh->m_usageCount++;
-
-    return static_cast<uint16_t>(itPssh - m_psshSets.begin());
+  if (itPssh != m_psshSets.end() && itPssh->m_usageCount == 0)
+  {
+    // If the existing psshSet is not used, replace it with the new one
+    *itPssh = psshSet;
   }
   else
   {
-    // Increase the usage of first empty psshSet
-    m_psshSets[0].m_usageCount++;
-    return PSSHSET_POS_DEFAULT;
+    // Add a new PsshSet
+    itPssh = m_psshSets.insert(m_psshSets.end(), psshSet);
   }
+
+  itPssh->m_usageCount++;
+
+  return static_cast<uint16_t>(itPssh - m_psshSets.begin());
 }
 
 void PLAYLIST::CPeriod::RemovePSSHSet(uint16_t pssh_set)
@@ -93,6 +84,13 @@ void PLAYLIST::CPeriod::RemovePSSHSet(uint16_t pssh_set)
         itRepr++;
     }
   }
+}
+
+void PLAYLIST::CPeriod::DecrasePSSHSetUsageCount(uint16_t pssh_set)
+{
+  PSSHSet& psshSet = m_psshSets[pssh_set];
+  if (psshSet.m_usageCount > 0)
+    psshSet.m_usageCount--;
 }
 
 void PLAYLIST::CPeriod::AddAdaptationSet(std::unique_ptr<CAdaptationSet>& adaptationSet)

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -86,7 +86,7 @@ void PLAYLIST::CPeriod::RemovePSSHSet(uint16_t pssh_set)
   }
 }
 
-void PLAYLIST::CPeriod::DecrasePSSHSetUsageCount(uint16_t pssh_set)
+void PLAYLIST::CPeriod::DecreasePSSHSetUsageCount(uint16_t pssh_set)
 {
   PSSHSet& psshSet = m_psshSets[pssh_set];
   if (psshSet.m_usageCount > 0)

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -112,7 +112,7 @@ public:
 
   uint16_t InsertPSSHSet(const PSSHSet& pssh);
   void RemovePSSHSet(uint16_t pssh_set);
-  void DecrasePSSHSetUsageCount(uint16_t pssh_set);
+  void DecreasePSSHSetUsageCount(uint16_t pssh_set);
   std::vector<PSSHSet>& GetPSSHSets() { return m_psshSets; }
 
   // Make use of PLAYLIST::StreamType flags

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -94,8 +94,8 @@ public:
     // Custom comparator for std::find
     bool operator==(const PSSHSet& other) const
     {
-      return m_usageCount == 0 || (media_ == other.media_ && pssh_ == other.pssh_ &&
-                                   defaultKID_ == other.defaultKID_ && iv == other.iv);
+      return media_ == other.media_ && pssh_ == other.pssh_ && defaultKID_ == other.defaultKID_ &&
+             iv == other.iv;
     }
 
     //! @todo: create getter/setters
@@ -110,10 +110,9 @@ public:
     CAdaptationSet* adaptation_set_{nullptr};
   };
 
-  uint16_t InsertPSSHSet(PSSHSet* pssh);
-  void InsertPSSHSet(uint16_t pssh_set) { m_psshSets[pssh_set].m_usageCount++; }
+  uint16_t InsertPSSHSet(const PSSHSet& pssh);
   void RemovePSSHSet(uint16_t pssh_set);
-  void DecrasePSSHSetUsageCount(uint16_t pssh_set) { m_psshSets[pssh_set].m_usageCount--; }
+  void DecrasePSSHSetUsageCount(uint16_t pssh_set);
   std::vector<PSSHSet>& GetPSSHSets() { return m_psshSets; }
 
   // Make use of PLAYLIST::StreamType flags

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -331,6 +331,15 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
 
         uint64_t duration = static_cast<uint64_t>(STRING::ToFloat(tagValue) * rep->GetTimescale());
         newSegment->m_duration = duration;
+
+        if (currentEncryptionType == EncryptionType::AES128 && psshSetPos == PSSHSET_POS_DEFAULT)
+        {
+          if (!m_currentKidUrl.empty())
+          {
+            psshSetPos = InsertPsshSet(StreamType::NOTYPE, period, adp, m_currentPssh,
+                                       m_currentDefaultKID, m_currentKidUrl, m_currentIV);
+          }
+        }
         newSegment->pssh_set_ = psshSetPos;
 
         currentSegStartPts += duration;
@@ -405,18 +414,6 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
         }
 
         newSegment->url = line;
-
-        if (currentEncryptionType == EncryptionType::AES128)
-        {
-          if (psshSetPos == PSSHSET_POS_DEFAULT)
-          {
-            psshSetPos = InsertPsshSet(StreamType::NOTYPE, period, adp, m_currentPssh,
-                                       m_currentDefaultKID, m_currentKidUrl, m_currentIV);
-            newSegment->pssh_set_ = psshSetPos;
-          }
-          else
-            period->InsertPSSHSet(newSegment->pssh_set_);
-        }
 
         newSegments.GetData().emplace_back(*newSegment);
         newSegment.reset();

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -274,6 +274,20 @@ uint32_t UTILS::STRING::HexStrToUint(std::string_view hexValue)
   return val;
 }
 
+bool UTILS::STRING::ToHexBytes(const std::string& str, std::vector<uint8_t>& bytes)
+{
+  for (int i = 0; i < str.length(); i += 2)
+  {
+    char* end;
+    uint8_t byte = static_cast<uint8_t>(std::strtol(str.substr(i, 2).c_str(), &end, 16));
+    if (*end != '\0') // Conversion failed, invalid characters in hexadecimal
+      return false;
+
+    bytes.emplace_back(byte);
+  }
+  return true;
+}
+
 std::vector<uint8_t> UTILS::STRING::ToVecUint8(std::string_view str)
 {
   std::vector<uint8_t> val;

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -181,6 +181,14 @@ std::string ToLower(std::string str);
 uint32_t HexStrToUint(std::string_view hexValue);
 
 /*!
+ * \brief Convert a string value to hex bytes.
+ * \param str The string to be converted
+ * \param bytes[OUT] The converted string to hex bytes
+ * \return True if has success, otherwise false.
+ */
+bool ToHexBytes(const std::string& str, std::vector<uint8_t>& bytes);
+
+/*!
  * \brief Convert a string in to a vector of uint8_t
  * \param str The string to be converted
  * \return The converted data


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There were two bugs
1) On Session i used STRING::ToHexadecimal to convert systemId, where instead was to be used the hex bytes conversion
2) On Dash parser when ContentProtection tag dont provide a pssh, before the PR #1388 instead of an empty pssh was set the placeholder PSSH_FROM_FILE value, after that PR, since there is an empty value cause AdaptiveTree::InsertPsshSet to fails. Now i have changed to allow always insert an empty pssh, because Session is able to use `ExtractStreamProtectionData` method to extract it when missing.

i have cleanup a bit also related code and i noticed that PSSHSet::m_usageCount usage is exclusive of a single HLS parser line for widevine case only:
https://github.com/xbmc/inputstream.adaptive/blob/51b565977c9a6921144bc44235c1bb25a15b4ae2/src/parser/HLSTree.cpp#L266C1-L266C1
that ask to myself if this could be maybe improved in future to remove in some way that count state

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug feedback comment https://github.com/xbmc/inputstream.adaptive/pull/1388#issuecomment-1772223023

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unfurnately the provided sample by user seem to be expired after short time
so i need a feedback by user itself

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
