### PR TITLE
Workaround to keep in memory cookies between http sessions

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay"
+    listitemprops="license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|internal_cookies"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADERS
   Session.h
   SrvBroker.h
   CompKodiProps.h
+  CompResources.h
   CompSettings.h
   Stream.h
   aes_decrypter.h

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -48,6 +48,8 @@ constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.pl
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay";
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
 
+constexpr std::string_view PROP_INTERNAL_COOKIES = "inputstream.adaptive.internal_cookies";
+
 // Chooser's properties
 constexpr std::string_view PROP_STREAM_SELECTION_TYPE = "inputstream.adaptive.stream_selection_type";
 constexpr std::string_view PROP_CHOOSER_BANDWIDTH_MAX = "inputstream.adaptive.chooser_bandwidth_max";
@@ -201,6 +203,10 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
         m_chooserProps.m_resolutionSecureMax = res;
       else
         LOG::Log(LOGERROR, "Resolution not valid on \"%s\" property.", prop.first.c_str());
+    }
+    else if (prop.first == PROP_INTERNAL_COOKIES)
+    {
+      m_isInternalCookies = STRING::CompareNoCase(prop.second, "true");
     }
     else
     {

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -86,6 +86,9 @@ public:
    */
   std::string_view GetDrmPreInitData() const { return m_drmPreInitData; }
 
+  // \brief Defines if cookies are internally handled by InputStream Adaptive add-on
+  bool IsInternalCookies() const { return m_isInternalCookies; }
+
   // \brief Specifies the chooser properties that will override XML settings
   const ChooserProps& GetChooserProps() const { return m_chooserProps; }
 
@@ -107,6 +110,7 @@ private:
   bool m_playTimeshiftBuffer{false};
   uint64_t m_liveDelay{0};
   std::string m_drmPreInitData;
+  bool m_isInternalCookies{false};
   ChooserProps m_chooserProps;
 };
 

--- a/src/CompResources.h
+++ b/src/CompResources.h
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/CurlUtils.h"
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "test/KodiStubs.h"
+#else
+#include <kodi/AddonBase.h>
+#endif
+
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+namespace ADP
+{
+namespace RESOURCES
+{
+class ATTR_DLL_LOCAL CCompResources
+{
+public:
+  CCompResources() = default;
+  ~CCompResources() = default;
+
+  /*!
+   * \brief Cookies that can be shared along with HTTP requests.
+   *        Some video services require you to accept cookies and send cookies along with requests.
+   *        Most common use case is when cookies are used as authentication to get files, so at the first HTTP request
+   *        of the manifest, the server send a "Set-Cookies" header from HTTP response, which the client will have to use
+   *        for each subsequent request, such as manifest update, segments, etc.
+   *        NOTE: Read/write accesses must be protected by mutex.
+   * \return The cookies
+   */
+  std::unordered_set<UTILS::CURL::Cookie>& Cookies() { return m_cookies; }
+
+  std::mutex& GetCookiesMutex() { return m_cookiesMutex; }
+
+private:
+  std::unordered_set<UTILS::CURL::Cookie> m_cookies;
+  std::mutex m_cookiesMutex;
+};
+} // namespace RESOURCES
+} // namespace ADP

--- a/src/SrvBroker.cpp
+++ b/src/SrvBroker.cpp
@@ -9,6 +9,7 @@
 #include "SrvBroker.h"
 
 #include "CompKodiProps.h"
+#include "CompResources.h"
 #include "CompSettings.h"
 
 using namespace ADP;
@@ -19,5 +20,6 @@ CSrvBroker::~CSrvBroker() = default;
 void CSrvBroker::Init(const std::map<std::string, std::string>& kodiProps)
 {
   m_compKodiProps = std::make_unique<KODI_PROPS::CCompKodiProps>(kodiProps);
+  m_compResources = std::make_unique<RESOURCES::CCompResources>();
   m_compSettings = std::make_unique<SETTINGS::CCompSettings>();
 }

