### PR TITLE
build_config.h: Add LoongArch support

### DIFF
--- a/lib/cdm/cdm/build/build_config.h
+++ b/lib/cdm/cdm/build/build_config.h
@@ -159,6 +159,15 @@
 #  define ARCH_CPU_32_BITS 1
 # endif
 #endif
+#elif defined(__loongarch__)
+#define ARCH_CPU_LOONGARCH_FAMILY 1
+#define ARCH_CPU_LOONGARCH 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#if (__loongarch_grlen == 64)
+#define ARCH_CPU_64_BITS 1
+#else
+#define ARCH_CPU_32_BITS 1
+#endif
 # else
 #error Please add support for your architecture in build/build_config.
 #endif


### PR DESCRIPTION
## Description

This package build failed in debian ports loong64 , this patch can help LoongArch build . 

## Motivation and context

This can support LoongArch build 

## How has this been tested?

I test this in kodi-inputstream-adaptive-20.3.11+ds

### this is buildinfo

root@43b08b652f0a:~# cat kodi-inputstream-adaptive*.buildinfo
Format: 1.0
Source: kodi-inputstream-adaptive
Binary: kodi-inputstream-adaptive kodi-inputstream-adaptive-dbgsym
Architecture: loong64 source
Version: 20.3.11+ds-1
Checksums-Md5:
 80fa7f3c85d05b6f9d5bdd53657bc30a 1761 kodi-inputstream-adaptive_20.3.11+ds-1.dsc
 d39c154e287d80564560cf50bc4712a4 6410600 kodi-inputstream-adaptive-dbgsym_20.3.11+ds-1_loong64.deb
 cd170ffc4ece6a0823c7788ef5172dea 898688 kodi-inputstream-adaptive_20.3.11+ds-1_loong64.deb
Checksums-Sha1:
 87f832a9fb4b0955b7bbba994d717cb37aa53ef6 1761 kodi-inputstream-adaptive_20.3.11+ds-1.dsc
 8b7746ae9ee40ceabf3fa8e4a15a2bead9ac584d 6410600 kodi-inputstream-adaptive-dbgsym_20.3.11+ds-1_loong64.deb
 a4714efe2dcfb4175d44f562ae1b775d97fbb8e2 898688 kodi-inputstream-adaptive_20.3.11+ds-1_loong64.deb
Checksums-Sha256:
 bfebdb3f656ed54500d8022530e33b4616da1fd113adf8367d41755fb36ed603 1761 kodi-inputstream-adaptive_20.3.11+ds-1.dsc
 32361a25550755ab08f4d6952cce27ee23be8d09c681dfe811c2394fe1a45721 6410600 kodi-inputstream-adaptive-dbgsym_20.3.11+ds-1_loong64.deb
 fe05d45fee7c7c7f379160a7b0f4ea0365771edf84ba333dcf54547fda6bbe7e 898688 kodi-inputstream-adaptive_20.3.11+ds-1_loong64.deb
Build-Origin: Debian
Build-Architecture: loong64
Build-Date: Fri, 22 Dec 2023 02:22:09 +0000
Build-Tainted-By:
 merged-usr-via-aliased-dirs
