### PR TITLE
[SubtitleSampleReader] Restored old pts workaound

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1065,6 +1065,12 @@ bool CSession::GetNextSample(ISampleReader*& sampleReader)
       {
         if (AP4_SUCCEEDED(streamReader->Start(isStarted)))
         {
+          //!@ todo: DTSorPTS comparison is wrong
+          //! currently we are compare audio/video/subtitles
+          //! for audio/video the pts/dts come from demuxer, but subtitles use pts from manifest
+          //! these values not always are comparable because pts/dts that come from demuxer packet data
+          //! can be different and makes this package selection ineffective
+          //! see also workaround on CSubtitleSampleReader::ReadSample
           if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())
           {
             if (stream->m_adStream.waitingForSegment())

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -160,7 +160,14 @@ AP4_Result CSubtitleSampleReader::ReadSample()
 
           AP4_UI32 duration =
               static_cast<AP4_UI32>((segDur * STREAM_TIME_BASE) / rep->GetTimescale());
-          AP4_UI64 pts = (currentSegment->startPTS_ * STREAM_TIME_BASE) / rep->GetTimescale();
+
+          //! @todo: startPTS workaround! pts has been taken by substracting the period start
+          //! this just to have a lower pts value, but the real problem is in CSession::GetNextSample
+          //! that that makes an incorrect comparison of DTSorPTS
+          const uint64_t pStart = m_adStream->getPeriod()->GetStart() * rep->GetTimescale() / 1000;
+          const uint64_t startPts = currentSegment->startPTS_ - pStart;
+
+          AP4_UI64 pts = (startPts * STREAM_TIME_BASE) / rep->GetTimescale();
 
           m_codecHandler->Transform(pts, duration, segData, 1000);
           if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This problem has been hidden since early ISA versions,
but it was highlighted when i reworked Dash parser and introduced also EXT-X-PROGRAM-DATE-TIME on HLS
the main problem is on DTSorPTS() comparison

https://github.com/xbmc/inputstream.adaptive/blob/a82e3eb8333187d8bb346bf5eca384524a553e57/src/Session.cpp#L1067-L1069

we are comparing audio/video/subtitles,
for audio/video the pts/dts come from demuxer, but subtitles use pts from manifest or from subtitle data "cue" timing
these values not always are comparable with audio/video, because pts/dts that come from demuxer packet data
can be different and makes this package selection totally ineffective

other details on comments:
https://github.com/xbmc/inputstream.adaptive/issues/1507#issuecomment-2029867689
https://github.com/xbmc/inputstream.adaptive/issues/1507#issuecomment-2028774719

this PR for now i restore the old behaviour by removing the period start pts from segment pts
this will result that the subtitle "packet" pts will have most of time always a lower pts compared to audio/video
and then will be processed immediately without any control

an appropriate solution will be needed in future
since i think that weird thing can happens anyway
for example with all uses of lastPts variable:

https://github.com/xbmc/inputstream.adaptive/blob/a82e3eb8333187d8bb346bf5eca384524a553e57/src/main.cpp#L396

that need to be at same time re-checked

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
"fix" https://github.com/xbmc/inputstream.adaptive/issues/1419#issuecomment-2041299336
"fix" https://github.com/xbmc/inputstream.adaptive/issues/1507#issuecomment-2028488867

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
D+

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
