### PR TITLE
[Codechandler][TTML] Fix TTML parsing and cleanups

### DIFF
--- a/src/CompResources.h
+++ b/src/CompResources.h
@@ -20,6 +20,12 @@
 #include <string>
 #include <unordered_set>
 
+// forwards
+namespace adaptive
+{
+class AdaptiveTree;
+}
+
 namespace ADP
 {
 namespace RESOURCES
@@ -29,6 +35,8 @@ class ATTR_DLL_LOCAL CCompResources
 public:
   CCompResources() = default;
   ~CCompResources() = default;
+
+  void InitStage2(adaptive::AdaptiveTree* tree) { m_tree = tree; }
 
   /*!
    * \brief Cookies that can be shared along with HTTP requests.
@@ -43,9 +51,16 @@ public:
 
   std::mutex& GetCookiesMutex() { return m_cookiesMutex; }
 
+  /*!
+   * \brief Get the manifest tree.
+   * \return The manifest tree.
+   */
+  const adaptive::AdaptiveTree& GetTree() const { return *m_tree; }
+
 private:
   std::unordered_set<UTILS::CURL::Cookie> m_cookies;
   std::mutex m_cookiesMutex;
+  adaptive::AdaptiveTree* m_tree{nullptr};
 };
 } // namespace RESOURCES
 } // namespace ADP

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -220,6 +220,8 @@ bool CSession::Initialize()
   m_adaptiveTree->PostOpen();
   m_reprChooser->PostInit();
 
+  CSrvBroker::GetInstance()->InitStage2(m_adaptiveTree);
+
   return InitializePeriod(isSessionOpened);
 }
 

--- a/src/SrvBroker.cpp
+++ b/src/SrvBroker.cpp
@@ -23,3 +23,8 @@ void CSrvBroker::Init(const std::map<std::string, std::string>& kodiProps)
   m_compResources = std::make_unique<RESOURCES::CCompResources>();
   m_compSettings = std::make_unique<SETTINGS::CCompSettings>();
 }
+
+void CSrvBroker::InitStage2(adaptive::AdaptiveTree* tree)
+{
+  m_compResources->InitStage2(tree);
+}

--- a/src/SrvBroker.h
+++ b/src/SrvBroker.h
@@ -31,6 +31,10 @@ namespace ADP::KODI_PROPS
 {
 class CCompKodiProps;
 }
+namespace adaptive
+{
+class AdaptiveTree;
+}
 
 /*
  * \brief Service broker is a singleton that give an easy access to the resources from anywhere in the code.
@@ -42,9 +46,15 @@ public:
   void operator=(const CSrvBroker&) = delete; // Not assignable
 
   /*
-   * \brief Initialize service broker components.
+   * \brief Initialize service broker components, on addon initialization.
    */
   void Init(const std::map<std::string, std::string>& kodiProps);
+
+  /*
+   * \brief Initialize service broker components, on session initialization.
+   * \param tree The adaptive tree
+   */
+  void InitStage2(adaptive::AdaptiveTree* tree);
 
   static CSrvBroker* GetInstance()
   {

--- a/src/codechandler/TTMLCodecHandler.cpp
+++ b/src/codechandler/TTMLCodecHandler.cpp
@@ -8,6 +8,18 @@
 
 #include "TTMLCodecHandler.h"
 
+#include "CompResources.h"
+#include "SrvBroker.h"
+#include "common/AdaptiveTree.h"
+
+// Kodi dont support TTML, so TTML is converted into "Text Subtitle Decoder" Kodi format
+// managed with Kodi core overlay decoder "CDVDOverlayCodecText".
+// This format must contain only subtitle text formatted as STR (SubRip) format in the packet data.
+// 
+// The Kodi overlay decoder can handle only one single subtitle (packet) at time.
+// For multiple subtitles with equal/similar PTS start, you will have to send the packets individually,
+// sequentially, at each next Kodi CInputStreamAdaptive::DemuxRead callback (routed to ReadNextSample).
+
 bool TTMLCodecHandler::ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf)
 {
   uint64_t pts;
@@ -17,7 +29,7 @@ bool TTMLCodecHandler::ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf)
   {
     buf.SetData(reinterpret_cast<const AP4_Byte*>(m_ttml.GetPreparedData()),
                 static_cast<const AP4_Size>(m_ttml.GetPreparedDataSize()));
-    sample.SetDts(pts);
+    sample.SetDts(pts + m_ptsOffset);
     sample.SetCtsDelta(0);
     sample.SetDuration(dur);
     return true;
@@ -27,10 +39,24 @@ bool TTMLCodecHandler::ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf)
   return false;
 }
 