--- a/src/SrvBroker.h
+++ b/src/SrvBroker.h
@@ -19,6 +19,10 @@
 #include <string>
 
 // forward
+namespace ADP::RESOURCES
+{
+class CCompResources;
+}
 namespace ADP::SETTINGS
 {
 class CCompSettings;
@@ -57,6 +61,14 @@ public:
   }
 
   /*
+   * \brief Get resources component, for shared resources.
+   */
+  static ADP::RESOURCES::CCompResources& GetResources()
+  {
+    return *GetInstance()->m_compResources;
+  }
+
+  /*
    * \brief Get settings component, to manage add-on XML settings.
    */
   static ADP::SETTINGS::CCompSettings& GetSettings()
@@ -69,5 +81,6 @@ private:
   ~CSrvBroker();
 
   std::unique_ptr<ADP::KODI_PROPS::CCompKodiProps> m_compKodiProps;
+  std::unique_ptr<ADP::RESOURCES::CCompResources> m_compResources;
   std::unique_ptr<ADP::SETTINGS::CCompSettings> m_compSettings;
 };

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -14,6 +14,7 @@
 #include "log.h"
 
 #include "CompResources.h"
+#include "CompKodiProps.h"
 #include "SrvBroker.h"
 
 using namespace UTILS;
@@ -191,14 +192,17 @@ UTILS::CURL::CUrl::CUrl(std::string_view url)
     // Add session cookies
     // NOTE: if kodi property inputstream.adaptive.stream_headers is set with "cookie" header
     // the cookies set by the property will replace these
-    m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "cookie", GetCookies(url));
+    if (CSrvBroker::GetKodiProps().IsInternalCookies())
+      m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "cookie", GetCookies(url));
   }
 }
 
 UTILS::CURL::CUrl::~CUrl()
 {
   std::vector<std::string> cookies = GetResponseHeaders("set-cookie");
-  StoreCookies(GetEffectiveUrl(), cookies);
+  if (CSrvBroker::GetKodiProps().IsInternalCookies())
+    StoreCookies(GetEffectiveUrl(), cookies);
+
   m_file.Close();
 }
 

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -9,9 +9,175 @@
 #include "CurlUtils.h"
 
 #include "StringUtils.h"
+#include "UrlUtils.h"
+#include "Utils.h"
 #include "log.h"
 
+#include "CompResources.h"
+#include "SrvBroker.h"
+
+using namespace UTILS;
 using namespace UTILS::CURL;
