### PR TITLE
[DashTree] Fix setting default AdaptationSet using ISA specific default attribute

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -465,7 +465,7 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
 
   std::string isDefault;
   if (XML::QueryAttrib(nodeAdp, "default", isDefault)) // ISA custom attribute
-    adpSet->SetIsOriginal(isDefault == "true");
+    adpSet->SetIsDefault(isDefault == "true");
 
   // Parse <AudioChannelConfiguration> child tag
   xml_node nodeAudioCh = nodeAdp.child("AudioChannelConfiguration");


### PR DESCRIPTION
## Description
Fix what is possibly a typo, to allow setting an AdaptationSet as default using the corresponding ISA specific `default` attribute

## Motivation and context
It is not otherwise possible to set a default AdaptationSet without changing its role to `main`, which is not appropriate for subtitles.

## How has this been tested?
Sorry don't have a build environment, so this hasn't been tested at all.

I have marked this as a breaking change, because I am not sure how this attribute is commonly used, but this should provide what I think is the expected functionality of this attribute.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
