### PR TITLE
[DashTree] Determine protection data from representation only

### DIFF
--- a/src/common/CommonAttribs.h
+++ b/src/common/CommonAttribs.h
@@ -25,6 +25,14 @@ enum class ContainerType;
 
 namespace PLAYLIST
 {
+struct ProtectionScheme
+{
+  std::string idUri;
+  std::string value;
+  std::string kid;
+  std::string pssh;
+};
+
 // CCommonAttribs class provide attribute data
 // of class itself or when not set of the parent class (if any).
 class ATTR_DLL_LOCAL CCommonAttribs
@@ -60,6 +68,9 @@ public:
   uint32_t GetAudioChannels() const;
   void SetAudioChannels(uint32_t audioChannels) { m_audioChannels = audioChannels; }
 
+  bool HasProtectionSchemes() const { return !m_protSchemes.empty(); }
+  std::vector<ProtectionScheme>& ProtectionSchemes() { return m_protSchemes; }
+
 protected:
   CCommonAttribs* m_parentCommonAttributes{nullptr};
   std::string m_mimeType;
@@ -71,6 +82,7 @@ protected:
   uint32_t m_frameRateScale{0};
   uint32_t m_sampleRate{0};
   uint32_t m_audioChannels{0};
+  std::vector<ProtectionScheme> m_protSchemes;
 };
 
 } // namespace PLAYLIST

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -627,13 +627,6 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
   // Parse <ContentProtection> child tags
   if (nodeAdp.child("ContentProtection"))
   {
-    if (adpSet->GetStreamType() == StreamType::SUBTITLE)
-    {
-      LOG::LogF(LOGWARNING, "Skipped AdaptationSet with id: \"%s\", encrypted subtitles not supported.",
-                adpSet->GetId().data());
-      return;
-    }
-
     period->SetEncryptionState(EncryptionState::ENCRYPTED);
     std::vector<uint8_t> pssh;
     std::string kid;
@@ -970,14 +963,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   // Parse <ContentProtection> tags
   if (nodeRepr.child("ContentProtection"))
   {
-    if (adpSet->GetStreamType() == StreamType::SUBTITLE)
-    {
-      LOG::LogF(LOGWARNING,
-                "Skipped Representation with id: \"%s\", encrypted subtitles not supported.",
-                repr->GetId().data());
-      return;
-    }
-
     period->SetEncryptionState(EncryptionState::ENCRYPTED);
     std::vector<uint8_t> pssh;
     std::string kid;

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -610,6 +610,13 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
     }
   }
 
+  // Parse <ContentProtection> child tags
+  if (nodeAdp.child("ContentProtection"))
+  {
+    period->SetEncryptionState(EncryptionState::ENCRYPTED);
+    ParseTagContentProtection(nodeAdp, adpSet->ProtectionSchemes());
+    period->SetSecureDecodeNeeded(ParseTagContentProtectionSecDec(nodeAdp));
+  }
 
   // Parse <Representation> child tags
   for (xml_node node : nodeAdp.children("Representation"))
@@ -622,42 +629,6 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
     LOG::LogF(LOGWARNING, "Skipped AdaptationSet with id: \"%s\", has no representations.",
               adpSet->GetId().data());
     return;
-  }
-
-  // Parse <ContentProtection> child tags
-  if (nodeAdp.child("ContentProtection"))
-  {
-    period->SetEncryptionState(EncryptionState::ENCRYPTED);
-    std::vector<uint8_t> pssh;
-    std::string kid;
-
-    // If a custom init PSSH is provided, should mean that a certain content protection tag
-    // is missing, in this case we ignore the content protection tags and we add a PsshSet without data
-    if (m_isCustomInitPssh || ParseTagContentProtection(nodeAdp, pssh, kid))
-    {
-      period->SetEncryptionState(EncryptionState::ENCRYPTED_SUPPORTED);
-      uint16_t currentPsshSetPos =
-          InsertPsshSet(adpSet->GetStreamType(), period, adpSet.get(), pssh, kid);
-
-      if (currentPsshSetPos == PSSHSET_POS_INVALID)
-      {
-        LOG::LogF(LOGWARNING, "Skipped adaptation set with id: \"%s\", due to not valid PSSH.",
-                  adpSet->GetId().data());
-        return;
-      }
-
-      period->SetSecureDecodeNeeded(ParseTagContentProtectionSecDec(nodeAdp));
-
-      if (currentPsshSetPos != PSSHSET_POS_DEFAULT)
-      {
-        // Set PSSHSet of AdaptationSet to representations when its not set
-        for (auto& rep : adpSet->GetRepresentations())
-        {
-          if (rep->m_psshSetPos == PSSHSET_POS_DEFAULT)
-            rep->m_psshSetPos = currentPsshSetPos;
-        }
-      }
-    }
   }
 
   // Copy codecs in the adaptation set to make MergeAdpSets more effective
