### PR TITLE
[decrypters] Various cleanups to interface

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -82,10 +82,10 @@ CSession::~CSession()
 
 void CSession::SetSupportedDecrypterURN(std::string& key_system)
 {
-  std::string specialpath = kodi::addon::GetSettingString("DECRYPTERPATH");
-  if (specialpath.empty())
+  std::string decrypterPath = CSrvBroker::GetSettings().GetDecrypterPath();
+  if (decrypterPath.empty())
   {
-    LOG::Log(LOGDEBUG, "DECRYPTERPATH not specified in settings.xml");
+    LOG::Log(LOGWARNING, "Decrypter path not set in the add-on settings");
     return;
   }
 
@@ -100,7 +100,7 @@ void CSession::SetSupportedDecrypterURN(std::string& key_system)
   }
 
   key_system = m_decrypter->SelectKeySytem(CSrvBroker::GetKodiProps().GetLicenseType());
-  m_decrypter->SetLibraryPath(kodi::vfs::TranslateSpecialProtocol(specialpath).c_str());
+  m_decrypter->SetLibraryPath(decrypterPath);
   m_decrypter->SetProfilePath(m_profilePath);
   m_decrypter->SetDebugSaveLicense(kodi::addon::GetSettingBoolean("debug.save.license"));
 }

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -32,10 +32,7 @@ using namespace PLAYLIST;
 using namespace SESSION;
 using namespace UTILS;
 
-CSession::CSession(const std::string& manifestUrl,
-                   const std::string& profilePath)
-  : m_manifestUrl(manifestUrl),
-    m_profilePath(profilePath)
+CSession::CSession(const std::string& manifestUrl) : m_manifestUrl(manifestUrl)
 {
   m_reprChooser = CHOOSER::CreateRepresentationChooser();
 
@@ -101,7 +98,6 @@ void CSession::SetSupportedDecrypterURN(std::string& key_system)
 
   key_system = m_decrypter->SelectKeySytem(CSrvBroker::GetKodiProps().GetLicenseType());
   m_decrypter->SetLibraryPath(decrypterPath);
-  m_decrypter->SetProfilePath(m_profilePath);
   m_decrypter->SetDebugSaveLicense(kodi::addon::GetSettingBoolean("debug.save.license"));
 }
 

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -98,7 +98,6 @@ void CSession::SetSupportedDecrypterURN(std::string& key_system)
 
   key_system = m_decrypter->SelectKeySytem(CSrvBroker::GetKodiProps().GetLicenseType());
   m_decrypter->SetLibraryPath(decrypterPath);
-  m_decrypter->SetDebugSaveLicense(kodi::addon::GetSettingBoolean("debug.save.license"));
 }
 
 void CSession::DisposeSampleDecrypter()

