### PR TITLE
[HLSTree] Fix empty audio codec

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1137,11 +1137,14 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
 
     // Find the codec string from a variant that references it
     const Variant* varFound = FindVariantByAudioGroupId(r.m_groupId, pl.m_variants);
-    std::string codecStr = CODEC::FOURCC_MP4A; // Fallback
+    std::string codecStr;
     if (varFound)
       codecStr = GetAudioCodec(varFound->m_codecs);
     else
       LOG::LogF(LOGERROR, "Cannot find variant for AUDIO GROUP-ID: %s", r.m_groupId.c_str());
+
+    if (codecStr.empty())
+      codecStr = CODEC::FOURCC_MP4A; // Fallback
 
     newRepr->AddCodecs(codecStr);
     newAdpSet->AddCodecs(codecStr);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
If CODEC attribute do not specify the audio codec the fallback codec was overwritten with an empty string, resulting in a no audio tracks

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i was testing a stream
https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