+void TTMLCodecHandler::SetPTSOffset(AP4_UI64 offset)
+{
+  if (m_isTimeRelative)
+    m_ptsOffset = offset;
+}
+
+TTMLCodecHandler::TTMLCodecHandler(AP4_SampleDescription* sd, bool isFile)
+  : CodecHandler(sd), m_ttml(isFile)
+{
+  // For Miscrosoft Smooth Streaming, the subtitle time is relative to sample time,
+  // in this case its needed apply an offset.
+  m_isTimeRelative = CSrvBroker::GetResources().GetTree().IsTTMLTimeRelative();
+}
+
 bool TTMLCodecHandler::Transform(AP4_UI64 pts,
                                  AP4_UI32 duration,
                                  AP4_DataBuffer& buf,
                                  AP4_UI64 timescale)
 {
-  return m_ttml.Parse(buf.GetData(), buf.GetDataSize(), timescale, m_ptsOffset);
+  return m_ttml.Parse(buf.GetData(), buf.GetDataSize(), timescale);
 }

--- a/src/codechandler/TTMLCodecHandler.h
+++ b/src/codechandler/TTMLCodecHandler.h
@@ -14,15 +14,22 @@
 class ATTR_DLL_LOCAL TTMLCodecHandler : public CodecHandler
 {
 public:
-  TTMLCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd), m_ptsOffset(0){};
+  /*!
+   * \brief TTML subtitles codec handler.
+   * \param sd The MP4 sample description, for MP4 segmented case.
+   * \param isFile Specify if parsing a single "sidecar" file
+   *               (subtitles for the whole duration of the video content).
+   */
+  TTMLCodecHandler(AP4_SampleDescription* sd, bool isFile);
 
   bool Transform(AP4_UI64 pts, AP4_UI32 duration, AP4_DataBuffer& buf, AP4_UI64 timescale) override;
   bool ReadNextSample(AP4_Sample& sample, AP4_DataBuffer& buf) override;
-  void SetPTSOffset(AP4_UI64 offset) override { m_ptsOffset = offset; };
+  void SetPTSOffset(AP4_UI64 offset) override;
   bool TimeSeek(AP4_UI64 seekPos) override { return m_ttml.TimeSeek(seekPos); };
   void Reset() override { m_ttml.Reset(); }
 
 private:
   TTML2SRT m_ttml;
-  AP4_UI64 m_ptsOffset;
+  AP4_UI64 m_ptsOffset{0};
+  bool m_isTimeRelative;
 };

--- a/src/codechandler/ttml/TTML.h
+++ b/src/codechandler/ttml/TTML.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <cinttypes>
-#include <deque>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -27,12 +26,14 @@ namespace pugi
 class xml_node;
 }
 
