### PR TITLE
[Cleanups] Get rid of CSpinCache / new segment container

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -938,7 +938,7 @@ void CSession::PrepareStream(CStream* stream)
 
   // Prepare the representation when the period change usually its not needed,
   // because the timeline is always already updated
-  if ((!m_adaptiveTree->IsChangingPeriod() || !repr->Timeline().IsEmpty()) &&
+  if ((!m_adaptiveTree->IsChangingPeriod() || repr->Timeline().IsEmpty()) &&
       (startEvent == EVENT_TYPE::STREAM_START || startEvent == EVENT_TYPE::STREAM_ENABLE))
   {
     m_adaptiveTree->PrepareRepresentation(stream->m_adStream.getPeriod(),

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -938,7 +938,7 @@ void CSession::PrepareStream(CStream* stream)
 
   // Prepare the representation when the period change usually its not needed,
   // because the timeline is always already updated
-  if ((!m_adaptiveTree->IsChangingPeriod() || !repr->HasSegmentTimeline()) &&
+  if ((!m_adaptiveTree->IsChangingPeriod() || !repr->Timeline().IsEmpty()) &&
       (startEvent == EVENT_TYPE::STREAM_START || startEvent == EVENT_TYPE::STREAM_ENABLE))
   {
     m_adaptiveTree->PrepareRepresentation(stream->m_adStream.getPeriod(),

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -13,6 +13,7 @@
 #include "utils/Utils.h"
 
 #include <algorithm> // any_of
+#include <iterator> // back_inserter
 
 using namespace PLAYLIST;
 using namespace UTILS;
@@ -53,7 +54,7 @@ void PLAYLIST::CAdaptationSet::AddRepresentation(
 std::vector<CRepresentation*> PLAYLIST::CAdaptationSet::GetRepresentationsPtr()
 {
   std::vector<CRepresentation*> ptrReprs;
-  std::transform(m_representations.begin(), m_representations.end(), back_inserter(ptrReprs),
+  std::transform(m_representations.begin(), m_representations.end(), std::back_inserter(ptrReprs),
                  [](const std::unique_ptr<CRepresentation>& r) { return r.get(); });
   return ptrReprs;
 }

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -79,8 +79,8 @@ public:
   void AddSwitchingIds(std::string_view switchingIds);
   const std::vector<std::string>& GetSwitchingIds() { return m_switchingIds; }
 
-  CSpinCache<uint32_t>& SegmentTimelineDuration() { return m_segmentTimelineDuration; }
-  bool HasSegmentTimelineDuration() { return !m_segmentTimelineDuration.IsEmpty(); }
+  std::vector<uint32_t>& SegmentTimelineDuration() { return m_segmentTimelineDuration; }
+  bool HasSegmentTimelineDuration() { return !m_segmentTimelineDuration.empty(); }
 
   /*!
    * \brief Get the timescale of segment durations tag.
@@ -175,7 +175,7 @@ protected:
   std::string m_language;
   std::vector<std::string> m_switchingIds;
 
-  CSpinCache<uint32_t> m_segmentTimelineDuration;
+  std::vector<uint32_t> m_segmentTimelineDuration;
   uint64_t m_segDurationsTimescale{NO_VALUE};
 
   // Custom ISAdaptive attributes (used on DASH only)

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -477,13 +477,6 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
         seg.range_begin_ = cue.pos_start;
         seg.range_end_ = cue.pos_end;
         rep->SegmentTimeline().GetData().emplace_back(seg);
-
-        //! todo: use SegmentTimelineDuration should not be needed
-        if (adpSet->SegmentTimelineDuration().GetSize() < rep->SegmentTimeline().GetSize())
-        {
-          adpSet->SegmentTimelineDuration().GetData().emplace_back(
-              static_cast<uint32_t>(cue.duration));
-        }
       }
       return true;
     }
@@ -549,12 +542,6 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
           seg.range_begin_ = seg.range_end_ + 1;
           seg.range_end_ = seg.range_begin_ + refs[i].m_ReferencedSize - 1;
           rep->SegmentTimeline().GetData().emplace_back(seg);
-
-          //! todo: use SegmentTimelineDuration should not be needed
-          if (adpSet->SegmentTimelineDuration().GetSize() < rep->SegmentTimeline().GetSize())
-          {
-            adpSet->SegmentTimelineDuration().GetData().emplace_back(refs[i].m_SubsegmentDuration);
-          }
 
           seg.startPTS_ += refs[i].m_SubsegmentDuration;
           seg.m_endPts = seg.startPTS_ + refs[i].m_SubsegmentDuration;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -478,6 +478,8 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
         seg.range_end_ = cue.pos_end;
         rep->Timeline().Add(seg);
       }
+
+      rep->SetDuration(rep->Timeline().GetDuration());
       return true;
     }
   }
@@ -495,7 +497,6 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
 
     bool isMoovFound{false};
     AP4_Cardinal sidxCount{1};
-    uint64_t reprDuration{0};
 
     CSegment seg;
     seg.startPTS_ = 0;
@@ -546,7 +547,6 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
           seg.startPTS_ += refs[i].m_SubsegmentDuration;
           seg.m_endPts = seg.startPTS_ + refs[i].m_SubsegmentDuration;
           seg.m_time += refs[i].m_SubsegmentDuration;
-          reprDuration += refs[i].m_SubsegmentDuration;
         }
 
         sidxCount--;
@@ -576,7 +576,7 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
       rep->SetInitSegment(initSeg);
     }
 
-    rep->SetDuration(reprDuration);
+    rep->SetDuration(rep->Timeline().GetDuration());
 
     return true;
   }

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -476,7 +476,7 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
         seg.m_time = cue.pts;
         seg.range_begin_ = cue.pos_start;
         seg.range_end_ = cue.pos_end;
-        rep->SegmentTimeline().GetData().emplace_back(seg);
+        rep->SegmentTimeline().Add(seg);
       }
       return true;
     }
@@ -541,7 +541,7 @@ bool AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
         {
           seg.range_begin_ = seg.range_end_ + 1;
           seg.range_end_ = seg.range_begin_ + refs[i].m_ReferencedSize - 1;
-          rep->SegmentTimeline().GetData().emplace_back(seg);
+          rep->SegmentTimeline().Add(seg);
 
           seg.startPTS_ += refs[i].m_SubsegmentDuration;
           seg.m_endPts = seg.startPTS_ + refs[i].m_SubsegmentDuration;
@@ -810,7 +810,7 @@ bool AdaptiveStream::ensureSegment()
     if (m_fixateInitialization)
       return false;
 
-    CSegment* nextSegment{nullptr};
+    const CSegment* nextSegment{nullptr};
 
     if (valid_segment_buffers_ > 0)
     {
@@ -938,7 +938,7 @@ bool AdaptiveStream::ensureSegment()
         segPos = nextSegPos;
       else // Continue adding segments that follow the last one added in to the buffer
       {
-        CSegment* followSeg =
+        const CSegment* followSeg =
             current_rep_->GetNextSegment(segment_buffers_[available_segment_buffers_ - 1]->segment);
         if (followSeg)
           segPos = current_rep_->get_segment_pos(followSeg);
@@ -1221,7 +1221,7 @@ bool AdaptiveStream::seek_time(double seek_seconds, bool preceeding, bool& needR
     ++choosen_seg;
   }
 
-  CSegment* old_seg = current_rep_->current_segment_;
+  const CSegment* old_seg = current_rep_->current_segment_;
   const CSegment* newSeg = current_rep_->get_segment(choosen_seg);
 
   if (newSeg)

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -114,7 +114,7 @@ namespace adaptive
 
   void AdaptiveTree::FreeSegments(CPeriod* period, CRepresentation* repr)
   {
-    for (auto& segment : repr->SegmentTimeline().GetData())
+    for (const CSegment& segment : repr->SegmentTimeline())
     {
       period->DecreasePSSHSetUsageCount(segment.pssh_set_);
     }

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -114,12 +114,12 @@ namespace adaptive
 
   void AdaptiveTree::FreeSegments(CPeriod* period, CRepresentation* repr)
   {
-    for (const CSegment& segment : repr->SegmentTimeline())
+    for (const CSegment& segment : repr->Timeline())
     {
       period->DecreasePSSHSetUsageCount(segment.pssh_set_);
     }
 
-    repr->SegmentTimeline().Clear();
+    repr->Timeline().Clear();
     repr->current_segment_ = nullptr;
   }
 
@@ -189,7 +189,7 @@ namespace adaptive
                                    const PLAYLIST::CRepresentation* segRep,
                                    const PLAYLIST::CSegment* segment) const
   {
-    if (segRep->SegmentTimeline().IsEmpty())
+    if (segRep->Timeline().IsEmpty())
       return true;
 
     if (!segment || !segPeriod || !segRep)
@@ -212,7 +212,7 @@ namespace adaptive
     }
     else
     {
-      const CSegment* lastSeg = segRep->SegmentTimeline().GetBack();
+      const CSegment* lastSeg = segRep->Timeline().GetBack();
       return segment == lastSeg;
     }
     return false;

--- a/src/common/AdaptiveUtils.cpp
+++ b/src/common/AdaptiveUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "AdaptiveStream.h"
 #include "Representation.h"
+#include "utils/log.h"
 #include "utils/Utils.h"
 
 #include <cinttypes>

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -9,12 +9,10 @@
 #pragma once
 
 #include <algorithm>
-#include <deque>
 #include <limits>
+#include <memory>
 #include <string_view>
 #include <vector>
-
-#include "utils/log.h"
 
 // forwards
 class AP4_Movie;
@@ -118,133 +116,6 @@ bool ParseRangeValues(std::string_view range,
  */
 AP4_Movie* CreateMovieAtom(adaptive::AdaptiveStream& adStream,
                            kodi::addon::InputstreamInfo& streamInfo);
-
-template<typename T>
-class CSpinCache
-{
-public:
-  /*!
-   * \brief Get the <T> value pointer from the specified position
-   * \param pos The position of <T>
-   * \return <T> value pointer, otherwise nullptr if not found
-   */
-  const T* Get(size_t pos) const
-  {
-    if (pos == SEGMENT_NO_POS || m_data.empty())
-      return nullptr;
-
-    if (pos >= m_data.size())
-    {
-      LOG::LogF(LOGWARNING, "Position out-of-range (%zu of %zu)", pos, m_data.size());
-      return nullptr;
-    }
-
-    return &m_data[pos];
-  }
-
-  /*!
-   * \brief Get the <T> value pointer from the specified position
-   * \param pos The position of <T>
-   * \return <T> value pointer, otherwise nullptr if not found
-   */
-  T* Get(size_t pos)
-  {
-    if (pos == SEGMENT_NO_POS || m_data.empty())
-      return nullptr;
-
-    if (pos >= m_data.size())
-    {
-      LOG::LogF(LOGWARNING, "Position out-of-range (%zu of %zu)", pos, m_data.size());
-      return nullptr;
-    }
-
-    return &m_data[pos];
-  }
-
-  /*!
-   * \brief Get the last <T> value pointer
-   * \return <T> value pointer, otherwise nullptr if not found
-   */
-  T* GetBack()
-  {
-    if (m_data.empty())
-      return nullptr;
-
-    return &m_data.back();
-  }
-
-  /*!
-   * \brief Get the first <T> value pointer
-   * \return <T> value pointer, otherwise nullptr if not found
-   */
-  T* GetFront()
-  {
-    if (m_data.empty())
-      return nullptr;
-
-    return &m_data.front();
-  }
-
-  /*!
-   * \brief Get index position of <T> value pointer
-   * \param elem The <T> pointer to get the position
-   * \return The index position, or SEGMENT_NO_POS if not found
-   */
-  const size_t GetPosition(const T* elem) const
-  {
-    for (size_t i = 0; i < m_data.size(); ++i)
-    {
-      if (&m_data[i] == elem)
-        return i;
-    }
-
-    return SEGMENT_NO_POS;
-  };
-
-  /*!
-   * \brief Append <T> value to the container, by increasing the count.
-   * \param elem The <T> value to append
-   */
-  void Append(const T& elem)
-  {
-    m_data.emplace_back(elem);
-    m_appendCount += 1;
-  }
-
-  void Swap(CSpinCache<T>& other)
-  {
-    m_data.swap(other.m_data);
-    std::swap(m_appendCount, other.m_appendCount);
-  }
-
-  void Clear()
-  {
-    m_data.clear();
-    m_appendCount = 0;
-  }
-
-  bool IsEmpty() const { return m_data.empty(); }
-
-  /*!
-   * \brief Get the number of the appended <T> elements.
-   * \return The number of appended elements.
-   */
-  size_t GetAppendCount() const { return m_appendCount; }
-
-  size_t GetSize() const { return m_data.size(); }
-
-  /*!
-   * \brief Get the number of elements without taking into account those appended.
-   * \return The number of elements.
-   */
-  size_t GetInitialSize() const { return m_data.size() - m_appendCount; }
-
-  std::deque<T>& GetData() { return m_data; }
-
-private:
-  std::deque<T> m_data;
-  size_t m_appendCount{0}; // Number of appended elements
-};
 
 // \brief Get the position of a pointer within a vector of unique_ptr
 template<typename T, typename Ptr>

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "AdaptiveUtils.h"
 #include "CommonSegAttribs.h"
 #include "SegTemplate.h"
 #include "utils/CryptoUtils.h"
@@ -89,8 +88,8 @@ public:
     m_isSecureDecoderNeeded = isSecureDecoderNeeded;
   };
 
-  CSpinCache<uint32_t>& SegmentTimelineDuration() { return m_segmentTimelineDuration; }
-  bool HasSegmentTimelineDuration() { return !m_segmentTimelineDuration.IsEmpty(); }
+  std::vector<uint32_t>& SegmentTimelineDuration() { return m_segmentTimelineDuration; }
+  bool HasSegmentTimelineDuration() { return !m_segmentTimelineDuration.empty(); }
 
   void CopyHLSData(const CPeriod* other);
 
@@ -143,7 +142,7 @@ protected:
   uint64_t m_duration{0};
   EncryptionState m_encryptionState{EncryptionState::UNENCRYPTED};
   bool m_isSecureDecoderNeeded{false};
-  CSpinCache<uint32_t> m_segmentTimelineDuration;
+  std::vector<uint32_t> m_segmentTimelineDuration;
 };
 
 } // namespace adaptive

--- a/src/common/Representation.cpp
+++ b/src/common/Representation.cpp
@@ -51,6 +51,29 @@ void PLAYLIST::CRepresentation::CopyHLSData(const CRepresentation* other)
   m_isEnabled = other->m_isEnabled;
 }
 
+const CSegment* PLAYLIST::CRepresentation::GetNextSegment()
+{
+  return m_segmentTimeline.GetNext(current_segment_);
+}
+
+const uint64_t PLAYLIST::CRepresentation::GetCurrentSegNumber() const
+{
+  return GetSegNumber(current_segment_);
+}
+
+const uint64_t PLAYLIST::CRepresentation::GetSegNumber(const CSegment* seg) const
+{
+  if (!seg)
+    return SEGMENT_NO_NUMBER;
+
+  const size_t segPos = m_segmentTimeline.GetPos(seg);
+
+  if (segPos == SEGMENT_NO_POS)
+    return SEGMENT_NO_NUMBER;
+
+  return static_cast<uint64_t>(segPos) + m_startNumber;
+}
+
 void PLAYLIST::CRepresentation::SetScaling()
 {
   if (!m_timescale)

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -103,8 +103,8 @@ public:
   uint16_t GetHdcpVersion() const { return m_hdcpVersion; }
   void SetHdcpVersion(uint16_t hdcpVersion) { m_hdcpVersion = hdcpVersion; }
 
-  CSpinCache<CSegment>& SegmentTimeline() { return m_segmentTimeline; }
-  CSpinCache<CSegment> SegmentTimeline() const { return m_segmentTimeline; }
+  CSegContainer& SegmentTimeline() { return m_segmentTimeline; }
+  CSegContainer SegmentTimeline() const { return m_segmentTimeline; }
   bool HasSegmentTimeline() { return !m_segmentTimeline.IsEmpty(); }
 
   std::optional<CSegmentBase>& GetSegmentBase() { return m_segmentBase; }
@@ -175,7 +175,7 @@ public:
 
   size_t expired_segments_{0};
 
-  CSegment* current_segment_{nullptr};
+  const CSegment* current_segment_{nullptr};
 
 
   bool HasInitSegment() const { return m_initSegment.has_value(); }
@@ -227,7 +227,7 @@ public:
     return m_segmentTimeline.IsEmpty() ? 0 : m_segmentTimeline.GetPosition(segment);
   }
 
-  CSegment* GetSegment(const CSegment& segment)
+  const CSegment* GetSegment(const CSegment& segment)
   {
     // If available, find the segment by number, this is because some
     // live services provide inconsistent timestamps between manifest updates
@@ -236,7 +236,7 @@ public:
     {
       const uint64_t number = segment.m_number;
 
-      for (CSegment& segment : m_segmentTimeline.GetData())
+      for (const CSegment& segment : m_segmentTimeline)
       {
         if (segment.m_number == number)
           return &segment;
@@ -246,7 +246,7 @@ public:
     {
       const uint64_t startPTS = segment.startPTS_;
 
-      for (CSegment& segment : m_segmentTimeline.GetData())
+      for (const CSegment& segment : m_segmentTimeline)
       {
         // Search by >= is intended to allow minimizing problems with encoders
         // that provide inconsistent timestamps between manifest updates
@@ -258,7 +258,7 @@ public:
     return nullptr;
   }
 
-  CSegment* GetNextSegment(const CSegment& segment)
+  const CSegment* GetNextSegment(const CSegment& segment)
   {
     // If available, find the segment by number, this is because some
     // live services provide inconsistent timestamps between manifest updates
@@ -267,7 +267,7 @@ public:
     {
       const uint64_t number = segment.m_number;
 
-      for (CSegment& segment : m_segmentTimeline.GetData())
+      for (const CSegment& segment : m_segmentTimeline)
       {
         if (segment.m_number > number)
           return &segment;
@@ -277,7 +277,7 @@ public:
     {
       const uint64_t startPTS = segment.startPTS_;
 
-      for (CSegment& segment : m_segmentTimeline.GetData())
+      for (const CSegment& segment : m_segmentTimeline)
       {
         if (segment.startPTS_ > startPTS)
           return &segment;
@@ -355,7 +355,7 @@ protected:
 
   uint64_t m_startNumber{1};
 
-  CSpinCache<CSegment> m_segmentTimeline;
+  CSegContainer m_segmentTimeline;
 
   uint64_t m_duration{0};
   uint32_t m_timescale{0};

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -110,7 +110,7 @@ public:
   /*!
    * \brief The segment timeline.
    */
-  CSegContainer Timeline() const { return m_segmentTimeline; }
+  const CSegContainer& Timeline() const { return m_segmentTimeline; }
 
   std::optional<CSegmentBase>& GetSegmentBase() { return m_segmentBase; }
   void SetSegmentBase(const CSegmentBase& segBase) { m_segmentBase = segBase; }
@@ -182,155 +182,27 @@ public:
 
   const CSegment* current_segment_{nullptr};
 
-
   bool HasInitSegment() const { return m_initSegment.has_value(); }
   void SetInitSegment(CSegment initSegment) { m_initSegment = initSegment; }
   std::optional<CSegment>& GetInitSegment() { return m_initSegment; }
 
   /*!
-   * \brief Get the next segment after the one specified.
+   * \brief Get segment following the current one.
    * \return If found the segment pointer, otherwise nullptr.
    */
-  CSegment* get_next_segment(const CSegment* seg)
-  {
-    if (!seg || seg->IsInitialization())
-      return m_segmentTimeline.Get(0);
-
-    const size_t segPos = m_segmentTimeline.GetPosition(seg);
-
-    if (segPos == SEGMENT_NO_POS)
-      return nullptr;
-
-    size_t nextPos = segPos + 1;
-    if (nextPos == m_segmentTimeline.GetSize())
-      return nullptr;
-
-    return m_segmentTimeline.Get(nextPos);
-  }
-
-  /*!
-   * \brief Get the segment from specified position.
-   * \return If found the segment pointer, otherwise nullptr.
-   */
-  CSegment* get_segment(size_t pos)
-  {
-    if (pos == SEGMENT_NO_POS)
-      return nullptr;
-
-    return m_segmentTimeline.Get(pos);
-  }
-
-  /*!
-   * \brief Get the segment position.
-   * \return If found the position, otherwise SEGMENT_NO_POS.
-   */
-  const size_t get_segment_pos(const CSegment* segment) const
-  {
-    if (!segment)
-      return SEGMENT_NO_POS;
-
-    return m_segmentTimeline.IsEmpty() ? 0 : m_segmentTimeline.GetPosition(segment);
-  }
-
-  const CSegment* GetSegment(const CSegment& segment)
-  {
-    // If available, find the segment by number, this is because some
-    // live services provide inconsistent timestamps between manifest updates
-    // which will make it ineffective to find the same segment
-    if (segment.m_number != SEGMENT_NO_NUMBER)
-    {
-      const uint64_t number = segment.m_number;
-
-      for (const CSegment& segment : m_segmentTimeline)
-      {
-        if (segment.m_number == number)
-          return &segment;
-      }
-    }
-    else
-    {
-      const uint64_t startPTS = segment.startPTS_;
-
-      for (const CSegment& segment : m_segmentTimeline)
-      {
-        // Search by >= is intended to allow minimizing problems with encoders
-        // that provide inconsistent timestamps between manifest updates
-        if (segment.startPTS_ >= startPTS)
-          return &segment;
-      }
-    }
-
-    return nullptr;
-  }
-
-  const CSegment* GetNextSegment(const CSegment& segment)
-  {
-    // If available, find the segment by number, this is because some
-    // live services provide inconsistent timestamps between manifest updates
-    // which will make it ineffective to find the next segment
-    if (segment.m_number != SEGMENT_NO_NUMBER)
-    {
-      const uint64_t number = segment.m_number;
-
-      for (const CSegment& segment : m_segmentTimeline)
-      {
-        if (segment.m_number > number)
-          return &segment;
-      }
-    }
-    else
-    {
-      const uint64_t startPTS = segment.startPTS_;
-
-      for (const CSegment& segment : m_segmentTimeline)
-      {
-        if (segment.startPTS_ > startPTS)
-          return &segment;
-      }
-    }
-    return nullptr;
-  }
-
-  /*!
-   * \brief Get the position of current segment.
-   * \return If found the position, otherwise SEGMENT_NO_POS.
-   */
-  const size_t getCurrentSegmentPos() const { return get_segment_pos(current_segment_); }
+  const CSegment* GetNextSegment();
 
   /*!
    * \brief Get the segment number of current segment.
    * \return If found the number, otherwise SEGMENT_NO_NUMBER.
    */
-  const uint64_t getCurrentSegmentNumber() const
-  {
-    if (!current_segment_)
-      return SEGMENT_NO_NUMBER;
-
-    const size_t segPos = get_segment_pos(current_segment_);
-
-    if (segPos == SEGMENT_NO_POS)
-      return SEGMENT_NO_NUMBER;
-
-    return static_cast<uint64_t>(segPos) + m_startNumber;
-  }
+  const uint64_t GetCurrentSegNumber() const;
 
   /*!
    * \brief Get the segment number of specified segment.
    * \return If found the number, otherwise SEGMENT_NO_NUMBER.
    */
-  const uint64_t getSegmentNumber(const CSegment* segment) const
-  {
-    if (!segment)
-      return SEGMENT_NO_NUMBER;
-
-    const size_t segPos = get_segment_pos(current_segment_);
-
-    if (segPos == SEGMENT_NO_POS)
-      return SEGMENT_NO_NUMBER;
-
-    return static_cast<uint64_t>(segPos) + m_startNumber;
-  }
-
+  const uint64_t GetSegNumber(const CSegment* seg) const;
 
   uint32_t timescale_ext_{0};
   uint32_t timescale_int_{0};

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -103,9 +103,14 @@ public:
   uint16_t GetHdcpVersion() const { return m_hdcpVersion; }
   void SetHdcpVersion(uint16_t hdcpVersion) { m_hdcpVersion = hdcpVersion; }
 
-  CSegContainer& SegmentTimeline() { return m_segmentTimeline; }
-  CSegContainer SegmentTimeline() const { return m_segmentTimeline; }
-  bool HasSegmentTimeline() { return !m_segmentTimeline.IsEmpty(); }
+  /*!
+   * \brief The segment timeline.
+   */
+  CSegContainer& Timeline() { return m_segmentTimeline; }
+  /*!
+   * \brief The segment timeline.
+   */
+  CSegContainer Timeline() const { return m_segmentTimeline; }
 
   std::optional<CSegmentBase>& GetSegmentBase() { return m_segmentBase; }
   void SetSegmentBase(const CSegmentBase& segBase) { m_segmentBase = segBase; }

--- a/src/common/Segment.cpp
+++ b/src/common/Segment.cpp
@@ -25,21 +25,7 @@ const CSegment* PLAYLIST::CSegContainer::Get(size_t pos) const
   return &m_segments[pos];
 }
 
-CSegment* PLAYLIST::CSegContainer::Get(size_t pos)
-{
-  if (pos == SEGMENT_NO_POS || m_segments.empty())
-    return nullptr;
-
-  if (pos >= m_segments.size())
-  {
-    LOG::LogF(LOGWARNING, "Position out-of-range (%zu of %zu)", pos, m_segments.size());
-    return nullptr;
-  }
-
-  return &m_segments[pos];
-}
-
-CSegment* PLAYLIST::CSegContainer::GetBack()
+const CSegment* PLAYLIST::CSegContainer::GetBack() const
 {
   if (m_segments.empty())
     return nullptr;
@@ -47,7 +33,7 @@ CSegment* PLAYLIST::CSegContainer::GetBack()
   return &m_segments.back();
 }
 
-CSegment* PLAYLIST::CSegContainer::GetFront()
+const CSegment* PLAYLIST::CSegContainer::GetFront() const
 {
   if (m_segments.empty())
     return nullptr;
@@ -55,27 +41,89 @@ CSegment* PLAYLIST::CSegContainer::GetFront()
   return &m_segments.front();
 }
 
-const size_t PLAYLIST::CSegContainer::GetPosition(const CSegment* elem) const
+const CSegment* PLAYLIST::CSegContainer::GetNext(const CSegment* seg) const
+{
+  if (!seg || seg->IsInitialization())
+    return GetFront();
+
+  // If available, find the segment by number, this is because some
+  // live services provide inconsistent timestamps between manifest updates
+  // which will make it ineffective to find the next segment
+  if (seg->m_number != SEGMENT_NO_NUMBER)
+  {
+    const uint64_t number = seg->m_number;
+
+    for (const CSegment& segment : m_segments)
+    {
+      if (segment.m_number > number)
+        return &segment;
+    }
+  }
+  else
+  {
+    const uint64_t startPTS = seg->startPTS_;
+
+    for (const CSegment& segment : m_segments)
+    {
+      if (segment.startPTS_ > startPTS)
+        return &segment;
+    }
+  }
+  return nullptr;
+}
+
+const CSegment* PLAYLIST::CSegContainer::Find(const CSegment& seg) const
+{
+  // If available, find the segment by number, this is because some
+  // live services provide inconsistent timestamps between manifest updates
+  // which will make it ineffective to find the same segment
+  if (seg.m_number != SEGMENT_NO_NUMBER)
+  {
+    const uint64_t number = seg.m_number;
+
+    for (const CSegment& segment : m_segments)
+    {
+      if (segment.m_number == number)
+        return &segment;
+    }
+  }
+  else
+  {
+    const uint64_t startPTS = seg.startPTS_;
+
+    for (const CSegment& segment : m_segments)
+    {
+      // Search by >= is intended to allow minimizing problems with encoders
+      // that provide inconsistent timestamps between manifest updates
+      if (segment.startPTS_ >= startPTS)
+        return &segment;
+    }
+  }
+
+  return nullptr;
+}
+
+const size_t PLAYLIST::CSegContainer::GetPos(const CSegment* seg) const
 {
   for (size_t i = 0; i < m_segments.size(); ++i)
   {
-    if (&m_segments[i] == elem)
+    if (&m_segments[i] == seg)
       return i;
   }
 
   return SEGMENT_NO_POS;
 }
 
-void PLAYLIST::CSegContainer::Add(const CSegment& elem)
+void PLAYLIST::CSegContainer::Add(const CSegment& seg)
 {
-  m_duration += elem.m_endPts - elem.startPTS_;
-  m_segments.emplace_back(elem);
+  m_duration += seg.m_endPts - seg.startPTS_;
+  m_segments.emplace_back(seg);
 }
 
-void PLAYLIST::CSegContainer::Append(const CSegment& elem)
+void PLAYLIST::CSegContainer::Append(const CSegment& seg)
 {
-  m_duration += elem.m_endPts - elem.startPTS_;
-  m_segments.emplace_back(elem);
+  m_duration += seg.m_endPts - seg.startPTS_;
+  m_segments.emplace_back(seg);
   m_appendCount += 1;
 }
 

--- a/src/common/Segment.cpp
+++ b/src/common/Segment.cpp
@@ -7,3 +7,89 @@
  */
 
 #include "Segment.h"
+#include "utils/log.h"
+
+using namespace PLAYLIST;
+
+const CSegment* PLAYLIST::CSegContainer::Get(size_t pos) const
+{
+  if (pos == SEGMENT_NO_POS || m_segments.empty())
+    return nullptr;
+
+  if (pos >= m_segments.size())
+  {
+    LOG::LogF(LOGWARNING, "Position out-of-range (%zu of %zu)", pos, m_segments.size());
+    return nullptr;
+  }
+
+  return &m_segments[pos];
+}
+
+CSegment* PLAYLIST::CSegContainer::Get(size_t pos)
+{
+  if (pos == SEGMENT_NO_POS || m_segments.empty())
+    return nullptr;
+
+  if (pos >= m_segments.size())
+  {
+    LOG::LogF(LOGWARNING, "Position out-of-range (%zu of %zu)", pos, m_segments.size());
+    return nullptr;
+  }
+
+  return &m_segments[pos];
+}
+
+CSegment* PLAYLIST::CSegContainer::GetBack()
+{
+  if (m_segments.empty())
+    return nullptr;
+
+  return &m_segments.back();
+}
+
+CSegment* PLAYLIST::CSegContainer::GetFront()
+{
+  if (m_segments.empty())
+    return nullptr;
+
+  return &m_segments.front();
+}
+
+const size_t PLAYLIST::CSegContainer::GetPosition(const CSegment* elem) const
+{
+  for (size_t i = 0; i < m_segments.size(); ++i)
+  {
+    if (&m_segments[i] == elem)
+      return i;
+  }
+
+  return SEGMENT_NO_POS;
+}
+
+void PLAYLIST::CSegContainer::Add(const CSegment& elem)
+{
+  m_duration += elem.m_endPts - elem.startPTS_;
+  m_segments.emplace_back(elem);
+}
+
+void PLAYLIST::CSegContainer::Append(const CSegment& elem)
+{
+  m_duration += elem.m_endPts - elem.startPTS_;
+  m_segments.emplace_back(elem);
+  m_appendCount += 1;
+}
+
+void PLAYLIST::CSegContainer::Swap(CSegContainer& other)
+{
+  m_segments.swap(other.m_segments);
+  std::swap(m_appendCount, other.m_appendCount);
+  std::swap(m_duration, other.m_duration);
+}
+
+void PLAYLIST::CSegContainer::Clear()
+{
+  m_segments.clear();
+  m_appendCount = 0;
+  m_duration = 0;
+}
+

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -76,42 +76,49 @@ public:
   const CSegment* Get(size_t pos) const;
 
   /*!
-   * \brief Get the segment pointer from the specified position
-   * \param pos The position of segment
-   * \return Segment pointer, otherwise nullptr if not found
-   */
-  CSegment* Get(size_t pos);
-
-  /*!
    * \brief Get the last segment pointer
    * \return Segment pointer, otherwise nullptr if not found
    */
-  CSegment* GetBack();
+  const CSegment* GetBack() const;
 
   /*!
    * \brief Get the first segment as pointer
    * \return Segment pointer, otherwise nullptr if not found
    */
-  CSegment* GetFront();
+  const CSegment* GetFront() const;
 
   /*!
-   * \brief Get index position of a segment pointer
+   * \brief Get the next segment after the one specified.
+   *        The search is done by number (if available) otherwise by PTS.
+   * \return If found the segment pointer, otherwise nullptr.
+   */
+  const CSegment* GetNext(const CSegment* seg) const;
+
+  /*!
+   * \brief Try find same/similar segment in the timeline.
+   *        The search is done by number (if available) otherwise by PTS.
+   * \return If found the segment pointer, otherwise nullptr.
+   */
+  const CSegment* Find(const CSegment& seg) const;
+
+  /*!
+   * \brief Get index position of a segment pointer in the timeline.
    * \param elem The segment pointer to get the position
    * \return The index position, or SEGMENT_NO_POS if not found
    */
-  const size_t GetPosition(const CSegment* elem) const;
+  const size_t GetPos(const CSegment* seg) const;
 
   /*!
    * \brief Add a segment to the container.
    * \param elem The segment to add
    */
-  void Add(const CSegment& elem);
+  void Add(const CSegment& seg);
 
   /*!
    * \brief Append segment to the container, by increasing the count.
    * \param elem The segment to append
    */
-  void Append(const CSegment& elem);
+  void Append(const CSegment& seg);
 
   void Swap(CSegContainer& other);
 

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -17,8 +17,10 @@
 #endif
 
 #include <algorithm>
+#include <deque>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace PLAYLIST
 {
@@ -58,6 +60,101 @@ public:
 
 private:
   bool m_isInitialization{false};
+};
+
+class ATTR_DLL_LOCAL CSegContainer
+{
+public:
+  CSegContainer() = default;
+  ~CSegContainer() = default;
+
+  /*!
+   * \brief Get the segment pointer from the specified position
+   * \param pos The position of segment
+   * \return Segment pointer, otherwise nullptr if not found
+   */
+  const CSegment* Get(size_t pos) const;
+
+  /*!
+   * \brief Get the segment pointer from the specified position
+   * \param pos The position of segment
+   * \return Segment pointer, otherwise nullptr if not found
+   */
+  CSegment* Get(size_t pos);
+
+  /*!
+   * \brief Get the last segment pointer
+   * \return Segment pointer, otherwise nullptr if not found
+   */
+  CSegment* GetBack();
+
+  /*!
+   * \brief Get the first segment as pointer
+   * \return Segment pointer, otherwise nullptr if not found
+   */
+  CSegment* GetFront();
+
+  /*!
+   * \brief Get index position of a segment pointer
+   * \param elem The segment pointer to get the position
+   * \return The index position, or SEGMENT_NO_POS if not found
+   */
+  const size_t GetPosition(const CSegment* elem) const;
+
+  /*!
+   * \brief Add a segment to the container.
+   * \param elem The segment to add
+   */
+  void Add(const CSegment& elem);
+
+  /*!
+   * \brief Append segment to the container, by increasing the count.
+   * \param elem The segment to append
+   */
+  void Append(const CSegment& elem);
+
+  void Swap(CSegContainer& other);
+
+  /*!
+   * \brief Delete all segments and clear the properties.
+   */
+  void Clear();
+
+  bool IsEmpty() const { return m_segments.empty(); }
+
+  /*!
+   * \brief Get the number of the appended segments.
+   * \return The number of appended segments.
+   */
+  size_t GetAppendCount() const { return m_appendCount; }
+
+  /*!
+   * \brief Get the number of segments.
+   * \return The number of segments.
+   */
+  size_t GetSize() const { return m_segments.size(); }
+
+  /*!
+   * \brief Get the number of elements without taking into account those appended.
+   * \return The number of elements.
+   */
+  size_t GetInitialSize() const { return m_segments.size() - m_appendCount; }
+
+  /*!
+   * \brief Get the duration of all segments.
+   * \return The duration of all segments.
+   */
+  uint64_t GetDuration() const { return m_duration; }
+
+  std::deque<CSegment>::const_iterator begin() const { return m_segments.begin(); }
+  std::deque<CSegment>::const_iterator end() const { return m_segments.end(); }
+
+private:
+  // Has been used std::deque because there are uses of pointer references
+  // deque container keeps memory addresses even if the container size increases (no reallocations)
+  std::deque<CSegment> m_segments;
+  size_t m_appendCount{0}; // Number of appended segments
+  uint64_t m_duration{0}; // Sum of the duration of all segments
 };
 
 } // namespace PLAYLIST

--- a/src/common/SegmentBase.cpp
+++ b/src/common/SegmentBase.cpp
@@ -10,6 +10,7 @@
 
 #include "AdaptiveUtils.h"
 #include "Segment.h"
+#include "utils/log.h"
 
 using namespace PLAYLIST;
 

--- a/src/common/SegmentList.cpp
+++ b/src/common/SegmentList.cpp
@@ -8,6 +8,7 @@
 
 #include "SegmentList.h"
 #include "Segment.h"
+#include "utils/log.h"
 
 using namespace PLAYLIST;
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1013,7 +1013,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   }
 
   if (repr->GetContainerType() == ContainerType::TEXT && repr->GetMimeType() != "application/mp4" &&
-      !repr->HasSegmentBase() && !repr->HasSegmentTemplate() && !repr->Timeline().IsEmpty())
+      !repr->HasSegmentBase() && !repr->HasSegmentTemplate() && repr->Timeline().IsEmpty())
   {
     // Raw unsegmented subtitles called "sidecar" is a single file specified in the <BaseURL> tag,
     // must not have the MP4 ISOBMFF mime type or any other dash element.
@@ -1021,7 +1021,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   }
 
   // Generate segments from SegmentTemplate
-  if (repr->HasSegmentTemplate() && !repr->Timeline().IsEmpty())
+  if (repr->HasSegmentTemplate() && repr->Timeline().IsEmpty())
   {
     auto& segTemplate = repr->GetSegmentTemplate();
 
@@ -1744,7 +1744,7 @@ void adaptive::CDashTree::OnUpdateSegments()
                 }
               }
 
-              if (repr->IsWaitForSegment() && (repr->get_next_segment(repr->current_segment_)))
+              if (repr->IsWaitForSegment() && repr->GetNextSegment())
               {
                 repr->SetIsWaitForSegment(false);
                 LOG::LogF(LOGDEBUG, "End WaitForSegment repr. id %s", repr->GetId().data());
@@ -1801,7 +1801,7 @@ bool adaptive::CDashTree::InsertLiveSegment(PLAYLIST::CPeriod* period,
   //! @todo: expired_segments_ should be reworked, see also other parsers
   repr->expired_segments_++;
 
-  CSegment* segment = repr->Timeline().Get(pos);
+  const CSegment* segment = repr->Timeline().Get(pos);
 
   if (!segment)
   {
@@ -1838,7 +1838,7 @@ bool adaptive::CDashTree::InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
   if (!m_isLive || !repr->HasSegmentTemplate() || m_minimumUpdatePeriod != NO_VALUE)
     return false;
 
-  CSegment* lastSeg = repr->Timeline().GetBack();
+  const CSegment* lastSeg = repr->Timeline().GetBack();
   if (!lastSeg)
     return false;
 

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -921,25 +921,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
       index++;
     }
 
-    // Determines total duration of segments
-    uint64_t totalDur;
-    if (adpSet->HasSegmentTimelineDuration())
-    {
-      auto& segTLData = adpSet->SegmentTimelineDuration();
-      totalDur = std::accumulate(segTLData.begin(), segTLData.end(), 0ULL);
-      if (isTLDurTsRescale)
-      {
-        totalDur =
-            static_cast<uint64_t>(static_cast<double>(totalDur) /
-                                  adpSet->GetSegDurationsTimescale() * segList.GetTimescale());
-      }
-    }
-    else
-    {
-      totalDur = static_cast<uint64_t>(repr->Timeline().GetSize()) * segList.GetDuration();
-    }
-
-    repr->SetDuration(totalDur);
     repr->SetTimescale(segList.GetTimescale());
 
     repr->SetSegmentList(segList);
@@ -1055,7 +1036,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
       if (segTemplate->HasTimeline()) // Generate segments from template timeline
       {
         uint64_t time{0};
-        uint64_t totalDuration{0};
 
         for (const auto& tlElem : segTemplate->Timeline())
         {
@@ -1079,7 +1059,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
 
             seg.m_time = time;
 
-            totalDuration += tlElem.duration;
             repr->Timeline().Add(seg);
 
             time += tlElem.duration;
@@ -1087,7 +1066,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
         }
 
         repr->SetTimescale(segTimescale);
-        repr->SetDuration(totalDuration);
       }
       else // Generate segments by using template
       {
@@ -1164,11 +1142,11 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
         }
 
         repr->SetTimescale(segTemplate->GetTimescale());
-        repr->SetDuration(static_cast<uint64_t>(segDuration) * segmentsCount);
       }
     }
   }
 
+  repr->SetDuration(repr->Timeline().GetDuration());
   repr->SetScaling();
 
   adpSet->AddRepresentation(repr);

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -915,7 +915,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
       seg.m_time = segStartPts;
       seg.m_number = segNumber++;
 
-      repr->SegmentTimeline().GetData().push_back(seg);
+      repr->SegmentTimeline().Add(seg);
 
       segStartPts += duration;
       index++;
@@ -1080,7 +1080,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
             seg.m_time = time;
 
             totalDuration += tlElem.duration;
-            repr->SegmentTimeline().GetData().emplace_back(seg);
+            repr->SegmentTimeline().Add(seg);
 
             time += tlElem.duration;
           } while (repeat-- > 0);
@@ -1158,7 +1158,7 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
 
           seg.m_time = time;
 
-          repr->SegmentTimeline().GetData().emplace_back(seg);
+          repr->SegmentTimeline().Add(seg);
 
           time = seg.m_endPts;
         }
@@ -1701,10 +1701,10 @@ void adaptive::CDashTree::OnUpdateSegments()
                   continue;
                 }
 
-                CSegment* foundSeg{nullptr};
+                const CSegment* foundSeg{nullptr};
                 const uint64_t segStartPTS = repr->current_segment_->startPTS_;
 
-                for (CSegment& segment : updRepr->SegmentTimeline().GetData())
+                for (const CSegment& segment : updRepr->SegmentTimeline())
                 {
                   if (segment.startPTS_ == segStartPTS)
                   {

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -68,7 +68,7 @@ protected:
                               PLAYLIST::CPeriod* period);
 
   void ParseTagSegmentTimeline(pugi::xml_node parentNode,
-                               PLAYLIST::CSpinCache<uint32_t>& SCTimeline);
+                               std::vector<uint32_t>& SCTimeline);
 
   void ParseSegmentTemplate(pugi::xml_node node, PLAYLIST::CSegmentTemplate& segTpl);
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -774,8 +774,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
       {
         period->SetSequence(m_discontSeq + discontCount);
 
-        uint64_t dur = newSegments.GetBack()->m_endPts - newSegments.GetFront()->startPTS_;
-        rep->SetDuration(dur);
+        rep->SetDuration(newSegments.GetDuration());
 
         if (adp->GetStreamType() != StreamType::SUBTITLE)
         {

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -462,7 +462,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
 
   uint64_t mediaSequenceNbr{0};
 
-  CSpinCache<CSegment> newSegments;
+  CSegContainer newSegments;
   std::optional<CSegment> newSegment;
 
   // Pssh set used between segments
@@ -701,7 +701,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
       }
       newSegment->pssh_set_ = psshSetPos;
 
-      newSegments.GetData().emplace_back(*newSegment);
+      newSegments.Add(*newSegment);
       newSegment.reset();
     }
     else if (tagName == "#EXT-X-DISCONTINUITY-SEQUENCE")

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -404,7 +404,7 @@ void adaptive::CSmoothTree::CreateSegmentTimeline()
           seg.m_time = nextStartPts + m_ptsBase;
           seg.m_number = index;
 
-          repr->SegmentTimeline().GetData().emplace_back(seg);
+          repr->SegmentTimeline().Add(seg);
 
           nextStartPts += segDuration;
           index++;

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -427,7 +427,7 @@ bool adaptive::CSmoothTree::InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
   //! then add a better way to delete old segments from the timeline based on timeshift window
   //! this also requires taking care of the Dash parser
 
-  CSegment* lastSeg = repr->Timeline().GetBack();
+  const CSegment* lastSeg = repr->Timeline().GetBack();
   if (!lastSeg)
     return false;
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -404,7 +404,7 @@ void adaptive::CSmoothTree::CreateSegmentTimeline()
           seg.m_time = nextStartPts + m_ptsBase;
           seg.m_number = index;
 
-          repr->SegmentTimeline().Add(seg);
+          repr->Timeline().Add(seg);
 
           nextStartPts += segDuration;
           index++;
@@ -427,7 +427,7 @@ bool adaptive::CSmoothTree::InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
   //! then add a better way to delete old segments from the timeline based on timeshift window
   //! this also requires taking care of the Dash parser
 
-  CSegment* lastSeg = repr->SegmentTimeline().GetBack();
+  CSegment* lastSeg = repr->Timeline().GetBack();
   if (!lastSeg)
     return false;
 
@@ -458,7 +458,7 @@ bool adaptive::CSmoothTree::InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
 
   for (auto& repr : adpSet->GetRepresentations())
   {
-    repr->SegmentTimeline().Append(segCopy);
+    repr->Timeline().Append(segCopy);
   }
 
   return true;

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -229,11 +229,11 @@ void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
     uint64_t t{0};
     if (XML::QueryAttrib(node, "t", t))
     {
-      if (!adpSet->SegmentTimelineDuration().IsEmpty())
+      if (!adpSet->SegmentTimelineDuration().empty())
       {
         //Go back to the previous timestamp to calculate the real gap.
-        previousPts -= adpSet->SegmentTimelineDuration().GetData().back();
-        adpSet->SegmentTimelineDuration().GetData().back() = static_cast<uint32_t>(t - previousPts);
+        previousPts -= adpSet->SegmentTimelineDuration().back();
+        adpSet->SegmentTimelineDuration().back() = static_cast<uint32_t>(t - previousPts);
       }
       else
       {
@@ -252,13 +252,13 @@ void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
     {
       while (repeatCount--)
       {
-        adpSet->SegmentTimelineDuration().GetData().emplace_back(duration);
+        adpSet->SegmentTimelineDuration().emplace_back(duration);
         previousPts += duration;
       }
     }
   }
 
-  if (adpSet->SegmentTimelineDuration().IsEmpty())
+  if (adpSet->SegmentTimelineDuration().empty())
   {
     LOG::LogF(LOGDEBUG, "No generated timeline, adaptation set skipped.");
     return;
@@ -396,7 +396,7 @@ void adaptive::CSmoothTree::CreateSegmentTimeline()
         uint64_t nextStartPts = adpSet->GetStartPTS() - m_ptsBase;
         uint64_t index = 1;
 
-        for (uint32_t segDuration : adpSet->SegmentTimelineDuration().GetData())
+        for (uint32_t segDuration : adpSet->SegmentTimelineDuration())
         {
           CSegment seg;
           seg.startPTS_ = nextStartPts;

--- a/src/samplereader/SampleReaderFactory.cpp
+++ b/src/samplereader/SampleReaderFactory.cpp
@@ -16,6 +16,7 @@
 #include "samplereader/SubtitleSampleReader.h"
 #include "samplereader/TSSampleReader.h"
 #include "samplereader/WebmSampleReader.h"
+#include "utils/log.h"
 
 #include <bento4/Ap4.h>
 

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -604,19 +604,19 @@ TEST_F(DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline)
   repr->current_segment_ = repr->Timeline().GetBack();
 
   EXPECT_EQ(repr->current_segment_->startPTS_, 95687379264);
-  EXPECT_EQ(repr->getCurrentSegmentPos(), 4);
+  EXPECT_EQ(repr->Timeline().GetPos(repr->current_segment_), 4);
 
   tree->RunManifestUpdate("mpd/bad_segtimeline_2.mpd");
   EXPECT_EQ(repr->current_segment_->startPTS_, 95687381280);
-  EXPECT_EQ(repr->getCurrentSegmentPos(), 2);
+  EXPECT_EQ(repr->Timeline().GetPos(repr->current_segment_), 2);
 
   tree->RunManifestUpdate("mpd/bad_segtimeline_3.mpd");
   EXPECT_EQ(repr->current_segment_->startPTS_, 95687382336);
-  EXPECT_EQ(repr->getCurrentSegmentPos(), 1);
+  EXPECT_EQ(repr->Timeline().GetPos(repr->current_segment_), 1);
 
   tree->RunManifestUpdate("mpd/bad_segtimeline_4.mpd");
   EXPECT_EQ(repr->current_segment_->startPTS_, 95687382337);
-  EXPECT_EQ(repr->getCurrentSegmentPos(), 0);
+  EXPECT_EQ(repr->Timeline().GetPos(repr->current_segment_), 0);
 }
 
 TEST_F(DASHTreeTest, AdaptionSetSwitching)

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -601,7 +601,7 @@ TEST_F(DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline)
 
   auto& repr = tree->m_currentPeriod->GetAdaptationSets()[1]->GetRepresentations()[0];
   // Set the last segment to the current segment to simulate reaching the last segment
-  repr->current_segment_ = &repr->SegmentTimeline().GetData().back();
+  repr->current_segment_ = repr->SegmentTimeline().GetBack();
 
   EXPECT_EQ(repr->current_segment_->startPTS_, 95687379264);
   EXPECT_EQ(repr->getCurrentSegmentPos(), 4);

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -270,7 +270,7 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTimeline)
   OpenTestFile("mpd/segtimeline_live_ast.mpd");
 
   auto& segments =
-      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(segments.GetSize(), 13);
   EXPECT_EQ(segments.Get(0)->m_number, 487050);
@@ -283,7 +283,7 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithPTO)
 
   OpenTestFile("mpd/segtpl_pto.mpd");
 
-  auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+  auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(segments.GetSize(), 450);
   EXPECT_EQ(segments.Get(0)->m_number, 404314437);
@@ -295,7 +295,7 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithOldPub
 
   OpenTestFile("mpd/segtpl_old_publish_time.mpd");
 
-  auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+  auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(segments.GetSize(), 30);
   EXPECT_EQ(segments.Get(0)->m_number, 603271);
@@ -492,22 +492,22 @@ TEST_F(DASHTreeTest, CalculateMultipleSegTpl)
   EXPECT_EQ(STR(adpSets[0]->GetRepresentations()[0]->GetSegmentTemplate()->GetInitialization()), "3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252init.mp4");
   EXPECT_EQ(STR(adpSets[0]->GetRepresentations()[0]->GetSegmentTemplate()->GetMedia()), "3c1055cb-a842-4449-b393-7f31693b4a8f_1_448x252_$Number%09d$.mp4");
   EXPECT_EQ(adpSets[0]->GetRepresentations()[0]->GetSegmentTemplate()->GetTimescale(), 120000);
-  EXPECT_EQ(adpSets[0]->GetRepresentations()[0]->SegmentTimeline().Get(0)->m_number, 3);
+  EXPECT_EQ(adpSets[0]->GetRepresentations()[0]->Timeline().Get(0)->m_number, 3);
 
   EXPECT_EQ(STR(adpSets[0]->GetRepresentations()[1]->GetSegmentTemplate()->GetInitialization()), "3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080init.mp4");
   EXPECT_EQ(STR(adpSets[0]->GetRepresentations()[1]->GetSegmentTemplate()->GetMedia()), "3c1055cb-a842-4449-b393-7f31693b4a8f_2_1920x1080_$Number%09d$.mp4");
   EXPECT_EQ(adpSets[0]->GetRepresentations()[1]->GetSegmentTemplate()->GetTimescale(), 90000);
-  EXPECT_EQ(adpSets[0]->GetRepresentations()[1]->SegmentTimeline().Get(0)->m_number, 5);
+  EXPECT_EQ(adpSets[0]->GetRepresentations()[1]->Timeline().Get(0)->m_number, 5);
 
   EXPECT_EQ(STR(adpSets[1]->GetRepresentations()[0]->GetSegmentTemplate()->GetInitialization()), "3c1055cb-a842-4449-b393-7f31693b4a8f_aac1init.mp4");
   EXPECT_EQ(STR(adpSets[1]->GetRepresentations()[0]->GetSegmentTemplate()->GetMedia()), "3c1055cb-a842-4449-b393-7f31693b4a8f_aac1_$Number%09d$.mp4");
   EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->GetSegmentTemplate()->GetTimescale(), 48000);
-  EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->SegmentTimeline().Get(0)->m_number, 1);
+  EXPECT_EQ(adpSets[1]->GetRepresentations()[0]->Timeline().Get(0)->m_number, 1);
 
   EXPECT_EQ(STR(adpSets[2]->GetRepresentations()[0]->GetSegmentTemplate()->GetInitialization()), "abc_aac1init.mp4");
   EXPECT_EQ(STR(adpSets[2]->GetRepresentations()[0]->GetSegmentTemplate()->GetMedia()), "abc2_$Number%09d$.mp4");
   EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->GetSegmentTemplate()->GetTimescale(), 68000);
-  EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->SegmentTimeline().Get(0)->m_number, 5);
+  EXPECT_EQ(adpSets[2]->GetRepresentations()[0]->Timeline().Get(0)->m_number, 5);
 }
 
 TEST_F(DASHTreeAdaptiveStreamTest, CalculateRedirectSegTpl)
