### PR TITLE
[DashTree] Implemented support to last segment number signal

### DIFF
--- a/src/common/CommonSegAttribs.cpp
+++ b/src/common/CommonSegAttribs.cpp
@@ -30,3 +30,20 @@ bool PLAYLIST::CCommonSegAttribs::HasSegmentList()
   return m_segmentList.has_value() ||
          (m_parentCommonSegAttribs && m_parentCommonSegAttribs->m_segmentList.has_value());
 }
+
+uint64_t PLAYLIST::CCommonSegAttribs::GetSegmentEndNr()
+{
+  if (m_segEndNr.has_value())
+    return *m_segEndNr;
+
+  if (m_parentCommonSegAttribs)
+    return m_parentCommonSegAttribs->GetSegmentEndNr();
+
+  return 0; // Default value
+}
+
+bool PLAYLIST::CCommonSegAttribs::HasSegmentEndNr()
+{
+  return m_segEndNr.has_value() ||
+         (m_parentCommonSegAttribs && m_parentCommonSegAttribs->HasSegmentEndNr());
+}

--- a/src/common/CommonSegAttribs.h
+++ b/src/common/CommonSegAttribs.h
@@ -26,9 +26,18 @@ public:
   void SetSegmentList(const CSegmentList& segmentList) { m_segmentList = segmentList; }
   bool HasSegmentList();
 
+  /*!
+   * \brief Get the optional segment end number. Use HasSegmentEndNr method to know if the value is set.
+   * \return The segment end number or the default value (0).
+   */
+  uint64_t GetSegmentEndNr();
+  void SetSegmentEndNr(const uint64_t segNumber) { m_segEndNr = segNumber; }
+  bool HasSegmentEndNr();
+
 protected:
   CCommonSegAttribs* m_parentCommonSegAttribs{nullptr};
   std::optional<CSegmentList> m_segmentList;
+  std::optional<uint64_t> m_segEndNr;
 };
 
 } // namespace PLAYLIST

--- a/src/common/SegTemplate.cpp
+++ b/src/common/SegTemplate.cpp
@@ -79,6 +79,17 @@ uint64_t PLAYLIST::CSegmentTemplate::GetStartNumber() const
   return 1; // Default value
 }
 
+uint64_t PLAYLIST::CSegmentTemplate::GetEndNumber() const
+{
+  if (m_endNumber.has_value())
+    return *m_endNumber;
+
+  if (m_parentSegTemplate)
+    return m_parentSegTemplate->GetEndNumber();
+
+  return 0; // Default value
+}
+
 bool PLAYLIST::CSegmentTemplate::HasVariableTime() const
 {
   return m_media.find("$Time") != std::string::npos;

--- a/src/common/SegTemplate.h
+++ b/src/common/SegTemplate.h
@@ -48,6 +48,14 @@ public:
   uint64_t GetStartNumber() const;
   void SetStartNumber(uint64_t startNumber) { m_startNumber = startNumber; }
 
+  /*!
+   * \brief Get the optional segment end number. Use HasEndNumber method to know if the value is set.
+   * \return The segment end number or the default value (0).
+   */
+  uint64_t GetEndNumber() const;
+  void SetEndNumber(uint64_t endNumber) { m_endNumber = endNumber; }
+  bool HasEndNumber() const { return m_endNumber.has_value(); }
+
   bool HasVariableTime() const;
   
   CSegment MakeInitSegment();
@@ -66,6 +74,7 @@ private:
   std::optional<uint32_t> m_timescale;
   std::optional<uint32_t> m_duration;
   std::optional<uint64_t> m_startNumber;
+  std::optional<uint64_t> m_endNumber;
 
   CSegmentTemplate* m_parentSegTemplate{nullptr};
 };

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -237,10 +237,7 @@ void adaptive::CDashTree::ParseTagMPDAttribs(pugi::xml_node nodeMPD)
   double timeShiftBufferDepth{0};
   std::string timeShiftBufferDepthStr;
   if (XML::QueryAttrib(nodeMPD, "timeShiftBufferDepth", timeShiftBufferDepthStr))
-  {
     timeShiftBufferDepth = XML::ParseDuration(timeShiftBufferDepthStr);
-    m_isLive = true;
-  }
 
   std::string availabilityStartTimeStr;
   if (XML::QueryAttrib(nodeMPD, "availabilityStartTime", availabilityStartTimeStr))

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -472,15 +472,16 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
   if (nodeAudioCh)
     adpSet->SetAudioChannels(ParseAudioChannelConfig(nodeAudioCh));
 