+constexpr uint64_t NO_PTS = ~0;
+
 class ATTR_DLL_LOCAL TTML2SRT
 {
 public:
-  TTML2SRT() {}
+  TTML2SRT(bool isFile) { m_isFile = isFile; }
 
-  bool Parse(const void* buffer, size_t bufferSize, uint64_t timescale, uint64_t ptsOffset);
+  bool Parse(const void* buffer, size_t bufferSize, uint64_t timescale);
 
   bool TimeSeek(uint64_t seekPos);
 
@@ -46,6 +47,7 @@ private:
   bool ParseData(const void* buffer, size_t bufferSize);
   void ParseTagHead(pugi::xml_node nodeHead);
   void ParseTagBody(pugi::xml_node nodeTT);
+  void ParseTagSpan(pugi::xml_node spanNode, std::string& subText);
 
   struct Style
   {
@@ -75,24 +77,22 @@ private:
 
   struct SubtitleData
   {
-    std::string id;
     uint64_t start{0};
     uint64_t end{0};
     std::string text;
   };
 
   size_t m_currSubPos{0};
-  std::deque<SubtitleData> m_subtitlesList;
+  std::vector<SubtitleData> m_subtitlesList;
 
   std::vector<Style> m_styles;
   std::vector<Style> m_styleStack;
 
   std::string m_preparedSubText;
-  std::string m_lastId;
 
   uint64_t m_timescale{0};
-  uint64_t m_ptsOffset{0};
-  uint64_t m_seekTime{0};
+  bool m_isFile;
+  uint64_t m_seekTime{NO_PTS};
   uint64_t m_tickRate{0};
   uint64_t m_frameRate{0};
 };

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -279,6 +279,12 @@ public:
    */
   std::string_view GetLicenseUrl() { return m_licenseUrl; }
 
+  /*!
+   * \brief Specifies if TTML subtitle time is relative to sample time.
+   * \return True if relative to sample time, otherwise false.
+   */
+  bool IsTTMLTimeRelative() const { return m_isTTMLTimeRelative; }
+
 protected:
   /*!
    * \brief Save manifest data to a file for debugging purpose.
@@ -314,6 +320,8 @@ protected:
   std::string m_pathSaveManifest;
 
   std::string m_licenseUrl;
+
+  bool m_isTTMLTimeRelative{false};
 };
 
 } // namespace adaptive

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -137,8 +137,8 @@ public:
   void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
 
   /*!
-   * \brief Determines when the representation contains subtitles as single file
-   *        for the entire duration of the video.
+   * \brief Determines if the representation contains a single "sidecar" file subtitle,
+   *        used for the entire duration of the video.
    * \return True if subtitles are as single file, otherwise false
    */
   bool IsSubtitleFileStream() const { return m_isSubtitleFileStream; }

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1030,12 +1030,11 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
     }
   }
 
-  // For subtitles that are not as ISOBMFF format and where there is no timeline for segments
-  // we should treat them as a single subtitle file
   if (repr->GetContainerType() == ContainerType::TEXT && repr->GetMimeType() != "application/mp4" &&
-      !adpSet->HasSegmentTimelineDuration() && !repr->HasSegmentTimeline())
+      !repr->HasSegmentBase() && !repr->HasSegmentTemplate() && !repr->HasSegmentTimeline())
   {
-
+    // Raw unsegmented subtitles called "sidecar" is a single file specified in the <BaseURL> tag,
+    // must not have the MP4 ISOBMFF mime type or any other dash element.
     repr->SetIsSubtitleFileStream(true);
   }
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -21,6 +21,11 @@ using namespace pugi;
 using namespace PLAYLIST;
 using namespace UTILS;
 