@@ -960,16 +931,22 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
     repr->SetSegmentList(segList);
   }
 
-  // Parse <ContentProtection> tags
+  // Parse <ContentProtection> child tags
   if (nodeRepr.child("ContentProtection"))
   {
     period->SetEncryptionState(EncryptionState::ENCRYPTED);
+    ParseTagContentProtection(nodeRepr, repr->ProtectionSchemes());
+  }
+
+  // Store the protection data
+  if (adpSet->HasProtectionSchemes() || repr->HasProtectionSchemes())
+  {
     std::vector<uint8_t> pssh;
     std::string kid;
-
     // If a custom init PSSH is provided, should mean that a certain content protection tag
     // is missing, in this case we ignore the content protection tags and we add a PsshSet without data
-    if (m_isCustomInitPssh || ParseTagContentProtection(nodeRepr, pssh, kid))
+    if (m_isCustomInitPssh ||
+        GetProtectionData(adpSet->ProtectionSchemes(), repr->ProtectionSchemes(), pssh, kid))
     {
       period->SetEncryptionState(EncryptionState::ENCRYPTED_SUPPORTED);
 
@@ -1280,89 +1257,103 @@ void adaptive::CDashTree::ParseSegmentTemplate(pugi::xml_node node, CSegmentTemp
     segTpl->SetInitialization(initialization);
 }
 
-bool adaptive::CDashTree::ParseTagContentProtection(pugi::xml_node nodeParent,
-                                                    std::vector<uint8_t>& pssh,
-                                                    std::string& kid)
+void adaptive::CDashTree::ParseTagContentProtection(
+    pugi::xml_node nodeParent, std::vector<PLAYLIST::ProtectionScheme>& protSchemes)
 {
-  std::optional<ProtectionScheme> commonProtScheme;
-  std::vector<ProtectionScheme> protectionSchemes;
   // Parse each ContentProtection tag to collect encryption schemes
   for (xml_node nodeCP : nodeParent.children("ContentProtection"))
   {
     std::string_view schemeIdUri = XML::GetAttrib(nodeCP, "schemeIdUri");
 
-    if (schemeIdUri == "urn:mpeg:dash:mp4protection:2011")
+    ProtectionScheme protScheme;
+    protScheme.idUri = schemeIdUri;
+    protScheme.value = XML::GetAttrib(nodeCP, "value");
+
+    // Get optional default KID
+    // Parse first attribute that end with "... default_KID"
+    // e.g. cenc:default_KID="01004b6f-0835-b807-9098-c070dc30a6c7"
+    xml_attribute attrKID = XML::FirstAttributeNoPrefix(nodeCP, "default_KID");
+    if (attrKID)
+      protScheme.kid = attrKID.value();
+
+    // Parse child tags
+    for (xml_node node : nodeCP.children())
     {
-      ProtectionScheme protScheme;
-      protScheme.idUri = schemeIdUri;
-      protScheme.value = XML::GetAttrib(nodeCP, "value");
+      std::string childName = node.name();
 
-      // Get optional default KID
-      // Parse first attribute that end with "... default_KID"
-      // e.g. cenc:default_KID="01004b6f-0835-b807-9098-c070dc30a6c7"
-      xml_attribute attrKID = XML::FirstAttributeNoPrefix(nodeCP, "default_KID");
-      if (attrKID)
-        protScheme.kid = attrKID.value();
-
-      commonProtScheme = protScheme;
-    }
-    else
-    {
-      ProtectionScheme protScheme;
-      protScheme.idUri = schemeIdUri;
-      protScheme.value = XML::GetAttrib(nodeCP, "value");
-
-      // We try find default KID also from the other protection schemes
-      xml_attribute attrKID = XML::FirstAttributeNoPrefix(nodeCP, "default_KID");
-      if (attrKID)
-        protScheme.kid = attrKID.value();
-
-      // Parse child tags
-      for (xml_node node : nodeCP.children())
+      if (StringUtils::EndsWith(childName, "pssh")) // e.g. <cenc:pssh> or <pssh> ...
       {
-        std::string childName = node.name();
-
-        if (StringUtils::EndsWith(childName, "pssh")) // e.g. <cenc:pssh> or <pssh> ...
-        {
-          protScheme.pssh = node.child_value();
-        }
-        else if (childName == "mspr:pro" || childName == "pro")
-        {
-          PRProtectionParser parser;
-          if (parser.ParseHeader(node.child_value()))
-            protScheme.kid = parser.GetKID();
-        }
+        protScheme.pssh = node.child_value();
       }
-      protectionSchemes.emplace_back(protScheme);
+      else if (childName == "mspr:pro" || childName == "pro")
+      {
+        PRProtectionParser parser;
+        if (parser.ParseHeader(node.child_value()))
+          protScheme.kid = parser.GetKID();
+      }
+    }
+
+    protSchemes.emplace_back(protScheme);
+  }
+}
+
+bool adaptive::CDashTree::GetProtectionData(
+    const std::vector<PLAYLIST::ProtectionScheme>& adpProtSchemes,
+    const std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
+    std::vector<uint8_t>& pssh,
+    std::string& kid)
+{
+  // Try find a protection scheme compatible for the current systemid
+  const ProtectionScheme* protSelected = nullptr;
+  const ProtectionScheme* protCommon = nullptr;
+
+  for (const ProtectionScheme& protScheme : reprProtSchemes)
+  {
+    if (STRING::CompareNoCase(protScheme.idUri, m_supportedKeySystem))
+    {
+      protSelected = &protScheme;
+    }
+    else if (protScheme.idUri == "urn:mpeg:dash:mp4protection:2011")
+    {
+      protCommon = &protScheme;
     }
   }
 
-  // Try find a protection scheme compatible for the current systemid
-  auto itProtScheme = std::find_if(protectionSchemes.cbegin(), protectionSchemes.cend(),
-                                   [&](const ProtectionScheme& item) {
-                                     return STRING::CompareNoCase(item.idUri, m_supportedKeySystem);
-                                   });
+  if (!protSelected || !protCommon)
+  {
+    for (const ProtectionScheme& protScheme : adpProtSchemes)
+    {
+      if (!protSelected && STRING::CompareNoCase(protScheme.idUri, m_supportedKeySystem))
+      {
+        protSelected = &protScheme;
+      }
+      else if (!protCommon && protScheme.idUri == "urn:mpeg:dash:mp4protection:2011")
+      {
+        protCommon = &protScheme;
+      }
+    }
+  }
 
   bool isEncrypted{false};
   std::string selectedKid;
   std::string selectedPssh;
 
-  if (itProtScheme != protectionSchemes.cend())
+  if (protSelected)
   {
     isEncrypted = true;
-    selectedKid = itProtScheme->kid;
-    selectedPssh = itProtScheme->pssh;
+    selectedKid = protSelected->kid;
+    selectedPssh = protSelected->pssh;
   }
-  if (commonProtScheme.has_value())
+  if (protCommon)
   {
     isEncrypted = true;
     if (selectedKid.empty())
-      selectedKid = commonProtScheme->kid;
+      selectedKid = protCommon->kid;
 
     // Set crypto mode
-    if (commonProtScheme->value == "cenc")
+    if (protCommon->value == "cenc")
       m_cryptoMode = CryptoMode::AES_CTR;
-    else if (commonProtScheme->value == "cbcs")
+    else if (protCommon->value == "cbcs")
       m_cryptoMode = CryptoMode::AES_CBC;
   }
 

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -20,6 +20,10 @@ namespace pugi
 {
 class xml_node;
 }
+namespace PLAYLIST
+{
+struct ProtectionScheme;
+}
 
 namespace adaptive
 {
@@ -70,9 +74,21 @@ protected:
 
   void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate* segTpl);
 
-  bool ParseTagContentProtection(pugi::xml_node nodeCP,
-                                 std::vector<uint8_t>& pssh,
-                                 std::string& kid);
+  void ParseTagContentProtection(pugi::xml_node nodeParent,
+                                 std::vector<PLAYLIST::ProtectionScheme>& protectionSchemes);
+
+  /*!
+   * \brief Get the protection data for the representation
+   * \param adpProtSchemes The protection schemes of the adaptation set relative to the representation
+   * \param reprProtSchemes The protection schemes of the representation
+   * \param pssh[OUT] The PSSH (if any) that match the supported systemid
+   * \param kid[OUT] The KID (should be provided)
+   * \return True if a protection has been found, otherwise false
+   */
+  bool GetProtectionData(const std::vector<PLAYLIST::ProtectionScheme>& adpProtSchemes,
+                         const std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
+                         std::vector<uint8_t>& pssh,
+                         std::string& kid);
 
   bool ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 
@@ -116,13 +132,5 @@ protected:
   bool m_allowInsertLiveSegments{false};
   // Determines if a custom PSSH initialization license data is provided
   bool m_isCustomInitPssh{false};
-
-  struct ProtectionScheme
-  {
-    std::string idUri;
-    std::string value;
-    std::string kid;
-    std::string pssh;
-  };
 };
 } // namespace adaptive


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Initially i had "fixed" issue #1448 by skipping encrypted subtitles streams, i didn't realize that the problem was a different one, and so PR #1479 will be reverted

there was a problem with duplicate PSSHSets added in the period,
as you can see on following manifest, the ContentProtection "urn:mpeg:dash:mp4protection:2011" is defined two times, on AdaptationSet and also in the Representation. Since parsing was done on AdaptationSet and Representation separately, there was no check to determine if a schemeIdUri type had already been added, so it was added twice the PSSHSets.

The first time without pssh the secon time with pssh+kid, the Session DRM initialization would take the first one without pssh and attempt extraction from the file (that was failing and stop playback)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2023-12-19T22:25:15Z" publishTime="2024-03-05T12:33:40Z" minimumUpdatePeriod="PT30S" timeShiftBufferDepth="PT64.0S" minBufferTime="PT1S" maxSegmentDuration="PT2S">
	<Period id="1" start="PT0S">
		<AdaptationSet id="3" lang="rus" contentType="text" segmentAlignment="true" mimeType="application/mp4" startWithSAP="1">
			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="subtitle"/>
			<SegmentTemplate timescale="10000000" duration="20000000" startNumber="1" media="$RepresentationID$_$Number$.m4s?hw_dash=1&amp;servicetype=1&amp;nil" initialization="$RepresentationID$_init.m4i?hw_dash=1&amp;servicetype=1&amp;nil"/>
			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="d5e8f2aa-3a56-ecf0-9dde-0088eaaf19b5"/>
			<ContentProtection xmlns:mspr="urn:microsoft:playready" value="MSPR 2.0" schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95">
				<cenc:pssh>AAADPnBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAx4eAwAAAQABABQDPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBxAHYATABvADEAVgBZADYAOABPAHkAZAAzAGcAQwBJADYAcQA4AFoAdABRAD0APQA8AC8ASwBJAEQAPgA8AEMASABFAEMASwBTAFUATQA+AHAASgBPAEkAVwBEAGcAYgB5AFIAOAA9ADwALwBDAEgARQBDAEsAUwBVAE0APgA8AEwAQQBfAFUAUgBMAD4AaAB0AHQAcABzADoALwAvAGgAdAB2AC0AcAByAGwAcwAuAG0AdABzAC4AcgB1AC8AUABsAGEAeQBSAGUAYQBkAHkALwByAGkAZwBoAHQAcwBtAGEAbgBhAGcAZQByAC4AYQBzAG0AeAA8AC8ATABBAF8AVQBSAEwAPgA8AEwAVQBJAF8AVQBSAEwAPgBoAHQAdABwAHMAOgAvAC8AaAB0AHYALQBwAHIAbABzAC4AbQB0AHMALgByAHUALwBQAGwAYQB5AFIAZQBhAGQAeQAvAHIAaQBnAGgAdABzAG0AYQBuAGEAZwBlAHIALgBhAHMAbQB4ADwALwBMAFUASQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
			</ContentProtection>
			<ContentProtection value="Widevine" schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
				<cenc:pssh>AAAAWXBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADkIARIQ1ejyqjpW7PCd3gCI6q8ZtRoNdmVyaW1hdHJpeG10cyINcj02NTQwNiZzPTk1MyoFU0RfSEQ=</cenc:pssh>
			</ContentProtection>
			<Representation id="subtitles" bandwidth="3200" codecs="stpp">
				<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="d5e8f2aa-3a56-ecf0-9dde-0088eaaf19b5"/>
			</Representation>
		</AdaptationSet>
...
```

To fix `InsertPsshSet` is now executed only within the Representation parsing, and the code is also clearer

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1448

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://htv-wv.mts.ru/?deviceId=MWFjMDU4NjktYjAxNC0zYmEyLWFmYjMtNjZmNzI3Nzg2NTgw||R{SSM}|
#EXTINF:-1 tvg-id="1",Encrypted Subtitles 1
https://htv-rrs.mts.ru/PLTV/88888888/224/3221228154/3221228154.mpd
```
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
