### PR TITLE
[CSubtitleSampleReader] Initialize reader appropriately, add STPP fourcc

### DIFF
--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -49,7 +49,7 @@ CFragmentedSampleReader::~CFragmentedSampleReader()
   delete m_codecHandler;
 }
 
-bool CFragmentedSampleReader::Initialize()
+bool CFragmentedSampleReader::Initialize(SESSION::CStream* stream)
 {
   EnableTrack(m_track->GetId());
 

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -25,7 +25,7 @@ public:
 
   ~CFragmentedSampleReader();
 
-  virtual bool Initialize() override;
+  virtual bool Initialize(SESSION::CStream* stream) override;
   virtual void SetDecrypter(Adaptive_CencSingleSampleDecrypter* ssd,
                             const DRM::DecrypterCapabilites& dcaps) override;
 

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -26,6 +26,10 @@ namespace DRM
 {
 struct DecrypterCapabilites;
 }
+namespace SESSION
+{
+class CStream;
+}
 
 class ATTR_DLL_LOCAL SampleReaderObserver
 {
@@ -40,7 +44,7 @@ class ATTR_DLL_LOCAL ISampleReader
 {
 public:
   virtual ~ISampleReader() = default;
-  virtual bool Initialize() { return true; };
+  virtual bool Initialize(SESSION::CStream* stream) { return true; }
   virtual void SetDecrypter(Adaptive_CencSingleSampleDecrypter* ssd,
                             const DRM::DecrypterCapabilites& dcaps){};
   virtual bool EOS() const = 0;

--- a/src/samplereader/SampleReaderFactory.cpp
+++ b/src/samplereader/SampleReaderFactory.cpp
@@ -30,17 +30,7 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
 
   if (containerType == ContainerType::TEXT)
   {
-    const CRepresentation* repr = stream->m_adStream.getRepresentation();
-    if (repr->IsSubtitleFileStream())
-    {
-      reader = std::make_unique<CSubtitleSampleReader>(
-          repr->GetBaseUrl(), streamId, stream->m_info.GetCodecInternalName());
-    }
-    else
-    {
-      reader = std::make_unique<CSubtitleSampleReader>(stream, streamId,
-                                                       stream->m_info.GetCodecInternalName());
-    }
+    reader = std::make_unique<CSubtitleSampleReader>(streamId);
   }
   else if (containerType == ContainerType::TS)
   {
@@ -104,7 +94,7 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
     return nullptr;
   }
 
-  if (!reader->Initialize())
+  if (!reader->Initialize(stream))
   {
     if (containerType == ContainerType::TS &&
         stream->m_adStream.GetStreamType() == StreamType::AUDIO)
@@ -120,7 +110,7 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
 
       stream->GetAdByteStream()->Seek(0); // Seek because bytes are consumed from previous reader
       reader = std::make_unique<CADTSSampleReader>(stream->GetAdByteStream(), streamId);
-      if (!reader->Initialize())
+      if (!reader->Initialize(stream))
         reader.reset();
     }
     else

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -40,7 +40,8 @@ bool CSubtitleSampleReader::Initialize(SESSION::CStream* stream)
     // Single subtitle file (for entire video duration)
     if (STRING::Contains(codecInternalName, CODEC::FOURCC_WVTT))
       m_codecHandler = std::make_unique<WebVTTCodecHandler>(nullptr, true);
-    else if (STRING::Contains(codecInternalName, CODEC::FOURCC_TTML))
+    else if (STRING::Contains(codecInternalName, CODEC::FOURCC_TTML) ||
+             STRING::Contains(codecInternalName, CODEC::FOURCC_STPP))
       m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr);
     else
     {
@@ -58,7 +59,8 @@ bool CSubtitleSampleReader::Initialize(SESSION::CStream* stream)
 
     if (STRING::Contains(codecInternalName, CODEC::FOURCC_WVTT))
       m_codecHandler = std::make_unique<WebVTTCodecHandler>(nullptr, false);
-    else if (STRING::Contains(codecInternalName, CODEC::FOURCC_TTML))
+    else if (STRING::Contains(codecInternalName, CODEC::FOURCC_TTML) ||
+             STRING::Contains(codecInternalName, CODEC::FOURCC_STPP))
       m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr);
     else
     {

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -27,14 +27,9 @@ class AdaptiveStream;
 class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
 {
 public:
-  CSubtitleSampleReader(std::string url,
-                        AP4_UI32 streamId,
-                        std::string_view codecInternalName);
+  CSubtitleSampleReader(AP4_UI32 streamId);
 
-  CSubtitleSampleReader(SESSION::CStream* stream,
-                        AP4_UI32 streamId,
-                        std::string_view codecInternalName);
-
+  virtual bool Initialize(SESSION::CStream* stream) override;
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_pts; }
@@ -56,6 +51,8 @@ public:
   bool IsEncrypted() const override { return false; }
 
 private:
+  bool InitializeFile(std::string url);
+
   uint64_t m_pts{0};
   uint64_t m_ptsOffset{0};
   uint64_t m_ptsDiff{0};

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -22,7 +22,7 @@ CTSSampleReader::CTSSampleReader(AP4_ByteStream* input,
   m_typeMap[type] = streamId;
 }
 
-bool CTSSampleReader::Initialize()
+bool CTSSampleReader::Initialize(SESSION::CStream* stream)
 {
   if (TSReader::Initialize())
   {

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -20,7 +20,7 @@ public:
                   AP4_UI32 streamId,
                   uint32_t requiredMask);
 
-  bool Initialize() override;
+  bool Initialize(SESSION::CStream* stream) override;
   void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
   void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
   bool RemoveStreamType(INPUTSTREAM_TYPE type) override;

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -15,7 +15,7 @@ CWebmSampleReader::CWebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
     m_streamId{streamId},
     m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)} {};
 
-bool CWebmSampleReader::Initialize()
+bool CWebmSampleReader::Initialize(SESSION::CStream* stream)
 {
   m_adByteStream->FixateInitialization(true);
   bool ret = WebmReader::Initialize();

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -21,7 +21,7 @@ public:
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_dts; }
   uint64_t PTS() const override { return m_pts; }
-  bool Initialize() override;
+  bool Initialize(SESSION::CStream* stream) override;
   AP4_Result Start(bool& bStarted) override;
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The first commit move the code in the `CSubtitleSampleReader` constructor to the separate `Initialize` overriden method,
the reason is that the code contained in the `CSubtitleSampleReader` constructor may fails on many points,
and the correct behaviour is have this code in the `Initialize` method to prevent initialize a broken subtitle reader.

The second commit add the STPP fourcc support, forgot to add it in to previous code refactors (in the past this fourcc was mixed with TTLM), due to missing STPP was causing a kodi crash because unsupported fourcc was causing nullptr `m_codecHandler` and the reader was initializated despite the fact that it should not be

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
user reported ISA crash on Kodi 21:
https://github.com/CastagnaIT/plugin.video.netflix/issues/1643

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By using NF addon

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
