### PR TITLE
[DashTree] Always ensure period duration

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -218,14 +218,12 @@ bool adaptive::CDashTree::ParseManifest(const std::string& data)
   // For multi-periods streaming must be ensured the duration of each period:
   // - If "duration" attribute is provided on each Period tag, do nothing
   // - If "duration" attribute is missing, but "start" attribute, use this last one to calculate the duration
-  // - If both attributes are missing, try get the duration from a representation
+  // - If both attributes are missing, try get the duration from a representation,
+  //   e.g. a single period in a live stream the duration must be determined by the available segments
 
   uint64_t totalDuration{0}; // Calculated duration, in ms
   uint64_t mpdTotalDuration = m_mediaPresDuration; // MPD total duration, in ms
-  if (mpdTotalDuration == 0)
-    mpdTotalDuration = m_timeShiftBufferDepth;
 
-  if (!IsLive())
   {
     for (auto itPeriod = m_periods.begin(); itPeriod != m_periods.end();)
     {
@@ -287,6 +285,9 @@ bool adaptive::CDashTree::ParseManifest(const std::string& data)
       ++itPeriod;
     }
   }
+
+  if (mpdTotalDuration == 0)
+    mpdTotalDuration = m_timeShiftBufferDepth;
 
   if (mpdTotalDuration > 0)
     m_totalTime = mpdTotalDuration;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
As PR title
following example:
[segtimeline_live_6h.mpd.txt](https://github.com/user-attachments/files/16333844/segtimeline_live_6h.mpd.txt)
instead to have the TSB, all segments are within a single period
since there is no period duration set, the video seek cant works

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1569
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i cant test it, user feedback
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
