### PR TITLE
[XMLUtils] Fix wrong result of ParseData due to second fraction

### DIFF
--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -11,6 +11,7 @@
 #include "../common/AdaptiveTreeFactory.h"
 #include "../common/SegTemplate.h"
 #include "../utils/UrlUtils.h"
+#include "../utils/XMLUtils.h"
 
 #include <gtest/gtest.h>
 
@@ -255,4 +256,13 @@ TEST_F(UtilsTest, SegTemplateFormatUrlChecks)
   url = "https://cdn.com/_$_example/$Bandwidth";
   ret = segTpl.FormatUrl(url, "repID", 1500, 1, 0);
   EXPECT_EQ(ret, "https://cdn.com/_$_example/$Bandwidth");
+}
+
+TEST_F(UtilsTest, XMLDateTimeConversions)
+{
+  EXPECT_EQ(XML::ParseDate("2024-04-30T20:20:13.145433Z"), 1714508413.1454329);
+
+  EXPECT_EQ(XML::ParseDate("2024-05-07T17:00:21"), 1715101221);
+
+  EXPECT_EQ(XML::ParseDate("2024-05-07T17:00:21.989+0200"), 1715101221.989);
 }

--- a/src/utils/XMLUtils.cpp
+++ b/src/utils/XMLUtils.cpp
@@ -24,10 +24,11 @@ using namespace pugi;
 double UTILS::XML::ParseDate(std::string_view timeStr,
                              double fallback /* = std::numeric_limits<double>::max() */)
 {
-  int year, mon, day, hour, minu, sec;
-  int msec{0};
-  if (std::sscanf(timeStr.data(), "%d-%d-%dT%d:%d:%d.%dZ", &year, &mon, &day, &hour, &minu, &sec,
-                  &msec) >= 6)
+  int year, mon, day, hour, minu;
+  double sec;
+
+  // This code dont take in account of timezone
+  if (std::sscanf(timeStr.data(), "%d-%d-%dT%d:%d:%lf", &year, &mon, &day, &hour, &minu, &sec) == 6)
   {
     tm tmd{0};
     tmd.tm_year = year - 1900;
@@ -35,9 +36,10 @@ double UTILS::XML::ParseDate(std::string_view timeStr,
     tmd.tm_mday = day;
     tmd.tm_hour = hour;
     tmd.tm_min = minu;
-    tmd.tm_sec = sec;
-    return static_cast<double>(_mkgmtime(&tmd)) + msec / 1000.0;
+    tmd.tm_sec = 0;
+    return static_cast<double>(_mkgmtime(&tmd)) + sec;
   }
+
   return fallback;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The second fraction part was assumed with a precision of 1000
ISO 8601 talk about decimal fraction of seconds
but many services provide a higher precision of second fraction that lead to a wrong result

removed "Z" from `"%d-%d-%dT%d:%d:%d.%dZ"`
this to better fit the also the format: `2024-05-07T17:00:21.989+0200`

added new test cases for ParseData

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
just debug not runtime

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
