### PR TITLE
[WebVTT] Reverted changes to align stream and fix turn off/on subs

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -987,26 +987,21 @@ uint64_t CSession::GetTimeshiftBufferStart()
 void CSession::StartReader(
     CStream* stream, uint64_t seekTime, int64_t ptsDiff, bool preceeding, bool timing)
 {
-  bool bReset = true;
   ISampleReader* streamReader = stream->GetReader();
-  if (timing)
-  {
-    seekTime += stream->m_adStream.GetAbsolutePTSOffset();
-  }
-  else
-  {
-    seekTime -= ptsDiff;
-    streamReader->SetStartPTS(GetTimingStartPTS());
-  }
-
-  stream->m_adStream.seek_time(static_cast<double>(seekTime / STREAM_TIME_BASE), preceeding,
-                               bReset);
-
   if (!streamReader)
   {
     LOG::LogF(LOGERROR, "Cannot get the stream reader");
     return;
   }
+
+  bool bReset = true;
+  if (timing)
+    seekTime += stream->m_adStream.GetAbsolutePTSOffset();
+  else
+    seekTime -= ptsDiff;
+
+  stream->m_adStream.seek_time(static_cast<double>(seekTime / STREAM_TIME_BASE), preceeding,
+                               bReset);
 
   if (bReset)
     streamReader->Reset(false);
@@ -1026,7 +1021,6 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
 {
   CStream* res{nullptr};
   CStream* waiting{nullptr};
-  CStream* timingStream{GetTimingStream()};
 
   for (auto& stream : m_streams)
   {
@@ -1047,16 +1041,6 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
       }
       else if (!streamReader->EOS())
       {
-        // Once the start PTS has been acquired for the timing stream, set this value
-        // to the other stream readers
-        if (timingStream && stream.get() != timingStream &&
-            timingStream->GetReader()->GetStartPTS() != STREAM_NOPTS_VALUE &&
-            streamReader->GetStartPTS() == STREAM_NOPTS_VALUE)
-        {
-          // want this to be the internal data's (not segment's) pts of
-          // the first segment in period
-          streamReader->SetStartPTS(GetTimingStartPTS());
-        }
         if (AP4_SUCCEEDED(streamReader->Start(isStarted)))
         {
           if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())
@@ -1196,6 +1180,8 @@ bool CSession::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
       if (!streamReader->IsStarted())
         StartReader(stream.get(), seekTimeCorrected, ptsDiff, preceeding, false);
 
+      streamReader->SetPTSDiff(ptsDiff);
+      
       double seekSecs{static_cast<double>(seekTimeCorrected - streamReader->GetPTSDiff()) /
                       STREAM_TIME_BASE};
       if (stream->m_adStream.seek_time(seekSecs, preceeding, reset))
@@ -1367,16 +1353,6 @@ int64_t CSession::GetChapterPos(int ch) const
   }
 
   return sum / STREAM_TIME_BASE;
-}
-
-uint64_t CSession::GetTimingStartPTS() const
-{
-  if (CStream* timing = GetTimingStream())
-  {
-    return timing->GetReader()->GetStartPTS();
-  }
-  else
-    return 0;
 }
 
 uint64_t CSession::GetChapterStartTime() const

--- a/src/Session.h
+++ b/src/Session.h
@@ -283,20 +283,10 @@ public:
    */
   uint64_t GetChapterStartTime() const;
 
-  /*! \brief Get starting PTS of the timing stream
-   *  \return PTS at start of the timing stream
-   */
-  uint64_t GetTimingStartPTS() const;
-
   /*! \brief Get value of m_chapterSeekTime
    *  \return Time stored in m_chapterSeekTime
    */
   double GetChapterSeekTime() { return m_chapterSeekTime; };
-
-  /*! \brief Get the timing stream
-   *  \return Timing stream if exists
-   */
-  CStream* GetTimingStream() const { return m_timingStream; }
 
   /*! \brief Set m_chapterSeekTime back to 0
    */

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -48,7 +48,7 @@ class AdaptiveTree;
     virtual ~AdaptiveStream();
     void set_observer(AdaptiveStreamObserver *observer){ observer_ = observer; };
     void Reset();
-    bool start_stream();
+    bool start_stream(uint64_t startPts =0);
     /*!
      * \brief Disable current representation, wait the current download is finished and stop downloads.
      */

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -41,6 +41,9 @@ constexpr uint64_t NO_PTS_VALUE = std::numeric_limits<uint64_t>::max();
 // Marker for undefined value
 constexpr uint64_t NO_VALUE = std::numeric_limits<uint64_t>::max();
 
+// Kodi VideoPlayer internal buffer
+constexpr uint64_t KODI_VP_BUFFER_SECS = 8;
+
 enum class EncryptionState
 {
   UNENCRYPTED,

--- a/src/demuxers/TSReader.cpp
+++ b/src/demuxers/TSReader.cpp
@@ -49,7 +49,7 @@ void DebugLog(int level, char* msg)
 } // unnamed namespace
 
 TSReader::TSReader(AP4_ByteStream* stream, uint32_t requiredMask)
-  : m_stream(stream), m_requiredMask(requiredMask), m_typeMask(0), m_startPts{STREAM_NOPTS_VALUE}
+  : m_stream(stream), m_requiredMask(requiredMask), m_typeMask(0)
 {
   // Uncomment to debug TSDemux library
   // TSDemux::DBGAll();
@@ -66,7 +66,6 @@ bool TSReader::Initialize()
     m_AVContext = nullptr;
     return false;
   }
-  m_startPts = GetPts();
   return true;
 }
 

