### PR TITLE
Use http manifest headers to download hls keys

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -882,7 +882,7 @@ void HLSTree::OnDataArrived(uint64_t segNum,
       if (pssh.defaultKID_.empty())
       {
       RETRY:
-        std::map<std::string, std::string> headers;
+        std::map<std::string, std::string> headers = m_manifestHeaders;
         std::vector<std::string> keyParts{StringUtils::Split(m_decrypter->getLicenseKey(), '|')};
         std::string url = pssh.pssh_.c_str();
 


### PR DESCRIPTION
## Description
Use the http headers of the hls manifest also for downloading the hls key

## Motivation and context
While experimenting with hls stream encryption I noticed that it is not possible to pass any http headers in the download of the key indicated in the #EXT-X-KEY tag

## How has this been tested?
I followed this tutorial https://hlsbook.net/how-to-encrypt-hls-video-with-ffmpeg/ to create the encrypted stream and set the basic authentication on the http server that provides it.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
