### PR TITLE
[DashTree] Cleanups and fixes

### DIFF
--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -215,3 +215,25 @@ CAdaptationSet* PLAYLIST::CAdaptationSet::FindMergeable(
 
   return nullptr;
 }
+
+PLAYLIST::CAdaptationSet* PLAYLIST::CAdaptationSet::FindByStreamType(
+    std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, StreamType type)
+{
+  auto itAdpSet = std::find_if(adpSets.cbegin(), adpSets.cend(),
+                               [&type](const std::unique_ptr<CAdaptationSet>& item)
+                               { return item->GetStreamType() == type; });
+  if (itAdpSet != adpSets.cend())
+    return (*itAdpSet).get();
+
+  return nullptr;
+}
+
+PLAYLIST::CAdaptationSet* PLAYLIST::CAdaptationSet::FindByFirstAVStream(
+  std::vector<std::unique_ptr<CAdaptationSet>>& adpSets)
+{
+  CAdaptationSet* adp = CAdaptationSet::FindByStreamType(adpSets, StreamType::VIDEO);
+  if (!adp)
+    adp = CAdaptationSet::FindByStreamType(adpSets, StreamType::AUDIO);
+
+  return adp;
+}

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -85,10 +85,17 @@ public:
   CSpinCache<uint32_t>& SegmentTimelineDuration() { return m_segmentTimelineDuration; }
   bool HasSegmentTimelineDuration() { return !m_segmentTimelineDuration.IsEmpty(); }
 
-  std::optional<CSegmentTemplate>& GetSegmentTemplate() { return m_segmentTemplate; }
-  std::optional<CSegmentTemplate> GetSegmentTemplate() const { return m_segmentTemplate; }
-  void SetSegmentTemplate(const CSegmentTemplate& segTemplate) { m_segmentTemplate = segTemplate; }
-  bool HasSegmentTemplate() const { return m_segmentTemplate.has_value(); }
+  /*!
+   * \brief Get the timescale of segment durations tag.
+   * \return The timescale value if set, otherwise NO_VALUE.
+   */
+  uint64_t GetSegDurationsTimescale() const { return m_segDurationsTimescale; }
+
+  /*!
+   * \brief Set the timescale of segment durations tag.
+   * \param timescale The timescale value.
+   */
+  void SetSegDurationsTimescale(const uint64_t timescale) { m_segDurationsTimescale = timescale; }
 
   void AddRepresentation(std::unique_ptr<CRepresentation>& representation);
   std::vector<std::unique_ptr<CRepresentation>>& GetRepresentations() { return m_representations; }
@@ -139,6 +146,22 @@ public:
   static CAdaptationSet* FindMergeable(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
                                        CAdaptationSet* adpSet);
 