--- a/src/demuxers/TSReader.h
+++ b/src/demuxers/TSReader.h
@@ -37,7 +37,6 @@ public:
 
   uint64_t GetDts() const { return m_pkt.dts == PTS_UNSET ? PTS_UNSET : m_pkt.dts; }
   uint64_t GetPts() const { return m_pkt.pts == PTS_UNSET ? PTS_UNSET : m_pkt.pts; }
-  uint64_t GetStartPts() const { return m_startPts; }
   uint64_t GetDuration() const { return m_pkt.duration; }
   const AP4_Byte *GetPacketData() const { return m_pkt.data; };
   const AP4_Size GetPacketSize() const { return static_cast<AP4_Size>(m_pkt.size); }
@@ -56,7 +55,6 @@ private:
   AP4_Position m_startPos;
   uint32_t m_requiredMask;
   uint32_t m_typeMask;
-  uint64_t m_startPts;
 
   struct TSINFO
   {

--- a/src/main.h
+++ b/src/main.h
@@ -65,6 +65,9 @@ private:
   bool m_checkChapterSeek = false;
   int m_failedSeekTime = ~0;
   std::string m_chapterName;
+  // The last PTS of the segment package fed to kodi.
+  // NO_PTS_VALUE only when playback starts or a new period starts
+  std::atomic<uint64_t> m_lastPts{PLAYLIST::NO_PTS_VALUE};
 
   void UnlinkIncludedStreams(SESSION::CStream* stream);
 };

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -30,8 +30,6 @@ public:
   }
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
-  uint64_t GetStartPTS() const override { return m_startPts; }
-  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 90000; }
   AP4_UI32 GetStreamId() const override { return m_streamId; }
@@ -47,6 +45,5 @@ private:
   uint64_t m_pts{0};
   int64_t m_ptsDiff{0};
   uint64_t m_ptsOffs{~0ULL};
-  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   CAdaptiveByteStream* m_adByteStream;
 };

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -211,9 +211,6 @@ AP4_Result CFragmentedSampleReader::ReadSample()
   m_dts = (m_sample.GetDts() * m_timeBaseExt) / m_timeBaseInt;
   m_pts = (m_sample.GetCts() * m_timeBaseExt) / m_timeBaseInt;
   
-  if (m_startPts == STREAM_NOPTS_VALUE)
-    SetStartPTS(m_pts - GetPTSDiff());
-
   m_codecHandler->UpdatePPSId(m_sampleData);
 
   return AP4_SUCCESS;

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -44,8 +44,6 @@ public:
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override;
-  uint64_t GetStartPTS() const override { return m_startPts; }
-  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetFragmentInfo(uint64_t& duration) override;
   uint32_t GetTimeScale() const override { return m_track->GetMediaTimeScale(); }
@@ -73,7 +71,6 @@ private:
   int64_t m_dts{0};
   int64_t m_pts{0};
   int64_t m_ptsDiff{0};
-  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   AP4_UI64 m_ptsOffs{~0ULL};
   uint64_t m_timeBaseExt{0};
   uint64_t m_timeBaseInt{0};

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -58,8 +58,7 @@ public:
   virtual bool TimeSeek(uint64_t pts, bool preceeding) = 0;
   virtual void SetPTSOffset(uint64_t offset) = 0;
   virtual int64_t GetPTSDiff() const = 0;
