### PR TITLE
[Omega] Use dca for dts codec name (regression fix)

### DIFF
--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -79,7 +79,7 @@ constexpr std::array VIDEO_NAME_LIST = {NAME_MPEG1, NAME_MPEG2, NAME_MPEG4, NAME
 // Audio definitions
 
 constexpr const char* NAME_AAC = "aac";
-constexpr const char* NAME_DTS = "dts";
+constexpr const char* NAME_DTS = "dca";
 constexpr const char* NAME_AC3 = "ac3";
 constexpr const char* NAME_EAC3 = "eac3"; // Enhanced AC-3
 constexpr const char* NAME_OPUS = "opus";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Marking this as regression fix as Nexus set these streams to dca and kodi would show them and suspect would work for normal DST (not DTS-X)

Trying to get DTS-X working on Disney+ (https://github.com/matthuisman/slyguy.addons/issues/742)

I notice on Nexus the codecname was dca:
https://github.com/xbmc/inputstream.adaptive/blob/Nexus/src/Session.cpp#L880
https://github.com/xbmc/xbmc/blob/master/xbmc/utils/StreamUtils.cpp#L27

HLS
```
#EXT-X-MEDIA:TYPE="AUDIO",GROUP-ID="DTS-X",NAME="English",LANGUAGE="en",AUTOSELECT="YES",CHANNELS="10",URI="r/composite_448k_dtsx_en_PRIMARY_bc81d2d4-da6d-42d5-92ee-2810badb8d94_f50c42ab-1461-4efa-b36d-124d4da9487e.m3u8",DEFAULT="YES"
#EXT-X-STREAM-INF:BANDWIDTH=5653092,AVERAGE-BANDWIDTH=3039650,CODECS="hvc1.2.4.L93.90,dtsx",RESOLUTION=1280x720,FRAME-RATE=24,VIDEO-RANGE=SDR,HDCP-LEVEL=TYPE-0,CHARACTERISTICS="com.dss.ctr.hd",AUDIO="DTS-X",SUBTITLES="sub-main"
r/composite_3500k_CENC_CTR_FHD_SDR_4c288d85-d15a-401d-a644-f38b64d3328b_818720d3-7fad-4f62-ab81-73e9d85fcf83.m3u8
```

IA is detecting the stream as if i use "blah" instead of "dtsx", it defaults to AAC.
So, it is detecting it - but just KODI doesnt show any stream for it.

## Motivation and context
Get Disney+ new DTS-X working

## How has this been tested?
Windows x64
i dont get any audio but its now showing as a audio track.
If i select it, kodi shows "dca" as audio codec with 10 channels.
But the audio stream just shows as unknown with no audio

## Screenshots (if appropriate):
Before this change:
![image](https://github.com/xbmc/inputstream.adaptive/assets/6225961/d18602ab-f665-4f3a-a9ee-a8a60a1c2557)

after this change:
![image](https://github.com/xbmc/inputstream.adaptive/assets/6225961/770feb20-9943-4508-9025-35cf3afe8109)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