+  /*!
+   * \brief Try find the first adpSet of specified type.
+   * \param adpSets The adaptation set list where to search
+   * \param type The type to search
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindByStreamType(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                                          StreamType type);
+
+  /*!
+   * \brief Try find the first video adpSet, if not found, try find the first audio adpSet.
+   * \param adpSets The adaptation set list where to search
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindByFirstAVStream(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets);
+
 protected:
   std::vector<std::unique_ptr<CRepresentation>> m_representations;
 
@@ -157,8 +180,7 @@ protected:
   std::vector<std::string> m_switchingIds;
 
   CSpinCache<uint32_t> m_segmentTimelineDuration;
-
-  std::optional<CSegmentTemplate> m_segmentTemplate;
+  uint64_t m_segDurationsTimescale{NO_VALUE};
 
   // Custom ISAdaptive attributes (used on DASH only)
   bool m_isImpaired{false};

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -68,7 +68,7 @@ public:
   std::string base_url_;
   
   std::optional<uint32_t> initial_sequence_; // HLS only
-  uint64_t m_totalTimeSecs{0}; // Total playing time in seconds
+  uint64_t m_totalTimeSecs{0}; // Total playing time in seconds (can include all periods/chapters or timeshift)
   uint64_t stream_start_{0};
   uint64_t available_time_{0};
   uint64_t m_liveDelay{0}; // Apply a delay in seconds from the live edge

--- a/src/common/CommonSegAttribs.cpp
+++ b/src/common/CommonSegAttribs.cpp
@@ -15,22 +15,6 @@ PLAYLIST::CCommonSegAttribs::CCommonSegAttribs(CCommonSegAttribs* parent /* = nu
   m_parentCommonSegAttribs = parent;
 }
 
-std::optional<CSegmentList>& PLAYLIST::CCommonSegAttribs::GetSegmentList()
-{
-  if (m_segmentList.has_value())
-    return m_segmentList;
-  if (m_parentCommonSegAttribs && m_parentCommonSegAttribs->m_segmentList.has_value())
-    return m_parentCommonSegAttribs->m_segmentList;
-
-  return m_segmentList; // Empty data
-}
-
-bool PLAYLIST::CCommonSegAttribs::HasSegmentList()
-{
-  return m_segmentList.has_value() ||
-         (m_parentCommonSegAttribs && m_parentCommonSegAttribs->m_segmentList.has_value());
-}
-
 uint64_t PLAYLIST::CCommonSegAttribs::GetSegmentEndNr()
 {
   if (m_segEndNr.has_value())

--- a/src/common/CommonSegAttribs.h
+++ b/src/common/CommonSegAttribs.h
@@ -8,23 +8,29 @@
 
 #pragma once
 
+#include "SegTemplate.h"
 #include "SegmentList.h"
 
 #include <optional>
 
 namespace PLAYLIST
 {
-// CCommonSegAttribs class provide attribute data
-// of class itself or when not set of the parent class (if any).
+// This class provide common place for shared members/methods
+// with the possibility to retrieve the value from the parent class, when needed.
 class ATTR_DLL_LOCAL CCommonSegAttribs
 {
 public:
   CCommonSegAttribs(CCommonSegAttribs* parent = nullptr);
   virtual ~CCommonSegAttribs() {}
 
-  std::optional<CSegmentList>& GetSegmentList();
+  std::optional<CSegmentList>& GetSegmentList() { return m_segmentList; }
   void SetSegmentList(const CSegmentList& segmentList) { m_segmentList = segmentList; }
-  bool HasSegmentList();
+  bool HasSegmentList() { return m_segmentList.has_value(); }
+
+  std::optional<CSegmentTemplate>& GetSegmentTemplate() { return m_segmentTemplate; }
+  std::optional<CSegmentTemplate> GetSegmentTemplate() const { return m_segmentTemplate; }
+  void SetSegmentTemplate(const CSegmentTemplate& segTemplate) { m_segmentTemplate = segTemplate; }
+  bool HasSegmentTemplate() const { return m_segmentTemplate.has_value(); }
 
   /*!
    * \brief Get the optional segment end number. Use HasSegmentEndNr method to know if the value is set.
@@ -37,6 +43,7 @@ public:
 protected:
   CCommonSegAttribs* m_parentCommonSegAttribs{nullptr};
   std::optional<CSegmentList> m_segmentList;
+  std::optional<CSegmentTemplate> m_segmentTemplate;
   std::optional<uint64_t> m_segEndNr;
 };
 

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -43,24 +43,45 @@ public:
   std::string GetBaseUrl() const { return m_baseUrl; }
   void SetBaseUrl(std::string_view baseUrl) { m_baseUrl = baseUrl; }
 
-  //! @todo: SetTimescale can be set/updated by period, adaptationSet and/or representation
-  //! maybe is possible improve how are updated these variables in a better way
-  uint32_t GetTimescale() const { return m_timescale; }
-  void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
-
   uint32_t GetSequence() const { return m_sequence; }
   void SetSequence(uint32_t sequence) { m_sequence = sequence; }
 
+  /*!
+   * \brief Get the start time, in ms.
+   * \return The start time value, otherwise NO_VALUE if not set.
+   */
   uint64_t GetStart() const { return m_start; }
+
+  /*!
+   * \brief Set the start time, in ms.
+   */
   void SetStart(uint64_t start) { m_start = start; }
 
   uint64_t GetStartPTS() const { return m_startPts; }
   void SetStartPTS(uint64_t startPts) { m_startPts = startPts; }
-  
-  // Could be set also by adaptation set or representation (in ms)
+
+  /*!
+   * \brief Get the duration, in timescale units.
+   * \return The duration value.
+   */
   uint64_t GetDuration() const { return m_duration; }
+
+  /*!
+   * \brief Set the duration, in timescale units.
+   */
   void SetDuration(uint64_t duration) { m_duration = duration; }
   
