### PR TITLE
[DashTree] Fix live streaming video freeze/buffering

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1406,7 +1406,7 @@ bool CSession::SeekChapter(int ch)
   {
     CPeriod* nextPeriod = m_adaptiveTree->m_periods[ch].get();
     m_adaptiveTree->m_nextPeriod = nextPeriod;
-    LOG::LogF(LOGDEBUG, "Switching to new Period (id=%s, start=%ld, seq=%d)",
+    LOG::LogF(LOGDEBUG, "Switching to new Period (id=%s, start=%llu, seq=%u)",
               nextPeriod->GetId().data(), nextPeriod->GetStart(), nextPeriod->GetSequence());
 
     for (auto& stream : m_streams)

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -472,9 +472,6 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
       rep->SetTimescale(1000);
       rep->SetScaling();
 
-      rep->SegmentTimeline().GetData().reserve(cuepoints.size());
-      adpSet->SegmentTimelineDuration().GetData().reserve(cuepoints.size());
-
       for (const WebmReader::CUEPOINT& cue : cuepoints)
       {
         seg.startPTS_ = cue.pts;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -72,7 +72,7 @@ public:
   uint64_t stream_start_{0};
   uint64_t available_time_{0};
   uint64_t m_liveDelay{0}; // Apply a delay in seconds from the live edge
-  
+
   std::string m_supportedKeySystem;
   std::string location_;
 

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -185,19 +185,31 @@ public:
   void SetInitSegment(CSegment initSegment) { m_initSegment = initSegment; }
   std::optional<CSegment>& GetInitSegment() { return m_initSegment; }
 
-
+  /*!
+   * \brief Get the next segment after the one specified.
+   * \return If found the segment pointer, otherwise nullptr.
+   */
   CSegment* get_next_segment(const CSegment* seg)
   {
     if (!seg || seg->IsInitialization())
       return m_segmentTimeline.Get(0);
 
-    size_t nextPos{m_segmentTimeline.GetPosition(seg) + 1};
+    const size_t segPos = m_segmentTimeline.GetPosition(seg);
+
+    if (segPos == SEGMENT_NO_POS)
+      return nullptr;
+
+    size_t nextPos = segPos + 1;
     if (nextPos == m_segmentTimeline.GetSize())
       return nullptr;
 
     return m_segmentTimeline.Get(nextPos);
   }
 
+  /*!
+   * \brief Get the segment from specified position.
+   * \return If found the segment pointer, otherwise nullptr.
+   */
   CSegment* get_segment(size_t pos)
   {
     if (pos == SEGMENT_NO_POS)
@@ -206,6 +218,10 @@ public:
     return m_segmentTimeline.Get(pos);
   }
 
+  /*!
+   * \brief Get the segment position.
+   * \return If found the position, otherwise SEGMENT_NO_POS.
+   */
   const size_t get_segment_pos(const CSegment* segment) const
   {
     if (!segment)
@@ -214,22 +230,44 @@ public:
     return m_segmentTimeline.IsEmpty() ? 0 : m_segmentTimeline.GetPosition(segment);
   }
 
+  /*!
+   * \brief Get the position of current segment.
+   * \return If found the position, otherwise SEGMENT_NO_POS.
+   */
   const size_t getCurrentSegmentPos() const { return get_segment_pos(current_segment_); }
 
+  /*!
+   * \brief Get the segment number of current segment.
+   * \return If found the number, otherwise SEGMENT_NO_NUMBER.
+   */
   const uint64_t getCurrentSegmentNumber() const
   {
     if (!current_segment_)
       return SEGMENT_NO_NUMBER;
 
-    return static_cast<uint64_t>(get_segment_pos(current_segment_)) + m_startNumber;
+    const size_t segPos = get_segment_pos(current_segment_);
+
+    if (segPos == SEGMENT_NO_POS)
+      return SEGMENT_NO_NUMBER;
+
+    return static_cast<uint64_t>(segPos) + m_startNumber;
   }
 
+  /*!
+   * \brief Get the segment number of specified segment.
+   * \return If found the number, otherwise SEGMENT_NO_NUMBER.
+   */
   const uint64_t getSegmentNumber(const CSegment* segment) const
   {
     if (!segment)
       return SEGMENT_NO_NUMBER;
 
-    return static_cast<uint64_t>(get_segment_pos(segment)) + m_startNumber;
+    const size_t segPos = get_segment_pos(current_segment_);
+
+    if (segPos == SEGMENT_NO_POS)
+      return SEGMENT_NO_NUMBER;
+
+    return static_cast<uint64_t>(segPos) + m_startNumber;
   }
 
 

--- a/src/common/SegTemplate.h
+++ b/src/common/SegTemplate.h
@@ -43,6 +43,10 @@ public:
   uint32_t GetTimescale() const;
   void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
 
+  /*!
+   * \brief Get the duration, in timescale unit.
+   * \return The duration value.
+   */
   uint32_t GetDuration() const;
   void SetDuration(uint32_t duration) { m_duration = duration; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -421,6 +421,9 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
   // in the current period and its needed to switch to the next period
   if (m_session->SeekChapter(m_session->GetChapter() + 1))
   {
+    //! @todo: If a live stream make use of "insert live segments" and have also multiple periods/chapters
+    //! "insert live segments" prevents the period change, by always inserting segments this code will never be reached
+
     // Switched to new period / chapter
     m_checkChapterSeek = true;
     m_lastPts = PLAYLIST::NO_PTS_VALUE;

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -40,6 +40,8 @@ public:
                     const std::map<std::string, std::string>& headers,
                     const std::string& data) override;
 
+  virtual void PostOpen() override;
+
   virtual void InsertLiveSegment(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adpSet,
                                  PLAYLIST::CRepresentation* repr,
@@ -61,8 +63,7 @@ protected:
                               PLAYLIST::CPeriod* period);
 
   uint64_t ParseTagSegmentTimeline(pugi::xml_node parentNode,
-                                   PLAYLIST::CSpinCache<uint32_t>& SCTimeline,
-                                   uint32_t timescale = 1000);
+                                   PLAYLIST::CSpinCache<uint32_t>& SCTimeline);
   uint64_t ParseTagSegmentTimeline(pugi::xml_node nodeSegTL,
                                    PLAYLIST::CSpinCache<PLAYLIST::CSegment>& SCTimeline,
                                    PLAYLIST::CSegmentTemplate& segTemplate);
@@ -76,11 +77,6 @@ protected:
   bool ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 
   uint32_t ParseAudioChannelConfig(pugi::xml_node node);
-
-  /*
-   * \brief Try estimate the count of segments on the MPD duration
-   */
-  size_t EstimateSegmentsCount(uint64_t duration, uint32_t timescale) const;
 
   void MergeAdpSets();
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -194,9 +194,7 @@ void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
   // Default frequency 10000000 (10Khz)
   uint32_t timescale = XML::GetAttribUint32(nodeSI, "TimeScale", 10000000);
 
-  uint64_t chunks = XML::GetAttribUint32(nodeSI, "Chunks");
-  if (chunks > 0)
-    adpSet->SegmentTimelineDuration().GetData().reserve(static_cast<size_t>(chunks));
+  // uint64_t chunks = XML::GetAttribUint32(nodeSI, "Chunks");
 
   std::string_view url = XML::GetAttrib(nodeSI, "Url");
   if (!url.empty())
@@ -390,8 +388,6 @@ void adaptive::CSmoothTree::CreateSegmentTimeline()
     {
       for (auto& repr : adpSet->GetRepresentations())
       {
-        repr->SegmentTimeline().GetData().reserve(adpSet->SegmentTimelineDuration().GetSize());
-
         // Adjust PTS with the StreamIndex with lower PTS to sync streams during playback
         uint64_t nextStartPts = adpSet->GetStartPTS() - m_ptsBase;
         uint64_t index = 1;
@@ -421,7 +417,7 @@ void adaptive::CSmoothTree::InsertLiveSegment(PLAYLIST::CPeriod* period,
                                               uint64_t fragmentDuration,
                                               uint32_t mediaTimescale)
 {
-  if (!m_isLive)
+  if (!m_isLive || pos == SEGMENT_NO_POS)
     return;
 
   //! @todo: This old code is now wrong because InsertLiveSegment can be called many times
@@ -439,7 +435,7 @@ void adaptive::CSmoothTree::InsertLiveSegment(PLAYLIST::CPeriod* period,
     return;
   }
 
-  adpSet->SegmentTimelineDuration().Insert(
+  adpSet->SegmentTimelineDuration().Append(
       static_cast<std::uint32_t>(fragmentDuration * period->GetTimescale() / mediaTimescale));
 
   CSegment* segment = repr->SegmentTimeline().Get(pos);
@@ -467,6 +463,6 @@ void adaptive::CSmoothTree::InsertLiveSegment(PLAYLIST::CPeriod* period,
 
   for (auto& repr : adpSet->GetRepresentations())
   {
-    repr->SegmentTimeline().Insert(segCopy);
+    repr->SegmentTimeline().Append(segCopy);
   }
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Following PR try find a solution to solve the problem with many live dash streaming that currently stall/freeze/buffering

### CSpinCache problem
If i understand correctly CSpinCache.Insert() method overwrite the segments from the first TimeLine position.
Imo i find this a very weird thing to do, seem that has been done in this way as workaround because if you add new segments with emplace_back will produce dead pointers to all variables that store a pointer on these segments. But may be other reasons that currently im not aware, if so please someone specify them.

However my idea is to remove the `CSpinCache::Insert` method, and use a `std::deque` for `CSpinCache::m_data`, deque can keep items pointers with same addresses also when you add new elements to the container, the only downside is that you cant do "reserve" like the vector.

This will allow to have a correctly sequenced segments, and also you can compare segments with the MPD updates, if needed, since original segments are kept (despite not done atm, read below about the problem to compare CSegment's).

NOTE: To notice a different behavior than in the past (before the many parsers reworks or however Matrix/Nexus branch)
When you have a manifest like the one attached that make use of "insert live segment", the manifest update was not being executed for this reason problem did not occur

### CDashTree::RefreshLiveSegments problem
on RefreshLiveSegments the representation loop have two different conditions/behaviours:
`else if (updRepr->GetStartNumber() <= 1)`
and
```
else if (updRepr->GetStartNumber() > repr->GetStartNumber() ||
          (updRepr->GetStartNumber() == repr->GetStartNumber() &&
          updRepr->SegmentTimeline().GetSize() > repr->SegmentTimeline().GetSize()))
```
both have almost same code but not so clear why its splitted, however, this is not the big problem,
the problem is on the code within the first condition:
`else if (updRepr->GetStartNumber() <= 1)`

in the case we have live streaming that dont provide new segments on MPD update, we should "insert"/add segment manually, but when we fall here, there is no code that check if the MPD update provide new segments or not.

Now i dont know exaclty how to detect if new segments has been added in a manifest update, my current solution is this:
If StartNumber is not changed and the timeline segment has same number of segments between current MPD and updated MPD, then we have no new data on the updated MPD

but could exists better solutions that im not aware like compare each timeline segment from the MPD update,
but do this currently is not possible, CSegment.m_number cannot be used as comparer since include stream_start_ pts that change, and there are no other member data that can be used to compare, so should be needed add some kind of new value to CSegment but i have no a clear idea the right way to calculate it

**TODO:** "insert live segments" seem to prevent the chapter switching, below i linked two sample streams with this common problem, this problem will not addressed with this PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
there are many users complaining about MPD live streaming video freeze/buffering on differents addons
this try to address the problem

fix #1461
fix #1448 (freeze comment https://github.com/xbmc/inputstream.adaptive/pull/1479#issuecomment-1949242761) sample stream is the Widevine RU IPTV
fix #1432

should fix also:
#1406

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://mcdn.daserste.de/daserste/dash2/manifest.mpd (geolock germany)
https://livesim.dashif.org/livesim/ato_10/testpic_2s/Manifest.mpd
https://livesim2.dashif.org/livesim2/ato_10/testpic_2s/Manifest.mpd
https://livesim.dashif.org/livesim2/periods_20/testpic_2s/Manifest.mpd (this sample stream "insert segments" seem to prevent the chapter switching)
Widevine RU IPTV, i dont attach here to keep safe user data
Facebook live, where should not "insert live segments" (mpd on website network flow)

_Following live stream, make use of manifest update + seem to require also "insert segments" (!? not full sure) and so mixes both things, moreover it make use of multiple periods, i think its a good test case for future fixes:_
https://d3cglye48cl6m2.cloudfront.net/out/v1/563ec3e9487340528616d736e1202232/index.mpd
Currently this stream seem to works more or less, but two main problems :
- problem on period change, "insert segments" seem to prevent the chapter switching (https://github.com/xbmc/inputstream.adaptive/blob/f337b394e87c8ef03cd4b8e9df271537aa06773e/src/main.cpp#L419-L435)
- time shown on kodi GUI is wrong could be due to chapter change or not managed presentationTimeOffset


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
