### PR TITLE
[widevine] Fix bad data pointer on clrb_out variable

### DIFF
--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -823,12 +823,10 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
       //check NAL / subsample
       const AP4_Byte *packetIn(dataIn.GetData()),
           *packetInEnd(dataIn.GetData() + dataIn.GetDataSize());
-      AP4_UI16* clrb_out(
-          iv ? reinterpret_cast<AP4_UI16*>(dataOut.UseData() + sizeof(subsampleCount))
-             : nullptr); // is there a use for this?
-      size_t nalUnitCount = 0; // is there a use for this?
+      unsigned int clrbPos = sizeof(subsampleCount);
+      // size_t nalUnitCount = 0; // is there a use for this?
       size_t nalUnitSum = 0;
-      size_t configSize = 0; // is there a use for this?
+      // size_t configSize = 0; // is there a use for this?
 
       while (packetIn < packetInEnd)
       {
@@ -843,20 +841,28 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
         {
           dataOut.AppendData(fragInfo.m_annexbSpsPps.GetData(),
                              fragInfo.m_annexbSpsPps.GetDataSize());
-          if (clrb_out)
+          if (iv)
+          {
+            AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrbPos);
             *clrb_out += fragInfo.m_annexbSpsPps.GetDataSize();
-          configSize = fragInfo.m_annexbSpsPps.GetDataSize();
+          }
+          
+          // configSize = fragInfo.m_annexbSpsPps.GetDataSize();
           fragInfo.m_annexbSpsPps.SetDataSize(0);
         }
-
         // Annex-B Start pos
         static AP4_Byte annexbStartCode[4] = {0x00, 0x00, 0x00, 0x01};
         dataOut.AppendData(annexbStartCode, 4);
         dataOut.AppendData(packetIn, nalSize);
         packetIn += nalSize;
-        if (clrb_out)
+        
+        if (iv)
+        {
+          AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrbPos);
           *clrb_out += (4 - fragInfo.m_nalLengthSize);
-        ++nalUnitCount;
+        }
+        
+        // ++nalUnitCount;
 
         if (!iv)
         {
@@ -871,7 +877,7 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
             summedBytes += *bytesOfCleartextData + *bytesOfEncryptedData;
             ++bytesOfCleartextData;
             ++bytesOfEncryptedData;
-            ++clrb_out;
+            ++clrbPos;
             --subsampleCount;
           } while (subsampleCount && nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes);
 

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -811,12 +811,10 @@ AP4_Result CWVCencSingleSampleDecrypterA::DecryptSampleData(AP4_UI32 poolId,
       //check NAL / subsample
       const AP4_Byte* packetIn(dataIn.GetData());
       const AP4_Byte* packetInEnd(dataIn.GetData() + dataIn.GetDataSize());
-      AP4_UI16* clrb_out(
-          iv ? reinterpret_cast<AP4_UI16*>(dataOut.UseData() + sizeof(subsampleCount))
-             : nullptr); //! @todo: what is the point of this?
-      size_t nalUnitCount = 0; //! @todo: what is the point of this?
+      unsigned int clrbPos = sizeof(subsampleCount);
+      // size_t nalUnitCount = 0; //! @todo: what is the point of this?
       size_t nalUnitSum = 0;
-      size_t configSize = 0; //! @todo:what is the point of this?
+      // size_t configSize = 0; //! @todo:what is the point of this?
 
       while (packetIn < packetInEnd)
       {
@@ -831,9 +829,12 @@ AP4_Result CWVCencSingleSampleDecrypterA::DecryptSampleData(AP4_UI32 poolId,
         {
           dataOut.AppendData(fragInfo.m_annexbSpsPps.GetData(),
                              fragInfo.m_annexbSpsPps.GetDataSize());
-          if (clrb_out)
+          if (iv)
+          {
+            AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrbPos);
             *clrb_out += fragInfo.m_annexbSpsPps.GetDataSize();
-          configSize = fragInfo.m_annexbSpsPps.GetDataSize();
+          }
+          // configSize = fragInfo.m_annexbSpsPps.GetDataSize();
           fragInfo.m_annexbSpsPps.SetDataSize(0);
         }
 
@@ -842,9 +843,14 @@ AP4_Result CWVCencSingleSampleDecrypterA::DecryptSampleData(AP4_UI32 poolId,
         dataOut.AppendData(annexbStartCode, 4);
         dataOut.AppendData(packetIn, nalsize);
         packetIn += nalsize;
-        if (clrb_out)
+
+        if (iv)
+        {
+          AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrbPos);
           *clrb_out += (4 - fragInfo.m_nalLengthSize);
-        ++nalUnitCount;
+        }
+        
+        // ++nalUnitCount;
 
         if (!iv)
         {
@@ -859,7 +865,7 @@ AP4_Result CWVCencSingleSampleDecrypterA::DecryptSampleData(AP4_UI32 poolId,
             summedBytes += *bytesOfCleartextData + *bytesOfEncryptedData;
             ++bytesOfCleartextData;
             ++bytesOfEncryptedData;
-            ++clrb_out;
+            ++clrbPos;
             --subsampleCount;
           } while (subsampleCount && nalsize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Premise, i havent understood the data target format of `dataOut`
this prevents me from understanding how the data should be composed/constructed in to dataOut

from my investigations i found that:
dataOut.UseData() was used to get and store current data pointer but after that, many times is used "AppendData",
this method before append data check if the internal buffer of AP4_DataBuffer is enough to store data if not re-create the internal buffer, and so the data pointer before stored (to `clrb_out`) will point to a bad memory address causing the segmentation fault crash

NOTE: the crash affect most of times aarch64/ARM64 cpu's, other systems looks like problem remains hidden maybe due to system optimization the "old" memory address still working

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1394
fix #1452

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested am@zon VOD videos episodes on:
CoreElec with aarch64 cpu
Android nvidia shield pro
Windows

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