--- a/src/Session.h
+++ b/src/Session.h
@@ -27,8 +27,7 @@ namespace SESSION
 class ATTR_DLL_LOCAL CSession : public adaptive::AdaptiveStreamObserver
 {
 public:
-  CSession(const std::string& manifestUrl,
-           const std::string& profilePath);
+  CSession(const std::string& manifestUrl);
   virtual ~CSession();
 
   /*! \brief Initialize the session
@@ -346,7 +345,6 @@ protected:
 
 private:
   std::string m_manifestUrl;
-  std::string m_profilePath;
   std::vector<uint8_t> m_serverCertificate;
   std::unique_ptr<kodi::tools::CDllHelper> m_dllHelper;
   DRM::IDecrypter* m_decrypter{nullptr};

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -170,12 +170,6 @@ public:
   virtual void SetLibraryPath(std::string_view libraryPath) = 0;
 
   /**
-   * \brief Set the path to inputstream.adaptive's user/profile directory
-   * \param profilePath The path to inputstream.adaptive's user/profile directory
-   */
-  virtual void SetProfilePath(const std::string& profilePath) = 0;
-
-  /**
    * \brief Set whether to enable saving of license challenge/response data for debugging
    * \param isDebugSaveLicense True to save data, otherwise false
    */
@@ -186,12 +180,6 @@ public:
    * \return The auxillary library path
    */
   virtual std::string_view GetLibraryPath() const = 0;
-
-  /**
-   * \brief Get the path to inputstream.adaptive's user/profile directory
-   * \return The path to inputstream.adaptive's user/profile directory
-   */
-  virtual const char* GetProfilePath() const = 0;
 
   /**
    * \brief Get whether to enable saving of license challenge/response data for debugging

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -167,7 +167,7 @@ public:
    * \brief Set the auxillary library path
    * \param libraryPath Filesystem path for the decrypter to locate any needed files such as CDMs
    */
-  virtual void SetLibraryPath(const char* libraryPath) = 0;
+  virtual void SetLibraryPath(std::string_view libraryPath) = 0;
 
   /**
    * \brief Set the path to inputstream.adaptive's user/profile directory
@@ -185,7 +185,7 @@ public:
    * \brief Get the auxillary library path
    * \return The auxillary library path
    */
-  virtual const char* GetLibraryPath() const = 0;
+  virtual std::string_view GetLibraryPath() const = 0;
 
   /**
    * \brief Get the path to inputstream.adaptive's user/profile directory

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -170,21 +170,10 @@ public:
   virtual void SetLibraryPath(std::string_view libraryPath) = 0;
 
   /**
-   * \brief Set whether to enable saving of license challenge/response data for debugging
-   * \param isDebugSaveLicense True to save data, otherwise false
-   */
-  virtual void SetDebugSaveLicense(bool isDebugSaveLicense) = 0;
-
-  /**
    * \brief Get the auxillary library path
    * \return The auxillary library path
    */
   virtual std::string_view GetLibraryPath() const = 0;
 
-  /**
-   * \brief Get whether to enable saving of license challenge/response data for debugging
-   * \return True to save data, otherwise false
-   */
-  virtual const bool IsDebugSaveLicense() const = 0;
 };
 }; // namespace DRM

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -36,13 +36,12 @@ CWVCdmAdapter::CWVCdmAdapter(std::string_view licenseURL,
                              CWVDecrypter* host)
   : m_licenseUrl(licenseURL), m_host(host), m_codecInstance(nullptr)
 {
-  std::string strLibPath = m_host->GetLibraryPath();
-  if (strLibPath.empty())
+  if (m_host->GetLibraryPath().empty())
   {
-    LOG::LogF(LOGERROR, "No Widevine library path specified in settings");
+    LOG::LogF(LOGERROR, "Widevine CDM library path not specified");
     return;
   }
-  strLibPath += LIBRARY_FILENAME;
+  std::string cdmPath = FILESYS::PathCombine(m_host->GetLibraryPath().data(), LIBRARY_FILENAME);
 
   if (licenseURL.empty())
   {
@@ -64,12 +63,12 @@ CWVCdmAdapter::CWVCdmAdapter(std::string_view licenseURL,
   basePath += FILESYS::SEPARATOR;
 
   wv_adapter = std::shared_ptr<media::CdmAdapter>(new media::CdmAdapter(
-      "com.widevine.alpha", strLibPath, basePath,
+      "com.widevine.alpha", cdmPath, basePath,
       media::CdmConfig(false, (config & DRM::IDecrypter::CONFIG_PERSISTENTSTORAGE) != 0),
       dynamic_cast<media::CdmAdapterClient*>(this)));
   if (!wv_adapter->valid())
   {
-    LOG::Log(LOGERROR, "Unable to load widevine shared library (%s)", strLibPath.c_str());
+    LOG::Log(LOGERROR, "Unable to load widevine shared library (%s)", cdmPath.c_str());
     wv_adapter = nullptr;
     return;
   }

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -58,7 +58,7 @@ CWVCdmAdapter::CWVCdmAdapter(std::string_view licenseURL,
 
   // Build up a CDM path to store decrypter specific stuff, each domain gets it own path
   // the domain name is hashed to generate a short folder name
-  std::string basePath = FILESYS::PathCombine(m_host->GetProfilePath(), "widevine");
+  std::string basePath = FILESYS::PathCombine(FILESYS::GetAddonUserPath(), "widevine");
   basePath = FILESYS::PathCombine(basePath, DRM::GenerateUrlDomainHash(licUrl));
   basePath += FILESYS::SEPARATOR;
 

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -41,7 +41,7 @@ CWVCdmAdapter::CWVCdmAdapter(std::string_view licenseURL,
     LOG::LogF(LOGERROR, "Widevine CDM library path not specified");
     return;
   }
-  std::string cdmPath = FILESYS::PathCombine(m_host->GetLibraryPath().data(), LIBRARY_FILENAME);
+  std::string cdmPath = FILESYS::PathCombine(m_host->GetLibraryPath(), LIBRARY_FILENAME);
 
   if (licenseURL.empty())
   {

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -70,8 +70,8 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
 
   if (m_host->IsDebugSaveLicense())
   {
-    std::string debugFilePath =
-        FILESYS::PathCombine(m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
+    std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath().data(),
+                                                     "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
 
     std::string data{reinterpret_cast<const char*>(pssh.data()), pssh.size()};
     UTILS::FILESYS::SaveFile(debugFilePath, data, true);
@@ -272,7 +272,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   if (m_host->IsDebugSaveLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
+        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
     std::string data{reinterpret_cast<const char*>(m_challenge.GetData()),
                      m_challenge.GetDataSize()};
     UTILS::FILESYS::SaveFile(debugFilePath, data, true);
@@ -494,7 +494,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   if (m_host->IsDebugSaveLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
+        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
     FILESYS::SaveFile(debugFilePath, response, true);
   }
 

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -72,7 +72,7 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
 
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {
-    std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath().data(),
+    std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath(),
                                                      "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
 
     std::string data{reinterpret_cast<const char*>(pssh.data()), pssh.size()};
@@ -274,7 +274,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
+        m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
     std::string data{reinterpret_cast<const char*>(m_challenge.GetData()),
                      m_challenge.GetDataSize()};
     UTILS::FILESYS::SaveFile(debugFilePath, data, true);
@@ -496,7 +496,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
+        m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
     FILESYS::SaveFile(debugFilePath, response, true);
   }
 

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -8,6 +8,8 @@
 
 #include "WVCencSingleSampleDecrypter.h"
 
+#include "CompSettings.h"
+#include "SrvBroker.h"
 #include "CdmDecryptedBlock.h"
 #include "CdmFixedBuffer.h"
 #include "CdmTypeConversion.h"
@@ -68,7 +70,7 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
 
   m_wvCdmAdapter.insertssd(this);
 
-  if (m_host->IsDebugSaveLicense())
+  if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath().data(),
                                                      "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
@@ -269,7 +271,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     return false;
   }
 
-  if (m_host->IsDebugSaveLicense())
+  if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
         m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
@@ -491,7 +493,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     return false;
   }
 
-  if (m_host->IsDebugSaveLicense())
+  if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
         m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -186,15 +186,9 @@ void CWVDecrypter::ResetVideo()
     m_decodingDecrypter->ResetVideo();
 }
 
-void CWVDecrypter::SetLibraryPath(const char* libraryPath)
+void CWVDecrypter::SetLibraryPath(std::string_view libraryPath)
 {
-  m_strLibraryPath = libraryPath;
-
-  const char* pathSep{libraryPath[0] && libraryPath[1] == ':' && isalpha(libraryPath[0]) ? "\\"
-                                                                                         : "/"};
-
-  if (m_strLibraryPath.size() && m_strLibraryPath.back() != pathSep[0])
-    m_strLibraryPath += pathSep;
+  m_libraryPath = libraryPath;
 }
 
 void CWVDecrypter::SetProfilePath(const std::string& profilePath)

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -191,28 +191,6 @@ void CWVDecrypter::SetLibraryPath(std::string_view libraryPath)
   m_libraryPath = libraryPath;
 }
 
-void CWVDecrypter::SetProfilePath(const std::string& profilePath)
-{
-  m_strProfilePath = profilePath;
-
-  const char* pathSep{profilePath[0] && profilePath[1] == ':' && isalpha(profilePath[0]) ? "\\"
-                                                                                         : "/"};
-
-  if (m_strProfilePath.size() && m_strProfilePath.back() != pathSep[0])
-    m_strProfilePath += pathSep;
-
-  //let us make cdm userdata out of the addonpath and share them between addons
-  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 2));
-  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1));
-  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1) +
-                          1);
-
-  kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
-  m_strProfilePath += "cdm";
-  m_strProfilePath += pathSep;
-  kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
-}
-
 bool CWVDecrypter::GetBuffer(void* instance, VIDEOCODEC_PICTURE& picture)
 {
   return instance ? static_cast<kodi::addon::CInstanceVideoCodec*>(instance)->GetFrameBuffer(

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -54,7 +54,6 @@ public:
                                                     VIDEOCODEC_PICTURE* picture) override;
   virtual void ResetVideo() override;
   virtual void SetLibraryPath(std::string_view libraryPath) override;
-  virtual void SetProfilePath(const std::string& profilePath) override;
   virtual void SetDebugSaveLicense(bool isDebugSaveLicense) override
   {
     m_isDebugSaveLicense = isDebugSaveLicense;
@@ -62,13 +61,11 @@ public:
   virtual bool GetBuffer(void* instance, VIDEOCODEC_PICTURE& picture);
   virtual void ReleaseBuffer(void* instance, void* buffer);
   virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
-  virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); }
   virtual const bool IsDebugSaveLicense() const override { return m_isDebugSaveLicense; }
 
 private:
   CWVCdmAdapter* m_WVCdmAdapter;
   CWVCencSingleSampleDecrypter* m_decodingDecrypter;
