### PR TITLE
[ChooserManualOSD] Fix wrong resolution

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -216,10 +216,9 @@ bool CSession::Initialize()
   }
 
   m_adaptiveTree->PostOpen();
-
-  bool isPeriodInit = InitializePeriod(isSessionOpened);
   m_reprChooser->PostInit();
-  return isPeriodInit;
+
+  return InitializePeriod(isSessionOpened);
 }
 
 void CSession::CheckHDCP()

--- a/src/common/Chooser.h
+++ b/src/common/Chooser.h
@@ -48,14 +48,14 @@ public:
 
   /*!
    * \brief Initialize the representation chooser.
-   *        (Variables like current screen resolution and
-   *        DRM data can be read only with PostInit callback)
+   *        (Variables like current screen resolution can be read only with PostInit callback)
    * \param m_kodiProps The Kodi properties
    */
   virtual void Initialize(const ADP::KODI_PROPS::ChooserProps& props) {}
 
   /*!
-   * \brief Post initialization, will be called after the session initialization
+   * \brief Post initialization, will be called after the manifest has been opened,
+   *        but the DRM is not initialized yet, when done it will be called SetSecureSession method.
    */
   virtual void PostInit() {}
 

--- a/src/common/ChooserManualOSD.cpp
+++ b/src/common/ChooserManualOSD.cpp
@@ -66,6 +66,12 @@ void CRepresentationChooserManualOSD::RefreshResolution()
   }
 }
 
+void CRepresentationChooserManualOSD::SetSecureSession(const bool isSecureSession)
+{
+  m_isSecureSession = isSecureSession;
+  RefreshResolution();
+}
+
 void CRepresentationChooserManualOSD::PostInit()
 {
   RefreshResolution();

--- a/src/common/ChooserManualOSD.h
+++ b/src/common/ChooserManualOSD.h
@@ -25,7 +25,7 @@ public:
   ~CRepresentationChooserManualOSD() override {}
 
   virtual void Initialize(const ADP::KODI_PROPS::ChooserProps& props) override;
-
+  virtual void SetSecureSession(const bool isSecureSession) override;
   virtual void PostInit() override;
 
   virtual StreamSelection GetStreamSelectionMode() override { return m_streamSelectionMode; }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Since PostInit was done after the period initialization the representation chooser has no screen resolution set and so when GetNextRepresentation was called (inside the period init) will result in a wrong default video resolution (the lowest quality)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #1460 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