+
+namespace
+{
+//! @todo: Cookies management here its an hack, currently there are no ways to have a persistent
+//! HTTP session with Kodi binary interface, at least not in the usual way.
+//! Curl library implementation in kodi manage a pool of connections (sessions) by domain,
+//! and this actually keeps the cookies in memory but not in a persistent way,
+//! when a connection remain unused for some seconds will be deleted and so delete cookies,
+//! or when there is a multithreading access could pick a session (easy_handle) currently busy,
+//! therefore it create a new empty session (easy_handle) ofc with no cookies,
+//! because they are stored on another curl session that could be meantime deleted, see:
+//! https://github.com/xbmc/xbmc/blob/21.0a3-Omega/xbmc/filesystem/DllLibCurl.cpp#L143-L146
+//! https://github.com/xbmc/xbmc/blob/21.0a3-Omega/xbmc/filesystem/DllLibCurl.cpp#L173
+//! A solution could be the use of curl shared data CURLOPT_SHARE to share data with multiple handles,
+//! but there is still a need to review how to implement this in the binary addons interface as well,
+//! or another solution could be add and implement the curl library dependency in to ISA itself.
+
+std::unordered_set<Cookie> ParseCookies(std::string_view url,
+                                        const std::vector<std::string>& cookies)
+{
+  // Be aware that kodi::vfs::GetCookies output dont provide all cookie attributes.
+  std::unordered_set<Cookie> cookieList;
+
+  // example: __Secure-NAME_EXAMPLE=VALUE; path=/; domain=.example.com
+  for (const std::string& cookieStr : cookies)
+  {
+    Cookie cookie;
+    const std::vector<std::string> params = STRING::SplitToVec(cookieStr, ';');
+    for (const std::string& param : params)
+    {
+      std::string name;
+      std::string value;
+      const size_t sepPos = param.find('=');
+      if (sepPos != std::string::npos)
+      {
+        name = STRING::ToLower(STRING::Trim(param.substr(0, sepPos)));
+        value = STRING::Trim(param.substr(sepPos + 1));
+      }
+      else
+        name = STRING::ToLower(STRING::Trim(param));
+
+      if (cookie.m_name.empty()) // First param cookie name/value
+      {
+        cookie.m_name = name;
+        cookie.m_value = value;
+      }
+      else if (name == "path")
+      {
+        cookie.m_path = value;
+      }
+      else if (name == "domain" && !value.empty())
+      {
+        if (value.front() == '*')
+          value.erase(0, 1);
+        cookie.m_domain = STRING::ToLower(value);
+      }
+      else if (name == "max-age") //! @todo: to implement "Expires" attribute parsing, but max-age value has the precedence over "Expires"
+      {
+        cookie.m_expires = GetTimestamp() + (STRING::ToUint64(value) * 1000);
+      }
+    }
+
+    if (cookie.m_domain.empty())
+    {
+      // If empty retrieve the hostname from the url (www.example.com)
+      cookie.m_domain = URL::GetBaseDomain(url.data());
+      const size_t protStartPos = cookie.m_domain.find("://");
+      if (protStartPos != std::string::npos)
+        cookie.m_domain.erase(0, protStartPos + 3);
+    }
+
+    if (cookie.m_path.empty())
+    {
+      // When empty fallback to current url path
+      cookie.m_path = URL::GetPath(url.data(), true);
+    }
+
+    cookieList.emplace(cookie);
+  }
+  return cookieList;
+}
+
+std::string GetCookies(std::string_view url)
+{
+  auto& srvResources = CSrvBroker::GetResources();
+  std::lock_guard<std::mutex> lock(srvResources.GetCookiesMutex());
+
+  // Get hostname (www.example.com)
+  std::string hostname = URL::GetBaseDomain(url.data());
+  const size_t protStartPos = hostname.find("://");
+  if (protStartPos != std::string::npos)
+    hostname.erase(0, protStartPos + 3);
+
+  // Get domain, following format: .example.com
+  std::string domain = hostname;
+  const size_t dotPos = domain.find('.');
+  if (dotPos != std::string::npos)
+    domain.erase(0, dotPos);
+
+  std::string urlPath = URL::GetPath(url.data(), true);
+
+  std::string cookiesStr;
+  std::unordered_set<Cookie>& cookies = srvResources.Cookies();
+  uint64_t currentTimestamp = UTILS::GetTimestamp();
+
+  for (const Cookie& cookie : cookies)
+  {
+    // Check domain
+    if (STRING::Contains(cookie.m_domain, domain) || STRING::Contains(cookie.m_domain, hostname))
+    {
+      // Check path, take in account directory and subdirectories
+      if (!cookie.m_path.empty() && cookie.m_path != "/")
+      {
+        if (!STRING::StartsWith(urlPath, cookie.m_path))
+          continue;
+        // else if cookie path is like a file path e.g. "/name" allow subdirectories only
+        else if (cookie.m_path.back() != '/' && urlPath.size() > cookie.m_path.size() &&
+                 urlPath[cookie.m_path.size()] != '/')
+          continue;
+      }
+
+      // Check expiry time
+      if (cookie.m_expires > currentTimestamp)
+        continue;
+
+      cookiesStr += cookie.m_name + "=" + cookie.m_value + ";";
+    }
+  }
+  return cookiesStr;
+}
+
+void StoreCookies(std::string_view url, const std::vector<std::string>& cookiesStr)
+{
+  auto& srvResources = CSrvBroker::GetResources();
+  std::lock_guard<std::mutex> lock(srvResources.GetCookiesMutex());
+  std::unordered_set<Cookie>& cookies = srvResources.Cookies();
+
+  // Delete existing expired cookies
+  uint64_t currentTimestamp = UTILS::GetTimestamp();
+  for (auto itCookie = cookies.begin(); itCookie != cookies.end();)
+  {
+    if (itCookie->m_expires > currentTimestamp)
+      itCookie = cookies.erase(itCookie);
+    else
+      itCookie++;
+  }
+
+  if (cookiesStr.empty())
+    return;
+
+  std::unordered_set<Cookie> cookiesParsed = ParseCookies(url, cookiesStr);
+  for (const auto& c : cookiesParsed)
+  {
+    if (cookies.find(c) != cookies.end())
+      cookies.erase(c); // Delete existing cookie to update it
+
+    cookies.insert(c);
+  }
+}
+} // unnamed namespace
 
 UTILS::CURL::CUrl::CUrl(std::string_view url)
 {
@@ -21,11 +187,18 @@ UTILS::CURL::CUrl::CUrl(std::string_view url)
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "gzip, deflate");
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
+
+    // Add session cookies
+    // NOTE: if kodi property inputstream.adaptive.stream_headers is set with "cookie" header
+    // the cookies set by the property will replace these
+    m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "cookie", GetCookies(url));
   }
 }
 
 UTILS::CURL::CUrl::~CUrl()
 {
+  std::vector<std::string> cookies = GetResponseHeaders("set-cookie");
+  StoreCookies(GetEffectiveUrl(), cookies);
   m_file.Close();
 }
 