-  std::string m_strProfilePath;
   std::string m_libraryPath;
   bool m_isDebugSaveLicense;
   void* m_hdlLibLoader{nullptr}; // Aarch64 loader library handle

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -53,7 +53,7 @@ public:
   virtual VIDEOCODEC_RETVAL VideoFrameDataToPicture(kodi::addon::CInstanceVideoCodec* codecInstance,
                                                     VIDEOCODEC_PICTURE* picture) override;
   virtual void ResetVideo() override;
-  virtual void SetLibraryPath(const char* libraryPath) override;
+  virtual void SetLibraryPath(std::string_view libraryPath) override;
   virtual void SetProfilePath(const std::string& profilePath) override;
   virtual void SetDebugSaveLicense(bool isDebugSaveLicense) override
   {
@@ -61,7 +61,7 @@ public:
   }
   virtual bool GetBuffer(void* instance, VIDEOCODEC_PICTURE& picture);
   virtual void ReleaseBuffer(void* instance, void* buffer);
-  virtual const char* GetLibraryPath() const override { return m_strLibraryPath.c_str(); }
+  virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
   virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); }
   virtual const bool IsDebugSaveLicense() const override { return m_isDebugSaveLicense; }
 
@@ -69,7 +69,7 @@ private:
   CWVCdmAdapter* m_WVCdmAdapter;
   CWVCencSingleSampleDecrypter* m_decodingDecrypter;
   std::string m_strProfilePath;
