### PR TITLE
[DashTree] Rework to improve live streaming

### DIFF
--- a/src/AdaptiveByteStream.cpp
+++ b/src/AdaptiveByteStream.cpp
@@ -25,6 +25,11 @@ AP4_Result CAdaptiveByteStream::WritePartial(const void* buffer,
   return AP4_ERROR_NOT_SUPPORTED;
 }
 
+bool CAdaptiveByteStream::ReadFull(std::vector<uint8_t>& buffer)
+{
+  return m_adStream->ReadFullBuffer(buffer);
+}
+
 AP4_Result CAdaptiveByteStream::Seek(AP4_Position position)
 {
   return m_adStream->seek(position) ? AP4_SUCCESS : AP4_ERROR_NOT_SUPPORTED;
@@ -39,15 +44,6 @@ AP4_Result CAdaptiveByteStream::Tell(AP4_Position& position)
 AP4_Result CAdaptiveByteStream::GetSize(AP4_LargeSize& size)
 {
   return AP4_ERROR_NOT_SUPPORTED;
-}
-
-AP4_Result CAdaptiveByteStream::GetSegmentSize(size_t& size)
-{
-  if (m_adStream->ensureSegment() && m_adStream->retrieveCurrentSegmentBufferSize(size))
-  {
-    return AP4_SUCCESS;
-  }
-  return AP4_ERROR_EOS;
 }
 
 bool CAdaptiveByteStream::waitingForSegment() const

--- a/src/AdaptiveByteStream.h
+++ b/src/AdaptiveByteStream.h
@@ -33,10 +33,17 @@ public:
   AP4_Result WritePartial(const void* buffer,
                           AP4_Size bytesToWrite,
                           AP4_Size& bytesWritten) override;
+
+  /*!
+  * \brief Read in full the stream.
+  * \param buffer[OUT] The full data buffer bytes
+  * \return True if has success, otherwise false
+  */
+  bool ReadFull(std::vector<uint8_t>& buffer);
+
   AP4_Result Seek(AP4_Position position) override;
   AP4_Result Tell(AP4_Position& position) override;
   AP4_Result GetSize(AP4_LargeSize& size) override;
-  AP4_Result GetSegmentSize(size_t& size);
 
   // AP4_Referenceable methods
   void AddReference() override{};

--- a/src/Session.h
+++ b/src/Session.h
@@ -156,7 +156,7 @@ public:
   /*! \brief Get the total time in ms of the stream
    *  \return The total time in ms of the stream
    */
-  uint64_t GetTotalTimeMs() const { return m_adaptiveTree->m_totalTimeSecs * 1000; };
+  uint64_t GetTotalTimeMs() const { return m_adaptiveTree->m_totalTime; };
 
   /*! \brief Get the elapsed time in ms of the stream including all chapters
    *  \return The elapsed time in ms of the stream including all chapters
@@ -307,13 +307,6 @@ public:
   void OnStreamChange(adaptive::AdaptiveStream* adStream) override;
 
 protected:
-  /*!
-   * \brief Event raised when the current segment is changed and
-   *        the data has already been read by the sample reader.
-   * \param stream The stream for which segment has changed.
-   */
-  void OnSegmentChangedRead(CStream* stream);
-
   /*! \brief Check for and load decrypter module matching the supplied key system
    *  \param key_system [OUT] Will be assigned to if a decrypter is found matching
    *                    the set license type

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -27,7 +27,6 @@ public:
       m_isEncrypted{false},
       m_mainId{0},
       m_adStream{tree, adp, initialRepr},
-      m_hasSegmentChanged{false},
       m_isValid{true} {};
 
 
@@ -87,7 +86,6 @@ public:
   uint16_t m_mainId;
   adaptive::AdaptiveStream m_adStream;
   kodi::addon::InputstreamInfo m_info;
-  bool m_hasSegmentChanged;
   bool m_isValid;
 
 private:

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -70,8 +70,6 @@ void PLAYLIST::CAdaptationSet::CopyHLSData(const CAdaptationSet* other)
 
   m_baseUrl = other->m_baseUrl;
   m_streamType = other->m_streamType;
-  m_duration = other->m_duration;
-  m_startPts = other->m_startPts;
   m_startNumber = other->m_startNumber;
   m_isImpaired = other->m_isImpaired;
   m_isOriginal = other->m_isOriginal;

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -58,9 +58,6 @@ public:
   uint64_t GetStartNumber() const { return m_startNumber; }
   void SetStartNumber(uint64_t startNumber) { m_startNumber = startNumber; }
 
-  uint64_t GetStartPTS() const { return m_startPts; }
-  void SetStartPTS(uint64_t startPts) { m_startPts = startPts; }
-
   void AddCodecs(std::string_view codecs);
   const std::set<std::string>& GetCodecs() { return m_codecs; }
 
@@ -170,7 +167,6 @@ protected:
   std::string m_group;
   std::string m_baseUrl;
   uint64_t m_startNumber{1};
-  uint64_t m_startPts{0};
   uint64_t m_duration{0};
 
   std::set<std::string> m_codecs;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -68,9 +68,9 @@ public:
   std::string base_url_;
   
   std::optional<uint32_t> initial_sequence_; // HLS only
-  uint64_t m_totalTimeSecs{0}; // Total playing time in seconds (can include all periods/chapters or timeshift)
-  uint64_t stream_start_{0};
-  uint64_t available_time_{0};
+  uint64_t m_totalTime{0}; // Total playing time in ms (can include all periods/chapters or timeshift)
+  uint64_t stream_start_{0}; // in ms
+  uint64_t available_time_{0}; // in ms
   uint64_t m_liveDelay{0}; // Apply a delay in seconds from the live edge
 
   std::string m_supportedKeySystem;
@@ -121,7 +121,8 @@ public:
   virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
                                      PLAYLIST::CAdaptationSet* adp,
                                      PLAYLIST::CRepresentation* rep,
-                                     bool& isDrmChanged)
+                                     bool& isDrmChanged,
+                                     uint64_t currentSegNumber)
   {
     return false;
   }
@@ -161,7 +162,7 @@ public:
    * \param fragmentDuration Fragment duration
    * \param movieTimescale Fragment movie timescale
    */
-  virtual void InsertLiveSegment(PLAYLIST::CPeriod* period,
+  virtual bool InsertLiveSegment(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adpSet,
                                  PLAYLIST::CRepresentation* repr,
                                  size_t pos,
@@ -169,6 +170,7 @@ public:
                                  uint64_t fragmentDuration,
                                  uint32_t movieTimescale)
   {
+    return false;
   }
 
   // Insert a PSSHSet to the specified Period and return the position
@@ -284,6 +286,17 @@ public:
    * \return True if relative to sample time, otherwise false.
    */
   bool IsTTMLTimeRelative() const { return m_isTTMLTimeRelative; }
+
+  /*!
+   * \brief Check if specified segment is the last of current period.
+   * \param segPeriod The period relative to the segment
+   * \param segRep The representation relative to the segment
+   * \param segment The segment.
+   * \return True if it is the last segment, otherwise false.
+   */
+  bool IsLastSegment(const PLAYLIST::CPeriod* segPeriod,
+                     const PLAYLIST::CRepresentation* segRep,
+                     const PLAYLIST::CSegment* segment) const;
 
 protected:
   /*!

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -162,6 +162,30 @@ public:
   }
 
   /*!
+   * \brief Get the last <T> value pointer
+   * \return <T> value pointer, otherwise nullptr if not found
+   */
+  T* GetBack()
+  {
+    if (m_data.empty())
+      return nullptr;
+
+    return &m_data.back();
+  }
+
+  /*!
+   * \brief Get the first <T> value pointer
+   * \return <T> value pointer, otherwise nullptr if not found
+   */
+  T* GetFront()
+  {
+    if (m_data.empty())
+      return nullptr;
+
+    return &m_data.front();
+  }
+
+  /*!
    * \brief Get index position of <T> value pointer
    * \param elem The <T> pointer to get the position
    * \return The index position, or SEGMENT_NO_POS if not found

--- a/src/common/CommonSegAttribs.cpp
+++ b/src/common/CommonSegAttribs.cpp
@@ -31,3 +31,10 @@ bool PLAYLIST::CCommonSegAttribs::HasSegmentEndNr()
   return m_segEndNr.has_value() ||
          (m_parentCommonSegAttribs && m_parentCommonSegAttribs->HasSegmentEndNr());
 }
+
+uint64_t PLAYLIST::CCommonSegAttribs::GetStartPTS() const
+{
+  if (m_startPts > 0 || !m_parentCommonSegAttribs)
+    return m_startPts;
+  return m_parentCommonSegAttribs->GetStartPTS();
+}

--- a/src/common/CommonSegAttribs.h
+++ b/src/common/CommonSegAttribs.h
@@ -40,11 +40,15 @@ public:
   void SetSegmentEndNr(const uint64_t segNumber) { m_segEndNr = segNumber; }
   bool HasSegmentEndNr();
 
+  uint64_t GetStartPTS() const;
+  void SetStartPTS(uint64_t startPts) { m_startPts = startPts; }
+
 protected:
   CCommonSegAttribs* m_parentCommonSegAttribs{nullptr};
   std::optional<CSegmentList> m_segmentList;
   std::optional<CSegmentTemplate> m_segmentTemplate;
   std::optional<uint64_t> m_segEndNr;
+  uint64_t m_startPts{0};
 };
 
 } // namespace PLAYLIST

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -36,8 +36,6 @@ void PLAYLIST::CPeriod::CopyHLSData(const CPeriod* other)
   m_id = other->m_id;
   m_timescale = other->m_timescale;
   m_start = other->m_start;
-  m_startPts = other->m_startPts;
-  m_duration = other->m_duration;
   m_encryptionState = other->m_encryptionState;
   m_includedStreamType = other->m_includedStreamType;
   m_isSecureDecoderNeeded = other->m_isSecureDecoderNeeded;

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -53,12 +53,9 @@ public:
   uint64_t GetStart() const { return m_start; }
 
   /*!
-   * \brief Set the start time, in ms.
+   * \brief Set the start time in ms, or NO_VALUE for not set.
    */
   void SetStart(uint64_t start) { m_start = start; }
-
-  uint64_t GetStartPTS() const { return m_startPts; }
-  void SetStartPTS(uint64_t startPts) { m_startPts = startPts; }
 
   /*!
    * \brief Get the duration, in timescale units.
@@ -143,7 +140,6 @@ protected:
   uint32_t m_timescale{1000};
   uint32_t m_sequence{0};
   uint64_t m_start{NO_VALUE};
-  uint64_t m_startPts{0};
   uint64_t m_duration{0};
   EncryptionState m_encryptionState{EncryptionState::UNENCRYPTED};
   bool m_isSecureDecoderNeeded{false};

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -230,6 +230,30 @@ public:
     return m_segmentTimeline.IsEmpty() ? 0 : m_segmentTimeline.GetPosition(segment);
   }
 
+  CSegment* GetSegmentByPts(const uint64_t startPts)
+  {
+    for (CSegment& segment : m_segmentTimeline.GetData())
+    {
+      // Search by >= is intended to allow minimizing problems with encoders
+      // that provide inconsistent timestamps between manifest updates
+      if (segment.startPTS_ >= startPts)
+        return &segment;
+    }
+    return nullptr;
+  }
+
+  CSegment* GetNextSegment(const CSegment& segment)
+  {
+    const uint64_t segStartPTS = segment.startPTS_;
+
+    for (CSegment& segment : m_segmentTimeline.GetData())
+    {
+      if (segment.startPTS_ > segStartPTS)
+        return &segment;
+    }
+    return nullptr;
+  }
+
   /*!
    * \brief Get the position of current segment.
    * \return If found the position, otherwise SEGMENT_NO_POS.
@@ -277,9 +301,6 @@ public:
   void SetScaling();
 
   std::chrono::time_point<std::chrono::system_clock> repLastUpdated_;
-
-  //! @todo: appears to be stored for convenience, a refactor could remove it
-  uint64_t nextPts_{0};
 
   //! @todo: to be reworked or deleted
   uint32_t assured_buffer_duration_{0};

--- a/src/common/SegTemplate.cpp
+++ b/src/common/SegTemplate.cpp
@@ -73,9 +73,12 @@ uint64_t PLAYLIST::CSegmentTemplate::GetEndNumber() const
   return 0; // Default value
 }
 
-bool PLAYLIST::CSegmentTemplate::HasVariableTime() const
+uint64_t PLAYLIST::CSegmentTemplate::GetPresTimeOffset() const
 {
-  return m_media.find("$Time") != std::string::npos;
+  if (m_ptsOffset.has_value())
+    return *m_ptsOffset;
+
+  return 0; // Default value
 }
 
 CSegment PLAYLIST::CSegmentTemplate::MakeInitSegment()

--- a/src/common/SegTemplate.h
+++ b/src/common/SegTemplate.h
@@ -61,8 +61,22 @@ public:
   void SetEndNumber(uint64_t endNumber) { m_endNumber = endNumber; }
   bool HasEndNumber() const { return m_endNumber.has_value(); }
 
-  bool HasVariableTime() const;
-  
+  uint64_t GetPresTimeOffset() const;
+  void SetPresTimeOffset(uint64_t ptsOffset) { m_ptsOffset = ptsOffset; }
+  bool HasPresTimeOffset() const { return m_ptsOffset.has_value(); }
+
+  // \brief Defines a <SegmentTimeline>, <S> element
+  struct TimelineElement
+  {
+    uint64_t time{0};
+    uint32_t duration{0};
+    uint32_t repeat{0};
+  };
+
+  std::vector<TimelineElement>& Timeline() { return m_timeline; }
+  const std::vector<TimelineElement>& Timeline() const { return m_timeline; }
+  bool HasTimeline() const { return !m_timeline.empty(); }
+
   CSegment MakeInitSegment();
 
   std::string FormatUrl(std::string_view url,
@@ -80,6 +94,8 @@ private:
   std::optional<uint32_t> m_duration;
   std::optional<uint64_t> m_startNumber;
   std::optional<uint64_t> m_endNumber;
+  std::optional <uint64_t> m_ptsOffset;
+  std::vector<TimelineElement> m_timeline;
 };
 
 } // namespace PLAYLIST

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -35,11 +35,12 @@ public:
   // Byte range end
   uint64_t range_end_ = NO_VALUE;
   std::string url;
-  uint64_t startPTS_ = NO_PTS_VALUE;
-  uint64_t m_duration = 0; // If available gives the media duration of a segment (depends on type of stream e.g. HLS)
+
+  uint64_t startPTS_ = NO_PTS_VALUE; // The start PTS, in timescale units
+  uint64_t m_endPts = NO_PTS_VALUE; // The end PTS, in timescale units
   uint16_t pssh_set_ = PSSHSET_POS_DEFAULT;
 
-  uint64_t m_time{0}; // The start time, in timescale units
+  uint64_t m_time{0}; // Timestamp
   uint64_t m_number{0};
 
   /*!

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -44,9 +44,7 @@ public:
                     const std::map<std::string, std::string>& headers,
                     const std::string& data) override;
 
-  virtual void PostOpen() override;
-
-  virtual void InsertLiveSegment(PLAYLIST::CPeriod* period,
+  virtual bool InsertLiveSegment(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adpSet,
                                  PLAYLIST::CRepresentation* repr,
                                  size_t pos,
@@ -66,13 +64,10 @@ protected:
                               PLAYLIST::CAdaptationSet* adpSet,
                               PLAYLIST::CPeriod* period);
 
-  uint64_t ParseTagSegmentTimeline(pugi::xml_node parentNode,
-                                   PLAYLIST::CSpinCache<uint32_t>& SCTimeline);
-  uint64_t ParseTagSegmentTimeline(pugi::xml_node nodeSegTL,
-                                   PLAYLIST::CSpinCache<PLAYLIST::CSegment>& SCTimeline,
-                                   PLAYLIST::CSegmentTemplate& segTemplate);
+  void ParseTagSegmentTimeline(pugi::xml_node parentNode,
+                               PLAYLIST::CSpinCache<uint32_t>& SCTimeline);
 
-  void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate* segTpl);
+  void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate& segTpl);
 
   void ParseTagContentProtection(pugi::xml_node nodeParent,
                                  std::vector<PLAYLIST::ProtectionScheme>& protectionSchemes);
@@ -111,11 +106,9 @@ protected:
   virtual void RefreshLiveSegments() override;
 
   /*
-   * \brief Get the current timestamp, overridable method for test project
+   * \brief Get the current timestamp in ms, overridable method for test project
    */
   virtual uint64_t GetTimestamp();
-
-  uint64_t m_firstStartNumber{0};
 
   // The lower start number of segments
   uint64_t m_segmentsLowerStartNumber{0};
@@ -125,12 +118,14 @@ protected:
   // Period sequence incremented to every new period added
   uint32_t m_periodCurrentSeq{0};
 
-  double m_timeShiftBufferDepth{0}; // MPD Timeshift buffer attribute value, in seconds
-  double m_mediaPresDuration{0}; // MPD Media presentation duration attribute value, in seconds (may be not provided)
+  uint64_t m_timeShiftBufferDepth{0}; // MPD Timeshift buffer attribute value, in ms
+  uint64_t m_mediaPresDuration{0}; // MPD Media presentation duration attribute value, in ms (may be not provided)
 
   uint64_t m_minimumUpdatePeriod{0}; // in seconds
-  bool m_allowInsertLiveSegments{false};
+
   // Determines if a custom PSSH initialization license data is provided
   bool m_isCustomInitPssh{false};
+
+  bool m_isMpdUpdate = false;
 };
 } // namespace adaptive

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -39,7 +39,8 @@ public:
   virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
                                      PLAYLIST::CAdaptationSet* adp,
                                      PLAYLIST::CRepresentation* rep,