@@ -601,7 +601,7 @@ TEST_F(DASHTreeAdaptiveStreamTest, MisalignedSegmentTimeline)
 
   auto& repr = tree->m_currentPeriod->GetAdaptationSets()[1]->GetRepresentations()[0];
   // Set the last segment to the current segment to simulate reaching the last segment
-  repr->current_segment_ = repr->SegmentTimeline().GetBack();
+  repr->current_segment_ = repr->Timeline().GetBack();
 
   EXPECT_EQ(repr->current_segment_->startPTS_, 95687379264);
   EXPECT_EQ(repr->getCurrentSegmentPos(), 4);
@@ -678,7 +678,7 @@ TEST_F(DASHTreeTest, SegmentTemplateStartNumber)
   EXPECT_EQ(adpSets[0]->GetRepresentations()[0]->GetSegmentTemplate()->GetDuration(), 48000);
 
   // Verify segments
-  auto& rep1Timeline = adpSets[0]->GetRepresentations()[0]->SegmentTimeline();
+  auto& rep1Timeline = adpSets[0]->GetRepresentations()[0]->Timeline();
   EXPECT_EQ(rep1Timeline.GetSize(), 144);
 
   EXPECT_EQ(rep1Timeline.Get(0)->startPTS_, 0);
@@ -700,14 +700,14 @@ TEST_F(DASHTreeTest, TSBMiddlePeriods)
   OpenTestFile("mpd/tsb_middle_periods.mpd");
 
   auto& tlPeriod1 =
