### PR TITLE
[DashTree] Implemented segment controlled live manifest

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -436,8 +436,7 @@ int AdaptiveStream::SecondsSinceUpdate() const
 
 void AdaptiveStream::OnTFRFatom(uint64_t ts, uint64_t duration, uint32_t mediaTimescale)
 {
-  m_tree->InsertLiveSegment(current_period_, current_adp_, current_rep_, getSegmentPos(), ts,
-                            duration, mediaTimescale);
+  m_tree->InsertLiveFragment(current_adp_, current_rep_, ts, duration, mediaTimescale);
 }
 
 bool adaptive::AdaptiveStream::IsRequiredCreateMovieAtom()
@@ -891,7 +890,7 @@ bool AdaptiveStream::ensureSegment()
       if (available_segment_buffers_ == 0)
       {
         if (m_tree->InsertLiveSegment(getPeriod(), getAdaptationSet(), getRepresentation(),
-                                      getSegmentPos(), 0, 0, 0))
+                                      getSegmentPos()))
         {
           //! @todo: seem to be possible get the segment from InsertLiveSegment and then avoid call get_next_segment
           nextSegment = current_rep_->get_next_segment(current_rep_->current_segment_);

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -156,24 +156,36 @@ public:
   void FreeSegments(PLAYLIST::CPeriod* period, PLAYLIST::CRepresentation* repr);
 
   /*!
-   * \brief Some adaptive streaming protocols allow the client to download the live playlist once and
-   *        build future segments based on metadata contained in the fragments e.g. to avoid repeated
-   *        manifest downloads or to cover the duration of a period not fully covered by the provided timeline.
+   * \brief Some types of live manifests do not include segments, so the client must create them,
+   *        this method could be used in conjunction with manifest updates.
    * \param period Current period
    * \param adpSet Current adaptation set
    * \param repr Current representation
    * \param pos Current segment position
-   * \param timestamp Fragment start timestamp
-   * \param fragmentDuration Fragment duration
-   * \param movieTimescale Fragment movie timescale
    */
   virtual bool InsertLiveSegment(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adpSet,
                                  PLAYLIST::CRepresentation* repr,
-                                 size_t pos,
-                                 uint64_t timestamp,
-                                 uint64_t fragmentDuration,
-                                 uint32_t movieTimescale)
+                                 size_t pos)
+  {
+    return false;
+  }
+
+  /*!
+   * \brief Some types of live manifests might include only the initial segments,
+   *        so the client by parsing the packet data (usually MP4) can get the
+   *        info to create future segments.
+   * \param adpSet Current adaptation set
+   * \param repr Current representation
+   * \param fTimestamp Fragment start timestamp
+   * \param fDuration Fragment duration
+   * \param fTimescale Fragment timescale
+   */
+  virtual bool InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
+                                  PLAYLIST::CRepresentation* repr,
+                                  uint64_t fTimestamp,
+                                  uint64_t fDuration,
+                                  uint32_t fTimescale)
   {
     return false;
   }

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -47,10 +47,13 @@ public:
   virtual bool InsertLiveSegment(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adpSet,
                                  PLAYLIST::CRepresentation* repr,
-                                 size_t pos,
-                                 uint64_t timestamp,
-                                 uint64_t fragmentDuration,
-                                 uint32_t movieTimescale) override;
+                                 size_t pos) override;
+
+  virtual bool InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
+                                  PLAYLIST::CRepresentation* repr,
+                                  uint64_t fTimestamp,
+                                  uint64_t fDuration,
+                                  uint32_t fTimescale) override;
 
 protected:
   virtual CDashTree* Clone() const override { return new CDashTree{*this}; }
@@ -116,7 +119,7 @@ protected:
   uint64_t m_timeShiftBufferDepth{0}; // MPD Timeshift buffer attribute value, in ms
   uint64_t m_mediaPresDuration{0}; // MPD Media presentation duration attribute value, in ms (may be not provided)
 
-  uint64_t m_minimumUpdatePeriod{0}; // in seconds
+  uint64_t m_minimumUpdatePeriod{PLAYLIST::NO_VALUE}; // in seconds, NO_VALUE if not set
 
   // Determines if a custom PSSH initialization license data is provided
   bool m_isCustomInitPssh{false};

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -34,13 +34,11 @@ public:
 
   virtual CSmoothTree* Clone() const override { return new CSmoothTree{*this}; }
 
-  virtual bool InsertLiveSegment(PLAYLIST::CPeriod* period,
-                                 PLAYLIST::CAdaptationSet* adpSet,
-                                 PLAYLIST::CRepresentation* repr,
-                                 size_t pos,
-                                 uint64_t timestamp,
-                                 uint64_t fragmentDuration,
-                                 uint32_t mediaTimescale) override;
+  virtual bool InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
+                                  PLAYLIST::CRepresentation* repr,
+                                  uint64_t fTimestamp,
+                                  uint64_t fDuration,
+                                  uint32_t fTimescale) override;
 
 protected:
   virtual bool ParseManifest(const std::string& data);

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -26,8 +26,8 @@ using namespace UTILS;
 
 namespace
 {
-constexpr uint8_t SMOOTHSTREAM_TFRFBOX_UUID[] = {0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46, 0x95,
-                                                 0x8e, 0x54, 0x26, 0xcb, 0x9e, 0x46, 0xa7, 0x9f};
+constexpr uint8_t MP4_TFRFBOX_UUID[] = {0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46, 0x95,
+                                        0x8e, 0x54, 0x26, 0xcb, 0x9e, 0x46, 0xa7, 0x9f};
 } // unnamed namespace
 
 
@@ -337,8 +337,10 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
     while ((atom = traf->GetChild(AP4_ATOM_TYPE_UUID, atom_pos++)) != nullptr)
     {
       AP4_UuidAtom* uuidAtom{AP4_DYNAMIC_CAST(AP4_UuidAtom, atom)};
-      // For smooth streaming live streams we have an TFRF atom with one / more following fragment durations
-      if (std::memcmp(uuidAtom->GetUuid(), SMOOTHSTREAM_TFRFBOX_UUID, 16) == 0)
+      // Some Dash and Smooth Streaming live streaming can be segment controlled
+      // these type of manifests dont have scheduled manifest updates
+      // so its needed to parse the TFRF in order to get new updates
+      if (std::memcmp(uuidAtom->GetUuid(), MP4_TFRFBOX_UUID, 16) == 0)
       {
         ParseTrafTfrf(uuidAtom);
         break;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This was already implemented to SmoothStreaming
where CFragmentedSampleReader parse segment data (MP4 TFRF box) to retrieve new updates
and i think that on Nexus branch should have worked also for Dash
but there is too mess in the old code that could cause side effects (user said that on Kodi 20 dont work)
this on Dash specs is called as segment-controlled live

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~try to~ fix #1495
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i have no dash streams to test this use case, user feedback  ~needed~ confirmed works

following is SmoothStreaming that is similar (and can provide more fragments in one packet)
https://gstv-tnz-gsmediastreaming.preview-jpea.channel.media.azure.net/dfd06b62-e9d1-4a7f-bcbb-89d2ecbc82ee/preview.ism/manifest

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