-  // Parse <SupplementalProperty> child tag
-  xml_node nodeSupplProp = nodeAdp.child("SupplementalProperty");
-  if (nodeSupplProp)
+  // Parse <SupplementalProperty> child tags
+  for (xml_node nodeSP : nodeAdp.children("SupplementalProperty"))
   {
-    std::string_view schemeIdUri = XML::GetAttrib(nodeSupplProp, "schemeIdUri");
-    std::string_view value = XML::GetAttrib(nodeSupplProp, "value");
+    std::string_view schemeIdUri = XML::GetAttrib(nodeSP, "schemeIdUri");
+    std::string_view value = XML::GetAttrib(nodeSP, "value");
 
     if (schemeIdUri == "urn:mpeg:dash:adaptation-set-switching:2016")
       adpSet->AddSwitchingIds(value);
+    else if (schemeIdUri == "http://dashif.org/guidelines/last-segment-number")
+      adpSet->SetSegmentEndNr(STRING::ToUint64(value));
   }
 
   // Parse <BaseURL> tag (just first, multi BaseURL not supported yet)
@@ -1007,6 +1008,10 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
       if (channels > 0)
         repr->SetAudioChannels(channels);
     }
+    else if (schemeIdUri == "http://dashif.org/guidelines/last-segment-number")
+    {
+      repr->SetSegmentEndNr(STRING::ToUint64(value));
+    }
   }
 
   // For subtitles that are not as ISOBMFF format and where there is no timeline for segments
@@ -1031,13 +1036,26 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
         segTemplate->GetTimescale() > 0 &&
         (segTemplate->GetDuration() > 0 || adpSet->HasSegmentTimelineDuration()))
     {
-      size_t segmentsCount = adpSet->SegmentTimelineDuration().GetSize();
-      if (segmentsCount == 0)
+      size_t segmentsCount{0};
+
+      if (adpSet->HasSegmentTimelineDuration())
       {
-        double lengthSecs =
-            static_cast<double>(segTemplate->GetDuration()) / segTemplate->GetTimescale();
-        segmentsCount =
-            static_cast<size_t>(std::ceil(static_cast<double>(reprTotalTimeSecs) / lengthSecs));
+        segmentsCount = adpSet->SegmentTimelineDuration().GetSize();
+      }
+      else
+      {
+        // If signalled use the value of the last segment number
+        if (segTemplate->HasEndNumber())
+          segmentsCount = segTemplate->GetEndNumber();
+        else if (repr->HasSegmentEndNr())
+          segmentsCount = repr->GetSegmentEndNr();
+        else // Calculate the number of segments
+        {
+          double lengthSecs =
+              static_cast<double>(segTemplate->GetDuration()) / segTemplate->GetTimescale();
+          segmentsCount =
+              static_cast<size_t>(std::ceil(static_cast<double>(reprTotalTimeSecs) / lengthSecs));
+        }
       }
 
       if (segmentsCount < 65536) // SIDX atom is limited to 65535 references (fragments)
@@ -1245,6 +1263,10 @@ void adaptive::CDashTree::ParseSegmentTemplate(pugi::xml_node node, CSegmentTemp
   uint32_t startNumber;
   if (XML::QueryAttrib(node, "startNumber", startNumber))
     segTpl->SetStartNumber(startNumber);
+
+  uint64_t endNumber;
+  if (XML::QueryAttrib(node, "endNumber", endNumber))
+    segTpl->SetEndNumber(endNumber);
 
   std::string initialization;
   if (XML::QueryAttrib(node, "initialization", initialization))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There are multiple ways that dash allow to use to signal last segment number
as `4.4.3.5. Last Segment Message`
1) Use the lmsg signalling as defined in clause 4.4.3.5.
2) Use the Segment Timeline with `@r` value greater or equal to 0.
3) Add a Supplemental Descriptor with @schemeIdUri set to http://dashif.org/guidelines/last-segment-number with the @value set to the last segment number.

and another way that i havent found in specs, but looks to be supported by most common players:
4. `endNumber` attribute to `SegmentTemplate`

For point 2 seem that we have to add nothing else new
For point 3 and 4 has been implemented with this PR, where the SupplementalProperty look to be allowed only to adaptationset and representation node only

**TODO:**
The point 1 (lmsg) its referred to ISOBMFF MP4 format, where the last segment should have the `styp` box including the `lmsg` brand.
now i have found a sample: http://video.internazionale.it/2016/05/20/250432_3aa47248f7d92a2b8d82de8ae50fbac8/250432.mpd
(could be region locked to Italy), the last segment its the nr.18 and show as follow:
![immagine](https://github.com/xbmc/inputstream.adaptive/assets/3257156/eb78f458-897d-4c2b-9fa0-7e032c075494)
so we have to read `styp` box to check if contains the the `lmsg` brand, then stop download new segments.
Now i was thinking that this should be implemented in to the `CFragmentedSampleReader` but i a bit lost maybe here we havent access to `styp` box but only to the media sample data?
is not mandatory implementing this now, but if someone has some suggest in how to read this mp4 box data?

**About timeShiftBufferDepth commit**
this fix the sample above where its a VOD stream but its played as live stream
timeShiftBufferDepth should not used for VOD no idea why there is, anyway should not force the parser to identify the stream as live.
Its not clear why in the past (7y ago) has been done this, maybe one of many hacks

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1417
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For the point 3: http://dash.akamaized.net/dash264/TestCasesIOP41/LastSegmentNumber/1/manifest_last_segment_num.mpd

For the point 4 ~its needed user feedback~ user confirmed work

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