+  /*!
+   * \brief Get the timescale unit.
+   * \return The timescale unit, if not set default value is 1000.
+   */
+  uint32_t GetTimescale() const { return m_timescale; }
+
+  /*!
+   * \brief Set the timescale unit.
+   */
+  void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
+
   EncryptionState GetEncryptionState() const { return m_encryptionState; }
   void SetEncryptionState(EncryptionState encryptState) { m_encryptionState = encryptState; }
 
@@ -73,11 +94,6 @@ public:
 
   CSpinCache<uint32_t>& SegmentTimelineDuration() { return m_segmentTimelineDuration; }
   bool HasSegmentTimelineDuration() { return !m_segmentTimelineDuration.IsEmpty(); }
-
-  std::optional<CSegmentTemplate>& GetSegmentTemplate() { return m_segmentTemplate; }
-  std::optional<CSegmentTemplate> GetSegmentTemplate() const { return m_segmentTemplate; }
-  void SetSegmentTemplate(const CSegmentTemplate& segTemplate) { m_segmentTemplate = segTemplate; }
-  bool HasSegmentTemplate() const { return m_segmentTemplate.has_value(); }
 
   void CopyHLSData(const CPeriod* other);
 
@@ -126,13 +142,12 @@ protected:
   std::string m_baseUrl;
   uint32_t m_timescale{1000};
   uint32_t m_sequence{0};
-  uint64_t m_start{0};
+  uint64_t m_start{NO_VALUE};
   uint64_t m_startPts{0};
   uint64_t m_duration{0};
   EncryptionState m_encryptionState{EncryptionState::UNENCRYPTED};
   bool m_isSecureDecoderNeeded{false};
   CSpinCache<uint32_t> m_segmentTimelineDuration;
-  std::optional<CSegmentTemplate> m_segmentTemplate;
 };
 
 } // namespace adaptive

--- a/src/common/Representation.cpp
+++ b/src/common/Representation.cpp
@@ -10,6 +10,8 @@
 
 #include "utils/StringUtils.h"
 
+#include <kodi/addon-instance/inputstream/TimingConstants.h>
+
 using namespace PLAYLIST;
 using namespace UTILS;
 
@@ -49,4 +51,27 @@ void PLAYLIST::CRepresentation::CopyHLSData(const CRepresentation* other)
   m_isEnabled = other->m_isEnabled;
   m_isWaitForSegment = other->m_isWaitForSegment;
   m_initSegment = other->m_initSegment;
+}
+
+void PLAYLIST::CRepresentation::SetScaling()
+{
+  if (!m_timescale)
+  {
+    timescale_ext_ = timescale_int_ = 1;
+    return;
+  }
+
+  timescale_ext_ = STREAM_TIME_BASE;
+  timescale_int_ = m_timescale;
+
+  while (timescale_ext_ > 1)
+  {
+    if ((timescale_int_ / 10) * 10 == timescale_int_)
+    {
+      timescale_ext_ /= 10;
+      timescale_int_ /= 10;
+    }
+    else
+      break;
+  }
 }

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -107,23 +107,34 @@ public:
   CSpinCache<CSegment> SegmentTimeline() const { return m_segmentTimeline; }
   bool HasSegmentTimeline() { return !m_segmentTimeline.IsEmpty(); }
 
-  std::optional<CSegmentTemplate>& GetSegmentTemplate() { return m_segmentTemplate; }
-  std::optional<CSegmentTemplate> GetSegmentTemplate() const { return m_segmentTemplate; }
-  void SetSegmentTemplate(const CSegmentTemplate& segTemplate) { m_segmentTemplate = segTemplate; }
-  bool HasSegmentTemplate() const { return m_segmentTemplate.has_value(); }
-
   std::optional<CSegmentBase>& GetSegmentBase() { return m_segmentBase; }
   void SetSegmentBase(const CSegmentBase& segBase) { m_segmentBase = segBase; }
   bool HasSegmentBase() const { return m_segmentBase.has_value(); }
 
-  uint32_t GetTimescale() const { return m_timescale; }
-  void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
-
   uint64_t GetStartNumber() const { return m_startNumber; }
   void SetStartNumber(uint64_t startNumber) { m_startNumber = startNumber; }
 