-  std::string m_strLibraryPath;
+  std::string m_libraryPath;
   bool m_isDebugSaveLicense;
   void* m_hdlLibLoader{nullptr}; // Aarch64 loader library handle
 };

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -54,19 +54,13 @@ public:
                                                     VIDEOCODEC_PICTURE* picture) override;
   virtual void ResetVideo() override;
   virtual void SetLibraryPath(std::string_view libraryPath) override;
-  virtual void SetDebugSaveLicense(bool isDebugSaveLicense) override
-  {
-    m_isDebugSaveLicense = isDebugSaveLicense;
-  }
   virtual bool GetBuffer(void* instance, VIDEOCODEC_PICTURE& picture);
   virtual void ReleaseBuffer(void* instance, void* buffer);
   virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
-  virtual const bool IsDebugSaveLicense() const override { return m_isDebugSaveLicense; }
 
 private:
   CWVCdmAdapter* m_WVCdmAdapter;
   CWVCencSingleSampleDecrypter* m_decodingDecrypter;
   std::string m_libraryPath;
-  bool m_isDebugSaveLicense;
   void* m_hdlLibLoader{nullptr}; // Aarch64 loader library handle
 };

--- a/src/decrypters/widevineandroid/WVCdmAdapter.cpp
+++ b/src/decrypters/widevineandroid/WVCdmAdapter.cpp
@@ -51,7 +51,7 @@ CWVCdmAdapterA::CWVCdmAdapterA(WV_KEYSYSTEM ks,
 
   // Build up a CDM path to store decrypter specific stuff, each domain gets it own path
   // the domain name is hashed to generate a short folder name
-  std::string basePath = FILESYS::PathCombine(m_host->GetProfilePath(), drmName);
+  std::string basePath = FILESYS::PathCombine(FILESYS::GetAddonUserPath(), drmName);
   basePath = FILESYS::PathCombine(basePath, DRM::GenerateUrlDomainHash(licUrl));
   basePath += FILESYS::SEPARATOR;
   m_strBasePath = basePath;

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -48,8 +48,8 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm
 
   if (m_host->IsDebugSaveLicense())
   {
-    std::string debugFilePath =
-        FILESYS::PathCombine(m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
+    std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath().data(),
+                                                     "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
     std::string data{reinterpret_cast<const char*>(pssh.data()), pssh.size()};
     FILESYS::SaveFile(debugFilePath, data, true);
   }
@@ -335,7 +335,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
   if (m_host->IsDebugSaveLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
+        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
     UTILS::FILESYS::SaveFile(debugFilePath, keyRequestData.data(), true);
   }
 
@@ -536,7 +536,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
       if (m_host->IsDebugSaveLicense())
       {
         std::string debugFilePath = FILESYS::PathCombine(
-            m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.postdata");
+            m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.postdata");
         UTILS::FILESYS::SaveFile(debugFilePath, blocks[2], true);
       }
     }
@@ -597,7 +597,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
   if (m_host->IsDebugSaveLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetProfilePath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
+        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
     UTILS::FILESYS::SaveFile(debugFilePath, response, true);
   }
 

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -50,8 +50,8 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm
 
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {
-    std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath().data(),
-                                                     "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
+    std::string debugFilePath =
+        FILESYS::PathCombine(m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
     std::string data{reinterpret_cast<const char*>(pssh.data()), pssh.size()};
     FILESYS::SaveFile(debugFilePath, data, true);
   }
@@ -337,7 +337,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
+        m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
     UTILS::FILESYS::SaveFile(debugFilePath, keyRequestData.data(), true);
   }
 
@@ -538,7 +538,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
       if (CSrvBroker::GetSettings().IsDebugLicense())
       {
         std::string debugFilePath = FILESYS::PathCombine(
-            m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.postdata");
+            m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.postdata");
         UTILS::FILESYS::SaveFile(debugFilePath, blocks[2], true);
       }
     }
@@ -599,7 +599,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
   if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
-        m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
+        m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");
     UTILS::FILESYS::SaveFile(debugFilePath, response, true);
   }
 

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -8,6 +8,8 @@
 
 #include "WVCencSingleSampleDecrypter.h"
 
+#include "CompSettings.h"
+#include "SrvBroker.h"
 #include "WVCdmAdapter.h"
 #include "WVDecrypter.h"
 #include "jsmn.h"
@@ -46,7 +48,7 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm
     return;
   }
 
