### PR TITLE
[HLSTree] New hls_ignore_endlist, hls_fix_mediasequence, hls_fix_discsequence params to fix faulty live services

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -262,6 +262,18 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseManifestConfig(const std::string& dat
       if (jDictVal.GetUint() > 0)
         m_manifestConfig.timeShiftBufferLimit = jDictVal.GetUint();
     }
+    else if (configName == "hls_ignore_endlist" && jDictVal.IsBool())
+    {
+       m_manifestConfig.hlsIgnoreEndList = jDictVal.GetBool();
+    }
+    else if (configName == "hls_fix_mediasequence" && jDictVal.IsBool())
+    {
+       m_manifestConfig.hlsFixMediaSequence = jDictVal.GetBool();
+    }
+    else if (configName == "hls_fix_discsequence" && jDictVal.IsBool())
+    {
+       m_manifestConfig.hlsFixDiscontSequence = jDictVal.GetBool();
+    }
     else
     {
       LOG::LogF(LOGERROR, "Unsupported \"%s\" config or wrong data type on \"%s\" property",

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -45,7 +45,17 @@ struct ChooserProps
 
 struct ManifestConfig
 {
-  std::optional<uint32_t> timeShiftBufferLimit; // Limit the timeshift buffer depth, in seconds
+  // Limit the timeshift buffer depth, in seconds
+  std::optional<uint32_t> timeShiftBufferLimit;
+  // Faulty HLS live services can send manifest updates with inconsistent EXT-X-ENDLIST
+  // when the stream is not finished, enabling this will ignore EXT-X-ENDLIST tags
+  bool hlsIgnoreEndList{false};
+  // Faulty HLS live services can send manifest updates with inconsistent EXT-X-MEDIA-SEQUENCE
+  // enabling this will correct the value by using EXT-X-PROGRAM-DATE-TIME tags
+  bool hlsFixMediaSequence{false};
+  // Faulty HLS live services can send manifest updates with inconsistent EXT-X-DISCONTINUITY-SEQUENCE
+  // enabling this will correct the value by using EXT-X-PROGRAM-DATE-TIME tags
+  bool hlsFixDiscontSequence{false};
 };
 
 class ATTR_DLL_LOCAL CCompKodiProps

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -943,9 +943,8 @@ void CSession::PrepareStream(CStream* stream)
   // Download the manifest only at first start of the stream
   if (startEvent == EVENT_TYPE::STREAM_START)
   {
-    bool noop;
     m_adaptiveTree->PrepareRepresentation(stream->m_adStream.getPeriod(),
-                                          stream->m_adStream.getAdaptationSet(), repr, noop,
+                                          stream->m_adStream.getAdaptationSet(), repr,
                                           SEGMENT_NO_NUMBER);
   }
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -953,8 +953,7 @@ bool AdaptiveStream::ensureSegment()
         {
           // On manifests type like HLS we need also to get update segments
           // because need to be downloaded/parsed from different child manifest files
-          bool isDrmChanged;
-          m_tree->PrepareRepresentation(current_period_, current_adp_, newRep, isDrmChanged,
+          m_tree->PrepareRepresentation(current_period_, current_adp_, newRep,
                                         current_rep_->getCurrentSegmentNumber());
 
           // If the representation has been changed, segments may have to be generated (DASH)

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -74,6 +74,7 @@ enum class EVENT_TYPE
     void Disable();
 
     void SetStartEvent(const EVENT_TYPE eventType) { m_startEvent = eventType; }
+    EVENT_TYPE GetStartEvent() const { return m_startEvent; }
 
     /*!
     * \brief Set the current segment to the one specified, and reset

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -186,6 +186,9 @@ namespace adaptive
                                    const PLAYLIST::CRepresentation* segRep,
                                    const PLAYLIST::CSegment* segment) const
   {
+    if (segRep->SegmentTimeline().IsEmpty())
+      return true;
+
     if (!segment || !segPeriod || !segRep)
       return false;
 
@@ -280,6 +283,11 @@ namespace adaptive
           break;
 
         updLck.lock();
+
+        // Reset interval value to allow forced update from manifest
+        if (m_resetInterval)
+          m_tree->m_updateInterval = PLAYLIST::NO_VALUE;
+
         m_tree->RefreshLiveSegments();
       }
     }

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -126,7 +126,6 @@ public:
   virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
                                      PLAYLIST::CAdaptationSet* adp,
                                      PLAYLIST::CRepresentation* rep,
-                                     bool& isDrmChanged,
                                      uint64_t currentSegNumber)
   {
     return false;

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -252,6 +252,9 @@ public:
     // \brief Reset start time (make exit the condition variable m_cvUpdInterval and re-start the timeout)
     void ResetStartTime() { m_cvUpdInterval.notify_all(); }
 
+    // \brief At next update reset the interval value to NO_VALUE, before make RefreshLiveSegments callback
+    void ResetInterval() { m_resetInterval = true; }
+
     // \brief As "std::mutex" lock, but put in pause the manifest updates (support std::lock_guard).
     //        If an update is in progress, block the code until the update is finished.
     void lock() { Pause(); }
@@ -281,6 +284,7 @@ public:
     std::mutex m_waitMutex;
     std::condition_variable m_cvWait;
     bool m_threadStop{false};
+    bool m_resetInterval{false};
   };
 
   /*!

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -36,7 +36,6 @@ void PLAYLIST::CPeriod::CopyHLSData(const CPeriod* other)
   m_baseUrl = other->m_baseUrl;
   m_id = other->m_id;
   m_timescale = other->m_timescale;
-  m_start = other->m_start;
   m_encryptionState = other->m_encryptionState;
   m_includedStreamType = other->m_includedStreamType;
   m_isSecureDecoderNeeded = other->m_isSecureDecoderNeeded;

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -46,7 +46,6 @@ public:
   virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
                                      PLAYLIST::CAdaptationSet* adp,
                                      PLAYLIST::CRepresentation* rep,
-                                     bool& isDrmChanged,
                                      uint64_t currentSegNumber) override;
 
   virtual void OnDataArrived(uint64_t segNum,
@@ -150,8 +149,7 @@ protected:
                                  std::string_view sourceUrl,
                                  PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adp,
-                                 PLAYLIST::CRepresentation* rep,
-                                 bool& isDrmChanged);
+                                 PLAYLIST::CRepresentation* rep);
 
   void PrepareSegments(PLAYLIST::CPeriod* period,
                        PLAYLIST::CAdaptationSet* adp,

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -86,8 +86,7 @@ protected:
       rep->SetSourceUrl(url);
 
     testHelper::testFile = filePath;
-    bool isDrmChanged;
-    return tree->PrepareRepresentation(per, adp, rep, isDrmChanged, PLAYLIST::SEGMENT_NO_NUMBER);
+    return tree->PrepareRepresentation(per, adp, rep, PLAYLIST::SEGMENT_NO_NUMBER);
   }
 
   adaptive::CHLSTree* tree;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Plutotv its a good example of faulty live service that violates the HLS specifications in different ways (not all specified here)
by providing malformed data on variant child manifests:

EXT-X-DISCONTINUITY-SEQUENCE: has inconsistent number between manifest updates, for example on first downloaded manifest could be of value 2, on the next update become 0 or 1. A decreasing number is not allowed on sane HLS.

EXT-X-MEDIA-SEQUENCE: has inconsistent number between manifest updates, that cause impossibility to keep track of the sequence of segments between updates, i couldn't figure out if there is a logical pattern, because the numbers seem pretty random...

EXT-X-ENDLIST: make a wrong use of EXT-X-ENDLIST tag, sometimes the service send a manifest update without segments, and specifying this tag although the live stream is not ended, thereby forcing the stop of playback

EXT-X-PROGRAM-DATE-TIME: sometime there is not a precise value, so on first downloaded manifest there is X PTS value, on next manifest update X varies by some seconds, or also they replace the original value with others, this leads to any kind of side effect since the fixes are based on this

To "fix" this bad situation i have add these new parameters to `inputstream.adaptive.manifest_config` property:

`hls_ignore_endlist`: allow to ignore EXT-X-ENDLIST, there are two situations
1) At playback start, can be sent the first manifest without segments and with EXT-X-ENDLIST
2) While in playback, can be sent the manifest update without segments and with EXT-X-ENDLIST
for the case 2, to mitigate buffering problems the time to perform the next manifest update is temporarily halved

`hls_fix_mediasequence`: allow to try correct a malformed EXT-X-MEDIA-SEQUENCE value, the corrected value is determined by finding the corresponding segment in the updated playlist referring to the PTS value of the segment provided by the EXT-X-PROGRAM-DATE-TIME tag. so to use this paramenter it is strictly required that the manifest provides EXT-X-PROGRAM-DATE-TIME tag

`hls_fix_discsequence`: allow to try correct a malformed EXT-X-DISCONTINUITY-SEQUENCE value, the corrected value is determined by checking whether a segment falls within an existing period if found use that sequence number to fix EXT-X-DISCONTINUITY-SEQUENCE in order to work EXT-X-PROGRAM-DATE-TIME tag is needed.

**However malformed manifest update can lead to any kind of playback oddities, such as segments played multiple times, or periods switched before the end of their playback, due to the impossibility of determining the right sequence number and segment to be played. In the worst case it will cause unexpected problems with Kodi VideoPlayer by freezing the playback either temporarily (a few seconds) or permanently.**

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1507 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
#KODIPROP:inputstream.adaptive.manifest_config={"hls_ignore_endlist":true,"hls_fix_mediasequence":true,"hls_fix_discsequence":true}
```
https://r.mjh.nz/PlutoTV/64b67f0424ade50008a3be17-alt.m3u8

played for more times until to catch ADS discontinuities

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
