### PR TITLE
[HLSTree] Fix encryption transitions

### DIFF
--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -10,6 +10,7 @@
 
 #include "AdaptationSet.h"
 #include "Representation.h"
+#include "utils/log.h"
 
 using namespace PLAYLIST;
 
@@ -86,6 +87,12 @@ void PLAYLIST::CPeriod::RemovePSSHSet(uint16_t pssh_set)
 
 void PLAYLIST::CPeriod::DecreasePSSHSetUsageCount(uint16_t pssh_set)
 {
+  if (pssh_set >= m_psshSets.size())
+  {
+    LOG::LogF(LOGERROR, "Cannot decrease PSSH usage, PSSHSet position %u exceeds the container size", pssh_set);
+    return;
+  }
+
   PSSHSet& psshSet = m_psshSets[pssh_set];
   if (psshSet.m_usageCount > 0)
     psshSet.m_usageCount--;

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -284,12 +284,22 @@ bool adaptive::CHLSTree::ParseChildManifest(const std::string& data,
 
       switch (ProcessEncryption(rep->GetBaseUrl(), attribs))
       {
+        case EncryptionType::CLEAR:
+          currentEncryptionType = EncryptionType::CLEAR;
+          period->SetEncryptionState(EncryptionState::UNENCRYPTED);
+          psshSetPos = PSSHSET_POS_DEFAULT;
+          break;
         case EncryptionType::UNKNOWN:
+          currentEncryptionType = EncryptionType::UNKNOWN;
+          period->SetEncryptionState(EncryptionState::ENCRYPTED);
+          break;
         case EncryptionType::NOT_SUPPORTED:
+          currentEncryptionType = EncryptionType::NOT_SUPPORTED;
           period->SetEncryptionState(EncryptionState::ENCRYPTED);
           break;
         case EncryptionType::AES128:
           currentEncryptionType = EncryptionType::AES128;
+          period->SetEncryptionState(EncryptionState::UNENCRYPTED);
           psshSetPos = PSSHSET_POS_DEFAULT;
           break;
         case EncryptionType::WIDEVINE:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
A manifest can contains more discontinuities with different encryptions or not, example:

Disc. 1 - AES128
Disc. 2 - unencrypted
Disc. 3 - AES128

the transition to unencrypted was not working
because currentEncryptionType was not set correctly

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
found while testing plutotv

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:5
#EXT-X-DISCONTINUITY-SEQUENCE:5
#EXT-X-MEDIA-SEQUENCE:96
#EXT-X-PROGRAM-DATE-TIME:2024-04-22T11:00:33.047Z
#EXT-X-KEY:METHOD=AES-128,URI="http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400_keyfile_0.key",IV=0x00000000000000000000000000000004
#EXTINF:5,
http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400-00003.ts
#EXT-X-KEY:METHOD=AES-128,URI="http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400_keyfile_0.key",IV=0x00000000000000000000000000000005
#EXTINF:5,
http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400-00004.ts
#EXT-X-KEY:METHOD=AES-128,URI="http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400_keyfile_0.key",IV=0x00000000000000000000000000000006
#EXTINF:5,
http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400-00005.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2024-04-22T11:00:48.047Z
#EXT-X-KEY:METHOD=AES-128,URI="http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400_keyfile_0.key",IV=0x00000000000000000000000000000001
#EXTINF:5,
http://siloh-ns1.plutotv.net/481_Pluto_TV_OandO/clip/607efb363bbc1b001aee5546_PlutoTV_SamsungTV_Error_30sec/720p/20230808_173212/hls/hls_2400-00000.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2024-04-22T11:00:53.047Z
#EXT-X-KEY:METHOD=NONE
#EXTINF:5,
http://siloh-ns1.plutotv.net/lilo/production/Nick/90sKidsTV/master_120240422T105936_2511628.ts
#EXTINF:5,
http://siloh-ns1.plutotv.net/lilo/production/Nick/90sKidsTV/master_120240422T105941_2511629.ts
```
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