Installed-Build-Depends:
 autoconf (= 2.71-3),
 automake (= 1:1.16.5-1.3),
 autopoint (= 0.21-14),
 autotools-dev (= 20220109.1),
 base-files (= 13+b1),
 base-passwd (= 3.6.1+loong64),
 bash (= 5.2.15-2+loong64),
 binutils (= 2.41.50.20231214-1),
 binutils-common (= 2.41.50.20231214-1),
 binutils-loongarch64-linux-gnu (= 2.41.50.20231214-1),
 bsdextrautils (= 2.39.3-2),
 bsdutils (= 1:2.39.3-2),
 build-essential (= 12.10),
 bzip2 (= 1.0.8-5+b1),
 cmake (= 3.28.0-1),
 cmake-data (= 3.28.0-1),
 coreutils (= 9.1-1+b1),
 cpp (= 4:13.2.0-1),
 cpp-13 (= 13.2.0-9),
 dash (= 0.5.12-6),
 debconf (= 1.5.82),
 debhelper (= 13.11.8),
 debianutils (= 5.13),
 dh-autoreconf (= 20),
 dh-strip-nondeterminism (= 1.13.1-1),
 diffutils (= 1:3.8-4+b1),
 dpkg (= 1.22.0),
 dpkg-dev (= 1.22.0),
 dwz (= 0.15-1+b1),
 file (= 1:5.45-2),
 findutils (= 4.9.0-5),
 g++ (= 4:13.2.0-1),
 g++-13 (= 13.2.0-9),
 gawk (= 1:5.2.1-2+b2),
 gcc (= 4:13.2.0-1),
 gcc-13 (= 13.2.0-9),
 gcc-13-base (= 13.2.0-9),
 gettext (= 0.21-14),
 gettext-base (= 0.21-14),
 googletest (= 1.14.0-1),
 grep (= 3.11-3),
 groff-base (= 1.23.0-3),
 gzip (= 1.12-1+b1),
 hostname (= 3.23+nmu1+b1),
 init-system-helpers (= 1.65.2),
 intltool-debian (= 0.35.0+20060710.6),
 kodi-addons-dev (= 2:20.2+dfsg-4),
 kodi-addons-dev-common (= 2:20.2+dfsg-4),
 libacl1 (= 2.3.1-3+b1),
 libarchive-zip-perl (= 1.68-1),
 libarchive13 (= 3.7.2-1),
 libatomic1 (= 13.2.0-9),
 libattr1 (= 1:2.5.1-4+b1),
 libaudit-common (= 1:3.1.1-1),
 libaudit1 (= 1:3.1.1-1),
 libbinutils (= 2.41.50.20231214-1),
 libblkid1 (= 2.39.3-2),
 libbrotli1 (= 1.1.0-2+b1),
 libbz2-1.0 (= 1.0.8-5+b1),
 libc-bin (= 2.37-9+loong64),
 libc-dev-bin (= 2.37-9+loong64),
 libc6 (= 2.37-9+loong64),
 libc6-dev (= 2.37-9+loong64),
 libcap-ng0 (= 0.8.3-1+b1),
 libcap2 (= 1:2.66-4+b1),
 libcc1-0 (= 13.2.0-9),
 libcom-err2 (= 1.47.0-2+b1),
 libcrypt-dev (= 1:4.4.36-2),
 libcrypt1 (= 1:4.4.36-2),
 libctf-nobfd0 (= 2.41.50.20231214-1),
 libctf0 (= 2.41.50.20231214-1),
 libcurl4 (= 8.2.1-1),
 libdb5.3 (= 5.3.28+dfsg2-2),
 libdebconfclient0 (= 0.271),
 libdebhelper-perl (= 13.11.8),
 libdpkg-perl (= 1.22.0),
 libelf1 (= 0.190-1),
 libexpat1 (= 2.5.0-2+b1),
 libexpat1-dev (= 2.5.0-2+b1),
 libffi8 (= 3.4.4-2),
 libfile-stripnondeterminism-perl (= 1.13.1-1),
 libgcc-13-dev (= 13.2.0-9),
 libgcc-s1 (= 13.2.0-9),
 libgcrypt20 (= 1.10.3-2),
 libgdbm-compat4 (= 1.23-3+b1),
 libgdbm6 (= 1.23-3+b1),
 libgmp10 (= 2:6.3.0+dfsg-2),
 libgnutls30 (= 3.8.2-1),
 libgomp1 (= 13.2.0-9),
 libgpg-error0 (= 1.47-3),
 libgssapi-krb5-2 (= 1.20.1-4),
 libgtest-dev (= 1.14.0-1),
 libhogweed6 (= 3.9.1-2),
 libicu72 (= 72.1-4),
 libidn2-0 (= 2.3.4-1+b2),
 libisl23 (= 0.26-3),
 libjansson4 (= 2.14-2+b1),
 libjsoncpp25 (= 1.9.5-6),
 libk5crypto3 (= 1.20.1-4),
 libkeyutils1 (= 1.6.3-2+b1),
 libkrb5-3 (= 1.20.1-4),
 libkrb5support0 (= 1.20.1-4),
 libldap-2.5-0 (= 2.5.13+dfsg-5+loong64),
 liblz4-1 (= 1.9.4-1+b1),
 liblzma5 (= 5.4.4-0.1),
 libmagic-mgc (= 1:5.45-2),
 libmagic1 (= 1:5.45-2),
 libmd0 (= 1.1.0-1),
 libmount1 (= 2.39.3-2),
 libmpc3 (= 1.3.1-1+b1),
 libmpfr6 (= 4.2.1-1),
 libncursesw6 (= 6.4+20231121-1),
 libnettle8 (= 3.9.1-2),
 libnghttp2-14 (= 1.58.0-1),
 libnsl-dev (= 1.3.0-2+b1),
 libnsl2 (= 1.3.0-2+b1),
 libp11-kit0 (= 0.25.3-4),
 libpam-modules (= 1.5.2-7+b1),
 libpam-modules-bin (= 1.5.2-7+b1),
 libpam-runtime (= 1.5.2-7),
 libpam0g (= 1.5.2-7+b1),
 libpcre2-8-0 (= 10.42-4),
 libperl5.36 (= 5.36.0-9),
 libpipeline1 (= 1.5.7-1+b1),
 libpkgconf3 (= 1.8.1-1+loong64),
 libproc2-0 (= 2:4.0.4-2),
 libpsl5 (= 0.21.2-1+loong64.1),
 libreadline8 (= 8.2-3),
 librhash0 (= 1.4.3-3+b1),
 librtmp1 (= 2.4+20151223.gitfa8646d.1-2+b1),
 libsasl2-2 (= 2.1.28+dfsg1-4),
 libsasl2-modules-db (= 2.1.28+dfsg1-4),
 libselinux1 (= 3.5-1+b1),
 libsframe1 (= 2.41.50.20231214-1),
 libsigsegv2 (= 2.14-1+b1),
 libsmartcols1 (= 2.39.3-2),
 libssh2-1 (= 1.11.0-3),
 libssl3 (= 3.1.4-2),
 libstdc++-13-dev (= 13.2.0-9),
 libstdc++6 (= 13.2.0-9),
 libsub-override-perl (= 0.10-1),
 libsystemd0 (= 255-1),
 libtasn1-6 (= 4.19.0-3),
 libtinfo6 (= 6.4+20231121-1),
 libtirpc-common (= 1.3.3+ds-1),
 libtirpc-dev (= 1.3.3+ds-1+b1),
 libtirpc3 (= 1.3.3+ds-1+b1),
 libtool (= 2.4.7-7),
 libuchardet0 (= 0.0.8-1),
 libudev1 (= 255-1),
 libunistring5 (= 1.1-2),
 libuuid1 (= 2.39.3-2),
 libuv1 (= 1.46.0-2),
 libwebm-dev (= 1.0.0.31-1),
 libwebm1 (= 1.0.0.31-1),
 libxml2 (= 2.9.14+dfsg-1.3+b1),
 libzstd1 (= 1.5.5+dfsg2-2),
 linux-libc-dev (= 6.1.27-1+loong64),
 login (= 1:4.13+dfsg1-3),
 m4 (= 1.4.19-4),
 make (= 4.3-4.1+b1),
 man-db (= 2.12.0-1),
 mawk (= 1.3.4.20230808-1),
 ncurses-base (= 6.4+20231121-1),
 ncurses-bin (= 6.4+20231121-1),
 patch (= 2.7.6-7+b1),
 perl (= 5.36.0-9),
 perl-base (= 5.36.0-9),
 perl-modules-5.36 (= 5.36.0-9),
 pkg-config (= 1.8.1-1+loong64),
 pkgconf (= 1.8.1-1+loong64),
 pkgconf-bin (= 1.8.1-1+loong64),
 po-debconf (= 1.0.21+nmu1),
 procps (= 2:4.0.4-2),
 readline-common (= 8.2-3),
 rpcsvc-proto (= 1.4.3-1+b1),
 sed (= 4.9-1+loong64),
 sensible-utils (= 0.0.20),
 sysvinit-utils (= 3.08-3),
 tar (= 1.34+dfsg-1.2+b1),
 usr-is-merged (= 37),
 util-linux (= 2.39.3-2),
 xz-utils (= 5.4.4-0.1),
 zlib1g (= 1:1.3.dfsg-3)
Environment:
 DEB_BUILD_OPTIONS="parallel=32"
 SOURCE_DATE_EPOCH="1691318410"