-      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(tlPeriod1.GetSize(), 90);
   EXPECT_EQ(tlPeriod1.GetFront()->m_number, 856065330);
   EXPECT_EQ(tlPeriod1.GetBack()->m_number, 856065419);
 
   auto& tlPeriod2 =
-      tree->m_periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+      tree->m_periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(tlPeriod2.GetSize(), 2);
   EXPECT_EQ(tlPeriod2.GetFront()->m_number, 856065420);
@@ -724,14 +724,14 @@ TEST_F(DASHTreeTest, TSBMiddlePeriodsPastNowTime)
   OpenTestFile("mpd/tsb_middle_periods.mpd");
 
   auto& tlPeriod1 =
-      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(tlPeriod1.GetSize(), 90);
   EXPECT_EQ(tlPeriod1.GetFront()->m_number, 856065330);
   EXPECT_EQ(tlPeriod1.GetBack()->m_number, 856065419);
 
   auto& tlPeriod2 =
-      tree->m_periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+      tree->m_periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(tlPeriod2.GetSize(), 1);
   EXPECT_EQ(tlPeriod2.GetFront()->m_number, 856065420);
@@ -746,7 +746,7 @@ TEST_F(DASHTreeTest, TSBAvailabilityStartTime)
   OpenTestFile("mpd/tsb_availstarttime.mpd");
 
   auto& tl =
