### PR TITLE
[UrlUtils]: Append parameters to an URL without overwriting existing params values

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -131,9 +131,8 @@ bool adaptive::AdaptiveStream::DownloadImpl(const DownloadInfo& downloadInfo,
   std::map<std::string, std::string> headers = m_streamHeaders;
   headers.insert(downloadInfo.m_addHeaders.begin(), downloadInfo.m_addHeaders.end());
 
-  // Append stream parameters, only if not already provided
-  if (url.find('?') == std::string::npos)
-    URL::AppendParameters(url, m_streamParams);
+  // Append stream parameters
+  URL::AppendParameters(url, m_streamParams);
 
   CURL::CUrl curl{url};
   curl.AddHeaders(headers);

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -75,9 +75,8 @@ bool CSubtitleSampleReader::InitializeFile(std::string url)
 {
   auto kodiProps = CSrvBroker::GetKodiProps();
 
-  // Append stream parameters, only if not already provided
-  if (url.find('?') == std::string::npos)
-    URL::AppendParameters(url, kodiProps.GetStreamParams());
+  // Append stream parameters
+  URL::AppendParameters(url, kodiProps.GetStreamParams());
 
   // Download the file
   CURL::CUrl curl(url);

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -223,12 +223,27 @@ void UTILS::URL::AppendParameters(std::string& url, std::string_view params)
   if (params.empty())
     return;
 
-  if (url.find_first_of('?') == std::string::npos)
-    url += "?";
-  else
-    url += "&";
+  params.remove_prefix(params.front() == '&' || params.front() == '?' ? 1 : 0);
+  size_t keyValDividerPos;
+  while ((keyValDividerPos = params.find('=')) != std::string::npos)
+  {
+    size_t ampersandPos = params.find('&');
+    std::string paramKey{params.substr(0, keyValDividerPos)};
 
-  url += params.substr(params.front() == '&' || params.front() == '?' ? 1 : 0);
+    // if param key is not in url add it
+    if (url.find('?' + paramKey + '=') == std::string::npos &&
+        url.find('&' + paramKey + '=') == std::string::npos)
+    {
+      url += url.find_first_of('?') == std::string::npos ? '?' : '&';
+      url += paramKey + '=';
+      url += params.substr(keyValDividerPos + 1, ampersandPos);
+    }
+
+    if (ampersandPos != std::string::npos)
+      params = params.substr(ampersandPos + 1);
+    else
+      break;
+  }
 }
 
 std::string UTILS::URL::GetBaseDomain(std::string url)

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -77,7 +77,7 @@ std::string GetPath(std::string url, bool includeFilePart);
  */
 std::string GetUrlPath(std::string url);
 
-/*! \brief Append a string of parameters to an URL with/without pre-existents params
+/*! \brief Append a string of parameters to an URL without overwriting existing params values
  *  \param url URL where append the parameters
  *  \param params Params to be appended
  */


### PR DESCRIPTION
## Description
Currently, stream parameters are only added to the URL via the "inputstream.adaptive.stream_params" property if the URL does not yet contain any parameters.

With this PR these parameters are only added if they are not already in the URL.

## Motivation and context
This PR is necessary for the DAZN addon because a parameter must be added to the stream URL, which you receive in a previous request.

Since the stream URL already contains parameters, the required parameter is not added.

Example of a stream URL:
https://dca-fs-live-dazn-cdn.dazn.com/1fn0a9tqiczun1316fe2mzgb8q/all/dash/avc_dash_global-video=6499968.dash?outlet=dazn-dach

## How has this been tested?
Tested with my android device and custom build of IA

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