-                                     bool& isDrmChanged) override;
+                                     bool& isDrmChanged,
+                                     uint64_t currentSegNumber) override;
 
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
@@ -84,7 +85,7 @@ protected:
     uint32_t m_bandwidth{0};
     std::string m_codecs;
     std::string m_resolution;
-    double m_frameRate{0};
+    float m_frameRate{0};
     std::string m_groupIdAudio;
     std::string m_groupIdSubtitles;
     std::string m_uri;
@@ -128,7 +129,7 @@ protected:
   void PrepareSegments(PLAYLIST::CPeriod* period,
                        PLAYLIST::CAdaptationSet* adp,
                        PLAYLIST::CRepresentation* rep,
-                       uint64_t segPosition);
+                       uint64_t segNumber);
 
   virtual void RefreshLiveSegments() override;
 

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -34,7 +34,7 @@ public:
 
   virtual CSmoothTree* Clone() const override { return new CSmoothTree{*this}; }
 
-  virtual void InsertLiveSegment(PLAYLIST::CPeriod* period,
+  virtual bool InsertLiveSegment(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adpSet,
                                  PLAYLIST::CRepresentation* repr,
                                  size_t pos,

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -210,7 +210,7 @@ AP4_Result CFragmentedSampleReader::ReadSample()
 
   m_dts = (m_sample.GetDts() * m_timeBaseExt) / m_timeBaseInt;
   m_pts = (m_sample.GetCts() * m_timeBaseExt) / m_timeBaseInt;
-  
+
   m_codecHandler->UpdatePPSId(m_sampleData);
 
   return AP4_SUCCESS;
@@ -356,6 +356,9 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
 
     //Correct PTS
     AP4_Sample sample;
+    //! @todo: there is something wrong on pts calculation,
+    //! m_ptsOffs have a value in seconds and so the substraction "m_pts - m_ptsOffs" looks to be inconsistent.
+    //! This code is present also on the others sample readers, that need to be verified
     if (~m_ptsOffs)
     {
       if (AP4_SUCCEEDED(GetSample(m_track->GetId(), sample, 0)))

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -180,7 +180,7 @@ AP4_Result CSubtitleSampleReader::ReadSample()
       LOG::LogF(LOGERROR, "Failed to get segment data from subtitle stream");
     }
   }
-  else if (m_adStream->getRepresentation()->IsWaitForSegment())
+  else if (m_adStream && m_adStream->getRepresentation()->IsWaitForSegment())
   {
     // Wait for manifest live update to get next segment
     return AP4_SUCCESS;

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -146,62 +146,44 @@ AP4_Result CSubtitleSampleReader::ReadSample()
   else if (m_adByteStream && m_adStream) // Read the sample data from a segment file stream (e.g. HLS)
   {
     // Get the next segment
-    if (m_adStream->ensureSegment())
+    std::vector<uint8_t> buffer;
+    if (m_adByteStream->ReadFull(buffer))
     {
-      size_t segSize;
-      if (m_adStream->retrieveCurrentSegmentBufferSize(segSize))
+      auto rep = m_adStream->getRepresentation();
+      if (rep)
       {
-        AP4_DataBuffer segData;
-        while (segSize > 0)
+        auto currentSegment = rep->current_segment_;
+        if (currentSegment)
         {
-          AP4_Size readSize = m_segmentChunkSize;
-          if (segSize < static_cast<size_t>(m_segmentChunkSize))
-            readSize = static_cast<AP4_Size>(segSize);
+          AP4_DataBuffer segData(buffer.data(), static_cast<AP4_Size>(buffer.size()));
+          uint64_t segDur = currentSegment->m_endPts - currentSegment->startPTS_;
 
-          AP4_Byte* buf = new AP4_Byte[readSize];
-          segSize -= readSize;
-          if (AP4_SUCCEEDED(m_adByteStream->Read(buf, readSize)))
+          AP4_UI32 duration =
+              static_cast<AP4_UI32>((segDur * STREAM_TIME_BASE) / rep->GetTimescale());
+          AP4_UI64 pts = (currentSegment->startPTS_ * STREAM_TIME_BASE) / rep->GetTimescale();
+
+          m_codecHandler->Transform(pts, duration, segData, 1000);
+          if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))
           {
-            segData.AppendData(buf, readSize);
-            delete[] buf;
+            m_pts = m_sample.GetCts();
+            return AP4_SUCCESS;
           }
-          else
-          {
-            delete[] buf;
-            break;
-          }
-        }
-        auto rep = m_adStream->getRepresentation();
-        if (rep)
-        {
-          auto currentSegment = rep->current_segment_;
-          if (currentSegment)
-          {
-            m_codecHandler->Transform(currentSegment->startPTS_,
-                                      static_cast<AP4_UI32>(currentSegment->m_duration), segData,
-                                      1000);
-            if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))
-            {
-              m_pts = m_sample.GetCts();
-              return AP4_SUCCESS;
-            }
-          }
-          else
-            LOG::LogF(LOGERROR, "Failed to get current segment of subtitle stream");
         }
         else
-          LOG::LogF(LOGERROR, "Failed to get Representation of subtitle stream");
+          LOG::LogF(LOGERROR, "Failed to get current segment of subtitle stream");
       }
       else
