### PR TITLE
Some tree / session cleanups

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -902,9 +902,8 @@ void CSession::UpdateStream(CStream& stream)
   stream.m_info.SetCodecInternalName(codecStr);
 }
 
-void CSession::PrepareStream(CStream* stream, bool& needRefetch)
+void CSession::PrepareStream(CStream* stream)
 {
-  needRefetch = false;
   CRepresentation* repr = stream->m_adStream.getRepresentation();
 
   switch (m_adaptiveTree->prepareRepresentation(stream->m_adStream.getPeriod(),
@@ -918,7 +917,6 @@ void CSession::PrepareStream(CStream* stream, bool& needRefetch)
       [[fallthrough]];
     case PrepareRepStatus::DRMUNCHANGED:
       stream->m_isEncrypted = repr->m_psshSetPos != PSSHSET_POS_DEFAULT;
-      needRefetch = true;
       break;
     default:
       break;

--- a/src/Session.h
+++ b/src/Session.h
@@ -87,12 +87,11 @@ public:
    */
   void UpdateStream(CStream& stream);
 
-  /*! \brief Update stream's InputstreamInfo
-   *  \param stream The stream to prepare
-   *  \param needRefetch [OUT] Set to true if stream info has changed
+  /*!
+   * \brief Update stream's InputstreamInfo
+   * \param stream The stream to prepare
    */
-  void PrepareStream(CStream* stream, bool& needRefetch);
-
+  void PrepareStream(CStream* stream);
 
   /*! \brief Get a stream by index (starting at 1)
    *  \param sid The one-indexed stream id

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1212,12 +1212,14 @@ void AdaptiveStream::FixateInitialization(bool on)
 
 bool AdaptiveStream::GenerateSidxSegments(PLAYLIST::CRepresentation* rep)
 {
-  if (rep->GetContainerType() != ContainerType::MP4 &&
-      rep->GetContainerType() != ContainerType::WEBM)
+  const ContainerType containerType = rep->GetContainerType();
+  if (containerType == ContainerType::NOTYPE)
+    return false;
+  else if (containerType != ContainerType::MP4 && containerType != ContainerType::WEBM)
   {
     LOG::LogF(LOGERROR,
               "[AS-%u] Cannot generate segments from SIDX on repr id \"%s\" with container \"%i\"",
-              clsId, rep->GetId().data(), static_cast<int>(rep->GetContainerType()));
+              clsId, rep->GetId().data(), static_cast<int>(containerType));
     return false;
   }
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -809,7 +809,7 @@ bool AdaptiveStream::ensureSegment()
 
     if (m_tree->HasManifestUpdatesSegs() && SecondsSinceUpdate() > 1)
     {
-      m_tree->RefreshSegments(current_period_, current_adp_, current_rep_, current_adp_->GetStreamType());
+      m_tree->RefreshSegments(current_period_, current_adp_, current_rep_);
       lastUpdated_ = std::chrono::system_clock::now();
     }
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -139,8 +139,7 @@ public:
 
   virtual void RefreshSegments(PLAYLIST::CPeriod* period,
                                PLAYLIST::CAdaptationSet* adp,
-                               PLAYLIST::CRepresentation* rep,
-                               PLAYLIST::StreamType type)
+                               PLAYLIST::CRepresentation* rep)
   {
   }
 

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -103,17 +103,13 @@ PLAYLIST::CRepresentation* CRepresentationChooserAskQuality::GetNextRepresentati
         if (fps > 0 && repr->GetFrameRateScale() > 0)
           fps /= repr->GetFrameRateScale();
 
-        std::string quality;
+        std::string quality = "(";
+        if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
+          quality += StringUtils::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
         if (fps > 0)
-        {
-          quality = StringUtils::Format("(%ix%i, %s fps, %u Kbps)", repr->GetWidth(), repr->GetHeight(),
-                                        CovertFpsToString(fps).c_str(), repr->GetBandwidth() / 1000);
-        }
-        else
-        {
-          quality = StringUtils::Format("(%ix%i, %u Kbps)", repr->GetWidth(), repr->GetHeight(),
-                                        repr->GetBandwidth() / 1000);
-        }
+          quality += StringUtils::Format("%s fps, ", CovertFpsToString(fps).c_str());
+
+        quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
         STRING::ReplaceFirst(entryName, "{quality}", quality);
 
         if (repr == bestRep)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,7 +224,6 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       return false;
   }
 
-  bool needRefetch = false; //Make sure that Kodi fetches changes
   stream->m_isEnabled = true;
 
   CRepresentation* rep = stream->m_adStream.getRepresentation();
@@ -259,7 +258,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     return false;
   }
 
-  m_session->PrepareStream(stream, needRefetch);
+  m_session->PrepareStream(stream);
 
   stream->m_adStream.start_stream();
   stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
@@ -309,7 +308,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     }
   }
   m_session->EnableStream(stream, true);
-  return stream->GetReader()->GetInformation(stream->m_info) || needRefetch;
+  return stream->GetReader()->GetInformation(stream->m_info);
 }
 
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1548,10 +1548,9 @@ bool adaptive::CDashTree::DownloadManifestUpd(std::string_view url,
 
 void adaptive::CDashTree::RefreshSegments(PLAYLIST::CPeriod* period,
                                           PLAYLIST::CAdaptationSet* adp,
-                                          PLAYLIST::CRepresentation* rep,
-                                          PLAYLIST::StreamType type)
+                                          PLAYLIST::CRepresentation* rep)
 {
-  if (type == StreamType::VIDEO || type == StreamType::AUDIO)
+  if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::AUDIO)
   {
     m_updThread.ResetStartTime();
     RefreshLiveSegments();

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -96,8 +96,7 @@ protected:
 
   virtual void RefreshSegments(PLAYLIST::CPeriod* period,
                                PLAYLIST::CAdaptationSet* adp,
-                               PLAYLIST::CRepresentation* rep,
-                               PLAYLIST::StreamType type) override;
+                               PLAYLIST::CRepresentation* rep) override;
 
   virtual void RefreshLiveSegments() override;
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -757,9 +757,9 @@ void adaptive::CHLSTree::RefreshLiveSegments()
         refreshList.emplace_back(std::make_tuple(adpSet.get(), repr.get()));
     }
   }
-  for (auto& itemList : refreshList)
+  for (auto& [adpSet, repr] : refreshList)
   {
-    prepareRepresentation(m_currentPeriod, std::get<0>(itemList), std::get<1>(itemList), true);
+    prepareRepresentation(m_currentPeriod, adpSet, repr, true);
   }
 }
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -754,7 +754,7 @@ void adaptive::CHLSTree::RefreshLiveSegments()
     for (auto& repr : adpSet->GetRepresentations())
     {
       if (repr->IsEnabled())
-        refreshList.emplace_back(std::make_tuple(adpSet.get(), repr.get()));
+        refreshList.emplace_back(adpSet.get(), repr.get());
     }
   }
   for (auto& [adpSet, repr] : refreshList)

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -715,8 +715,7 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
 //Called each time before we switch to a new segment
 void adaptive::CHLSTree::RefreshSegments(PLAYLIST::CPeriod* period,
                                          PLAYLIST::CAdaptationSet* adp,
-                                         PLAYLIST::CRepresentation* rep,
-                                         PLAYLIST::StreamType type)
+                                         PLAYLIST::CRepresentation* rep)
 {
   if (rep->IsIncludedStream())
     return;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1019,7 +1019,7 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
       rend.m_language = attribs["LANGUAGE"];
       if (streamType == StreamType::AUDIO)
       {
-        rend.m_channels = STRING::ToUint32(attribs["CHANNELS"]);
+        rend.m_channels = STRING::ToUint32(attribs["CHANNELS"], 2);
         if (STRING::Contains(attribs["CHANNELS"], "/JOC"))
           rend.m_features |= REND_FEATURE_EC3_JOC;
       }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1375,6 +1375,18 @@ void adaptive::CHLSTree::AddIncludedAudioStream(std::unique_ptr<PLAYLIST::CPerio
   repr->SetScaling();
 
   newAdpSet->AddRepresentation(repr);
+
+  // Ensure that we dont have already an existing adaptation set with same attributes,
+  // usually should happens when we have more EXT-X-STREAM-INF with audio included to video
+  // and we need to keep just one
+  CAdaptationSet* foundAdpSet =
+      CAdaptationSet::FindMergeable(period->GetAdaptationSets(), newAdpSet.get());
+
+  if (foundAdpSet && foundAdpSet->GetRepresentations().size() == 1)
+  {
+    if (foundAdpSet->GetRepresentations()[0]->IsIncludedStream())
+      return; // Repr. with included audio already exists
+  }
   period->AddAdaptationSet(newAdpSet);
 }
 

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -52,8 +52,7 @@ public:
 
   virtual void RefreshSegments(PLAYLIST::CPeriod* period,
                                PLAYLIST::CAdaptationSet* adp,
-                               PLAYLIST::CRepresentation* rep,
-                               PLAYLIST::StreamType type) override;
+                               PLAYLIST::CRepresentation* rep) override;
 
 protected:
   // \brief Rendition features


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
some cleanups while investigating on current issues

commits:
1) We want avoid print a log error when an HLS child manifest has not been prepared yet
and ContainerType result as NOTYPE
2) cleanups
3) cleanups
4) Prevent to show empty resolution to GUI, can happens when there is no HLS RESOLUTION info, like on some live streams
5) Removed not needed method argument stream type
6) Removed needRefetch, the reasons behind this of this forced behaviour are unclear to me, `OpenStream` require return value to be true only when there is need to update stream info, but this is already done by the reader with `GetInformation` and extradata if needed is already taken in account. Tested with and without DRM HLS stream not found weirdness. @glennguy if you remember something let me know, also too much old GH history there are no explanations
7) small fix, if there is no CHANNELS info on rendition, fallback to 2 channels
8) as title, reproducible with royal family stream https://cdn-ue1-prod.tsv2.amagi.tv/avod/simplestream-lds-ldtimln/ODYPPCS001EP001/ODYPPCS001EP001.m3u8

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