@@ -65,6 +238,11 @@ void UTILS::CURL::CUrl::AddHeaders(const std::map<std::string, std::string>& hea
 std::string UTILS::CURL::CUrl::GetResponseHeader(std::string_view name)
 {
   return m_file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_HEADER, name.data());
+}
+
+std::vector<std::string> UTILS::CURL::CUrl::GetResponseHeaders(std::string_view name)
+{
+  return m_file.GetPropertyValues(ADDON_FILE_PROPERTY_RESPONSE_HEADER, name.data());
 }
 
 std::string UTILS::CURL::CUrl::GetEffectiveUrl()

--- a/src/utils/CurlUtils.h
+++ b/src/utils/CurlUtils.h
@@ -15,6 +15,7 @@
 #include <kodi/Filesystem.h>
 #endif
 
+#include <iostream>
 #include <map>
 #include <string>
 #include <string_view>
@@ -59,6 +60,8 @@ public:
   * \return The header value, or empty if none
   */
   std::string GetResponseHeader(std::string_view name);
+
+  std::vector<std::string> GetResponseHeaders(std::string_view name);
 
  /*!
   * \brief Get the last used url (after following redirects).
@@ -117,7 +120,21 @@ struct HTTPResponse
   double downloadSpeed{0}; // Download speed in byte/s
 };
 
- /*!
+struct Cookie
+{
+  std::string m_name;
+  std::string m_value;
+  std::string m_domain;
+  std::string m_path;
+  uint64_t m_expires{0}; // expire timestamp
+
+  bool operator==(const Cookie& other) const
+  {
+    return m_name == other.m_name && m_domain == other.m_domain;
+  }
+};
+
+/*!
   * \brief Helper method to download a file.
   * \param url Url of the file to download
   * \param reqHeaders Headers to use for the HTTP request
@@ -133,3 +150,16 @@ bool DownloadFile(std::string_view url,
 
 } // namespace CURL
 } // namespace UTILS
+
+// Embedded Cookie hash specialization
+namespace std
+{
+template<>
+struct hash<UTILS::CURL::Cookie>
+{
+  size_t operator()(const UTILS::CURL::Cookie& cookie) const
+  {
+    return hash<string>()(cookie.m_name + cookie.m_domain);
+  }
+};
+} // namespace std

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -305,3 +305,9 @@ std::string UTILS::STRING::ToHexadecimal(std::string_view str)
   }
   return ss.str();
 }
+
+std::string UTILS::STRING::Trim(std::string value)
+{
+  StringUtils::Trim(value);
+  return value;
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -224,5 +224,12 @@ std::vector<uint8_t> ToVecUint8(std::string_view str);
  */
 std::string ToHexadecimal(std::string_view str);
 