+  /*!
+   * \brief Get the duration, in timescale units.
+   * \return The duration value.
+   */
   uint64_t GetDuration() const { return m_duration; }
+
+  /*!
+   * \brief Set the duration, in timescale units.
+   */
   void SetDuration(uint64_t duration) { m_duration = duration; }
+
+  /*!
+   * \brief Get the timescale unit.
+   * \return The timescale unit, otherwise 0 if not set.
+   */
+  uint32_t GetTimescale() const { return m_timescale; }
+
+  /*!
+   * \brief Set the timescale unit.
+   */
+  void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
 
   /*!
    * \brief Determines when the representation contains subtitles as single file
@@ -225,28 +236,7 @@ public:
   uint32_t timescale_ext_{0};
   uint32_t timescale_int_{0};
 
-  void SetScaling()
-  {
-    if (!m_timescale)
-    {
-      timescale_ext_ = timescale_int_ = 1;
-      return;
-    }
-
-    timescale_ext_ = 1000000;
-    timescale_int_ = m_timescale;
-
-    while (timescale_ext_ > 1)
-    {
-      if ((timescale_int_ / 10) * 10 == timescale_int_)
-      {
-        timescale_ext_ /= 10;
-        timescale_int_ /= 10;
-      }
-      else
-        break;
-    }
-  }
+  void SetScaling();
 
   std::chrono::time_point<std::chrono::system_clock> repLastUpdated_;
 
@@ -269,7 +259,6 @@ protected:
 
   uint16_t m_hdcpVersion{0}; // 0 if not set
 
-  std::optional<CSegmentTemplate> m_segmentTemplate;
   std::optional<CSegmentBase> m_segmentBase;
   std::optional<CSegment> m_initSegment;
 

--- a/src/common/SegTemplate.cpp
+++ b/src/common/SegTemplate.cpp
@@ -19,18 +19,16 @@ using namespace PLAYLIST;
 using namespace UTILS;
 using namespace kodi::tools;
 
-PLAYLIST::CSegmentTemplate::CSegmentTemplate(CSegmentTemplate* parent /* = nullptr */)
+PLAYLIST::CSegmentTemplate::CSegmentTemplate(const std::optional<CSegmentTemplate>& other)
 {
-  m_parentSegTemplate = parent;
+  if (other.has_value())
+    *this = *other;
 }
 
 std::string PLAYLIST::CSegmentTemplate::GetInitialization() const
 {
   if (!m_initialization.empty())
     return m_initialization;
-
-  if (m_parentSegTemplate)
-    return m_parentSegTemplate->GetInitialization();
 
   return ""; // Default value
 }
@@ -40,9 +38,6 @@ std::string PLAYLIST::CSegmentTemplate::GetMedia() const
   if (!m_media.empty())
     return m_media;
 
-  if (m_parentSegTemplate)
-    return m_parentSegTemplate->GetMedia();
-
   return ""; // Default value
 }
 
@@ -50,9 +45,6 @@ uint32_t PLAYLIST::CSegmentTemplate::GetTimescale() const
 {
   if (m_timescale.has_value())
     return *m_timescale;
-
-  if (m_parentSegTemplate)
-    return m_parentSegTemplate->GetTimescale();
 
   return 0; // Default value
 }
@@ -62,9 +54,6 @@ uint32_t PLAYLIST::CSegmentTemplate::GetDuration() const
   if (m_duration.has_value())
     return *m_duration;
 
-  if (m_parentSegTemplate)
-    return m_parentSegTemplate->GetDuration();
-
   return 0; // Default value
 }
 
@@ -73,9 +62,6 @@ uint64_t PLAYLIST::CSegmentTemplate::GetStartNumber() const
   if (m_startNumber.has_value())
     return *m_startNumber;
 
-  if (m_parentSegTemplate)
-    return m_parentSegTemplate->GetStartNumber();
-
   return 1; // Default value
 }
 
@@ -83,9 +69,6 @@ uint64_t PLAYLIST::CSegmentTemplate::GetEndNumber() const
 {
   if (m_endNumber.has_value())
     return *m_endNumber;
-
-  if (m_parentSegTemplate)
-    return m_parentSegTemplate->GetEndNumber();
 
   return 0; // Default value
 }

