### PR TITLE
[AdaptiveStream] Find segment by number otherwise by pts

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -874,10 +874,8 @@ bool AdaptiveStream::ensureSegment()
     {
       if (!segment_buffers_[0]->segment.IsInitialization())
       {
-        // Always search by PTS, the segment buffer is static and meantime manifest updates
-        // may be happened so search by position/segment number could lead to misalignments
-        // moreover some streams dont use segments numbers or may have inconsistent timestamps
-        nextSegment = current_rep_->GetSegmentByPts(segment_buffers_[0]->segment.startPTS_);
+        // Search the same segment on the timeline (which in the meantime may have been updated)
+        nextSegment = current_rep_->GetSegment(segment_buffers_[0]->segment);
       }
     }
     else

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -162,8 +162,8 @@ enum class EVENT_TYPE
     };
     // Be aware! All data related to segments stored in the SEGMENTBUFFER object are static,
     // these data are totally unrelated to manifest updates that may change the segments timeline,
-    // so if you need to find a segment stored here in the timeline you must use Start PTS,
-    // otherwise you could cause misalignments due to different start numbers / segment positions.
+    // so if you need to find a segment stored here in the timeline you must use segment number or PTS,
+    // never by position otherwise you could cause misalignments.
     std::vector<SEGMENTBUFFER*> segment_buffers_;
 
     void AllocateSegmentBuffers(size_t size);

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -230,26 +230,61 @@ public:
     return m_segmentTimeline.IsEmpty() ? 0 : m_segmentTimeline.GetPosition(segment);
   }
 
-  CSegment* GetSegmentByPts(const uint64_t startPts)
+  CSegment* GetSegment(const CSegment& segment)
   {
-    for (CSegment& segment : m_segmentTimeline.GetData())
+    // If available, find the segment by number, this is because some
+    // live services provide inconsistent timestamps between manifest updates
+    // which will make it ineffective to find the same segment
+    if (segment.m_number != SEGMENT_NO_NUMBER)
     {
-      // Search by >= is intended to allow minimizing problems with encoders
-      // that provide inconsistent timestamps between manifest updates
-      if (segment.startPTS_ >= startPts)
-        return &segment;
+      const uint64_t number = segment.m_number;
+
+      for (CSegment& segment : m_segmentTimeline.GetData())
+      {
+        if (segment.m_number == number)
+          return &segment;
+      }
     }
+    else
+    {
+      const uint64_t startPTS = segment.startPTS_;
+
+      for (CSegment& segment : m_segmentTimeline.GetData())
+      {
+        // Search by >= is intended to allow minimizing problems with encoders
+        // that provide inconsistent timestamps between manifest updates
+        if (segment.startPTS_ >= startPTS)
+          return &segment;
+      }
+    }
+
     return nullptr;
   }
 
   CSegment* GetNextSegment(const CSegment& segment)
   {
-    const uint64_t segStartPTS = segment.startPTS_;
-
-    for (CSegment& segment : m_segmentTimeline.GetData())
+    // If available, find the segment by number, this is because some
+    // live services provide inconsistent timestamps between manifest updates
+    // which will make it ineffective to find the next segment
+    if (segment.m_number != SEGMENT_NO_NUMBER)
     {
-      if (segment.startPTS_ > segStartPTS)
-        return &segment;
+      const uint64_t number = segment.m_number;
+
+      for (CSegment& segment : m_segmentTimeline.GetData())
+      {
+        if (segment.m_number > number)
+          return &segment;
+      }
+    }
+    else
+    {
+      const uint64_t startPTS = segment.startPTS_;
+
+      for (CSegment& segment : m_segmentTimeline.GetData())
+      {
+        if (segment.startPTS_ > startPTS)
+          return &segment;
+      }
     }
     return nullptr;
   }

--- a/src/common/SegTemplate.cpp
+++ b/src/common/SegTemplate.cpp
@@ -41,6 +41,11 @@ std::string PLAYLIST::CSegmentTemplate::GetMedia() const
   return ""; // Default value
 }
 
