### PR TITLE
Rework to DRM config, new properties, introducing DRM auto-selection, XML wrapper support

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|internal_cookies|manifest_config"
+    listitemprops="drm|drm_license|license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|internal_cookies|manifest_config"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -8,6 +8,7 @@
 
 #include "CompKodiProps.h"
 #include "CompSettings.h"
+#include "decrypters/Helpers.h"
 #include "utils/StringUtils.h"
 #include "utils/Utils.h"
 #include "utils/log.h"
@@ -21,8 +22,8 @@ using namespace UTILS;
 namespace
 {
 // clang-format off
-constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type";
-constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key";
+constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type"; //! @todo: deprecated, to be removed on next Kodi release
+constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"; //! @todo: deprecated, to be removed on next Kodi release
 // PROP_LICENSE_URL and PROP_LICENSE_URL_APPEND has been added as workaround for Kodi PVR API bug
 // where limit property values to max 1024 chars, if exceeds the string is truncated.
 // Since some services provide license urls that exceeds 1024 chars,
@@ -32,9 +33,9 @@ constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"
 // this problem should be fixed on Kodi 22
 constexpr std::string_view PROP_LICENSE_URL = "inputstream.adaptive.license_url";
 constexpr std::string_view PROP_LICENSE_URL_APPEND = "inputstream.adaptive.license_url_append";
-constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data";
-constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags";
-constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate";
+constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data"; //! @todo: deprecated, to be removed on next Kodi release
+constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags"; //! @todo: deprecated, to be removed on next Kodi release
+constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate"; //! @todo: deprecated, to be removed on next Kodi release
 
 constexpr std::string_view PROP_MANIFEST_TYPE = "inputstream.adaptive.manifest_type"; //! @todo: deprecated, to be removed on next Kodi release
 constexpr std::string_view PROP_MANIFEST_UPD_PARAM = "inputstream.adaptive.manifest_update_parameter"; //! @todo: deprecated, to be removed on next Kodi release
@@ -49,7 +50,10 @@ constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_he
 constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay";
-constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
+constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: deprecated, to be removed on next Kodi release
+
+constexpr std::string_view PROP_DRM = "inputstream.adaptive.drm";
+constexpr std::string_view PROP_DRM_LICENSE = "inputstream.adaptive.drm_license";
 
 constexpr std::string_view PROP_INTERNAL_COOKIES = "inputstream.adaptive.internal_cookies";
 
@@ -59,26 +63,46 @@ constexpr std::string_view PROP_CHOOSER_BANDWIDTH_MAX = "inputstream.adaptive.ch
 constexpr std::string_view PROP_CHOOSER_RES_MAX = "inputstream.adaptive.chooser_resolution_max";
 constexpr std::string_view PROP_CHOOSER_RES_SECURE_MAX = "inputstream.adaptive.chooser_resolution_secure_max";
 // clang-format on
+
+void LogProp(std::string_view name, std::string_view value, bool isValueRedacted = false)
+{
+  LOG::Log(LOGDEBUG, "Property found \"%s\" value: %s", name.data(),
+           isValueRedacted ? "[redacted]" : value.data());
+}
+
+void LogDrmJsonDictKeys(const rapidjson::Value& dict, std::string_view keySystem)
+{
+  if (dict.IsObject())
+  {
+    std::string keys;
+    for (auto it = dict.MemberBegin(); it != dict.MemberEnd(); ++it)
+    {
+      keys += it->name.GetString();
+      keys += "; ";
+    }
+    LOG::Log(LOGDEBUG, "DRM config for key system: \"%s\", parameters: %s", keySystem.data(),
+             keys.c_str());
+  }
+}
 } // unnamed namespace
 
 ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std::string>& props)
 {
   std::string licenseUrl;
 
+  bool isNewDrmPropsSet =
+      STRING::KeyExists(props, PROP_DRM) || STRING::KeyExists(props, PROP_DRM_LICENSE);
+  if (!isNewDrmPropsSet)
+  {
+    //! @todo: deprecated DRM properties, all them should be removed on next Kodi version.
+    ParseLegacyDrm(props);
+  }
+
   for (const auto& prop : props)
   {
     bool logPropValRedacted{false};
 
-    if (prop.first == PROP_LICENSE_TYPE)
-    {
-      m_licenseType = prop.second;
-    }
-    else if (prop.first == PROP_LICENSE_KEY)
-    {
-      m_licenseKey = prop.second;
-      logPropValRedacted = true;
-    }
-    else if (prop.first == PROP_LICENSE_URL)
+    if (prop.first == PROP_LICENSE_URL)
     {
       // If PROP_LICENSE_URL_APPEND is parsed before this one, we need to append it
       licenseUrl = prop.second + licenseUrl;
@@ -87,23 +111,6 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
     else if (prop.first == PROP_LICENSE_URL_APPEND)
     {
       licenseUrl += prop.second;
-      logPropValRedacted = true;
-    }
-    else if (prop.first == PROP_LICENSE_DATA)
-    {
-      m_licenseData = prop.second;
-      logPropValRedacted = true;
-    }
-    else if (prop.first == PROP_LICENSE_FLAGS)
-    {
-      if (prop.second.find("persistent_storage") != std::string::npos)
-        m_isLicensePersistentStorage = true;
-      if (prop.second.find("force_secure_decoder") != std::string::npos)
-        m_isLicenseForceSecureDecoder = true;
-    }
-    else if (prop.first == PROP_SERVER_CERT)
-    {
-      m_serverCertificate = prop.second;
       logPropValRedacted = true;
     }
     else if (prop.first == PROP_MANIFEST_TYPE) //! @todo: deprecated, to be removed on next Kodi release
@@ -178,11 +185,6 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
     {
       m_liveDelay = STRING::ToUint64(prop.second); //! @todo: move to PROP_MANIFEST_CONFIG
     }
-    else if (prop.first == PROP_PRE_INIT_DATA)
-    {
-      m_drmPreInitData = prop.second;
-      logPropValRedacted = true;
-    }
     else if (prop.first == PROP_STREAM_SELECTION_TYPE)
     {
       m_chooserProps.m_chooserType = prop.second;
@@ -215,14 +217,36 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
     {
       ParseManifestConfig(prop.second);
     }
+    else if (prop.first == PROP_DRM && !prop.second.empty())
+    {
+      if (!ParseDrm(prop.second))
+        LOG::LogF(LOGERROR, "Cannot parse \"%s\" property, wrong or malformed data.",
+                  prop.first.c_str());
+
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_DRM_LICENSE && !prop.second.empty())
+    {
+      if (!ParseDrmLicense(prop.second))
+        LOG::LogF(LOGERROR, "Cannot parse \"%s\" property, wrong or malformed data.",
+                  prop.first.c_str());
+
+      logPropValRedacted = true;
+    }
     else
     {
+      // Ignore legacy DRM props, because has been parsed separately
+      if (prop.first == PROP_LICENSE_TYPE || prop.first == PROP_LICENSE_FLAGS ||
+          prop.first == PROP_LICENSE_DATA || prop.first == PROP_PRE_INIT_DATA ||
+          prop.first == PROP_SERVER_CERT || prop.first == PROP_LICENSE_KEY)
+      {
+        continue;
+      }
       LOG::Log(LOGWARNING, "Property found \"%s\" is not supported", prop.first.c_str());
       continue;
     }
 
-    LOG::Log(LOGDEBUG, "Property found \"%s\" value: %s", prop.first.c_str(),
-             logPropValRedacted ? "[redacted]" : prop.second.c_str());
+    LogProp(prop.first, prop.second, logPropValRedacted);
   }
 
   if (!licenseUrl.empty())
@@ -280,4 +304,337 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseManifestConfig(const std::string& dat
                 configName.c_str(), PROP_MANIFEST_CONFIG.data());
     }
   }
+}
+
+void ADP::KODI_PROPS::CCompKodiProps::ParseLegacyDrm(
+    const std::map<std::string, std::string>& props)
+{
+  // Translate data from old ISA properties to the new DRM configuration,
+  // Proceed only if "inputstream.adaptive.license_key" is set
+  if (!STRING::KeyExists(props, PROP_LICENSE_KEY))
+    return;
+
+  LOG::Log(
+      LOGWARNING,
+      "<<< PROPERTIES DEPRECATION NOTICE >>>\n"
+      "DEPRECATED PROPERTIES HAS BEEN USED TO SET THE DRM CONFIGURATION.\n"
+      "THE FOLLOWING PROPERTIES WILL BE REMOVED STARTING FROM KODI 22:\n"
+      "- inputstream.adaptive.license_type\n"
+      "- inputstream.adaptive.license_key\n"
+      "- inputstream.adaptive.license_data\n"
+      "- inputstream.adaptive.license_flags\n"
+      "- inputstream.adaptive.server_certificate\n"
+      "- inputstream.adaptive.pre_init_data\n"
+      "TO AVOID PLAYBACK FAILURES, YOU SHOULD INCLUDE THE NEW PROPERTIES AS SOON AS POSSIBLE:\n"
+      "- inputstream.adaptive.drm\n"
+      "- inputstream.adaptive.drm_license\n"
+      "FOR MORE INFO, PLEASE READ INPUTSTREAM ADAPTIVE WIKI ON GITHUB.");
+
+  std::string drmKeySystem = props.at(PROP_LICENSE_TYPE.data());
+  LogProp(PROP_LICENSE_TYPE, drmKeySystem);
+
+  if (drmKeySystem.empty())
+    drmKeySystem = DRM::KS_NONE;
+
+  if (!DRM::IsKeySystemSupported(drmKeySystem))
+  {
+    LOG::LogF(LOGERROR,
+              "Cannot parse DRM configuration, unknown key system \"%s\" on license_type property",
+              drmKeySystem.c_str());
+    return;
+  }
+
+  // Create a DRM configuration for the specified key system
+  DrmCfg& drmCfg = m_drmConfigs[drmKeySystem];
+
+  drmCfg.m_priority = 1;
+  std::string propValue;
+
+  // Parse DRM properties
+
+  if (STRING::GetMapValue(props, std::string(PROP_LICENSE_FLAGS), propValue))
+  {
+    if (propValue.find("persistent_storage") != std::string::npos)
+      drmCfg.m_isPersistentStorage = true;
+    if (propValue.find("force_secure_decoder") != std::string::npos)
+      drmCfg.m_isSecureDecoderForced = true;
+
+    LogProp(PROP_LICENSE_FLAGS, propValue);
+  }
+
+  if (STRING::GetMapValue(props, std::string(PROP_LICENSE_DATA), propValue))
+  {
+    drmCfg.m_streamsPsshData = propValue;
+    LogProp(PROP_LICENSE_DATA, propValue, true);
+  }
+
+  if (STRING::GetMapValue(props, std::string(PROP_PRE_INIT_DATA), propValue))
+  {
+    drmCfg.m_preInitData = propValue;
+    LogProp(PROP_PRE_INIT_DATA, propValue, true);
+  }
+
+  // Parse DRM license properties
+
+  if (STRING::GetMapValue(props, std::string(PROP_SERVER_CERT), propValue))
+  {
+    drmCfg.m_license.m_serverCertificate = propValue;
+    LogProp(PROP_SERVER_CERT, propValue, true);
+  }
+
+  if (STRING::GetMapValue(props, std::string(PROP_LICENSE_KEY), propValue))
+  {
+    std::vector<std::string> fields = STRING::SplitToVec(propValue, '|');
+    size_t fieldCount = fields.size();
+
+    if (drmKeySystem == DRM::KS_NONE)
+    {
+      // We assume its HLS AES-128 encrypted case
+      // where "inputstream.adaptive.license_key" have different fields
+
+      // Field 1: HTTP request params to append to key URL
+      if (fieldCount >= 1)
+        drmCfg.m_license.m_reqParams = fields[0];
+
+      // Field 2: HTTP request headers
+      if (fieldCount >= 2)
+        ParseHeaderString(drmCfg.m_license.m_reqHeaders, fields[1]);
+    }
+    else
+    {
+      // Field 1: License server url
+      if (fieldCount >= 1)
+        drmCfg.m_license.m_serverUrl = fields[0];
+
+      // Field 2: HTTP request headers
+      if (fieldCount >= 2)
+        ParseHeaderString(drmCfg.m_license.m_reqHeaders, fields[1]);
+
+      // Field 3: HTTP request data (POST request)
+      if (fieldCount >= 3)
+        drmCfg.m_license.m_reqData = fields[2];
+
+      // Field 4: HTTP response data (license wrappers)
+      if (fieldCount >= 4)
+      {
+        bool isJsonWrapper{false};
+        std::string jsonWrapperCfg;
+        std::string_view wrapperPrefix = fields[3];
+
+        if (wrapperPrefix.empty() || wrapperPrefix == "R")
+        {
+          // Raw, no wrapper, no-op
+        }
+        else if (wrapperPrefix == "B")
+        {
+          drmCfg.m_license.m_wrapper = "base64";
+        }
+        else if (STRING::StartsWith(wrapperPrefix, "BJ"))
+        {
+          isJsonWrapper = true;
+          drmCfg.m_license.m_wrapper = "base64+json";
+          jsonWrapperCfg = wrapperPrefix.substr(2);
+        }
+        else if (STRING::StartsWith(wrapperPrefix, "JB"))
+        {
+          isJsonWrapper = true;
+          drmCfg.m_license.m_wrapper = "json+base64";
+          jsonWrapperCfg = wrapperPrefix.substr(2);
+        }
+        else if (STRING::StartsWith(wrapperPrefix, "J"))
+        {
+          isJsonWrapper = true;
+          drmCfg.m_license.m_wrapper = "json";
+          jsonWrapperCfg = wrapperPrefix.substr(1);
+        }
+        else if (STRING::StartsWith(wrapperPrefix, "HB"))
+        {
+          // HB has been removed, we have no info about this use case
+          // if someone will open an issue we can try get more info for the reimplementation
+          //! @todo: if no feedbacks in future this can be removed, see also todo on decrypters/Helpers.cpp
+          LOG::Log(LOGERROR, "The support for \"HB\" parameter in the \"Response data\" field of "
+                             "license_key property has been removed. If this is a requirement for "
+                             "your video service, let us know by opening an issue on GitHub.");
+        }
+        else
+        {
+          LOG::Log(
+              LOGERROR,
+              "Unknown \"%s\" parameter in the \"response data\" field of license_key property",
+              wrapperPrefix.data());
+        }
+
+        // Parse JSON configuration
+        if (isJsonWrapper)
+        {
+          if (jsonWrapperCfg.empty())
+          {
+            LOG::Log(LOGERROR, "Missing JSON dict key names in the \"response data\" field of "
+                               "license_key property");
+          }
+          else
+          {
+            drmCfg.m_license.m_isJsonPathTraverse = true;
+            // Expected format as "KeyNameForData;KeyNameForHDCP" with exact order
+            std::vector<std::string> jPaths = STRING::SplitToVec(jsonWrapperCfg, ';');
+            // Position 1: The dict Key name to get license data
+            if (jPaths.size() >= 1)
+              drmCfg.m_license.m_wrapperParams.emplace("path_data", jPaths[0]);
+
+            // Position 2: The dict Key name to get HDCP value (optional)
+            if (jPaths.size() >= 2)
+              drmCfg.m_license.m_wrapperParams.emplace("path_hdcp", jPaths[1]);
+          }
+        }
+      }
+    }
+    LogProp(PROP_LICENSE_KEY, propValue, true);
+  }
+}
+
+bool ADP::KODI_PROPS::CCompKodiProps::ParseDrm(std::string data)
+{
+  /* Expected JSON structure:
+   * { "keysystem_name" : { "persistent_storage" : bool,
+   *                        "force_secure_decoder" : bool,
+   *                        "streams_pssh_data" : str,
+   *                        "pre_init_data" : str,
+   *                        "priority": int },
+   *   "keysystem_name_2" : { ... }}
+   */
+  rapidjson::Document jDoc;
+  jDoc.Parse(data.c_str(), data.size());
+
+  if (!jDoc.IsObject())
+  {
+    LOG::LogF(LOGERROR, "Malformed JSON data in to \"%s\" property", PROP_DRM.data());
+    return false;
+  }
+
+  // Iterate key systems dict
+  for (auto& jChildObj : jDoc.GetObject())
+  {
+    const char* keySystem = jChildObj.name.GetString();
+
+    if (!DRM::IsKeySystemSupported(keySystem))
+    {
+      LOG::LogF(LOGERROR, "Ignored unknown key system \"%s\" on DRM property", keySystem);
+      continue;
+    }
+
+    DrmCfg& drmCfg = m_drmConfigs[keySystem];
+    auto& jDictVal = jChildObj.value;
+
+    if (!jDictVal.IsObject())
+    {
+      LOG::LogF(LOGERROR, "Cannot parse key system \"%s\" value on DRM property, wrong data type",
+                keySystem);
+      continue;
+    }
+
+    if (jDictVal.HasMember("persistent_storage") && jDictVal["persistent_storage"].IsBool())
+      drmCfg.m_isPersistentStorage = jDictVal["persistent_storage"].GetBool();
+
+    if (jDictVal.HasMember("force_secure_decoder") && jDictVal["force_secure_decoder"].IsBool())
+      drmCfg.m_isPersistentStorage = jDictVal["force_secure_decoder"].GetBool();
+
+    if (jDictVal.HasMember("streams_pssh_data") && jDictVal["streams_pssh_data"].IsString())
+      drmCfg.m_streamsPsshData = jDictVal["streams_pssh_data"].GetString();
+
+    if (jDictVal.HasMember("pre_init_data") && jDictVal["pre_init_data"].IsString())
+      drmCfg.m_preInitData = jDictVal["pre_init_data"].GetString();
+
+    if (jDictVal.HasMember("priority") && jDictVal["priority"].IsInt())
+      drmCfg.m_priority = jDictVal["priority"].GetInt();
+
+    LogDrmJsonDictKeys(
+        jDictVal,
+        keySystem); // todo: <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< comment this, maybe an appropriate config log elsewere
+  }
+
+  return true;
+}
+
+bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmLicense(std::string data)
+{
+  /* Expected JSON structure:
+   * { "keysystem_name" : { "wrapper" : str,
+   *                        "wrapper_params" : dict,
+   *                        "server_certificate" : str,
+   *                        "server_url" : str,
+   *                        "req_headers" : str,
+   *                        "req_params" : str,
+   *                        "req_data" : str },
+   *   "keysystem_name_2" : { ... }}
+   */
+  rapidjson::Document jDoc;
+  jDoc.Parse(data.c_str(), data.size());
+
+  if (!jDoc.IsObject())
+  {
+    LOG::LogF(LOGERROR, "Malformed JSON data in to \"%s\" property", PROP_DRM_LICENSE.data());
+    return false;
+  }
+
+  // Iterate key system dict
+  for (auto& jChildObj : jDoc.GetObject())
+  {
+    const char* keySystem = jChildObj.name.GetString();
+
+    if (!DRM::IsKeySystemSupported(keySystem))
+    {
+      LOG::LogF(LOGERROR, "Ignored unknown key system \"%s\" on DRM license property", keySystem);
+      continue;
+    }
+
+    DrmCfg& drmCfg = m_drmConfigs[keySystem];
+    auto& jDictVal = jChildObj.value;
+
+    if (!jDictVal.IsObject())
+    {
+      LOG::LogF(LOGERROR,
+                "Cannot parse key system \"%s\" value on DRM license property, wrong data type",
+                keySystem);
+      continue;
+    }
+
+    if (jDictVal.HasMember("wrapper") && jDictVal["wrapper"].IsString())
+    {
+      drmCfg.m_license.m_wrapper = STRING::ToLower(jDictVal["wrapper"].GetString());
+    }
+
+    if (jDictVal.HasMember("wrapper_params") && jDictVal["wrapper_params"].IsObject())
+    {
+      // Iterate wrapper_params dict
+      for (auto& cWrapParam : jDictVal["wrapper_params"].GetObject())
+      {
+        if (cWrapParam.name.IsString() && cWrapParam.value.IsString())
+        {
+          drmCfg.m_license.m_wrapperParams.emplace(cWrapParam.name.GetString(),
+                                                   cWrapParam.value.GetString());
+        }
+      }
+    }
+
+    if (jDictVal.HasMember("server_certificate") && jDictVal["server_certificate"].IsString())
+      drmCfg.m_license.m_serverCertificate = jDictVal["server_certificate"].GetString();
+
+    if (jDictVal.HasMember("server_url") && jDictVal["server_url"].IsString())
+      drmCfg.m_license.m_serverUrl = jDictVal["server_url"].GetString();
+
+    if (jDictVal.HasMember("req_headers") && jDictVal["req_headers"].IsString())
+      ParseHeaderString(drmCfg.m_license.m_reqHeaders, jDictVal["req_headers"].GetString());
+
+    if (jDictVal.HasMember("req_params") && jDictVal["req_params"].IsString())
+      drmCfg.m_license.m_reqParams = jDictVal["req_params"].GetString();
+
+    if (jDictVal.HasMember("req_data") && jDictVal["req_data"].IsString())
+      drmCfg.m_license.m_reqData = jDictVal["req_data"].GetString();
+
+    LogDrmJsonDictKeys(
+        jDictVal,
+        keySystem); // todo: <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< comment this, maybe an appropriate config log elsewere
+  }
+
+  return true;
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -46,7 +46,7 @@ public:
    *  \param isSessionOpened [OUT] Will be true if the DRM session has been opened
    *  \return True if has success, false otherwise
    */
-  bool PreInitializeDRM(std::string& challengeB64, std::string& sessionId, bool& isSessionOpened);
+  bool PreInitializeDRM(std::string_view preInitData, std::string& challengeB64, std::string& sessionId, bool& isSessionOpened);
 
   /*! \brief Initialize the DRM
    *  \param addDefaultKID Set True to add the default KID to the first session

--- a/src/decrypters/DrmFactory.cpp
+++ b/src/decrypters/DrmFactory.cpp
@@ -8,6 +8,10 @@
 
 #include "DrmFactory.h"
 
+#include "SrvBroker.h"
+#include "CompKodiProps.h"
+#include "Helpers.h"
+
 #include <kodi/addon-instance/inputstream/StreamCrypto.h>
 #if ANDROID
 #include "widevineandroid/WVDecrypter.h"
@@ -41,4 +45,19 @@ IDecrypter* DRM::FACTORY::GetDecrypter(STREAM_CRYPTO_KEY_SYSTEM keySystem)
   }
 
   return nullptr;
+}
+
+bool DRM::IsKeySystemDRMSupported(std::string_view ks)
+{
+#if ANDROID
+  if (CWVDecrypterA::IsKeySystemSupported(ks))
+    return true;
+#else
+// Darwin embedded are apple platforms different than MacOS (e.g. IOS)
+#ifndef TARGET_DARWIN_EMBEDDED
+  if (CWVDecrypter::IsKeySystemSupported(ks))
+    return true;
+#endif
+#endif
+  return false;
 }

--- a/src/decrypters/DrmFactory.h
+++ b/src/decrypters/DrmFactory.h
@@ -12,6 +12,12 @@
 
 namespace DRM
 {
+/*!
+  * \brief Test if there is a compatible DRM that support the specified key system.
+  * \return True if DRM supported, otherwise false.
+  */
+bool IsKeySystemDRMSupported(std::string_view ks);
+
 namespace FACTORY
 {
 IDecrypter* GetDecrypter(STREAM_CRYPTO_KEY_SYSTEM keySystem);

--- a/src/decrypters/Helpers.cpp
+++ b/src/decrypters/Helpers.cpp
@@ -8,11 +8,245 @@
 
 #include "Helpers.h"
 
+#include "utils/Base64Utils.h"
 #include "utils/DigestMD5Utils.h"
+#include "utils/JsonUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/UrlUtils.h"
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
 
+#include <pugixml.hpp>
+
+using namespace pugi;
 using namespace UTILS;
+
+namespace
+{
+
+// Supported wrappers
+enum class Wrapper
+{
+  AUTO, // Try auto-detect wrappers
+  NONE, // Implicit for raw binary data
+  BASE64,
+  JSON,
+  XML
+};
+
+// \brief Translate a wrapper string in to relative vector of enum values.
+//        e.g. "json+base64" --> JSON, BASE64
+std::vector<Wrapper> TranslateWrapper(std::string_view wrapper)
+{
+  const std::vector<std::string> wrappers = STRING::SplitToVec(wrapper, '+');
+
+  if (wrappers.empty())
+    return {};
+
+  std::vector<Wrapper> result;
+  // Here we have to keep the order because
+  // defines the order in which data will be unwrapped
+  for (const std::string& wrapper : wrappers)
+  {
+    if (wrapper == "auto")
+      result.emplace_back(Wrapper::AUTO);
+    else if (wrapper == "none")
+      result.emplace_back(Wrapper::NONE);
+    else if (wrapper == "base64")
+      result.emplace_back(Wrapper::BASE64);
+    else if (wrapper == "json")
+      result.emplace_back(Wrapper::JSON);
+    else if (wrapper == "xml")
+      result.emplace_back(Wrapper::XML);
+    else
+    {
+      LOG::LogF(LOGERROR, "Cannot translate license wrapper, unknown type \"%s\"", wrapper.c_str());
+      return {Wrapper::AUTO};
+    }
+  }
+  return result;
+}
+
+} // unnamed namespace
+
+bool DRM::IsKeySystemSupported(std::string_view keySystem)
+{
+  return keySystem == DRM::KS_NONE || keySystem == DRM::KS_WIDEVINE ||
+         keySystem == DRM::KS_PLAYREADY || keySystem == DRM::KS_WISEPLAY;
+}
+
+bool DRM::WvUnwrapLicense(std::string wrapper,
+                          std::string contentType,
+                          std::string data,
+                          std::string& dataOut,
+                          int& hdcpLimit)
+{
+  // By default the license response should be in binary data format
+  // but many services have a proprietary implementations therefore
+  // the license data could be wrapped (such as base64, json, etc...)
+  // here we provide the support for some common wrappers,
+  // as alternative an add-on must implement a proxy where it can request
+  // and process the license in a custom way and so return here the binary data
+
+  std::vector<Wrapper> wrappers = TranslateWrapper(wrapper);
+
+  std::map<std::string, std::string> params;
+
+  bool isAuto = (wrappers.size() == 0 || wrappers.front() == Wrapper::AUTO) &&
+                wrappers.front() != Wrapper::NONE;
+
+  bool isAllowedFallbacks{false};
+
+  if (isAuto)
+  {
+    wrappers.clear();
+    // Check mime types to try detect the wrapper
+    if (contentType == "application/octet-stream")
+    {
+      // its binary
+    }
+    else if (contentType == "application/json")
+    {
+      if (BASE64::IsBase64(data))
+        wrappers.emplace_back(Wrapper::BASE64);
+
+      wrappers.emplace_back(Wrapper::JSON);
+    }
+    else if (contentType == "application/xml" || contentType == "text/xml")
+    {
+      wrappers.emplace_back(Wrapper::XML);
+    }
+    else if (contentType == "text/plain")
+    {
+      // Some service use text mime type for XML
+      isAllowedFallbacks = true;
+      wrappers.emplace_back(Wrapper::XML);
+    }
+    else // Unknown
+    {
+      // Assumed to be binary with a possible base64 wrap
+      if (BASE64::IsBase64(data))
+        wrappers.emplace_back(Wrapper::BASE64);
+    }
+  }
+
+  // Process multiple wrappers with sequential order
+
+  for (size_t i = 0; i < wrappers.size(); ++i)
+  {
+    const auto& wrapper = wrappers[i];
+
+    if (wrapper == Wrapper::NONE)
+    {
+      break;
+    }
+    else if (wrapper == Wrapper::BASE64)
+    {
+      data = BASE64::DecodeToStr(data);
+    }
+    else if (wrapper == Wrapper::JSON)
+    {
+      if (params["path_data"].empty())
+      {
+        LOG::LogF(LOGERROR,
+                  "Cannot parse JSON license data, \"path_data\" parameter not specified");
+        return false;
+      }
+
+      rapidjson::Document jDoc;
+      jDoc.Parse(data.c_str(), data.size());
+
+      if (!jDoc.IsObject())
+      {
+        LOG::LogF(LOGERROR,
+                  "Unable to parse license data as JSON format, malformed data or wrong wrapper");
+        return false;
+      }
+
+      rapidjson::Value* jDataObjValue = JSON::GetValueAtPath(jDoc, params["path_data"]);
+
+      if (!jDataObjValue || !jDataObjValue->IsString())
+      {
+        LOG::LogF(LOGERROR, "Unable to get license data from JSON path, possible wrong path on "
+                            "\"path_data\" parameter");
+        return false;
+      }
+
+      data = jDataObjValue->GetString();
+
+      if (!params["path_hdcp"].empty())
+      {
+        rapidjson::Value* jHdcpObjValue = JSON::GetValueAtPath(jDoc, params["path_hdcp"]);
+
+        if (!jHdcpObjValue || !jHdcpObjValue->IsInt())
+        {
+          LOG::LogF(LOGERROR, "Unable to parse JSON HDCP path, possible wrong path or data type on "
+                              "\"path_hdcp\" parameter");
+        }
+        else
+          hdcpLimit = jHdcpObjValue->GetInt();
+      }
+
+      if (isAuto && BASE64::IsBase64(data))
+        wrappers.emplace_back(Wrapper::BASE64);
+    }
+    else if (wrapper == Wrapper::XML)
+    {
+      if (params["path_data"].empty())
+      {
+        LOG::LogF(LOGERROR, "Cannot parse XML license data, \"path_data\" parameter not specified");
+        return false;
+      }
+
+      xml_document doc;
+      xml_parse_result parseRes = doc.load_buffer(data.c_str(), data.size());
+
+      if (parseRes.status != status_ok)
+      {
+        if (isAllowedFallbacks)
+        {
+          LOG::LogF(LOGDEBUG, "License data not in XML format, fallback to binary");
+          wrappers.emplace_back(Wrapper::NONE);
+          continue;
+        }
+        else
+        {
+          LOG::LogF(LOGERROR, "Unable to parse XML license data, malformed data or wrong wrapper");
+          return false;
+        }
+      }
+
+      pugi::xml_node node = doc.select_node(params["path_data"].c_str()).node();
+      if (!node)
+      {
+        LOG::LogF(LOGERROR, "Unable to get license data from XML path, possible wrong path on "
+                            "\"path_data\" parameter");
+        return false;
+      }
+      data = node.child_value();
+
+      if (isAuto && BASE64::IsBase64(data))
+        wrappers.emplace_back(Wrapper::BASE64);
+    }
+  }
+
+  if (data.empty())
+  {
+    LOG::LogF(LOGERROR, "No license data, a problem occurred while processing license wrappers");
+    return false;
+  }
+
+  //! @todo: the support to binary license data (with HB) that start with "\r\n\r\n" has not been reintroduced with the
+  //! rework of this code, this is a very old unclear addition, seem there are no info about this on web,
+  //! and seem no addons use it, so for now is removed, if in the future someone complain about this lack
+  //! will be possible reintroduce it and include more clear info about this use case.
+  // if (data.compare(0, 4, "\r\n\r\n") == 0)
+  //   data.erase(0, 4);
+
+  dataOut = data;
+
+  return true;
+}
 
 std::string DRM::GenerateUrlDomainHash(std::string_view url)
 {

--- a/src/decrypters/Helpers.h
+++ b/src/decrypters/Helpers.h
@@ -13,6 +13,28 @@
 
 namespace DRM
 {
+// CDM Key systems
+
+constexpr std::string_view KS_NONE = "none"; // No DRM but however encrypted (e.g. AES-128 on HLS)
+constexpr std::string_view KS_WIDEVINE = "com.widevine.alpha";
+constexpr std::string_view KS_PLAYREADY = "com.microsoft.playready";
+constexpr std::string_view KS_WISEPLAY = "com.huawei.wiseplay";
+
+// CDM UUIDs
+
+constexpr std::string_view UUID_WIDEVINE = "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
+constexpr std::string_view UUID_PLAYREADY = "9a04f079-9840-4286-ab92-e65be0885f95";
+constexpr std::string_view UUID_WISEPLAY = "3d5e6d35-9b9a-41e8-b843-dd3c6e72c42c";
+// constexpr std::string_view UUID_COMMON = "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b";
+
+
+bool IsKeySystemSupported(std::string_view keySystem);
+
+bool WvUnwrapLicense(std::string wrapper,
+                     std::string contentType,
+                     std::string data,
+                     std::string& dataOut,
+                     int& hdcpLimit);
 
 /*!
  * \brief Generate an hash by using the base domain of an URL.

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -43,7 +43,31 @@ struct DecrypterCapabilites
   uint16_t hdcpVersion{0}; //The HDCP version streams has to be restricted 0,10,20,21,22.....
   int hdcpLimit{0}; // If set (> 0) streams that are greater than the multiplication of "Width x Height" cannot be played.
 };
+/*
+struct DrmConfig
+{
+  struct License
+  {
+    enum class Wrapper
+    {
+      AUTO, // Try auto-detect wrappers
+      NONE, // Implicit for binary data
+      BASE64,
+      JSON,
+      XML
+    };
 
+    // Define each wrapper used to wrap the license data,
+    // on multiple wrappers e.g. BASE64+JSON the order in which the wrappers are added
+    // defines the order in which the data will be unwrapped
+    std::vector<Wrapper> m_wrappers;
+    // Wrapper params
+    std::map<std::string, std::string> m_wrapperParams;
+  };
+
+  License m_license;
+};
+*/
 class IDecrypter
 {
 public:

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -305,7 +305,9 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     md5.Finalize();
     blocks[0].replace(insPos, 6, md5.HexDigest());
   }
-
+  LOG::LogF(LOGERROR, "licenza url: %s", blocks[0].c_str());
+  LOG::LogF(LOGERROR, "licenza key: %s", m_wvCdmAdapter.GetLicenseURL().c_str());
+  
   CURL::CUrl file{blocks[0].c_str()};
   file.AddHeader("Expect", "");
 
@@ -479,6 +481,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
 
   resLimit = file.GetResponseHeader("X-Limit-Video");
   contentType = file.GetResponseHeader("Content-Type");
+  LOG::LogF(LOGERROR, "contentType: %s", contentType.c_str());
 
   if (!resLimit.empty())
   {
@@ -492,6 +495,8 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     LOG::LogF(LOGERROR, "Could not read full SessionMessage response");
     return false;
   }
+
+  LOG::LogF(LOGERROR, "lic response: %s", response.c_str());
 
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -10,6 +10,7 @@
 
 #include "WVCdmAdapter.h"
 #include "WVCencSingleSampleDecrypter.h"
+#include "decrypters/Helpers.h"
 #include "utils/Base64Utils.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
@@ -202,4 +203,9 @@ void CWVDecrypter::ReleaseBuffer(void* instance, void* buffer)
 {
   if (instance)
     static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->ReleaseFrameBuffer(buffer);
+}
+
+bool CWVDecrypter::IsKeySystemSupported(std::string_view ks)
+{
+  return ks == DRM::KS_WIDEVINE;
 }

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -58,6 +58,8 @@ public:
   virtual void ReleaseBuffer(void* instance, void* buffer);
   virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
 
+  static bool IsKeySystemSupported(std::string_view ks);
+
 private:
   CWVCdmAdapter* m_WVCdmAdapter;
   CWVCencSingleSampleDecrypter* m_decodingDecrypter;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(${BINARY}
     ../common/SegmentBase.cpp
     ../common/SegmentList.cpp
     ../common/SegTemplate.cpp
+    ../decrypters/Helpers.cpp
     ../oscompat.cpp
     ../SrvBroker.cpp
     ../CompSettings.cpp
@@ -42,14 +43,16 @@ add_executable(${BINARY}
     ../utils/Base64Utils.cpp
     ../utils/CharArrayParser.cpp
     ../utils/CurlUtils.cpp
+    ../utils/DigestMD5Utils.cpp
     ../utils/FileUtils.cpp
+    ../utils/JsonUtils.cpp
     ../utils/StringUtils.cpp
     ../utils/UrlUtils.cpp
     ../utils/Utils.cpp
     ../utils/XMLUtils.cpp
     )
 
-target_link_libraries(${BINARY} PRIVATE ${BENTO4_LIBRARIES} ${PUGIXML_LIBRARIES} ${GTEST_LIBRARIES} Threads::Threads ${CMAKE_DL_LIBS})
+target_link_libraries(${BINARY} PRIVATE ${BENTO4_LIBRARIES} ${PUGIXML_LIBRARIES} ${RAPIDJSON_LIBRARIES} ${GTEST_LIBRARIES} Threads::Threads ${CMAKE_DL_LIBS})
 
 set(TEST_DATA_DIR "${CMAKE_SOURCE_DIR}/src/test/manifests")
 add_test(NAME manifest_tests COMMAND ${BINARY} "${TEST_DATA_DIR}")

--- a/src/utils/Base64Utils.cpp
+++ b/src/utils/Base64Utils.cpp
@@ -10,6 +10,8 @@
 
 #include "log.h"
 
+#include <regex>
+
 using namespace UTILS::BASE64;
 
 namespace
@@ -40,6 +42,17 @@ constexpr unsigned char BASE64_TABLE[] = {
 };
 // clang-format on
 } // namespace
+
+bool UTILS::BASE64::IsBase64(const std::string& str)
+{
+  // Check if the string length is a multiple of 4
+  if (str.size() % 4 == 0)
+  {
+    static const std::regex base64Regex("^[A-Za-z0-9+/]*={0,2}$");
+    return std::regex_match(str, base64Regex);
+  }
+  return false;
+}
 
 void UTILS::BASE64::Encode(const uint8_t* input, const size_t length, std::string& output)
 {

--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -17,6 +17,7 @@ namespace UTILS
 {
 namespace BASE64
 {
+bool IsBase64(const std::string& str);
 
 void Encode(const uint8_t* input, const size_t length, std::string& output);
 std::string Encode(const uint8_t* input, const size_t length);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
   CurlUtils.cpp
   DigestMD5Utils.cpp
   FileUtils.cpp
+  JsonUtils.cpp
   StringUtils.cpp
   UrlUtils.cpp
   Utils.cpp
@@ -17,6 +18,7 @@ set(HEADERS
   CurlUtils.h
   DigestMD5Utils.h
   FileUtils.h
+  JsonUtils.h
   log.h
   StringUtils.h
   UrlUtils.h

--- a/src/utils/JsonUtils.cpp
+++ b/src/utils/JsonUtils.cpp
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JsonUtils.h"
+
+rapidjson::Value* UTILS::JSON::GetValueAtPath(rapidjson::Value& node, const std::string& path)
+{
+  size_t pos = path.find('/');
+  std::string current_level = path.substr(0, pos);
+
+  if (node.IsObject() && node.HasMember(current_level.c_str()))
+  {
+    if (pos == std::string::npos)
+    {
+      return &node[current_level.c_str()];
+    }
+    else
+    {
+      return GetValueAtPath(node[current_level.c_str()], path.substr(pos + 1));
+    }
+  }
+
+  return nullptr;
+}

--- a/src/utils/JsonUtils.h
+++ b/src/utils/JsonUtils.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <rapidjson/document.h>
+
+namespace UTILS
+{
+namespace JSON
+{
+
+/*!
+ * \brief Get value from a JSON path e.g. "a/b/c"
+ * \param node The json object where get the value
+ * \param path The path where the value is contained
+ * \return The json object if found, otherwise nullptr.
+ */
+rapidjson::Value* GetValueAtPath(rapidjson::Value& node, const std::string& path);
+
+} // namespace JSON
+} // namespace UTILS

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -21,8 +21,22 @@ namespace STRING
 {
 
 // \brief Template function to check if a key exists in a container e.g. <map>
-template<typename T, typename Key>
-bool KeyExists(const T& container, const Key& key)
+template<typename T>
+bool KeyExists(const T& container, const std::string_view& key)
+{
+  return container.find(key.data()) != std::end(container);
+}
+
+// \brief Template function to check if a key exists in a container e.g. <map>
+template<typename T>
+bool KeyExists(const T& container, const std::string& key)
+{
+  return container.find(key) != std::end(container);
+}
+
+// \brief Template function to check if a key exists in a container e.g. <map>
+template<typename T>
+bool KeyExists(const T& container, const char* key)
 {
   return container.find(key) != std::end(container);
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR is currently WIP not buildable, for now opened PR for feedback and/or clarifications

UPDATE:
I WILL DO SEPARATE PR'S TO ACHIEVE THIS CHANGE, SINCE SOURCE CODE CHANGES ARE TOO BIG, PARTS OF SPECS ON THIS PR ARE OUTDATED

### New properties
There are two new properties, and both require JSON values (dumped as string), i have chosen JSON because is easy to implement into python addons, a bit less on binary addon, but JSON string can also be manually constructed with not too much problems.
i have prefer add two separated props to avoid to do too nested JSON dictionaries, that otherwise make more complex add JSON values to playlist files like STRM:

**inputstream.adaptive.drm**
This property is to set general DRM parameters, based on CDM Key System

JSON structure:
```json
{
    "com.widevine.alpha": {
        "persistent_storage": bool,
        "force_secure_decoder": bool,
        "streams_pssh_data": str,
        "pre_init_data": str,
        "priority": int
    },
    "com.microsoft.playready": {
        ...
    }
}
```

**inputstream.adaptive.drm_license**
This property is to set license DRM parameters, based on CDM Key System

JSON structure:
```json
{
    "com.widevine.alpha": {
        "wrapper": str,
        "wrapper_params": dict,
        "server_certificate": str,
        "server_url": str,
        "req_headers": str,
        "req_params": str,
        "req_data": str
    },
    "com.microsoft.playready": {
        ...
    },
    "none": {
        ... // special case that can be used to set parameters for encrypted streams like HLS AES-128
    }
}
```

The JSON parameters to be set in the new configuration are not much different from the old properties,
and you can guess, i will add some more info later

### Deprecated properties
The two new properties, will deprecate these old ones,
and they will be removed on future Kodi (major) versions
more likely in the Kodi 22 RC (theorically first quarter of 2025):
```
inputstream.adaptive.license_type
inputstream.adaptive.license_key
inputstream.adaptive.license_data
inputstream.adaptive.license_flags
inputstream.adaptive.server_certificate
inputstream.adaptive.pre_init_data
```

### Auto-selection of CDM

The idea is to make CDM selection automatic without that an addon have to specify which one should be used.
This can be possible since we know that supported CDM on the operative system, and we know also what DRM's are supported on a manifest

### XML license wrapper support

License wrapper term i mean the things that are set in to [inputstream.adaptive.license_key](https://github.com/xbmc/inputstream.adaptive/wiki/Integration#inputstreamadaptivelicense_key) `[Response-Data]` field, where we currently support base64 and JSON, wrappers

Since here the code that manage the license wrapper has been reworked (for widevine), add the XML wrapper support its a very small change, so is included here

### Breaking changes
This huge change is thought to be backward compatible with the existing (deprecated) properties.

For now the only breaking change is on [inputstream.adaptive.license_key](https://github.com/xbmc/inputstream.adaptive/wiki/Integration#inputstreamadaptivelicense_key) `[Response-Data]` field, where the `HB` type has been removed. This because we have no info about this addition, i have not found info on web, nor addon that use it, therefore if in future someone will complain about this removal, we can obtain more info about it to reimplement it.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Main reasons:
- with multiple DRM support we have to provide a way to set configuration parameters for each DRM, the use case is when a manifest support more DRMs and the target system that play the stream support all them or one of them
- video addons may support more DRM, that can depends also on the OS used, so we can automatize the CDM selection based on what the system supports and what the manifest supports, without that a video addon have to find a way to manually handle this
- more times is happened that video addon devs are confused by our complex properties because are not easy to understand, unfurnately we cannot simplify too much things, but at least we can remove the pipe `|` uses in the `inputstream.adaptive.license_key` that is the most complex property and make more clear parameters to be set
- group all DRM configuration with less properties that can be in future expanded without add or change existing properties

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
