### PR TITLE
[Widevine] Accept R for raw response data

### DIFF
--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -503,7 +503,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   if (serverCertRequest && contentType.find("application/octet-stream") == std::string::npos)
     serverCertRequest = false;
 
-  if (!blocks[3].empty() && !serverCertRequest)
+  if (!blocks[3].empty() && blocks[3][0] != 'R' && !serverCertRequest)
   {
     if (blocks[3][0] == 'J' || (blocks[3].size() > 1 && blocks[3][0] == 'B' && blocks[3][1] == 'J'))
     {

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -603,8 +603,9 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
     UTILS::FILESYS::SaveFile(debugFilePath, response, true);
   }
 
-  if (!blocks[3].empty() && (keyRequestData.size() > 2 ||
-                             contentType.find("application/octet-stream") == std::string::npos))
+  if (!blocks[3].empty() && blocks[3][0] != 'R' &&
+      (keyRequestData.size() > 2 ||
+       contentType.find("application/octet-stream") == std::string::npos))
   {
     if (blocks[3][0] == 'J' || (blocks[3].size() > 1 && blocks[3][0] == 'B' && blocks[3][1] == 'J'))
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
As specified in wiki
https://github.com/xbmc/inputstream.adaptive/wiki/Integration#inputstreamadaptivelicense_key
the response data template field can be "R" for raw
so lets accept it

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1447
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