-  virtual void SetStartPTS(uint64_t pts) = 0;
-  virtual uint64_t GetStartPTS() const = 0;
+  virtual void SetPTSDiff(uint64_t pts) {}
 
   /*!
    * \brief Read info about fragment on current segment (fMP4)

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -39,10 +39,9 @@ public:
   void Reset(bool bEOS) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
   bool TimeSeek(uint64_t pts, bool preceeding) override;
-  void SetPTSOffset(uint64_t offset) override { m_ptsOffset = offset; }
-  uint64_t GetStartPTS() const override { return m_startPts; }
-  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
+  void SetPTSOffset(uint64_t offset) override { }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
+  void SetPTSDiff(uint64_t pts) override;
   uint32_t GetTimeScale() const override { return 1000; }
   AP4_UI32 GetStreamId() const override { return m_streamId; }
   AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); }
@@ -54,9 +53,7 @@ private:
   bool InitializeFile(std::string url);
 
   uint64_t m_pts{0};
-  uint64_t m_ptsOffset{0};
-  uint64_t m_ptsDiff{0};
-  uint64_t m_startPts{STREAM_NOPTS_VALUE};
+  int64_t m_ptsDiff{0};
   AP4_UI32 m_streamId;
   bool m_eos{false};
   bool m_started{false};

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -24,12 +24,7 @@ CTSSampleReader::CTSSampleReader(AP4_ByteStream* input,
 
 bool CTSSampleReader::Initialize(SESSION::CStream* stream)
 {
-  if (TSReader::Initialize())
-  {
-    SetStartPTS(((TSReader::GetStartPts() * 100) / 9) - GetPTSDiff());
-    return true;
-  }
-  return false;
+  return TSReader::Initialize();
 }
 
 void CTSSampleReader::AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid)

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -37,8 +37,6 @@ public:
   }
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
-  uint64_t GetStartPTS() const override { return m_startPts; }
-  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 90000; }
   AP4_UI32 GetStreamId() const override { return m_typeMap[GetStreamType()]; }
@@ -54,7 +52,6 @@ private:
   uint64_t m_dts{0};
   uint64_t m_ptsOffs{~0ULL};
   int64_t m_ptsDiff{0};
-  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   bool m_eos{false};
   bool m_started{false};
   CAdaptiveByteStream* m_adByteStream;

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -31,8 +31,6 @@ public:
   }
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
-  uint64_t GetStartPTS() const override { return m_startPts; }
-  void SetStartPTS(uint64_t pts) override { m_startPts = pts; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 1000; }
   AP4_UI32 GetStreamId() const override { return m_streamId; }
@@ -47,7 +45,6 @@ private:
   uint64_t m_dts{0};
   uint64_t m_ptsOffs{~0ULL};
   int64_t m_ptsDiff{0};
-  uint64_t m_startPts{STREAM_NOPTS_VALUE};
   bool m_eos{false};
   bool m_started{false};
   CAdaptiveByteStream* m_adByteStream;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
## 1° commit
From commit https://github.com/xbmc/inputstream.adaptive/pull/1082/commits/cfb8538e4c546b0a47a4a01191a3700e13a54e31
force add GetStartPTS from timing stream (usually referred to video stream) to subtitle pts, this can lead to a side effect,
that can happens when the timing stream have a PTSDiff with -1 value, and then when you seek video (like D+ video resume of the Issue) `AdaptiveStream::seek_time` its not able to find the segment to be read and so no subtitles loaded

So this change full revert the old commit above, and introduce a different solution, so use the PTSDiff from the timing stream to sync subs when a video seek happen

## 2° commit
When you play segmented webvtt (such as D+, akmai HLS, or other similar segmented) and you turn off/on subs
subtitles are full broken and no subtitles are shown on screen.
reference to comment in Issue: https://github.com/xbmc/xbmc/issues/24165#issuecomment-1840755531

This because when you turn off, current segment is wrong seem to point to the already consumed segment,
this implies that when you re-enable subs the data segment provided to kodi will be from a future point and not what is being played on the screen at that time. This happens because when you reenable subs `OpenStream` is called by kodi but dont provide the current pts where start finding the right segment and so start from the last consumed or from starts.
My idea to fix this is kept stored the  current pts from `DemuxRead` and use it to find the appropriate segment when subtitles will be re-enabled.

this fix also seems to solve another problem, the delay (temporary no subs displayed for some secs) that happens when you switch to a different sub track/language (as explained on this issue https://github.com/xbmc/xbmc/issues/21086), but should be tested better i dont remember anymore if linked Issue was using ISA

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1419
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i have tested most of sample streams that i have, but better have a confirmation by someonelse:

DASH isobmff webvtt: starts ok + seek/resume ok
HLS segmented with D+: starts ok + seek/resume ok
HLS segmented Akmai "local" with multiple periods: starts ok + seek ok + after ended a chapter ok + seek between chapters ok
DASH segmented with more periods: starts ok + seek ok + seek between chapters ok

~Not tested (due to broken sample stream) DASH with segment template webvtt~
DASH with segment template webvtt, tested with this one:
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://drm-widevine-licensing.axtest.net/AcquireLicense|X-AxDRM-Message=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiNmU1YTFkMjYtMjc1Ny00N2Q3LTgwNDYtZWFhNWQxZDM0YjVhIn1dfX0.yF7PflOPv9qHnu3ZWJNZ12jgkqTabmwXbDWk_47tLNE|R{SSM}|
https://media.axprod.net/TestVectors/v6.1-MultiDRM/Manifest_1080p.mpd
```

Just to check for regressions with other types:
DASH with webvtt "as file": starts ok + seek ok ~but after some seeks subtitles are broken, should not related to this, i suspect a kodi bug, i will try investigate before merging this~ was the sample stream broken

DASH with ttml: starts ok+ seek ok

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