--- a/src/common/SegTemplate.h
+++ b/src/common/SegTemplate.h
@@ -28,8 +28,9 @@ class CSegment;
 class ATTR_DLL_LOCAL CSegmentTemplate
 {
 public:
-  CSegmentTemplate(CSegmentTemplate* parent = nullptr);
-  ~CSegmentTemplate() {}
+  CSegmentTemplate() = default;
+  CSegmentTemplate(const std::optional<CSegmentTemplate>& other);
+  ~CSegmentTemplate() = default;
 
   std::string GetInitialization() const;
   void SetInitialization(std::string_view init) { m_initialization = init; }
@@ -75,8 +76,6 @@ private:
   std::optional<uint32_t> m_duration;
   std::optional<uint64_t> m_startNumber;
   std::optional<uint64_t> m_endNumber;
-
-  CSegmentTemplate* m_parentSegTemplate{nullptr};
 };
 
 } // namespace PLAYLIST

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -39,7 +39,7 @@ public:
   uint64_t m_duration = 0; // If available gives the media duration of a segment (depends on type of stream e.g. HLS)
   uint16_t pssh_set_ = PSSHSET_POS_DEFAULT;
 
-  uint64_t m_time{0};
+  uint64_t m_time{0}; // The start time, in timescale units
   uint64_t m_number{0};
 
   /*!

--- a/src/common/SegmentList.cpp
+++ b/src/common/SegmentList.cpp
@@ -11,32 +11,10 @@
 
 using namespace PLAYLIST;
 
-uint64_t PLAYLIST::CSegmentList::GetStartNumber() const
+PLAYLIST::CSegmentList::CSegmentList(const std::optional<CSegmentList>& other)
 {
-  if (m_startNumber > 0 || !m_parentSegList)
-    return m_startNumber;
-  return m_parentSegList->GetStartNumber();
-}
-
-uint64_t PLAYLIST::CSegmentList::GetDuration() const
-{
-  if (m_duration > 0 || !m_parentSegList)
-    return m_duration;
-  return m_parentSegList->GetDuration();
-}
-
-uint32_t PLAYLIST::CSegmentList::GetTimescale() const
-{
-  if (m_timescale > 0 || !m_parentSegList)
-    return m_timescale;
-  return m_parentSegList->GetTimescale();
-}
-
-uint64_t PLAYLIST::CSegmentList::GetPresTimeOffset() const
-{
-  if (m_ptsOffset > 0 || !m_parentSegList)
-    return m_ptsOffset;
-  return m_parentSegList->GetPresTimeOffset();
+  if (other.has_value())
+    *this = *other;
 }
 
 void PLAYLIST::CSegmentList::SetInitRange(std::string_view range)

--- a/src/common/SegmentList.h
+++ b/src/common/SegmentList.h
@@ -16,6 +16,7 @@
 #include <kodi/AddonBase.h>
 #endif
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -27,19 +28,20 @@ class CSegment;
 class ATTR_DLL_LOCAL CSegmentList
 {
 public:
-  CSegmentList(CSegmentList* parent = nullptr) { m_parentSegList = parent; }
-  ~CSegmentList() {}
+  CSegmentList() = default;
+  CSegmentList(const std::optional<CSegmentList>& other);
+  ~CSegmentList() = default;
 
-  uint64_t GetStartNumber() const;
+  uint64_t GetStartNumber() const { return m_startNumber; }
   void SetStartNumber(uint64_t startNumber) { m_startNumber = startNumber; }
 
-  uint64_t GetDuration() const;
+  uint64_t GetDuration() const { return m_duration; }
   void SetDuration(uint64_t duration) { m_duration = duration; }
 
-  uint32_t GetTimescale() const;
+  uint32_t GetTimescale() const { return m_timescale; }
   void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
 
-  uint64_t GetPresTimeOffset() const;
+  uint64_t GetPresTimeOffset() const { return m_ptsOffset; }
   void SetPresTimeOffset(uint64_t ptsOffset) { m_ptsOffset = ptsOffset; }
 
   void SetInitSourceUrl(std::string_view url) { m_initSourceUrl = url; }
@@ -56,8 +58,6 @@ private:
   uint64_t m_initRangeBegin = NO_VALUE;
   uint64_t m_initRangeEnd = NO_VALUE;
   std::string m_initSourceUrl;
-
-  CSegmentList* m_parentSegList{nullptr};
 };
 
 } // namespace adaptive

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -65,9 +65,7 @@ protected:
                                    uint32_t timescale = 1000);
   uint64_t ParseTagSegmentTimeline(pugi::xml_node nodeSegTL,
                                    PLAYLIST::CSpinCache<PLAYLIST::CSegment>& SCTimeline,
-                                   uint32_t timescale = 1000,
-                                   uint64_t totalTimeSecs = 0,
-                                   PLAYLIST::CSegmentTemplate* segTemplate = nullptr);
+                                   PLAYLIST::CSegmentTemplate& segTemplate);
 
   void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate* segTpl);
 
@@ -80,9 +78,9 @@ protected:
   uint32_t ParseAudioChannelConfig(pugi::xml_node node);
 
   /*
-   * \brief Estimate the count of segments on the period duration
+   * \brief Try estimate the count of segments on the MPD duration
    */