+bool PLAYLIST::CSegmentTemplate::HasMediaNumber() const
+{
+  return STRING::Contains(m_media, "$Number");
+}
+
 uint32_t PLAYLIST::CSegmentTemplate::GetTimescale() const
 {
   if (m_timescale.has_value())

--- a/src/common/SegTemplate.h
+++ b/src/common/SegTemplate.h
@@ -40,6 +40,12 @@ public:
   std::string GetMedia() const;
   void SetMedia(std::string_view media) { m_media = media; }
 
+  /*!
+   * \brief Check if media make use of $Number$ template variable.
+   * \return True if media has $Number$ template variable, otherwise false.
+   */
+  bool HasMediaNumber() const;
+
   uint32_t GetTimescale() const;
   void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
 

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -41,7 +41,7 @@ public:
   uint16_t pssh_set_ = PSSHSET_POS_DEFAULT;
 
   uint64_t m_time{0}; // Timestamp
-  uint64_t m_number{0};
+  uint64_t m_number{SEGMENT_NO_NUMBER};
 
   /*!
    * \brief Determines if it is an initialization segment.

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1043,6 +1043,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
     else
     {
       uint64_t segNumber = segTemplate->GetStartNumber();
+      const bool hasMediaNumber = segTemplate->HasMediaNumber();
       const uint32_t segTimescale = segTemplate->GetTimescale();
       const uint64_t periodStartMs = period->GetStart() == NO_VALUE ? 0 : period->GetStart();
       const uint64_t periodStartScaled = periodStartMs * segTemplate->GetTimescale() / 1000;
@@ -1071,7 +1072,10 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
             if (!hasPTO)
               seg.startPTS_ += periodStartScaled;
             seg.m_endPts = seg.startPTS_ + tlElem.duration;
-            seg.m_number = segNumber++;
+
+            if (hasMediaNumber)
+              seg.m_number = segNumber++;
+
             seg.m_time = time;
 
             totalDuration += tlElem.duration;
@@ -1147,7 +1151,10 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
           CSegment seg;
           seg.startPTS_ = time;
           seg.m_endPts = seg.startPTS_ + segDuration;
-          seg.m_number = segNumber++;
+
+          if (hasMediaNumber)
+            seg.m_number = segNumber++;
+
           seg.m_time = time;
 
           repr->SegmentTimeline().GetData().emplace_back(seg);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is a kind of regression due to new code improvements/fixes

On live HLS if EXT-X-PROGRAM-DATE-TIME is used as segment PTS
and the video provider provide an inconsistent EXT-X-PROGRAM-DATE-TIME
value between manifest updates, will cause a badly selected segment
if you search the segment by PTS, since segment numbers must be
consistents its more safe use them instead of PTS

**Why `GetSegment`/`GetNextSegment` try search by number and otherwise by PTS?**
Some DASH manifests can use `SegmentTemplate` that dont make use of segment numbers
so instead of `$Number$` should use `$Time$` therefore you cant search segments by number but you need to search by PTS

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1544

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
a live HLS channel "DVR", that i dont provide link since expire
and i dont know if i can publish the script to get the updated manifest links

and this one:
https://stream01.willfonk.com/live_playlist.m3u8?cid=CS325&r=FHD&ccode=JP&m=d0:20:20:04:35:cc&t=0d6938cb3dcf4b79848bc1753a59daf1

in particular this last one has no EXT-X-PROGRAM-DATE-TIME
and current HLS parser at each manifest update start to create segments by start PTS always from 0,
this seem to happens also on old Nexus and is a bit weird to have
i noticed that VLC in this use case make a "restamp" of the segments PTS's after the parsing
in order to have a consistent segment PTS that continue between manifest updates (and new segments)
instead to start segments PTS always from 0 at each update
im working to try porting this code to ISA that seem not so hard to do

Tested facebook live for Dash case mentioned on description, about `SegmentTemplate` with `$Time$`

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
