### PR TITLE
[Widevine] Fix wrong byte position of clearbytes data array

### DIFF
--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -190,6 +190,9 @@ void CWVCencSingleSampleDecrypterA::GetCapabilities(std::string_view keyId,
   if (caps.hdcpLimit == 0)
     caps.hdcpLimit = m_resolutionLimit;
 
+  // Note: Currently we check for L1 only, Kodi core at later time check if secure decoder is needed
+  // by using requiresSecureDecoderComponent method of MediaDrm API
+  // https://github.com/xbmc/xbmc/blob/Nexus/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp#L639-L641
   if (m_mediaDrm.GetMediaDrm()->getPropertyString("securityLevel") == "L1")
   {
     caps.hdcpLimit = m_resolutionLimit; //No restriction


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Previous PR #1464 has fixed the the segmentation fault crash
but has introduced a wrong byte position when moved to the next subsample
and so was writing the data size of subsample in a wrong data position

the old code was using: `AP4_UI16* clrb_out` notice the AP4_UI16 data type of 2 bytes
the new code of previous PR instead save the byte position by using `unsigned int` (4 bytes but dosnt matter because now its not a pointer) and so when we move to the next byte by using ++ `++clrb_out` 
the data is moved with different byte positions raising the playback decoding problem

~not full tested yet~

tests:
- [x] android armv7: la7 and drm stream provided by user
- [x] android arm64: am@zon
- [x] windows: am@zon and drm stream provided by user

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1473 
fix #1468

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