+/*!
+ * \brief Trim a string with remove of not wanted spaces at begin and end of string.
+ * \param value The string to be trimmed
+ * \return The string trimmed
+ */
+std::string Trim(std::string value);
+
 } // namespace STRING
 } // namespace UTILS

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -173,6 +173,31 @@ std::string UTILS::URL::RemoveParameters(std::string url)
   return url;
 }
 
+std::string UTILS::URL::GetPath(std::string url, bool includeFilePart)
+{
+  if (url.empty())
+    return url;
+
+  size_t paramsPos = url.find('?');
+  if (paramsPos != std::string::npos)
+    url.resize(paramsPos);
+
+  const size_t domainStartPos = url.find("://") + 3;
+  const size_t slashPos = url.find_first_of('/', domainStartPos);
+  if (slashPos != std::string::npos)
+  {
+    if (!includeFilePart && url.back() != '/')
+    {
+      // The part of the base url after last / is not a directory so will not be taken into account
+      size_t slashPos = url.rfind("/");
+      if (slashPos > domainStartPos)
+        url.erase(slashPos + 1);
+    }
+    return url.substr(slashPos);
+  }
+  return "/";
+}
+
 std::string UTILS::URL::GetUrlPath(std::string url)
 {
   if (url.empty())

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -61,6 +61,15 @@ std::string GetParameters(std::string& url);
 std::string RemoveParameters(std::string url);
 
 /*!
+ * \brief Get the path part of an url,
+ *        e.g. https://sample.com/part1/part2?test become /part1/
+ * \param url An URL
+ * \param includeFilePart If true, keep the file name of the path
+ * \return The path
+ */
+std::string GetPath(std::string url, bool includeFilePart);
+
+/*!
  * \brief Get the url path, by removing file part and parameters
  *        e.g. https://sample.com/part1/part2?test become https://sample.com/part1/
  * \param url An URL


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Cookies management here its an hack,
currently there are no way to have a persistent HTTP session with Kodi binary interface, at least not in the usual way.

Curl library implementation in kodi manage a pool of connections (called sessions) by domain, and this actually keeps the cookies in memory but not in a persistent way

when a connection remain unused for some seconds will be deleted and so delete cookies,
or when there is a multithreading access could pick a session (easy_handle) currently busy,
therefore it create a new empty session (easy_handle) ofc with no cookies,
because they are stored on another curl session that could be meantime deleted, see:
https://github.com/xbmc/xbmc/blob/21.0a3-Omega/xbmc/filesystem/DllLibCurl.cpp#L143-L146
https://github.com/xbmc/xbmc/blob/21.0a3-Omega/xbmc/filesystem/DllLibCurl.cpp#L173

A solution is the use of curl shared data CURLOPT_SHARE to share data with multiple handles,
but there is still a need to review how to implement this in the binary addons interface as well,
this seem however not easy fix to do in kodi core and could be done in future kodi versions only

~currently WIP until someone can give me a feedback~
**UPDATE:**
looks like atm no one can provide a feedback, i still finished the PR in principle it should work at least now i can see persistent cookies from curl log.

Since cookies are a special use case of some HLS/DASH services so not commonly used,
i add a property to enable the internal cookies management "workaround", so by default its _disabled_.
I choosen to default disable it, because from a web search seem that other players not support cookies, or support them but require to be enabled by player properties etc... and also because its not full tested yet (no users feedbacks)
maybe in future this could be changed as default enabled, depends on whether the problem will be fixed/implemented in kodi core itself or what will be done

**New property:** `inputstream.adaptive.internal_cookies`
**Accepted values:** `true` or `false`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
followup of PR #1390

fix #184
fix #1195

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have "tested" with a RAI live stream that share a weird cookie that its not really needed for the playback

**NOT tested** with a service that use cookies as authentication to allow download streams

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
