### PR TITLE
[CDM] Create StreamCryptoSession from OpenStream

### DIFF
--- a/src/Session.h
+++ b/src/Session.h
@@ -113,11 +113,17 @@ public:
    */
   unsigned int GetStreamCount() const { return static_cast<unsigned int>(m_streams.size()); }
 
+  /*!
+   * \brief Determines if the CDM session at specified index require Secure Path (TEE).
+   * \return True if Secure Path is required, otherwise false.
+   */
+  bool IsCDMSessionSecurePath(size_t index);
+
   /*! \brief Get a session string (session id) by index from the cdm sessions
    *  \param index The index (psshSet number) of the cdm session
    *  \return The session string
    */
-  const char* GetCDMSession(unsigned int index) { return m_cdmSessions[index].m_cdmSessionStr; }
+  const char* GetCDMSession(unsigned int index);
 
   /*! \brief Get the media type mask
    *  \return The media type mask

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -467,7 +467,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   int statusCode = file.Open();
   if (statusCode == -1 || statusCode >= 400)
   {
-    LOG::Log(LOGERROR, "License server returned failure");
+    LOG::Log(LOGERROR, "License server returned failure (HTTP error %i)", statusCode);
     return false;
   }
 

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -553,7 +553,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<char>& 
   int statusCode = file.Open();
   if (statusCode == -1 || statusCode >= 400)
   {
-    LOG::Log(LOGERROR, "License server returned failure");
+    LOG::Log(LOGERROR, "License server returned failure (HTTP error %i)", statusCode);
     return false;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,30 +136,6 @@ bool CInputStreamAdaptive::GetStream(int streamid, kodi::addon::InputstreamInfo&
 
   if (stream)
   {
-    uint8_t cdmId(static_cast<uint8_t>(stream->m_adStream.getRepresentation()->m_psshSetPos));
-    if (stream->m_isEncrypted && m_session->GetCDMSession(cdmId) != nullptr)
-    {
-      kodi::addon::StreamCryptoSession cryptoSession;
-
-      LOG::Log(LOGDEBUG, "GetStream(%d): initalizing crypto session", streamid);
-      cryptoSession.SetKeySystem(m_session->GetCryptoKeySystem());
-
-      const char* sessionId(m_session->GetCDMSession(cdmId));
-      cryptoSession.SetSessionId(sessionId);
-
-      if (m_session->GetDecrypterCaps(cdmId).flags &
-          DRM::DecrypterCapabilites::SSD_SUPPORTS_DECODING)
-        stream->m_info.SetFeatures(INPUTSTREAM_FEATURE_DECODE);
-      else
-        stream->m_info.SetFeatures(0);
-
-      cryptoSession.SetFlags((m_session->GetDecrypterCaps(cdmId).flags &
-                          DRM::DecrypterCapabilites::SSD_SECURE_DECODER)
-                             ? STREAM_CRYPTO_FLAG_SECURE_DECODER
-                             : 0);
-      stream->m_info.SetCryptoSession(cryptoSession);
-    }
-
     info = stream->m_info;
     return true;
   }
@@ -322,7 +298,39 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     }
   }
   m_session->EnableStream(stream, true);
-  return stream->GetReader()->GetInformation(stream->m_info);
+
+  bool isInfoChanged = stream->GetReader()->GetInformation(stream->m_info);
+
+  uint16_t cdmSessionIndex = stream->m_adStream.getRepresentation()->m_psshSetPos;
+
+  if (stream->m_isEncrypted && m_session->IsCDMSessionSecurePath(cdmSessionIndex))
+  {
+    LOG::Log(LOGDEBUG, "OpenStream(%d): Create secure crypto session", streamid);
+
+    // StreamCryptoSession enable the use of ISA VideoCodecAdaptive decoder
+    kodi::addon::StreamCryptoSession cryptoSession;
+    cryptoSession.SetKeySystem(m_session->GetCryptoKeySystem());
+
+    const char* sessionId(m_session->GetCDMSession(cdmSessionIndex));
+    cryptoSession.SetSessionId(sessionId);
+
+    if (m_session->GetDecrypterCaps(cdmSessionIndex).flags &
+        DRM::DecrypterCapabilites::SSD_SUPPORTS_DECODING)
+      stream->m_info.SetFeatures(INPUTSTREAM_FEATURE_DECODE);
+    else
+      stream->m_info.SetFeatures(INPUTSTREAM_FEATURE_NONE);
+
+    if (m_session->GetDecrypterCaps(cdmSessionIndex).flags &
+        DRM::DecrypterCapabilites::SSD_SECURE_DECODER)
+      cryptoSession.SetFlags(STREAM_CRYPTO_FLAG_SECURE_DECODER);
+    else
+      cryptoSession.SetFlags(STREAM_CRYPTO_FLAG_NONE);
+
+    stream->m_info.SetCryptoSession(cryptoSession);
+    isInfoChanged = true;
+  }
+
+  return isInfoChanged;
 }
 
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The `kodi::addon::StreamCryptoSession` object was created by `CInputStreamAdaptive::GetStream` and set into stream m_info,
this PR move the creation of that object in to `CInputStreamAdaptive::OpenStream` method

the reason of this change is due to HLS case when switching stream quality (usually for network bandwidth change)
GetStream is called before that CDM sessions (of switched repr streams) are created,
causing crashes since dont find the cdmId when call GetCDMSession method.
CDM sessions are created at later time with OpenStream.

Flow is:
1) Quality change: DEMUX_SPECIALID_STREAMCHANGE packet event
2) Kodi call GetStreamIds followed by GetStream callbacks to get all streams
3) Kodi request streams with OpenStream followed by another GetStream callback

you can notice that GetStream is called before and after OpenStream, this is the cause of the problem
since in the first GetStream callback cdm sessions are not created yet
moving the creation of StreamCryptoSession at end of OpenStream seem a good solution

---

I have also done a cleanup, following code in the GetStream:
`if (stream->m_isEncrypted && m_session->GetCDMSession(cdmId) != nullptr)`
it was enabling secure decoding by depending from cdm sessionid string it's an awful way to handle this condition,
has more sense check for SSD_SECURE_PATH flag and avoid relying on a string content

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1580

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested on Windows and Android with D+ by using stream selection type "Test", when switch stream quality the playback continue correctly and dont crash/freeze

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
