### PR TITLE
[HLSTree] Moved back insert psshset to EXTINF parsing

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -607,17 +607,6 @@ void adaptive::CHLSTree::FixDiscSequence(std::stringstream& streamData, uint32_t
       newSegment->m_endPts = startPts + durMs;
       newSegment->m_number = currentSegNumber++;
 
-
-      if (currentEncryptionType == EncryptionType::AES128 && psshSetPos == PSSHSET_POS_DEFAULT)
-      {
-        if (!m_currentKidUrl.empty())
-        {
-          psshSetPos = InsertPsshSet(StreamType::NOTYPE, period, adp, m_currentPssh,
-                                     m_currentDefaultKID, m_currentKidUrl, m_currentIV);
-        }
-      }
-      newSegment->pssh_set_ = psshSetPos;
-
       // Reset EXT-X-PROGRAM-DATE-TIME, some playlists do not have this tag on each segment
       programDateTime = NO_VALUE;
     }
@@ -690,6 +679,18 @@ void adaptive::CHLSTree::FixDiscSequence(std::stringstream& streamData, uint32_t
       }
 
       newSegment->url = line;
+
+      // The EXT-X-KEY tag might appear before or after the EXTINF tag
+      // so its needed process it just before add the segment to timeline
+      if (currentEncryptionType == EncryptionType::AES128 && psshSetPos == PSSHSET_POS_DEFAULT)
+      {
+        if (!m_currentKidUrl.empty())
+        {
+          psshSetPos = InsertPsshSet(StreamType::NOTYPE, period, adp, m_currentPssh,
+                                     m_currentDefaultKID, m_currentKidUrl, m_currentIV);
+        }
+      }
+      newSegment->pssh_set_ = psshSetPos;
 
       newSegments.GetData().emplace_back(*newSegment);
       newSegment.reset();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Moved back insert psshset to EXTINF parsing

example use cases:
EXT-X-KEY before EXTINF
[manifest_1715839971_child-video.txt](https://github.com/xbmc/inputstream.adaptive/files/15330579/manifest_1715839971_child-video.txt)
```
#EXT-X-KEY:METHOD=AES-128,URI="segment-00000.key"
#EXTINF:4.458667,
segment-00000.ts.enc
```
EXT-X-KEY after EXTINF
[manifest_1715453777_child-video.txt](https://github.com/xbmc/inputstream.adaptive/files/15330604/manifest_1715453777_child-video.txt)
```
#EXTINF:4.0,
#EXT-X-KEY:METHOD=AES-128,URI="https://.../key/keyaes.key",IV=0x00000000000000000000000000163C77
https://.../live_720_07271.ts
```

i havent found a real rule of tags order on HLS specs

on Nexus user stream was working because that code was already placed before add segment to timeline
on Omega has been moved on EXTINF parsing by PR #1403

now i dont remember anymore the reason why i changed this way maybe because was not documented so now we have a confirmation

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1553 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i dont have a similar user stream that place EXT-X-KEY after EXTINF (user confirmed works)

this one https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8
that place EXT-X-KEY before EXTINF

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
