### PR TITLE
[HLSTree] Fix check for EXTM3U on child playlist

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -234,17 +234,17 @@ PLAYLIST::PrepareRepStatus adaptive::CHLSTree::prepareRepresentation(PLAYLIST::C
       // if we move forward within the loop code
       std::streampos currentStreamPos = streamData.tellg();
 
-      std::string tagName;
-      std::string tagValue;
-      ParseTagNameValue(line, tagName, tagValue);
-
       // Find the extended M3U file initialization tag
       if (!isExtM3Uformat)
       {
-        if (tagName == "#EXTM3U")
+        if (STRING::StartsWith(line, "#EXTM3U"))
           isExtM3Uformat = true;
         continue;
       }
+
+      std::string tagName;
+      std::string tagValue;
+      ParseTagNameValue(line, tagName, tagValue);
 
       if (tagName == "#EXT-X-KEY")
       {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
if the EXTM3U tag has some kind of comments or else inline on the tag fails to check for it
e.g.
`#EXTM3U this is a inline comment that contains a : char`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i was testing some streams

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