-      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+      tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(tl.GetSize(), 1200);
   EXPECT_EQ(tl.GetFront()->m_number, 129069);

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -292,7 +292,7 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
 
     auto& periodSecond = tree->m_periods[1];
     auto& adp0rep1 = periodSecond->GetAdaptationSets()[0]->GetRepresentations()[0];
-    auto adp0rep1seg1 = adp0rep1->SegmentTimeline().GetFront();
+    auto adp0rep1seg1 = adp0rep1->Timeline().GetFront();
     EXPECT_EQ(adp0rep1seg1->startPTS_, 0);
   }
   {
@@ -308,7 +308,7 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
 
     auto& periodSecond = tree->m_periods[1];
     auto& adp1rep0 = periodSecond->GetAdaptationSets()[1]->GetRepresentations()[0];
-    auto adp1rep0seg1 = adp1rep0->SegmentTimeline().GetFront();
+    auto adp1rep0seg1 = adp1rep0->Timeline().GetFront();
     EXPECT_EQ(adp1rep0seg1->startPTS_, 0);
   }
 }

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -292,8 +292,8 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
 
     auto& periodSecond = tree->m_periods[1];
     auto& adp0rep1 = periodSecond->GetAdaptationSets()[0]->GetRepresentations()[0];
-    auto& adp0rep1seg1 = adp0rep1->SegmentTimeline().GetData().front();
-    EXPECT_EQ(adp0rep1seg1.startPTS_, 0);
+    auto adp0rep1seg1 = adp0rep1->SegmentTimeline().GetFront();
+    EXPECT_EQ(adp0rep1seg1->startPTS_, 0);
   }
   {
     auto& periodFirst = tree->m_periods[0];
@@ -308,8 +308,8 @@ TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
 
     auto& periodSecond = tree->m_periods[1];
     auto& adp1rep0 = periodSecond->GetAdaptationSets()[1]->GetRepresentations()[0];
-    auto& adp1rep0seg1 = adp1rep0->SegmentTimeline().GetData().front();
-    EXPECT_EQ(adp1rep0seg1.startPTS_, 0);
+    auto adp1rep0seg1 = adp1rep0->SegmentTimeline().GetFront();
+    EXPECT_EQ(adp1rep0seg1->startPTS_, 0);
   }
 }
 

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -95,21 +95,21 @@ TEST_F(SmoothTreeTest, CheckAsyncTimelineStartPTS)
   // Each <StreamIndex> start with different chunk timestamp
   // so to sync streams we adjust PTS with <StreamIndex> which has the lowest timestamp (CSmoothTree::m_ptsBase)
   auto& period = tree->m_periods[0];