-  size_t EstimateSegmentsCount(uint64_t duration, uint32_t timescale, uint64_t totalTimeSecs = 0);
+  size_t EstimateSegmentsCount(uint64_t duration, uint32_t timescale) const;
 
   void MergeAdpSets();
 
@@ -114,6 +112,9 @@ protected:
 
   // Period sequence incremented to every new period added
   uint32_t m_periodCurrentSeq{0};
+
+  double m_timeShiftBufferDepth{0}; // MPD Timeshift buffer attribute value, in seconds
+  double m_mediaPresDuration{0}; // MPD Media presentation duration attribute value, in seconds (may be not provided)
 
   uint64_t m_minimumUpdatePeriod{0}; // in seconds
   bool m_allowInsertLiveSegments{false};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
With this PR im doing various types of cleanups and fixes
discovered while i was investigating for a fix for the live streaming that stops/freeze after some time
so this is one of the middle steps for future fixes

my problem is started with this "sanitize"
https://github.com/xbmc/inputstream.adaptive/blob/87d90d5416b45108c88c86eb7f7562d7e236be65/src/parser/DASHTree.cpp#L1128-L1132
it is done while parsing representation, so the first representation parsing set the values "win" (also without take in account if it is video/audio or subtitles, maybe its not so important but im not full sure)
the problem is that there are parsing code that use `period->GetDuration` method on various parsing points and this lead to unexpected/malformed parsed data of subsequent representations parsing,
moreover there are use of `period->SetDuration`/`period->SetTimescale` on different parsing points
with confused behaviour where the first or the last one that set the value from parsing "win"...

Recap changes:
- The use of `period->SetDuration`/`period->SetTimescale` now is done only in two cases, 1) when the "Period" tag provide "duration" attrib, and after whole manifest parsing see last code step of `CDashTree::ParseManifest`
- As first point, no more dispersive unclear use of `period->SetDuration`/`period->SetTimescale`
- Fix wrong behaviour of `SegmentList` tag parsing, where was setting the duration of a single segment in the period duration
- Cleanup of "Generate timeline segments" code in the `ParseTagRepresentation` method
- Add in the "Generate timeline segments" code a fallback to the segment duration when we cannot determine the representation duration, this is a first step to fix #731
- Removed parent pointer reference in the `CSegmentTemplate` class, now semplified code by making copy of var between period/adpset/repr
- Removed parent pointer reference in the `CSegmentList` class
- In the Period class SetStart/GetStart now have the default value of NO_VALUE, this allow to distinguish when the manifest provide the value or not, and so related cleanups
- Handled in the  `SegmentDurations` tag possible different `timescale` attrib value by rescaling the segment duration, if required
- Add note todo note in to `SegmentList` tag parsing in the representation parsing, to make evidence of a bug about `SetPresTimeOffset` use
- Semplified `EstimateSegmentsCount` method doesnt matter much if dont always provide a good segment count
- `GetSegmentTemplate`/`SetSegmentTemplate`/`HasSegmentTemplate `methods of period/adpset/repr classes has been moved in to `CCommonSegAttribs`, only a cleanup to avoid multiple same methods between classes
- Limited the use of `m_totalTimeSecs`, and also now the value is set from the `ParseManifest` method, same behavior but can be better handled in case of missing "duration" values
- Other little cleanups

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
a step for future live streams fixes

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested by playing dash with multiperiods and single period

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