+adaptive::CSmoothTree::CSmoothTree() : AdaptiveTree()
+{
+  m_isTTMLTimeRelative = true;
+}
+
 adaptive::CSmoothTree::CSmoothTree(const CSmoothTree& left) : AdaptiveTree(left)
 {
 }

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -23,7 +23,7 @@ class PRProtectionParser;
 class ATTR_DLL_LOCAL CSmoothTree : public AdaptiveTree
 {
 public:
-  CSmoothTree() : AdaptiveTree() {}
+  CSmoothTree();
   CSmoothTree(const CSmoothTree& left);
 
   virtual TreeType GetTreeType() override { return TreeType::SMOOTH_STREAMING; }

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -477,7 +477,7 @@ void CFragmentedSampleReader::UpdateSampleDescription()
         m_codecHandler = new HEVCCodecHandler(desc);
         break;
       case AP4_SAMPLE_FORMAT_STPP:
-        m_codecHandler = new TTMLCodecHandler(desc);
+        m_codecHandler = new TTMLCodecHandler(desc, false);
         break;
       case AP4_SAMPLE_FORMAT_WVTT:
         m_codecHandler = new WebVTTCodecHandler(desc, false);

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -37,12 +37,12 @@ bool CSubtitleSampleReader::Initialize(SESSION::CStream* stream)
 
   if (repr->IsSubtitleFileStream())
   {
-    // Single subtitle file (for entire video duration)
+    // Single "sidecar" subtitle file (for entire video duration)
     if (STRING::Contains(codecInternalName, CODEC::FOURCC_WVTT))
       m_codecHandler = std::make_unique<WebVTTCodecHandler>(nullptr, true);
     else if (STRING::Contains(codecInternalName, CODEC::FOURCC_TTML) ||
              STRING::Contains(codecInternalName, CODEC::FOURCC_STPP))
-      m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr);
+      m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr, true);
     else
     {
       LOG::LogF(LOGERROR, "Codec \"%s\" not implemented", codecInternalName.data());
@@ -61,7 +61,7 @@ bool CSubtitleSampleReader::Initialize(SESSION::CStream* stream)
       m_codecHandler = std::make_unique<WebVTTCodecHandler>(nullptr, false);
     else if (STRING::Contains(codecInternalName, CODEC::FOURCC_TTML) ||
              STRING::Contains(codecInternalName, CODEC::FOURCC_STPP))
-      m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr);
+      m_codecHandler = std::make_unique<TTMLCodecHandler>(nullptr, false);
     else
     {
       LOG::LogF(LOGERROR, "Codec \"%s\" not implemented", codecInternalName.data());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR fixes some TTML bugs:

1) Lack of subtitle text data (also on TTML "sidecar" single file's, not only for segmented)
The problem was caused by `SubtitleData` `id` member that store a kind of subtitle ID, it can be based on begin time. This ID is set to m_lastId when we Prepare() the data, the problem of missing/skipped subtitle text data happens because subtitle ID's can be all the same equal ID string, and so the while loop in the TTML2SRT::Parse skip all subs with same id...

2) Reworked and clarified the use of pts offset, that was forced on `TTML2SRT::m_ptsOffset`. This is a MS SmoothStreaming properietary customization, so before was applied wrongly to all use cases.

3) Fix "Span" tag parsing, text lines after "br" tag were cut off, and nested Span tag was not parsed, example:
```xml
  ...
  <body style="defaultStyle">
    <div>
      <p begin="295:11:12.080" end="295:11:15.000" region="region-1" style="style-1" xml:id="s384821">
        <span style="style-2">und zum Teil zu besteigen.<br/>Es kann gerne losgehen.</span>
      </p>
  ...
       <p begin="00:02:40:17" end="00:02:41:17"><span style="basic" xml:space="preserve">The <span tts:color="lime" tts:textDecoration="underline">Green UL</span> Mid-Row Code</span></p>
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1341
fix problem explained on comment: https://github.com/xbmc/inputstream.adaptive/issues/1461#issuecomment-1964176659

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Following SmoothStreaming, have the TTML case that seem to be similar to the issue
https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multiple-subtitles.ism/Manifest
for example at time 9:15 after some seconds is shown a middle-aged man in a chair that say:
> There's a lesson to be learned from this.

after that a girl say:

> Could a gone worse.

but this last text is not displayed on screen because have same ID of previous text

TTML Sidecar single file case:
https://dash.akamaized.net/dash264/CTA/imsc1/IT1-20171027_dash.mpd

For missing text after "br" tag can be tested also with stream https://github.com/xbmc/inputstream.adaptive/issues/1109#issuecomment-1905785094

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