-  if (m_host->IsDebugSaveLicense())
+  if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath().data(),
                                                      "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
@@ -332,7 +334,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
     return false;
   }
 
-  if (m_host->IsDebugSaveLicense())
+  if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
         m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.challenge");
@@ -533,7 +535,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
         blocks[2] = msgEncoded;
       }
 
-      if (m_host->IsDebugSaveLicense())
+      if (CSrvBroker::GetSettings().IsDebugLicense())
       {
         std::string debugFilePath = FILESYS::PathCombine(
             m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.postdata");
@@ -594,7 +596,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
     }
   }
 
-  if (m_host->IsDebugSaveLicense())
+  if (CSrvBroker::GetSettings().IsDebugLicense())
   {
     std::string debugFilePath = FILESYS::PathCombine(
         m_host->GetLibraryPath().data(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.response");

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -82,28 +82,6 @@ void JNIThread(JavaVM* vm)
 }
 #endif
 
-void CWVDecrypterA::SetProfilePath(const std::string& profilePath)
-{
-  m_strProfilePath = profilePath;
-
-  const char* pathSep{profilePath[0] && profilePath[1] == ':' && isalpha(profilePath[0]) ? "\\"
-                                                                                         : "/"};
-
-  if (m_strProfilePath.size() && m_strProfilePath.back() != pathSep[0])
-    m_strProfilePath += pathSep;
-
-  //let us make cdm userdata out of the addonpath and share them between addons
-  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 2));
-  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1));
-  m_strProfilePath.resize(m_strProfilePath.find_last_of(pathSep[0], m_strProfilePath.length() - 1) +
-                          1);
-
-  kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
-  m_strProfilePath += "cdm";
-  m_strProfilePath += pathSep;
-  kodi::vfs::CreateDirectory(m_strProfilePath.c_str());
-}
-
 std::string CWVDecrypterA::SelectKeySytem(std::string_view keySystem)
 {
   LOG::Log(LOGDEBUG, "Key system request: %s", keySystem.data());

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -128,15 +128,13 @@ public:
 
   virtual void ResetVideo() override {}
 
-  virtual void SetProfilePath(const std::string& profilePath) override;
-  virtual void SetLibraryPath(std::string_view libraryPath) override {}
   virtual void SetDebugSaveLicense(bool isDebugSaveLicense) override
   {
     m_isDebugSaveLicense = isDebugSaveLicense;
   }
 
+  virtual void SetLibraryPath(std::string_view libraryPath) override {}
   virtual std::string_view GetLibraryPath() const override { return ""; }
-  virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); }
   virtual const bool IsDebugSaveLicense() const override { return m_isDebugSaveLicense; }
 
   virtual void OnMediaDrmEvent(const CJNIMediaDrm& mediaDrm,
@@ -154,7 +152,6 @@ private:
   std::vector<CWVCencSingleSampleDecrypterA*> m_decrypterList;
   std::mutex m_decrypterListMutex;
   std::string m_retvalHelper;
-  std::string m_strProfilePath;
   bool m_isDebugSaveLicense;
 #ifdef DRMTHREAD
   std::mutex m_jniMutex;

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -129,13 +129,13 @@ public:
   virtual void ResetVideo() override {}
 
   virtual void SetProfilePath(const std::string& profilePath) override;
-  virtual void SetLibraryPath(const char* libraryPath) override{};
+  virtual void SetLibraryPath(std::string_view libraryPath) override {}
   virtual void SetDebugSaveLicense(bool isDebugSaveLicense) override
   {
     m_isDebugSaveLicense = isDebugSaveLicense;
   }
 
-  virtual const char* GetLibraryPath() const override { return ""; }
+  virtual std::string_view GetLibraryPath() const override { return ""; }
   virtual const char* GetProfilePath() const override { return m_strProfilePath.c_str(); }
   virtual const bool IsDebugSaveLicense() const override { return m_isDebugSaveLicense; }
 

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -128,14 +128,8 @@ public:
 
   virtual void ResetVideo() override {}
 
-  virtual void SetDebugSaveLicense(bool isDebugSaveLicense) override
-  {
-    m_isDebugSaveLicense = isDebugSaveLicense;
-  }
-
   virtual void SetLibraryPath(std::string_view libraryPath) override {}
   virtual std::string_view GetLibraryPath() const override { return ""; }
-  virtual const bool IsDebugSaveLicense() const override { return m_isDebugSaveLicense; }
 
   virtual void OnMediaDrmEvent(const CJNIMediaDrm& mediaDrm,
                                const std::vector<char>& sessionId,
@@ -152,7 +146,6 @@ private:
   std::vector<CWVCencSingleSampleDecrypterA*> m_decrypterList;
   std::mutex m_decrypterListMutex;
   std::string m_retvalHelper;
-  bool m_isDebugSaveLicense;
 #ifdef DRMTHREAD
   std::mutex m_jniMutex;
   std::condition_variable m_jniCondition;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
 
   CSrvBroker::GetInstance()->Init(props.GetProperties());
 
-  m_session = std::make_shared<CSession>(url, props.GetProfileFolder());
+  m_session = std::make_shared<CSession>(url);
   m_session->SetVideoResolution(m_currentVideoWidth, m_currentVideoHeight, m_currentVideoMaxWidth,
                                 m_currentVideoMaxHeight);
 

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -199,9 +199,8 @@ UTILS::CURL::CUrl::CUrl(std::string_view url)
 
 UTILS::CURL::CUrl::~CUrl()
 {
-  std::vector<std::string> cookies = GetResponseHeaders("set-cookie");
   if (CSrvBroker::GetKodiProps().IsInternalCookies())
-    StoreCookies(GetEffectiveUrl(), cookies);
+    StoreCookies(GetEffectiveUrl(), GetResponseHeaders("set-cookie"));
 
   m_file.Close();
 }

--- a/src/utils/FileUtils.cpp
+++ b/src/utils/FileUtils.cpp
@@ -36,18 +36,21 @@ bool UTILS::FILESYS::SaveFile(const std::string filePath, const std::string& dat
   return isWritten;
 }
 
-std::string UTILS::FILESYS::PathCombine(std::string path, std::string filePath)
+std::string UTILS::FILESYS::PathCombine(std::string_view path, std::string_view filePath)
 {
   if (path.empty())
-    return filePath;
+    return std::string(filePath);
 
   if (path.back() == SEPARATOR)
-    path.pop_back();
+    path.remove_suffix(1);
 
   if (filePath.front() == SEPARATOR)
-    filePath.erase(0, 1);
+    filePath.remove_prefix(1);
 
-  return path + SEPARATOR + filePath;
+  std::string cPath{path};
+  cPath += SEPARATOR;
+  cPath += filePath;
+  return cPath;
 }
 
 std::string UTILS::FILESYS::GetAddonUserPath()

--- a/src/utils/FileUtils.h
+++ b/src/utils/FileUtils.h
@@ -37,7 +37,7 @@ bool SaveFile(const std::string filePath, const std::string& data, bool overwrit
  * \param filePath The path to be combined, like filename or another path.
  * \return The combined path.
  */
-std::string PathCombine(std::string path, std::string filePath);
+std::string PathCombine(std::string_view path, std::string_view filePath);
 
 /*!
  * \brief Get the user-related data folder of the addon.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1) Some cleanups to use the new service broker
2) The session m_profilePath is the path on user folder of the addon, that can be obtained also by using `UTILS::FILESYS::GetAddonUserPath`, this was used to set the decrypter SetProfilePath that was performing a manual path string shrinks to obtain the same path of the libraryPath...its not clear why there is this round of code apparently for nothing...all that code now has been removed
3) the "widevine" folder created under "cdm" folder used by cdm to store persistent data has been now moved to the addon user folder:
`..\data\userdata\addon_data\inputstream.adaptive\widevine`
I thought that if there are multiple kodi profiles, this will keep the cdm persistent data separate per kodi profile used, where previously it was not

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
long postponed cleaning
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
