### PR TITLE
[AdaptiveStream] Rework to improve HLS manifest updates

### DIFF
--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -231,6 +231,7 @@ class AdaptiveTree;
     PLAYLIST::CPeriod* current_period_;
     PLAYLIST::CAdaptationSet* current_adp_;
     PLAYLIST::CRepresentation* current_rep_;
+    PLAYLIST::CRepresentation* m_switchRep{nullptr};
 
     // Decrypter IV used to decrypt HLS segment
     // We need to store here because linked to representation

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -114,12 +114,16 @@ public:
    */
   virtual void PostOpen();
 
-  virtual PLAYLIST::PrepareRepStatus prepareRepresentation(PLAYLIST::CPeriod* period,
-                                                           PLAYLIST::CAdaptationSet* adp,
-                                                           PLAYLIST::CRepresentation* rep,
-                                                           bool update = false)
+  /*!
+   * \brief Prepare the representation data by downloading and parsing manifest
+   * \return True if has success, otherwise false
+   */
+  virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
+                                     PLAYLIST::CAdaptationSet* adp,
+                                     PLAYLIST::CRepresentation* rep,
+                                     bool& isDrmChanged)
   {
-    return PLAYLIST::PrepareRepStatus::OK;
+    return false;
   }
 
   virtual std::chrono::time_point<std::chrono::system_clock> GetRepLastUpdated(

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -60,14 +60,6 @@ enum class EncryptionType
   UNKNOWN,
 };
 
-enum class PrepareRepStatus
-{
-  FAILURE,
-  OK,
-  DRMCHANGED,
-  DRMUNCHANGED,
-};
-
 enum class ContainerType
 {
   NOTYPE,

--- a/src/common/Representation.cpp
+++ b/src/common/Representation.cpp
@@ -48,6 +48,5 @@ void PLAYLIST::CRepresentation::CopyHLSData(const CRepresentation* other)
   m_isIncludedStream = other->m_isIncludedStream;
   m_isEnabled = other->m_isEnabled;
   m_isWaitForSegment = other->m_isWaitForSegment;
-  m_isDownloaded = other->m_isDownloaded;
   m_initSegment = other->m_initSegment;
 }

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -136,11 +136,6 @@ public:
     m_isSubtitleFileStream = isSubtitleFileStream;
   }
 
-  // Currently used for HLS only
-  bool IsPrepared() const { return m_isPrepared; }
-  // Currently used for HLS only
-  void SetIsPrepared(bool isPrepared) { m_isPrepared = isPrepared; }
-
   bool IsEnabled() const { return m_isEnabled; }
   void SetIsEnabled(bool isEnabled) { m_isEnabled = isEnabled; }
 
@@ -150,6 +145,9 @@ public:
   // Define if it is a dummy representation for audio stream, that is embedded on the video stream
   bool IsIncludedStream() const { return m_isIncludedStream; }
   void SetIsIncludedStream(bool isIncludedStream) { m_isIncludedStream = isIncludedStream; }
+
+  bool IsNeedsUpdates() const { return m_isNeedsUpdates; }
+  void SetIsNeedsUpdates(bool isNeedsUpdates) { m_isNeedsUpdates = isNeedsUpdates; }
 
   void CopyHLSData(const CRepresentation* other);
 
@@ -259,9 +257,6 @@ public:
   uint32_t assured_buffer_duration_{0};
   uint32_t max_buffer_duration_{0};
 
-  //! @todo: used for HLS only, not reflect the right meaning
-  bool m_isDownloaded{false};
-
 protected:
   std::string m_id;
   std::string m_sourceUrl;
@@ -287,11 +282,11 @@ protected:
 
   bool m_isSubtitleFileStream{false};
 
-  bool m_isPrepared{false};
   bool m_isEnabled{false};
   bool m_isWaitForSegment{false};
 
   bool m_isIncludedStream{false};
+  bool m_isNeedsUpdates{true};
 };
 
 } // namespace PLAYLIST

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1552,7 +1552,6 @@ void adaptive::CDashTree::RefreshSegments(PLAYLIST::CPeriod* period,
 {
   if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::AUDIO)
   {
-    m_updThread.ResetStartTime();
     RefreshLiveSegments();
   }
 }

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -36,10 +36,10 @@ public:
                     const std::map<std::string, std::string>& headers,
                     const std::string& data) override;
 
-  virtual PLAYLIST::PrepareRepStatus prepareRepresentation(PLAYLIST::CPeriod* period,
-                                                            PLAYLIST::CAdaptationSet* adp,
-                                                            PLAYLIST::CRepresentation* rep,
-                                                            bool update = false) override;
+  virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
+                                     PLAYLIST::CAdaptationSet* adp,
+                                     PLAYLIST::CRepresentation* rep,
+                                     bool& isDrmChanged) override;
 
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
@@ -113,6 +113,22 @@ protected:
                                      const std::map<std::string, std::string>& reqHeaders,
                                      const std::vector<std::string>& respHeaders,
                                      UTILS::CURL::HTTPResponse& resp);
