### PR TITLE
[backport][HLSTree] Fix container m4s, fix avc codec detection

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -60,7 +60,7 @@ static std::string getVideoCodec(const std::string& codecs)
 {
   if (codecs.empty())
     return "h264";
-  else if (codecs.find("avc1.") != std::string::npos)
+  else if (codecs.find("avc") != std::string::npos)
     return "h264";
   else if (codecs.find("hvc1.") != std::string::npos)
     return "hvc1";

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -550,7 +550,8 @@ HLSTree::PREPARE_RESULT HLSTree::prepareRepresentation(Period* period,
                 rep->containerType_ = CONTAINERTYPE_TS;
               else if (strncmp(line.c_str() + ext, ".aac", 4) == 0)
                 rep->containerType_ = CONTAINERTYPE_ADTS;
-              else if (strncmp(line.c_str() + ext, ".mp4", 4) == 0)
+              else if (strncmp(line.c_str() + ext, ".mp4", 4) == 0 ||
+                       strncmp(line.c_str() + ext, ".m4s", 4) == 0)
                 rep->containerType_ = CONTAINERTYPE_MP4;
               else if (strncmp(line.c_str() + ext, ".vtt", 4) == 0 ||
                        strncmp(line.c_str() + ext, ".webvtt", 7) == 0)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
backported two small fixes from omega (not full PRs)
should be safe with no regression

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1443 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://cdndai.pl/tvp1hd/index.m3u8 (require add useragent header to manifest/stream)
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