-      {
-        LOG::LogF(LOGWARNING, "Failed to get subtitle segment buffer size");
-      }
+        LOG::LogF(LOGERROR, "Failed to get Representation of subtitle stream");
     }
-    else if (m_adStream->getRepresentation()->IsWaitForSegment())
+    else
     {
-      // Wait for manifest live update to get next segment
-      return AP4_SUCCESS;
+      LOG::LogF(LOGERROR, "Failed to get segment data from subtitle stream");
     }
+  }
+  else if (m_adStream->getRepresentation()->IsWaitForSegment())
+  {
+    // Wait for manifest live update to get next segment
+    return AP4_SUCCESS;
   }
 
   m_eos = true;

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -69,6 +69,18 @@ AP4_Result CTSSampleReader::ReadSample()
 {
   if (ReadPacket())
   {
+    //! @todo: there is something wrong on pts calculation,
+    //! m_ptsOffs have a value in seconds and so the substraction "m_pts - m_ptsOffs" looks to be inconsistent,
+    //! To have pts in seconds on m_pts must be: pts = GetDts() / 90000,
+    //! but packet PTS seem to be different from m_ptsOffs pts value, as if it did not include the period start
+    //! so the substraction "m_pts - m_ptsOffs" it is not a clear thing.
+    //! There is also something weird on HLS discontinuities (multiple chapters/periods)
+    //! where after a discontinuity the packet pts is lower than the last segment of previous period/discontinuity
+    //! this cause a VP resync e.g:
+    //!   debug <general>: CVideoPlayer::CheckContinuity - resync backward :1, prev:587175999.000000, curr:577170666.000000, diff:-10005333.000000
+    //!   debug <general>: CVideoPlayer::CheckContinuity - update correction: -10026666.000000
+    //! not sure if this is correct or not (tested with pluto-tv)
+    //! This code is present also on the others sample readers, that need to be verified
     m_dts = (GetDts() == PTS_UNSET) ? STREAM_NOPTS_VALUE : (GetDts() * 100) / 9;
     m_pts = (GetPts() == PTS_UNSET) ? STREAM_NOPTS_VALUE : (GetPts() * 100) / 9;
 

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -120,7 +120,7 @@ private:
 
   virtual CDashTree* Clone() const override { return new DASHTestTree{*this}; }
 
-  uint64_t m_mockTime = 10000000L;
+  uint64_t m_mockTime = 10000000000;
   std::chrono::system_clock::time_point m_mock_time_chrono = std::chrono::system_clock::now();
 
   std::string m_manifestUpdUrl; // Temporarily stores the url where to request the manifest update

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -15,7 +15,6 @@
 #include <algorithm> // any_of
 #include <chrono>
 #include <cstring>
-#include <ctime>
 #include <stdio.h>
 
 using namespace UTILS;
@@ -329,9 +328,16 @@ void UTILS::ParseHeaderString(std::map<std::string, std::string>& headerMap,
 
 uint64_t UTILS::GetTimestamp()
 {
-  std::chrono::seconds unix_timestamp = std::chrono::seconds(std::time(NULL));
-  using dCast = std::chrono::duration<std::uint64_t>;
-  return std::chrono::duration_cast<dCast>(std::chrono::milliseconds(unix_timestamp)).count();
+  auto currentTime = std::chrono::system_clock::now();
+  auto epochTime = currentTime.time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::seconds>(epochTime).count();
+}
+
+uint64_t UTILS::GetTimestampMs()
+{
+  auto currentTime = std::chrono::system_clock::now();
+  auto epochTime = currentTime.time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(epochTime).count();
 }
 
 std::vector<uint8_t> UTILS::ZeroPadding(const std::vector<uint8_t>& data, const size_t padSize)

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -34,9 +34,15 @@ void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std:
 
 /*!
  * \brief Get the current timestamp
- * \return The timestamp in milliseconds
+ * \return The timestamp in seconds
  */
 uint64_t GetTimestamp();
+
+/*!
+ * \brief Get the current timestamp
+ * \return The timestamp in milliseconds
+ */
+uint64_t GetTimestampMs();
 
 /*!
  * \brief Add zero-pad on the left side of data when the data size is less than pad size

--- a/src/utils/XMLUtils.cpp
+++ b/src/utils/XMLUtils.cpp
@@ -21,11 +21,13 @@ using namespace UTILS::XML;
 using namespace kodi::tools;
 using namespace pugi;
 
-uint64_t UTILS::XML::ParseDate(std::string_view timeStr,
-                               uint64_t fallback /* = std::numeric_limits<uint64_t>::max() */)
+double UTILS::XML::ParseDate(std::string_view timeStr,
+                             double fallback /* = std::numeric_limits<double>::max() */)
 {
   int year, mon, day, hour, minu, sec;
-  if (std::sscanf(timeStr.data(), "%d-%d-%dT%d:%d:%d", &year, &mon, &day, &hour, &minu, &sec) == 6)
+  int msec{0};
+  if (std::sscanf(timeStr.data(), "%d-%d-%dT%d:%d:%d.%dZ", &year, &mon, &day, &hour, &minu, &sec,
+                  &msec) >= 6)
   {
     tm tmd{0};
     tmd.tm_year = year - 1900;
@@ -34,7 +36,7 @@ uint64_t UTILS::XML::ParseDate(std::string_view timeStr,
     tmd.tm_hour = hour;
     tmd.tm_min = minu;
     tmd.tm_sec = sec;
-    return static_cast<uint64_t>(_mkgmtime(&tmd));
+    return static_cast<double>(_mkgmtime(&tmd)) + msec / 1000.0;
   }
   return fallback;
 }

--- a/src/utils/XMLUtils.h
+++ b/src/utils/XMLUtils.h
@@ -34,8 +34,7 @@ namespace XML
  * \param fallback [OPT] The fallback value when parse fails, by default set as max uint64_t value
  * \return The parsed date in seconds, or fallback value when fails.
  */
-uint64_t ParseDate(std::string_view timeStr,
-                   uint64_t fallback = std::numeric_limits<uint64_t>::max());
+double ParseDate(std::string_view timeStr, double fallback = std::numeric_limits<double>::max());
 
 /*!
  * \brief Parses an XML duration string.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Its difficult to explain every single change here, i would end up writing a book!
So i try to summarize most important changes/problems

Unfortunately while i was fixing one thing it was breaking another, this due to wrong or missing implementations done in the past, since everything is connected there is no way to create separate small PRs you need to include all changes together

1) Nasty bug! on segment_buffers_ uses
https://github.com/xbmc/inputstream.adaptive/blob/df8b32db36cbf4e2e14441ebe533d547ebf3c947/src/common/AdaptiveStream.cpp#L882-L883
`segment_buffers_` is unrelated to MPD manifest updates! and can lead to wrong next segment!
because between MPD updates old segments can disappears from the timeline
and new one added, this will produce misaligned segment_number saved in to segment_buffers_
because the stored segment_number is not aware of MPD updates and keep the reference
to the initial (start number) segment position referred to oldest manifest!
with segment_buffers_ you need to find the next segment by compare segment startPTS.

2) Mess of segment timeline update on `CDashTree::RefreshLiveSegments`
https://github.com/xbmc/inputstream.adaptive/blob/df8b32db36cbf4e2e14441ebe533d547ebf3c947/src/parser/DASHTree.cpp#L1750-L1885
All this code was a lot messy, i have removed all, by looking one another video player source code, was checking to align updated segments by using segment start PTS, and not the start number as was done here. This should also allow more clean implementation for the misalignment workaround that before was force changing the start number, this was causing problems with some live streams and make working some others (like facebook), force change start number is a killer operation to do that may lead problems on many source code parts, often if you works with multiple periods

3) Nasty multiple bugs in the segment alignment code on representation segments (template) generation
https://github.com/xbmc/inputstream.adaptive/blob/df8b32db36cbf4e2e14441ebe533d547ebf3c947/src/parser/DASHTree.cpp#L1084-L1099
from the earliest versions of ISA i never understood this unclear code part, so it was used to adjust the start number for live streams, but...
after tons of try and check, i understood that:
3.1) Bug! this move the start number for the current live edge position, was ok, but if you move the number you must change also the start PTS! this last one was missing, and least to hidden weird behaviours
3.2) Bug! you can align the initial segment, but dont do it for all periods! this will kill the other period timeline! leading to unclear weird behaviours
3.3) Bug! you can align the initial segment, but if you dont know the period duration you will generate segments that can overlap up to and beyond the next period! with live streaming you need to wait the MPD update to know the period duration, so limit to generate the 1st segment and leaves the task to InsertLiveSegment
3.4) Bug! Dont align with MPD updates it its needed only for playback start or will affect the right periods timeline

4) Removed m_allowInsertLiveSegments workaround
the solution was if the SegmentTemplate provide the timeline dont insert live segments

5) InsertLiveSegment bug with multiple periods
"insert live segment's" when was used, was a non ending operation, that was preventing switch to the next period.
I found a way to limit the "live segment insert" that consist in to fetch the duration from MPD update during playback, and so i have add a code to check on-fly that inserted segment dont exceeds the period duration.
Also i tried to move the InsertLiveSegment call to the AdaptiveStream::ensureSegment instead of use Session,
this IMO will result in a more clean code

6) Reworked in full generation of segments for SegmentTemplate, there were wrong parts

7) `CSegment` `startPTS_` now is always referred to be within the period Start pts

8) ~Add support to MPD having SegmentTemplate and PresentationTimeOffset~ changes reverted/removed

9) Removed all Youtube outdated specific code about `$START_NUMBER$` on manifest update URL for MPD update and all code workarounds (`inputstream.adaptive.manifest_update_parameter` or `inputstream.adaptive.manifest_upd_params`)

10) `GetFragmentInfo` on `CSession::OnSegmentChangedRead` has been full removed, this because `InsertLiveSegment` is now done inside `AdaptiveStream::ensureSegment` that allow to remove specific code on Session like `m_hasSegmentChanged`

11) `AdaptiveStream::waitingForSegment` has been simplified and removed the weird `checkTime` var, i could not understand the reason for checking GetStreamType, where imo the only thing to take in account is make sure that available_segment_buffers_ is empty, if someone has some info please let me know, from my part i havent found regressions (i tested also HLS stream with audio "included" to video)

12) HLS add support to `EXT-X-PROGRAM-DATE-TIME` for live streams, this has been mandatory since now the `CSegment` `startPTS_` use PTS within the period, and so you need the datetime anchor (when possible)

13) some code TODO's added, for future cleanups

14) changes to gtest's. Some tests has been adjusted due to segment startPts fixes, two cases that may require some explanation are:
`DASHTreeTest updateParameterLiveSegmentStartNumber` removed was outdated youtube test
`DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline` i have reflected the changes to have the real segment timing as explained of old PR #724

15) Changes in to `CSubtitleSampleReader::ReadSample`, done because it was calling two times ensureSegment and was not so nice, so i have add a way to get the full data from segment buffer.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was investigating to fix the problem with `m_allowInsertLiveSegments` workaround
that since very old ISA versions was always handled in bad way,
i took time to try understand things that was not working good and i endedup finding a lot of bugs...

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested mainly with these live MPD,each one has different behaviour:
https://livesim.dashif.org/livesim/periods_20/testpic_2s/Manifest.mpd (+periods+insert segs)
https://d3cglye48cl6m2.cloudfront.net/out/v1/563ec3e9487340528616d736e1202232/index.mpd (+periods)
https://htv-rrs.mts.ru/PLTV/88888888/224/3221228154/3221228154.mpd (+insert segs, idr if there are periods maybe rare)
facebook live, mpd not linked find it on website flow (it expire) (NO insert segs, but with MPD updates old segments can disappears from timeline that can lead to  1° bug and others)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