+
+  bool DownloadChildManifest(PLAYLIST::CAdaptationSet* adp,
+                             PLAYLIST::CRepresentation* rep,
+                             UTILS::CURL::HTTPResponse& resp);
+
+  bool ParseChildManifest(const std::string& data,
+                          std::string_view sourceUrl,
+                          PLAYLIST::CPeriod* period,
+                          PLAYLIST::CAdaptationSet* adp,
+                          PLAYLIST::CRepresentation* rep,
+                          bool& isDrmChanged);
+
+  void PrepareSegments(PLAYLIST::CPeriod* period,
+                       PLAYLIST::CAdaptationSet* adp,
+                       PLAYLIST::CRepresentation* rep,
+                       uint64_t segPosition);
 
   virtual void RefreshLiveSegments() override;
 

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -47,7 +47,16 @@ public:
   virtual bool Initialize(SESSION::CStream* stream) { return true; }
   virtual void SetDecrypter(Adaptive_CencSingleSampleDecrypter* ssd,
                             const DRM::DecrypterCapabilites& dcaps){};
+  /*!
+   * \brief Defines if the end of the stream is reached
+   */
   virtual bool EOS() const = 0;
+  /*!
+   * \brief Defines if the sample reader is ready to process data,
+   *        may be needed for streams that do not need to pause kodi VP buffer
+   *        when there are no segments such as subtitles
+   */
+  virtual bool IsReady() { return true; }
   virtual uint64_t DTS() const = 0;
   virtual uint64_t PTS() const = 0;
   virtual uint64_t DTSorPTS() const { return DTS() < PTS() ? DTS() : PTS(); };

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -32,6 +32,7 @@ public:
   virtual bool Initialize(SESSION::CStream* stream) override;
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
+  bool IsReady() override;
   uint64_t DTS() const override { return m_pts; }
   uint64_t PTS() const override { return m_pts; }
   AP4_Result Start(bool& bStarted) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
While was developing this i found many weirdness that i think are not new bugs,
most of these bugs can be reproduced by using "Stream selection" setting to "Test" by switching per 1 segment.
That could happens for example on live stream, that when switch quality kodi call OpenStream, but when AdaptiveStream::start_stream is called, dont find the next segment because not yet available and stop the playback wrongly....

One single time, i catched two kodi freeze/crash, when played "akmai" local stream:
1 case when doing video seek, two times, in fast way on the "same" point (with mouse)
1 case when stop playback
more likely i think are already existings bugs

PR Changes for live streams:
- HLS: Fix problem of playback stops after some time
- HLS: Fix playback stop with adaptive stream switching (not fully but much better than before)
- HLS: RAI live buzz sound mentioned in issue #1132 seem not happens anymore, and instead of buzz sound the stream pause for in right way buffering, but the workaround its still needed, to avoid better the buffer loading
- HLS: Fix child manifest subtitles still in download also when are disabled
- HLS: Fix subtitles segments not downloaded from new manifest updates (only show subtitles for first secs/segments) related to #1109

Unsolved bug was already existing:
if you play a HLS live stream with subtitles that are disabled,
when switch to a new period (DEMUX_SPECIALID_STREAMCHANGE) the subtitle stream will be re-enabled, this cause error
GenerateSidxSegments: [AS-20] Cannot generate segments
due to not downloaded child manifest

Unsolved bug i think was already existing:
Chapter change (DEMUX_SPECIALID_STREAMCHANGE) may be executed 2 times! by audio and video stream, i think due to slight differrent pts, could be?!, not easy to catch but its happened to me 1 or 2 times
idk if kodi expect one single chapter change?

~tomorrow i will comment some code parts... to give some details on code changes~ done

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have lost 2 weeks of nights on this also because its a big mess from old messy implementations and things that from my part i find difficult to learn how works

i think however that what i have done here should be better of what was there before and after estenuants tests seem almost stable, at least without hard use of adaptive streaming quality switching (on my tests always: "Test" mode per 1 segment)

fix #1438

this will fix also subtitles segment problem of #1109
where subtitles was displayed only for the first segments only and then stopped

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For multiperiod/chapters/ads:
Live Pluto TV i cant post the master manifest m3u8 link because expire after hours, but can be found on network flow of:
https://pluto.tv/en/live-tv/

http://mcdn.daserste.de/daserste/de/master.m3u8 (also for subs, not always there are news/tvshow)

"Akmai local stream"

Other live, no chapters:
https://cdndai.pl/tvp1hd/index.m3u8 (sometime the server may temporary ban your IP for ~30minuts)

RAI:
#KODIPROP:inputstream.adaptive.live_delay=30
https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
