### PR TITLE
[AdaptiveStream] On start stream prevent to stop subtitles stream

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -737,7 +737,7 @@ bool AdaptiveStream::start_stream(uint64_t startPts)
   const CSegment* next_segment =
       current_rep_->get_next_segment(current_rep_->current_segment_);
 
-  if (!next_segment)
+  if (!next_segment && current_adp_->GetStreamType() != StreamType::SUBTITLE)
   {
     //! @todo: THIS MUST BE CHANGED - !! BUG !!
     //! this will broken/stop playback on live streams when adaptive stream change stream quality (so representation)
@@ -787,11 +787,14 @@ bool AdaptiveStream::start_stream(uint64_t startPts)
     return false;
   }
 
-  currentPTSOffset_ =
-      (next_segment->startPTS_ * current_rep_->timescale_ext_) / current_rep_->timescale_int_;
-  absolutePTSOffset_ =
-      (current_rep_->SegmentTimeline().Get(0)->startPTS_ * current_rep_->timescale_ext_) /
-      current_rep_->timescale_int_;
+  if (next_segment)
+  {
+    currentPTSOffset_ =
+        (next_segment->startPTS_ * current_rep_->timescale_ext_) / current_rep_->timescale_int_;
+    absolutePTSOffset_ =
+        (current_rep_->SegmentTimeline().Get(0)->startPTS_ * current_rep_->timescale_ext_) /
+        current_rep_->timescale_int_;
+  }
 
   if (state_ == RUNNING)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Use case for mp4 isobmff segmented subtitles,
if you disable and re-enable subtitles while in playback (OSD) there is no guarantee of having segments available immediately here (next_segment), for live stream, you need to wait "insert live segments" and/or next manifest update
and this prevented getting the initialization segment

Indirectly this depends form PR #1505, just if you want test the attached sample stream


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
if you disable and re-enable subtitles while in playback (OSD) potentially can be broken
and following error is shown:

`2024-03-07 10:01:25.414 T:11904   error <general>: AddOnLog: inputstream.adaptive: ADP::CreateStreamReader: No MOOV atom in stream`

this happens because when you disable subs the stream is deleted with all related compents,
when you re-enable it, it is reinitialized from scratch again

fix #1448

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://htv-wv.mts.ru/?deviceId=MWFjMDU4NjktYjAxNC0zYmEyLWFmYjMtNjZmNzI3Nzg2NTgw||R{SSM}|
#EXTINF:-1 tvg-id="1",Encrypted Subtitles 1
https://htv-rrs.mts.ru/PLTV/88888888/224/3221228154/3221228154.mpd
```
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
