### PR TITLE
AdaptiveTree methods cleanups and fix period change for HLS case

### DIFF
--- a/src/Session.h
+++ b/src/Session.h
@@ -80,8 +80,7 @@ public:
                  PLAYLIST::CRepresentation* repr,
                  bool isDefaultRepr,
                  uint32_t uniqueId,
-                 std::string_view audioLanguageOrig,
-                 const bool isPeriodChange);
+                 std::string_view audioLanguageOrig);
 
   /*! \brief Update stream's InputstreamInfo
    *  \param stream The stream to update
@@ -292,6 +291,11 @@ public:
   /*! \brief Set m_chapterSeekTime back to 0
    */
   void ResetChapterSeekTime() { m_chapterSeekTime = 0; };
+
+  /*!
+   * \brief Callback from DemuxRead method of InputStream interface
+   */
+  void OnDemuxRead();
 
   //Observer Section
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -678,7 +678,8 @@ bool AdaptiveStream::start_stream(const uint64_t startPts)
 
   if (!current_rep_->current_segment_)
   {
-    if (m_startEvent == EVENT_TYPE::STREAM_START && m_tree->IsLive() && !play_timeshift_buffer_ &&
+    if (m_startEvent == EVENT_TYPE::STREAM_START && m_tree->IsLive() &&
+        !m_tree->IsChangingPeriod() && !play_timeshift_buffer_ &&
         !current_rep_->SegmentTimeline().IsEmpty())
     {
       size_t segPos = current_rep_->SegmentTimeline().GetSize() - 1;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1154,9 +1154,12 @@ uint64_t AdaptiveStream::getMaxTimeMs()
 
 void adaptive::AdaptiveStream::Disable()
 {
-  // Prepare the future event to re-enable the stream, but preserve following events
-  if (m_startEvent != EVENT_TYPE::REP_CHANGE && m_startEvent != EVENT_TYPE::PERIOD_CHANGE)
-    m_startEvent = EVENT_TYPE::STREAM_ENABLE;
+  // Preserve following events
+  if (m_startEvent == EVENT_TYPE::REP_CHANGE)
+    return;
+
+  // Prepare it for the future event
+  m_startEvent = EVENT_TYPE::STREAM_ENABLE;
 }
 
 void AdaptiveStream::ResetCurrentSegment(const PLAYLIST::CSegment* newSegment)

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -57,7 +57,6 @@ AdaptiveStream::AdaptiveStream(AdaptiveTree* tree,
   auto& kodiProps = CSrvBroker::GetKodiProps();
   m_streamParams = kodiProps.GetStreamParams();
   m_streamHeaders = kodiProps.GetStreamHeaders();
-  play_timeshift_buffer_ = kodiProps.IsPlayTimeshift();
 
   current_rep_->current_segment_ = nullptr;
 
@@ -679,7 +678,7 @@ bool AdaptiveStream::start_stream(const uint64_t startPts)
   if (!current_rep_->current_segment_)
   {
     if (m_startEvent == EVENT_TYPE::STREAM_START && m_tree->IsLive() &&
-        !m_tree->IsChangingPeriod() && !play_timeshift_buffer_ &&
+        !m_tree->IsChangingPeriod() && !CSrvBroker::GetKodiProps().IsPlayTimeshift() &&
         !current_rep_->SegmentTimeline().IsEmpty())
     {
       size_t segPos = current_rep_->SegmentTimeline().GetSize() - 1;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -790,29 +790,6 @@ bool AdaptiveStream::start_stream(const uint64_t startPts)
   return false;
 }
 
-void AdaptiveStream::ReplacePlaceholder(std::string& url, const std::string placeholder, uint64_t value)
-{
-  std::string::size_type lenReplace(placeholder.length());
-  std::string::size_type np(url.find(placeholder));
-  char rangebuf[128];
-
-  if (np == std::string::npos)
-    return;
-
-  np += lenReplace;
-
-  std::string::size_type npe(url.find('$', np));
-
-  char fmt[16];
-  if (np == npe)
-    strcpy(fmt, "%" PRIu64);
-  else
-    strcpy(fmt, url.substr(np, npe - np).c_str());
-
-  sprintf(rangebuf, fmt, value);
-  url.replace(np - lenReplace, npe - np + lenReplace + 1, rangebuf);
-}
-
 bool AdaptiveStream::ensureSegment()
 {
   // NOTE: Some demuxers may call ensureSegment more times to try make more attempts when it return false.

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -224,7 +224,7 @@ enum class EVENT_TYPE
     void worker();
 
     int SecondsSinceUpdate() const;
-    static void ReplacePlaceholder(std::string& url, const std::string placeholder, uint64_t value);
+
     bool GenerateSidxSegments(PLAYLIST::CRepresentation* rep);
 
     struct THREADDATA

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -288,7 +288,6 @@ enum class EVENT_TYPE
     std::atomic<bool> worker_processing_;
     bool m_fixateInitialization;
     uint64_t m_segmentFileOffset;
-    bool play_timeshift_buffer_;
 
     // Defines the event to start the stream, the status will be resetted by start stream method.
     EVENT_TYPE m_startEvent{EVENT_TYPE::STREAM_START};

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -38,7 +38,6 @@ enum class EVENT_TYPE
   NONE,
   STREAM_START, // First start of the stream
   STREAM_ENABLE, // Has been re-enabled the disabled stream
-  PERIOD_CHANGE, // Has been changed period
   REP_CHANGE // Has been changed representation (stream quality)
 };
 
@@ -73,7 +72,6 @@ enum class EVENT_TYPE
 
     void Disable();
 
-    void SetStartEvent(const EVENT_TYPE eventType) { m_startEvent = eventType; }
     EVENT_TYPE GetStartEvent() const { return m_startEvent; }
 
     /*!

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -288,7 +288,7 @@ namespace adaptive
         if (m_resetInterval)
           m_tree->m_updateInterval = PLAYLIST::NO_VALUE;
 
-        m_tree->RefreshLiveSegments();
+        m_tree->OnUpdateSegments();
       }
     }
   }

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -43,6 +43,9 @@ namespace adaptive
     m_supportedKeySystem = left.m_supportedKeySystem;
     m_pathSaveManifest = left.m_pathSaveManifest;
     stream_start_ = left.stream_start_;
+
+    m_isTTMLTimeRelative = left.m_isTTMLTimeRelative;
+    m_isReqPrepareStream = left.m_isReqPrepareStream;
   }
 
   void AdaptiveTree::Configure(CHOOSER::IRepresentationChooser* reprChooser,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -125,8 +125,7 @@ public:
    */
   virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
                                      PLAYLIST::CAdaptationSet* adp,
-                                     PLAYLIST::CRepresentation* rep,
-                                     uint64_t currentSegNumber)
+                                     PLAYLIST::CRepresentation* rep)
   {
     return false;
   }
@@ -225,6 +224,18 @@ public:
                ? m_currentPeriod->GetAdaptationSets()[pos].get()
                : nullptr;
   }
+
+  /*!
+   * \brief Checks if a period change is in progress (m_nextPeriod is set).
+   * \return True the period will be changed, otherwise false.
+   */
+  bool IsChangingPeriod() const { return m_nextPeriod; }
+
+  /*!
+   * \brief Check if the period change has been made.
+   * \return True the period is changed, otherwise false.
+   */
+  bool IsChangingPeriodDone() const { return m_nextPeriod == m_currentPeriod; }
 
   /*!
    * \brief Check for live streaming content (timeshift buffer)
@@ -329,6 +340,14 @@ public:
   bool IsTTMLTimeRelative() const { return m_isTTMLTimeRelative; }
 
   /*!
+   * \brief Specifies if the manifest parser require to prepare the stream representation.
+   *        Usually this is needed for protocols that use separate manifests
+   *        for each stream such as HLS.
+   * \return True if prepare the stream is required, otherwise false.
+   */
+  bool IsReqPrepareStream() const { return m_isReqPrepareStream; }
+
+  /*!
    * \brief Check if specified segment is the last of current period.
    * \param segPeriod The period relative to the segment
    * \param segRep The representation relative to the segment
@@ -381,6 +400,7 @@ protected:
   std::string m_licenseUrl;
 
   bool m_isTTMLTimeRelative{false};
+  bool m_isReqPrepareStream{false};
 };
 
 } // namespace adaptive

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -157,9 +157,6 @@ public:
   bool IsIncludedStream() const { return m_isIncludedStream; }
   void SetIsIncludedStream(bool isIncludedStream) { m_isIncludedStream = isIncludedStream; }
 
-  bool IsNeedsUpdates() const { return m_isNeedsUpdates; }
-  void SetIsNeedsUpdates(bool isNeedsUpdates) { m_isNeedsUpdates = isNeedsUpdates; }
-
   void CopyHLSData(const CRepresentation* other);
 
   static bool CompareBandwidth(std::unique_ptr<CRepresentation>& left,
@@ -369,7 +366,6 @@ protected:
   bool m_isWaitForSegment{false};
 
   bool m_isIncludedStream{false};
-  bool m_isNeedsUpdates{true};
 };
 
 } // namespace PLAYLIST

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,15 +328,7 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
   if (!m_session)
     return NULL;
 
-  if (m_checkChapterSeek)
-  {
-    m_checkChapterSeek = false;
-    if (m_session->GetChapterSeekTime() > 0)
-    {
-      m_session->SeekTime(m_session->GetChapterSeekTime());
-      m_session->ResetChapterSeekTime();
-    }
-  }
+  m_session->OnDemuxRead();
 
   if (~m_failedSeekTime)
   {
@@ -422,7 +414,6 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
   if (m_session->SeekChapter(m_session->GetChapter() + 1))
   {
     // Switched to new period / chapter
-    m_checkChapterSeek = true;
     m_lastPts = PLAYLIST::NO_PTS_VALUE;
     for (unsigned int i(1);
          i <= INPUTSTREAM_MAX_STREAM_COUNT && i <= m_session->GetStreamCount(); ++i)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,6 +208,9 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   // - Chapter/period change
   // - Automatic stream (representation) quality change (such as adaptive)
   // - Manual stream (representation) quality change (from OSD)
+  // streamid behaviour:
+  // - The streamid can be influenced by Kodi core based on preferences set in Kodi settings (e.g. language)
+  // - Fallback calls, e.g. if the opened video streamid fails, Kodi core will try to open another video streamid
 
   if (!m_session)
     return false;

--- a/src/main.h
+++ b/src/main.h
@@ -62,7 +62,6 @@ private:
   int m_currentVideoMaxWidth{0};
   int m_currentVideoMaxHeight{0};
   std::map<INPUTSTREAM_TYPE, unsigned int> m_IncludedStreams;
-  bool m_checkChapterSeek = false;
   int m_failedSeekTime = ~0;
   std::string m_chapterName;
   // The last PTS of the segment package fed to kodi.

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -37,7 +37,7 @@ using namespace UTILS;
 /*
  * Supported dynamic live services:
  * - MPD-controlled live:
- *   - SegmentTemplate with segments, updates are sheduled to call RefreshLiveSegments method to retrieve updated segments
+ *   - SegmentTemplate with segments, updates are sheduled to call OnUpdateSegments method to retrieve updated segments
  *   - SegmentTemplate without segments, InsertLiveSegment method will be called to add new segments, combined with sheduled updates
  * - Segment-controlled live:
  *   - SegmentTemplate without segments, demuxer parse the packets and calls InsertLiveFragment method to provide new segments
@@ -1542,19 +1542,18 @@ bool adaptive::CDashTree::DownloadManifestUpd(std::string_view url,
   return CURL::DownloadFile(url, reqHeaders, respHeaders, resp);
 }
 
-void adaptive::CDashTree::RefreshSegments(PLAYLIST::CPeriod* period,
-                                          PLAYLIST::CAdaptationSet* adp,
-                                          PLAYLIST::CRepresentation* rep)
+void adaptive::CDashTree::OnRequestSegments(PLAYLIST::CPeriod* period,
+                                            PLAYLIST::CAdaptationSet* adp,
+                                            PLAYLIST::CRepresentation* rep)
 {
   if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::AUDIO)
   {
-    RefreshLiveSegments();
+    OnUpdateSegments();
   }
 }
 
-// Can be called form update-thread!
 //! @todo: check updated variables that are not thread safe
-void adaptive::CDashTree::RefreshLiveSegments()
+void adaptive::CDashTree::OnUpdateSegments()
 {
   lastUpdated_ = std::chrono::system_clock::now();
 

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -102,11 +102,11 @@ protected:
                                    const std::vector<std::string>& respHeaders,
                                    UTILS::CURL::HTTPResponse& resp);
 
-  virtual void RefreshSegments(PLAYLIST::CPeriod* period,
-                               PLAYLIST::CAdaptationSet* adp,
-                               PLAYLIST::CRepresentation* rep) override;
+  virtual void OnRequestSegments(PLAYLIST::CPeriod* period,
+                                 PLAYLIST::CAdaptationSet* adp,
+                                 PLAYLIST::CRepresentation* rep) override;
 
-  virtual void RefreshLiveSegments() override;
+  virtual void OnUpdateSegments() override;
 
   // The lower start number of segments
   uint64_t m_segmentsLowerStartNumber{0};

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -26,7 +26,7 @@ public:
     INVALID, // Invalid manifest e.g. without segments
   };
 
-  CHLSTree() : AdaptiveTree() {}
+  CHLSTree();
   virtual ~CHLSTree() {}
 
   virtual TreeType GetTreeType() override { return TreeType::HLS; }
@@ -45,8 +45,7 @@ public:
 
   virtual bool PrepareRepresentation(PLAYLIST::CPeriod* period,
                                      PLAYLIST::CAdaptationSet* adp,
-                                     PLAYLIST::CRepresentation* rep,
-                                     uint64_t currentSegNumber) override;
+                                     PLAYLIST::CRepresentation* rep) override;
 
   virtual void OnDataArrived(uint64_t segNum,
                              uint16_t psshSet,
@@ -149,6 +148,11 @@ protected:
    *        in order to work EXT-X-PROGRAM-DATE-TIME tag is needed.
    */
   void FixDiscSequence(std::stringstream& streamData, uint32_t& discSeqNumber);
+
+  bool ProcessChildManifest(PLAYLIST::CPeriod* period,
+                            PLAYLIST::CAdaptationSet* adp,
+                            PLAYLIST::CRepresentation* rep,
+                            uint64_t currentSegNumber);
 
   ParseStatus ParseChildManifest(const std::string& data,
                                  std::string_view sourceUrl,

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -57,9 +57,14 @@ public:
                              size_t segBufferSize,
                              bool isLastChunk) override;
 
-  virtual void RefreshSegments(PLAYLIST::CPeriod* period,
-                               PLAYLIST::CAdaptationSet* adp,
-                               PLAYLIST::CRepresentation* rep) override;
+  virtual void OnStreamChange(PLAYLIST::CPeriod* period,
+                              PLAYLIST::CAdaptationSet* adp,
+                              PLAYLIST::CRepresentation* previousRep,
+                              PLAYLIST::CRepresentation* currentRep) override;
+
+  virtual void OnRequestSegments(PLAYLIST::CPeriod* period,
+                                 PLAYLIST::CAdaptationSet* adp,
+                                 PLAYLIST::CRepresentation* rep) override;
 
 protected:
   // \brief Rendition features
@@ -156,7 +161,7 @@ protected:
                        PLAYLIST::CRepresentation* rep,
                        uint64_t segNumber);
 
-  virtual void RefreshLiveSegments() override;
+  virtual void OnUpdateSegments() override;
 
   virtual bool ParseManifest(const std::string& stream);
 

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -89,7 +89,7 @@ protected:
       rep->SetSourceUrl(url);
 
     testHelper::testFile = filePath;
-    return tree->PrepareRepresentation(per, adp, rep, PLAYLIST::SEGMENT_NO_NUMBER);
+    return tree->PrepareRepresentation(per, adp, rep);
   }
 
   adaptive::CHLSTree* tree;

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -165,7 +165,7 @@ std::string DASHTestTree::RunManifestUpdate(std::string manifestUpdFile)
 {
   m_manifestUpdUrl.clear();
   testHelper::testFile = manifestUpdFile;
-  RefreshLiveSegments();
+  OnUpdateSegments();
   return m_manifestUpdUrl;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Commit 1:
Just cleanups without functional changes, the more noticeable change is that has been decoupled `AdaptiveTree::PrepareRepresentation` with the new `AdaptiveTree::OnStreamChange`. The other methods have been renamed to give more evidence that they are callbacks

Commit 2:
- Partially revert code introduced with PR #1518 about `EVENT_TYPE::PERIOD_CHANGE` and `AdaptiveStream::SetStartEvent`, set period change state to streams turned out to be more problematic than i thought it would be, the current handling of periods and change periods and how streams are initialized makes things too messy and complex, at least I couldn't find a decent way to keep `EVENT_TYPE::PERIOD_CHANGE` state. So as "generic" solution i re-used `AdaptiveTree::m_nextPeriod` to identify a transition state for period changing.
- By re-using `AdaptiveTree::m_nextPeriod` to identify a transition state for period changing, has allowed to remove `m_checkChapterSeek` state from main.cpp
- I have removed also `CRepresentation::IsNeedsUpdates` and `CRepresentation::SetIsNeedsUpdates` that imo its not more needed keep saved this additional state (hoping i haven't missed any particular use cases...)
- I have add to AdaptiveTree the new `m_isReqPrepareStream` config (in similar way of `m_isTTMLTimeRelative`), allows you to configure the parser if it requires the use of `CSession::PrepareStream` to prepare streams, without having hardcoded `TreeType::HLS` condition

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1551
fix #1563

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
played D+movies
sequence to replicate period seek problem:

1) seek to next period/chapter
2) seek to initial (previous) chapter
3) change audio track
4) the audio track before was not working because manifest was never downloaded

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