-  auto& segTL = period->GetAdaptationSets()[0]->GetRepresentations()[0]->SegmentTimeline();
+  auto& segTL = period->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(segTL.GetSize(), 30);
   EXPECT_EQ(segTL.Get(0)->startPTS_, 7058030);
   EXPECT_EQ(segTL.Get(0)->m_time, 3903180167058030);
   EXPECT_EQ(segTL.Get(0)->m_number, 1);
 
-  segTL = period->GetAdaptationSets()[1]->GetRepresentations()[0]->SegmentTimeline();
+  segTL = period->GetAdaptationSets()[1]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(segTL.GetSize(), 30);
   EXPECT_EQ(segTL.Get(0)->startPTS_, 71363);
   EXPECT_EQ(segTL.Get(0)->m_time, 3903180160071363);
   EXPECT_EQ(segTL.Get(0)->m_number, 1);
 
-  segTL = period->GetAdaptationSets()[3]->GetRepresentations()[0]->SegmentTimeline();
+  segTL = period->GetAdaptationSets()[3]->GetRepresentations()[0]->Timeline();
 
   EXPECT_EQ(segTL.GetSize(), 29);
   EXPECT_EQ(segTL.Get(0)->startPTS_, 0);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
I think it's time to get rid of `CSpinCache`
then create a kind of container for segments where we can move all segment methods which are also on Representation.h on the container itself,
a starting point where to have a common place where manage segments not a final solution but an intermediate step (ideally it would be ideal to have the interface for manifests _tree_ detached from the data of streams, but needs too much changes)

i have leave untouched the `CRepresentation::current_segment_`
i think can be possible to move it to the new CSegContainer but you need to check some parts of code well (more likely for live) here there are already many changes and i would like to avoid possible regressions

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
a long-delayed cleanup,
this also helps to have a way to know the period duration "on the fly" without the need to do calculations separately for each use case along the parsers

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
couple of HLS/Dash streams

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
