### PR TITLE
ClearKey

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|internal_cookies|config|manifest_config"
+    listitemprops="drm|license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|internal_cookies|config|manifest_config"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -68,6 +68,11 @@ struct ManifestConfig
   bool hlsFixDiscontSequence{false};
 };
 
+struct DrmCfg
+{
+  std::map<std::string, std::string> m_keys;
+};
+
 class ATTR_DLL_LOCAL CCompKodiProps
 {
 public:
@@ -121,9 +126,16 @@ public:
   // \brief Specifies the manifest configuration
   const ManifestConfig& GetManifestConfig() const { return m_manifestConfig; }
 
+  // \brief Get DRM configuration for specified keysystem, if not found will return default values
+  const DrmCfg& GetDrmConfig(const std::string& keySystem) { return m_drmConfigs[keySystem]; }
+
+  const std::map<std::string, DrmCfg>& GetDrmConfigs() const { return m_drmConfigs; }
+
 private:
   void ParseConfig(const std::string& data);
   void ParseManifestConfig(const std::string& data);
+
+  bool ParseDrmConfig(const std::string& data);
 
   std::string m_licenseType;
   std::string m_licenseKey;
@@ -145,6 +157,7 @@ private:
   ChooserProps m_chooserProps;
   Config m_config;
   ManifestConfig m_manifestConfig;
+  std::map<std::string, DrmCfg> m_drmConfigs;
 };
 
 } // namespace KODI_PROPS

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -373,12 +373,6 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
 
     LOG::Log(LOGDEBUG, "Entering encryption section");
 
-    if (licenseKey.empty())
-    {
-      LOG::Log(LOGERROR, "Invalid license_key");
-      return false;
-    }
-
     if (!m_decrypter)
     {
       LOG::Log(LOGERROR, "No decrypter found for encrypted stream");
@@ -405,6 +399,7 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
     }
 
     std::string_view licenseData = CSrvBroker::GetKodiProps().GetLicenseData();
+    std::string_view licenseType = CSrvBroker::GetKodiProps().GetLicenseType();
 
     // cdmSession 0 is reserved for unencrypted streams
     for (size_t ses{1}; ses < m_cdmSessions.size(); ++ses)
@@ -451,6 +446,11 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
           //! To take in account that license_data property is also used on DASH parser to bypass ContentProtection tags.
           drmOptionalKeyParam = licenseData;
         }
+      }
+      else if (licenseType == "org.w3.clearkey")
+      {
+        // URL for license server is set to PSSH, use this as is
+        initData = sessionPsshset.pssh_;
       }
       else if (!licenseData.empty())
       {
@@ -1354,6 +1354,8 @@ STREAM_CRYPTO_KEY_SYSTEM CSession::GetCryptoKeySystem() const
     return STREAM_CRYPTO_KEY_SYSTEM_WISEPLAY;
   else if (licenseType == "com.microsoft.playready")
     return STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY;
+  else if (licenseType == "org.w3.clearkey")
+    return STREAM_CRYPTO_KEY_SYSTEM_CLEARKEY;
   else
     return STREAM_CRYPTO_KEY_SYSTEM_NONE;
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -322,7 +322,7 @@ protected:
    *  \param key_system [OUT] Will be assigned to if a decrypter is found matching
    *                    the set license type
    */
-  void SetSupportedDecrypterURN(std::string& key_system);
+  void SetSupportedDecrypterURN(std::vector<std::string_view>& keySystems);
 
   /*! \brief Destroy all CencSingleSampleDecrypter instances
    */
@@ -334,7 +334,7 @@ protected:
 
   bool ExtractStreamProtectionData(PLAYLIST::CPeriod::PSSHSet& sessionPsshset,
                                    std::vector<uint8_t>& initData,
-                                   std::string keySystem);
+                                   std::vector<std::string_view> keySystems);
 
 private:
   std::string m_manifestUrl;

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -140,13 +140,13 @@ namespace adaptive
                                        PLAYLIST::CAdaptationSet* adp,
                                        const std::vector<uint8_t>& pssh,
                                        std::string_view defaultKID,
-                                       std::string_view kidUrl /* = "" */,
+                                       std::string_view licenseUrl /* = "" */,
                                        std::string_view iv /* = "" */)
   {
     CPeriod::PSSHSet psshSet;
     psshSet.pssh_ = pssh;
     psshSet.defaultKID_ = defaultKID;
-    psshSet.m_kidUrl = kidUrl;
+    psshSet.m_licenseUrl = licenseUrl;
     psshSet.iv = iv;
     psshSet.m_cryptoMode = m_cryptoMode;
     psshSet.adaptation_set_ = adp;

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -40,7 +40,7 @@ namespace adaptive
     m_manifestParams = left.m_manifestParams;
     m_manifestHeaders = left.m_manifestHeaders;
     m_settings = left.m_settings;
-    m_supportedKeySystem = left.m_supportedKeySystem;
+    m_supportedKeySystems = left.m_supportedKeySystems;
     m_pathSaveManifest = left.m_pathSaveManifest;
     stream_start_ = left.stream_start_;
 
@@ -49,11 +49,11 @@ namespace adaptive
   }
 
   void AdaptiveTree::Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                               std::string_view supportedKeySystem,
+                               std::vector<std::string_view> supportedKeySystems,
                                std::string_view manifestUpdParams)
   {
     m_reprChooser = reprChooser;
-    m_supportedKeySystem = supportedKeySystem;
+    m_supportedKeySystems = supportedKeySystems;
 
     auto srvBroker = CSrvBroker::GetInstance();
 

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -73,7 +73,7 @@ public:
   uint64_t available_time_{0}; // in ms
   uint64_t m_liveDelay{0}; // Apply a delay in seconds from the live edge
 
-  std::string m_supportedKeySystem;
+  std::vector<std::string_view> m_supportedKeySystems;
   std::string location_;
 
   CryptoMode m_cryptoMode{CryptoMode::NONE};
@@ -90,7 +90,7 @@ public:
    * \param manifestUpdParams Parameters to be add to manifest request url, depends on manifest implementation
    */
   virtual void Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                         std::string_view supportedKeySystem,
+                         std::vector<std::string_view> supportedKeySystems,
                          std::string_view manifestUpdParams);
 
   /*

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -215,7 +215,7 @@ public:
                          PLAYLIST::CAdaptationSet* adp,
                          const std::vector<uint8_t>& pssh,
                          std::string_view defaultKID,
-                         std::string_view kidUrl = "",
+                         std::string_view licenseUrl = "",
                          std::string_view iv = "");
 
   PLAYLIST::CAdaptationSet* GetAdaptationSet(size_t pos) const

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -54,7 +54,8 @@ enum class EncryptionState
 enum class EncryptionType
 {
   NOT_SUPPORTED,
-  CLEAR,
+  NONE,
+  CLEARKEY,
   AES128,
   WIDEVINE,
 };

--- a/src/common/CommonAttribs.h
+++ b/src/common/CommonAttribs.h
@@ -31,6 +31,7 @@ struct ProtectionScheme
   std::string value;
   std::string kid;
   std::string pssh;
+  std::string licenseUrl;
 };
 
 // CCommonAttribs class provide attribute data

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -43,7 +43,7 @@ uint16_t PLAYLIST::CPeriod::InsertPSSHSet(const PSSHSet& psshSet)
 {
   auto itPssh = m_psshSets.end();
 
-  if (psshSet.m_kidUrl.empty())
+  if (psshSet.m_licenseUrl.empty())
   {
     // Find the psshSet by skipping the first one of the list (for unencrypted streams)
     // note that PSSHSet struct has a custom comparator for std::find

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -111,7 +111,7 @@ public:
 
     //! @todo: create getter/setters
     std::vector<uint8_t> pssh_; // Data as bytes (not base64)
-    std::string m_kidUrl; // Url where get the KID
+    std::string m_licenseUrl; // License server URL
     std::string defaultKID_;
     std::string iv;
     uint32_t media_{0};

--- a/src/decrypters/CMakeLists.txt
+++ b/src/decrypters/CMakeLists.txt
@@ -11,6 +11,7 @@ set(HEADERS
 
 add_dir_sources(SOURCES HEADERS)
 
+add_subdirectory(clearkey)
 if(NOT CORE_SYSTEM_NAME STREQUAL ios AND NOT CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   if(CORE_SYSTEM_NAME STREQUAL android)
     add_subdirectory(widevineandroid)

--- a/src/decrypters/DrmFactory.cpp
+++ b/src/decrypters/DrmFactory.cpp
@@ -9,6 +9,7 @@
 #include "DrmFactory.h"
 
 #include <kodi/addon-instance/inputstream/StreamCrypto.h>
+#include "clearkey/ClearKeyDecrypter.h"
 #if ANDROID
 #include "widevineandroid/WVDecrypter.h"
 #else
@@ -21,7 +22,11 @@ using namespace DRM;
 
 IDecrypter* DRM::FACTORY::GetDecrypter(STREAM_CRYPTO_KEY_SYSTEM keySystem)
 {
-  if (keySystem == STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE)
+  if (keySystem == STREAM_CRYPTO_KEY_SYSTEM_CLEARKEY)
+  {
+    return new CClearKeyDecrypter();
+  }
+  else if (keySystem == STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE)
   {
 #if ANDROID
     return new CWVDecrypterA();

--- a/src/decrypters/Helpers.cpp
+++ b/src/decrypters/Helpers.cpp
@@ -11,6 +11,7 @@
 #include "utils/DigestMD5Utils.h"
 #include "utils/StringUtils.h"
 #include "utils/UrlUtils.h"
+#include "utils/log.h"
 
 using namespace UTILS;
 
@@ -44,6 +45,19 @@ std::string DRM::GenerateUrlDomainHash(std::string_view url)
   md5.Update(baseDomain.c_str(), static_cast<uint32_t>(baseDomain.size()));
   md5.Finalize();
   return md5.HexDigest();
+}
+
+std::string DRM::UrnToSystemId(std::string_view urn)
+{
+  std::string sysId{urn.substr(9)}; // Remove prefix "urn:uuid:"
+  STRING::ReplaceAll(sysId, "-", "");
+
+  if (sysId.size() != 32)
+  {
+    LOG::Log(LOGERROR, "Cannot convert URN (%s) to System ID", urn.data());
+    return "";
+  }
+  return sysId;
 }
 
 bool DRM::IsKeySystemSupported(std::string_view keySystem)

--- a/src/decrypters/Helpers.cpp
+++ b/src/decrypters/Helpers.cpp
@@ -45,3 +45,10 @@ std::string DRM::GenerateUrlDomainHash(std::string_view url)
   md5.Finalize();
   return md5.HexDigest();
 }
+
+bool DRM::IsKeySystemSupported(std::string_view keySystem)
+{
+  return keySystem == DRM::KS_NONE || keySystem == DRM::KS_WIDEVINE ||
+    keySystem == DRM::KS_PLAYREADY || keySystem == DRM::KS_WISEPLAY ||
+    keySystem == DRM::KS_CLEARKEY;
+}

--- a/src/decrypters/Helpers.h
+++ b/src/decrypters/Helpers.h
@@ -13,7 +13,24 @@
 
 namespace DRM
 {
+  // DRM Key systems
 
+  constexpr std::string_view KS_NONE = "none"; // No DRM but however encrypted (e.g. AES-128 on HLS)
+  constexpr std::string_view KS_WIDEVINE = "com.widevine.alpha";
+  constexpr std::string_view KS_PLAYREADY = "com.microsoft.playready";
+  constexpr std::string_view KS_WISEPLAY = "com.huawei.wiseplay";
+  constexpr std::string_view KS_CLEARKEY = "org.w3.clearkey";
+
+  // DRM UUIDs
+
+  constexpr std::string_view URN_WIDEVINE = "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
+  constexpr std::string_view URN_PLAYREADY = "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95";
+  constexpr std::string_view URN_WISEPLAY = "urn:uuid:3d5e6d35-9b9a-41e8-b843-dd3c6e72c42c";
+  constexpr std::string_view URN_CLEARKEY = "urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e";
+  constexpr std::string_view URN_COMMON = "urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b";
+
+
+  bool IsKeySystemSupported(std::string_view keySystem);
 /*!
  * \brief Generate an hash by using the base domain of an URL.
  * \param url An URL

--- a/src/decrypters/Helpers.h
+++ b/src/decrypters/Helpers.h
@@ -13,29 +13,37 @@
 
 namespace DRM
 {
-  // DRM Key systems
+// DRM Key systems
 
-  constexpr std::string_view KS_NONE = "none"; // No DRM but however encrypted (e.g. AES-128 on HLS)
-  constexpr std::string_view KS_WIDEVINE = "com.widevine.alpha";
-  constexpr std::string_view KS_PLAYREADY = "com.microsoft.playready";
-  constexpr std::string_view KS_WISEPLAY = "com.huawei.wiseplay";
-  constexpr std::string_view KS_CLEARKEY = "org.w3.clearkey";
+constexpr std::string_view KS_NONE = "none"; // No DRM but however encrypted (e.g. AES-128 on HLS)
+constexpr std::string_view KS_WIDEVINE = "com.widevine.alpha";
+constexpr std::string_view KS_PLAYREADY = "com.microsoft.playready";
+constexpr std::string_view KS_WISEPLAY = "com.huawei.wiseplay";
+constexpr std::string_view KS_CLEARKEY = "org.w3.clearkey";
 
-  // DRM UUIDs
+// DRM UUIDs
 
-  constexpr std::string_view URN_WIDEVINE = "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
-  constexpr std::string_view URN_PLAYREADY = "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95";
-  constexpr std::string_view URN_WISEPLAY = "urn:uuid:3d5e6d35-9b9a-41e8-b843-dd3c6e72c42c";
-  constexpr std::string_view URN_CLEARKEY = "urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e";
-  constexpr std::string_view URN_COMMON = "urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b";
+constexpr std::string_view URN_WIDEVINE = "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
+constexpr std::string_view URN_PLAYREADY = "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95";
+constexpr std::string_view URN_WISEPLAY = "urn:uuid:3d5e6d35-9b9a-41e8-b843-dd3c6e72c42c";
+constexpr std::string_view URN_CLEARKEY = "urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e";
+constexpr std::string_view URN_COMMON = "urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b";
 
 
-  bool IsKeySystemSupported(std::string_view keySystem);
+bool IsKeySystemSupported(std::string_view keySystem);
+
 /*!
  * \brief Generate an hash by using the base domain of an URL.
  * \param url An URL
  * \return The hash of a base domain URL
  */
 std::string GenerateUrlDomainHash(std::string_view url);
+
+/*!
+ * \brief Convert DRM URN to System ID.
+ * \param urn The URN
+ * \return The System ID, otherwise empty if fails.
+ */
+std::string UrnToSystemId(std::string_view urn);
 
 }; // namespace DRM

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -62,7 +62,7 @@ public:
    * \param keySystem The URN to be matched
    * \return Supported URN if type matches to capabilities, otherwise null
    */
-  virtual std::string SelectKeySytem(std::string_view keySystem) = 0;
+  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) = 0;
 
   /**
    * \brief Initialise the DRM system

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -77,17 +77,19 @@ public:
   
   /**
    * \brief Creates a Single Sample Decrypter for decrypting content 
-   * \param pssh The PSSH for initialising the decrypter
+   * \param initData The data for initialising the decrypter (e.g. PSSH)
    * \param optionalKeyParameter License key data passed into IA as parameter
    * \param defaultkeyid The default KeyID to initialise with
+   * \param licenseUrl The license server URL
    * \param skipSessionMessage False for preinitialisation case
    * \param cryptoMode The crypto/cypher mode to initialise with
    * \return The single sample decrypter if successfully created
    */
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
-      std::vector<uint8_t>& pssh,
+      std::vector<uint8_t>& initData,
       std::string_view optionalKeyParameter,
       std::string_view defaultKeyId,
+      std::string_view licenseUrl,
       bool skipSessionMessage,
       CryptoMode cryptoMode) = 0;
 

--- a/src/decrypters/clearkey/CMakeLists.txt
+++ b/src/decrypters/clearkey/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SOURCES
+  ClearKeyCencSingleSampleDecrypter.cpp
+  ClearKeyDecrypter.cpp
+)
+
+set(HEADERS
+  ClearKeyCencSingleSampleDecrypter.h
+  ClearKeyDecrypter.h
+)
+
+add_dir_sources(SOURCES HEADERS)

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -1,0 +1,268 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ClearKeyCencSingleSampleDecrypter.h"
+
+#include "ClearKeyDecrypter.h"
+#include "CompSettings.h"
+#include "SrvBroker.h"
+#include "utils/Base64Utils.h"
+#include "utils/CurlUtils.h"
+#include "utils/FileUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <algorithm>
+
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+using namespace UTILS;
+
+CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
+    std::string_view licenseUrl, std::string_view defaultKeyId, CClearKeyDecrypter* host)
+  : m_host(host)
+{
+  const std::string postData = CreateLicenseRequest(defaultKeyId);
+
+  if (CSrvBroker::GetSettings().IsDebugLicense())
+  {
+    const std::string debugFilePath =
+        FILESYS::PathCombine(m_host->GetLibraryPath(), "ClearKey.init");
+    FILESYS::SaveFile(debugFilePath, postData.c_str(), true);
+  }
+
+  CURL::CUrl curl{licenseUrl};
+  curl.AddHeader("Accept", "application/json");
+  curl.AddHeader("Content-Type", "application/json");
+  curl.AddHeader("postdata", UTILS::BASE64::Encode(postData));
+
+  std::string response;
+  int statusCode = curl.Open();
+  if (statusCode == -1 || statusCode >= 400)
+  {
+    LOG::Log(LOGERROR, "License server returned failure (HTTP error %i)", statusCode);
+    return;
+  }
+
+  if (curl.Read(response) != CURL::ReadStatus::IS_EOF)
+  {
+    LOG::LogF(LOGERROR, "Could not read the license server response");
+    return;
+  }
+
+  if (CSrvBroker::GetSettings().IsDebugLicense())
+  {
+    const std::string debugFilePath =
+        FILESYS::PathCombine(m_host->GetLibraryPath(), "ClearKey.response");
+    FILESYS::SaveFile(debugFilePath, response, true);
+  }
+
+  if (!ParseLicenseResponse(response))
+  {
+    LOG::LogF(LOGERROR, "Could not read full license server response");
+    return;
+  }
+
+  const std::string b64DefaultKeyId = UTILS::BASE64::Encode(defaultKeyId.data());
+  if (!STRING::KeyExists(m_keyPairs, b64DefaultKeyId))
+  {
+    LOG::LogF(LOGERROR, "Key not found on license response");
+    return;
+  }
+
+  std::vector<uint8_t> keyBytes = BASE64::Decode(m_keyPairs[b64DefaultKeyId]);
+  if (AP4_FAILED(AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, keyBytes.data(),
+                                                       16, 0, 0, nullptr, false,
+                                                       m_singleSampleDecrypter)))
+  {
+    LOG::LogF(LOGERROR, "Failed to create AP4_CencSingleSampleDecrypter");
+  }
+  SetParentIsOwner(false);
+  AddSessionKey(defaultKeyId);
+}
+
+CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
+    std::vector<uint8_t>& pssh,
+    std::string_view defaultKeyId,
+    std::map<std::string, std::string> keys,
+    CClearKeyDecrypter* host)
+  : m_host(host)
+{
+  std::vector<uint8_t> hexKey;
+
+  if (!keys.empty()) // get key from map provided in props
+    UTILS::STRING::ToHexBytes(keys[UTILS::STRING::ToHexadecimal(defaultKeyId)], hexKey);
+  else // key is provided directly in playlist
+    hexKey = pssh;
+
+  const AP4_UI08* ap4Key = reinterpret_cast<const AP4_UI08*>(hexKey.data());
+  AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, ap4Key, 16, 0, 0, nullptr,
+                                        false, m_singleSampleDecrypter);
+  SetParentIsOwner(false);
+  AddSessionKey(defaultKeyId);
+}
+
+void CClearKeyCencSingleSampleDecrypter::AddSessionKey(std::string_view keyId)
+{
+  if (std::find(m_keyIds.begin(), m_keyIds.end(), keyId) == m_keyIds.end())
+    m_keyIds.push_back(std::string(keyId));
+}
+
+bool CClearKeyCencSingleSampleDecrypter::HasKeyId(std::string_view keyid)
+{
+  if (!keyid.empty())
+  {
+    for (const std::string& key : m_keyIds)
+    {
+      if (key == keyid)
+        return true;
+    }
+  }
+  return false;
+}
+
+AP4_Result CClearKeyCencSingleSampleDecrypter::DecryptSampleData(
+    AP4_UI32 pool_id,
+    AP4_DataBuffer& data_in,
+    AP4_DataBuffer& data_out,
+    const AP4_UI08* iv,
+    unsigned int subsample_count,
+    const AP4_UI16* bytes_of_cleartext_data,
+    const AP4_UI32* bytes_of_encrypted_data)
+{
+  if (!m_singleSampleDecrypter)
+  {
+    return AP4_FAILURE;
+  }
+  return (m_singleSampleDecrypter)
+      ->DecryptSampleData(data_in, data_out, iv, subsample_count, bytes_of_cleartext_data,
+                          bytes_of_encrypted_data);
+}
+
+std::string CClearKeyCencSingleSampleDecrypter::CreateLicenseRequest(std::string_view defaultKeyId)
+{
+  // github.com/Dash-Industry-Forum/ClearKey-Content-Protection/blob/master/README.md
+  /* Expected JSON structure for license request:
+   * { "kids":
+   *     [
+   *         "nrQFDeRLSAKTLifXUIPiZg"
+   *     ]
+   * "type":"temporary" }
+   */
+  std::string kid{defaultKeyId};
+  UTILS::STRING::ReplaceAll(kid, "-", "");
+  std::string b64Kid = UTILS::BASE64::Encode(kid);
+  UTILS::STRING::ReplaceAll(b64Kid, "=", "");
+
+  rapidjson::Document jDoc;
+  jDoc.SetObject();
+  auto& allocator = jDoc.GetAllocator();
+
+  rapidjson::Value kids{rapidjson::kArrayType};
+  rapidjson::Value jKid;
+
+  jKid.SetString(b64Kid.c_str(), allocator);
+  kids.PushBack(jKid, allocator);
+
+  jDoc.AddMember("kids", kids, allocator);
+  jDoc.AddMember("type", "temporary", allocator);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer{buffer};
+  jDoc.Accept(writer);
+  return buffer.GetString();
+}
+
+bool CClearKeyCencSingleSampleDecrypter::ParseLicenseResponse(std::string data)
+{
+  /* Expected JSON structure for license response:
+   * { "keys": [
+   *     {
+   *         "k": "FmY0xnWCPCNaSpRG-tUuTQ",
+   *         "kid": "nrQFDeRLSAKTLifXUIPiZg",
+   *         "kty": "oct"
+   *     }
+   * "type": "temporary"}
+   */
+
+  rapidjson::Document jDoc;
+  jDoc.Parse(data.c_str(), data.size());
+
+  if (!jDoc.IsObject())
+  {
+    LOG::LogF(LOGERROR, "Malformed JSON data in license response");
+    return false;
+  }
+
+  for (auto& jChildObj : jDoc.GetObject())
+  {
+    std::string b64Key;
+    std::string b64KeyId;
+    const std::string keyName = jChildObj.name.GetString();
+    rapidjson::Value& jDictVal = jChildObj.value;
+
+    if (keyName == "Message" && jDictVal.IsString())
+    {
+      LOG::LogF(LOGERROR, "Error in license response: %s", jDictVal.GetString());
+      return false;
+    }
+
+    if (!jDoc.HasMember("keys"))
+    {
+      LOG::LogF(LOGERROR, "No keys in license response");
+      return false;
+    }
+
+    if (keyName == "keys" && jDictVal.IsArray())
+    {
+      // NOTE: for now we assume that one key only is requested and one only will come in the license response
+      for (auto const& jArrayKey : jDictVal.GetArray())
+      {
+        if (jArrayKey.IsObject())
+        {
+          if (jArrayKey.HasMember("k") && jArrayKey["k"].IsString())
+            b64Key = jArrayKey["k"].GetString();
+
+          if (jArrayKey.HasMember("kid") && jArrayKey["kid"].IsString())
+            b64KeyId = jArrayKey["kid"].GetString();
+        }
+
+        if (!b64Key.empty() && !b64KeyId.empty())
+        {
+          UTILS::STRING::ReplaceAll(b64Key, "-", "+");
+          UTILS::STRING::ReplaceAll(b64KeyId, "-", "+");
+
+          // pad b64
+          int left = 4 - (b64Key.length() % 4);
+          if (b64Key.length() % 4)
+          {
+            for (int i = 0; i < left; i++)
+            {
+              b64Key.push_back('=');
+            }
+          }
+
+          left = 4 - (b64KeyId.length() % 4);
+          if (b64KeyId.length() % 4)
+          {
+            for (int i = 0; i < left; i++)
+            {
+              b64KeyId.push_back('=');
+            }
+          }
+
+          m_keyPairs.emplace(b64KeyId, b64Key);
+          break;
+        }
+      }
+    }
+  }
+  return true;
+}

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
@@ -19,9 +19,9 @@ public:
   CClearKeyCencSingleSampleDecrypter(std::string_view licenseUrl,
                                      std::string_view defaultKeyId,
                                      CClearKeyDecrypter* host);
-  CClearKeyCencSingleSampleDecrypter(std::vector<uint8_t>& pssh,
+  CClearKeyCencSingleSampleDecrypter(const std::vector<uint8_t>& initdata,
                                      std::string_view defaultKeyId,
-                                     std::map<std::string, std::string> keys,
+                                     const std::map<std::string, std::string>& keys,
                                      CClearKeyDecrypter* host);
   virtual ~CClearKeyCencSingleSampleDecrypter(){};
   void AddSessionKey(std::string_view keyId);

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "common/AdaptiveCencSampleDecrypter.h"
+#include "decrypters/IDecrypter.h"
+
+#include <map>
+
+class CClearKeyDecrypter;
+
+class CClearKeyCencSingleSampleDecrypter : public Adaptive_CencSingleSampleDecrypter
+{
+public:
+  CClearKeyCencSingleSampleDecrypter(std::string_view licenseUrl,
+                                     std::string_view defaultKeyId,
+                                     CClearKeyDecrypter* host);
+  CClearKeyCencSingleSampleDecrypter(std::vector<uint8_t>& pssh,
+                                     std::string_view defaultKeyId,
+                                     std::map<std::string, std::string> keys,
+                                     CClearKeyDecrypter* host);
+  virtual ~CClearKeyCencSingleSampleDecrypter(){};
+  void AddSessionKey(std::string_view keyId);
+  bool HasKeyId(std::string_view keyid);
+  virtual AP4_Result SetFragmentInfo(AP4_UI32 pool_id,
+                                     const std::vector<uint8_t>& key,
+                                     const AP4_UI08 nal_length_size,
+                                     AP4_DataBuffer& annexb_sps_pps,
+                                     AP4_UI32 flags,
+                                     CryptoInfo cryptoInfo) override
+  {
+    return AP4_SUCCESS;
+  }
+  virtual AP4_Result DecryptSampleData(AP4_UI32 pool_id,
+                                       AP4_DataBuffer& data_in,
+                                       AP4_DataBuffer& data_out,
+                                       const AP4_UI08* iv,
+                                       unsigned int subsample_count,
+                                       const AP4_UI16* bytes_of_cleartext_data,
+                                       const AP4_UI32* bytes_of_encrypted_data) override;
+  std::string CreateLicenseRequest(std::string_view defaultKeyId);
+  bool ParseLicenseResponse(std::string data);
+  void SetDefaultKeyId(std::string_view keyId) override{};
+  void AddKeyId(std::string_view keyId) override{};
+  bool HasKeys() { return !m_keyIds.empty(); }
+
+private:
+  AP4_CencSingleSampleDecrypter* m_singleSampleDecrypter{nullptr};
+  std::string m_strSession;
+  std::string m_licenceDefaultKeyId;
+  std::vector<std::string> m_keyIds;
+  std::map<std::string, std::string> m_keyPairs;
+  CClearKeyDecrypter* m_host;
+};

--- a/src/decrypters/clearkey/ClearKeyDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ClearKeyDecrypter.h"
+
+#include "ClearKeyCencSingleSampleDecrypter.h"
+#include "CompKodiProps.h"
+#include "SrvBroker.h"
+#include "decrypters/Helpers.h"
+
+std::vector<std::string_view> CClearKeyDecrypter::SelectKeySystems(std::string_view keySystem)
+{
+  std::vector<std::string_view> keySystems;
+  if (keySystem == KS_CLEARKEY)
+  {
+    keySystems.emplace_back(URN_CLEARKEY);
+    keySystems.emplace_back(URN_COMMON);
+  }
+  return keySystems;
+}
+
+bool CClearKeyDecrypter::OpenDRMSystem(std::string_view licenseURL,
+                                       const std::vector<uint8_t>& serverCertificate,
+                                       const uint8_t config)
+{
+  return true;
+}
+
+Adaptive_CencSingleSampleDecrypter* CClearKeyDecrypter::CreateSingleSampleDecrypter(
+    std::vector<uint8_t>& pssh,
+    std::string_view optionalKeyParameter,
+    std::string_view defaultkeyid,
+    bool skipSessionMessage,
+    CryptoMode cryptoMode)
+{
+  CClearKeyCencSingleSampleDecrypter* decrypter = nullptr;
+  auto& keys = CSrvBroker::GetKodiProps().GetDrmConfig(std::string(DRM::KS_CLEARKEY)).m_keys;
+  std::string_view licenseUrl(reinterpret_cast<char*>(pssh.data()), pssh.size());
+  if (!keys.empty() || licenseUrl.substr(0, 4) != "http") // keys provided in props or directly in playlist (HLS)
+  {
+    decrypter = new CClearKeyCencSingleSampleDecrypter(pssh, defaultkeyid, keys, this);
+  }
+  else // Clearkey license server URL provided
+  {
+    decrypter = new CClearKeyCencSingleSampleDecrypter(licenseUrl, defaultkeyid, this);
+  }
+  if (!decrypter->HasKeys())
+  {
+    delete decrypter;
+    decrypter = nullptr;
+  }
+  return decrypter;
+}
+
+void CClearKeyDecrypter::DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter)
+{
+  if (decrypter)
+  {
+    delete static_cast<CClearKeyCencSingleSampleDecrypter*>(decrypter);
+  }
+}
+
+bool CClearKeyDecrypter::HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
+                                       std::string_view keyId)
+{
+  if (decrypter)
+    return static_cast<CClearKeyCencSingleSampleDecrypter*>(decrypter)->HasKeyId(keyId);
+  return false;
+}

--- a/src/decrypters/clearkey/ClearKeyDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.cpp
@@ -32,23 +32,25 @@ bool CClearKeyDecrypter::OpenDRMSystem(std::string_view licenseURL,
 }
 
 Adaptive_CencSingleSampleDecrypter* CClearKeyDecrypter::CreateSingleSampleDecrypter(
-    std::vector<uint8_t>& pssh,
+    std::vector<uint8_t>& initData,
     std::string_view optionalKeyParameter,
     std::string_view defaultkeyid,
+    std::string_view licenseUrl,
     bool skipSessionMessage,
     CryptoMode cryptoMode)
 {
   CClearKeyCencSingleSampleDecrypter* decrypter = nullptr;
   auto& keys = CSrvBroker::GetKodiProps().GetDrmConfig(std::string(DRM::KS_CLEARKEY)).m_keys;
-  std::string_view licenseUrl(reinterpret_cast<char*>(pssh.data()), pssh.size());
-  if (!keys.empty() || licenseUrl.substr(0, 4) != "http") // keys provided in props or directly in playlist (HLS)
+
+  if (!keys.empty() || !initData.empty()) // Keys provided from manifest or Kodi property
   {
-    decrypter = new CClearKeyCencSingleSampleDecrypter(pssh, defaultkeyid, keys, this);
+    decrypter = new CClearKeyCencSingleSampleDecrypter(initData, defaultkeyid, keys, this);
   }
   else // Clearkey license server URL provided
   {
     decrypter = new CClearKeyCencSingleSampleDecrypter(licenseUrl, defaultkeyid, this);
   }
+
   if (!decrypter->HasKeys())
   {
     delete decrypter;

--- a/src/decrypters/clearkey/ClearKeyDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.h
@@ -23,9 +23,10 @@ public:
                              const std::vector<uint8_t>& serverCertificate,
                              const uint8_t config) override;
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
-      std::vector<uint8_t>& pssh,
+      std::vector<uint8_t>& initData,
       std::string_view optionalKeyParameter,
       std::string_view defaultkeyid,
+      std::string_view licenseUrl,
       bool skipSessionMessage,
       CryptoMode cryptoMode) override;
   virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override;

--- a/src/decrypters/clearkey/ClearKeyDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.h
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+#include "decrypters/IDecrypter.h"
+
+#include <bento4/Ap4.h>
+
+using namespace DRM;
+
+class CClearKeyDecrypter : public IDecrypter
+{
+public:
+  CClearKeyDecrypter(){};
+  virtual ~CClearKeyDecrypter() override{};
+  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) override;
+  virtual bool OpenDRMSystem(std::string_view licenseURL,
+                             const std::vector<uint8_t>& serverCertificate,
+                             const uint8_t config) override;
+  virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
+      std::vector<uint8_t>& pssh,
+      std::string_view optionalKeyParameter,
+      std::string_view defaultkeyid,
+      bool skipSessionMessage,
+      CryptoMode cryptoMode) override;
+  virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override;
+  virtual void GetCapabilities(Adaptive_CencSingleSampleDecrypter* decrypter,
+                               std::string_view keyid,
+                               uint32_t media,
+                               DRM::DecrypterCapabilites& caps) override
+  {
+  }
+  virtual bool HasLicenseKey(Adaptive_CencSingleSampleDecrypter* decrypter,
+                             std::string_view keyid) override;
+  virtual bool IsInitialised() override { return true; }
+  virtual std::string GetChallengeB64Data(Adaptive_CencSingleSampleDecrypter* decrypter) override
+  {
+    return "";
+  }
+  virtual bool OpenVideoDecoder(Adaptive_CencSingleSampleDecrypter* decrypter,
+                                const VIDEOCODEC_INITDATA* initData) override
+  {
+    return false;
+  }
+  virtual VIDEOCODEC_RETVAL DecryptAndDecodeVideo(kodi::addon::CInstanceVideoCodec* hostInstance,
+                                                  const DEMUX_PACKET* sample) override
+  {
+    return VC_NONE;
+  }
+  virtual VIDEOCODEC_RETVAL VideoFrameDataToPicture(kodi::addon::CInstanceVideoCodec* hostInstance,
+                                                    VIDEOCODEC_PICTURE* picture) override
+  {
+    return VC_NONE;
+  }
+  virtual void ResetVideo() override {}
+  virtual void SetLibraryPath(std::string_view libraryPath) override
+  {
+    m_libraryPath = libraryPath;
+  }
+
+  virtual bool GetBuffer(void* instance, VIDEOCODEC_PICTURE& picture) { return false; }
+  virtual void ReleaseBuffer(void* instance, void* buffer) {}
+  virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
+
+  void insertssd(AP4_CencSingleSampleDecrypter* ssd) { ssds.push_back(ssd); };
+  void removessd(AP4_CencSingleSampleDecrypter* ssd)
+  {
+    std::vector<AP4_CencSingleSampleDecrypter*>::iterator res(
+        std::find(ssds.begin(), ssds.end(), ssd));
+    if (res != ssds.end())
+      ssds.erase(res);
+  };
+
+private:
+  std::vector<AP4_CencSingleSampleDecrypter*> ssds;
+  std::string m_libraryPath;
+};

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -61,7 +61,7 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
 {
   SetParentIsOwner(false);
 
-  if (pssh.size() > 4096)
+  if (pssh.size() < 4 || pssh.size() > 4096)
   {
     LOG::LogF(LOGERROR, "PSSH init data with length %zu seems not to be cenc init data",
               pssh.size());

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -8,6 +8,7 @@
 
 #include "WVDecrypter.h"
 
+#include "decrypters/Helpers.h"
 #include "WVCdmAdapter.h"
 #include "WVCencSingleSampleDecrypter.h"
 #include "utils/Base64Utils.h"
@@ -76,12 +77,13 @@ bool CWVDecrypter::Initialize()
   return true;
 }
 
-std::string CWVDecrypter::SelectKeySytem(std::string_view keySystem)
+std::vector<std::string_view> CWVDecrypter::SelectKeySystems(std::string_view keySystem)
 {
-  if (keySystem == "com.widevine.alpha")
-    return "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
+  std::vector<std::string_view> keySystems;
+  if (keySystem == KS_WIDEVINE)
+    keySystems.push_back(URN_WIDEVINE);
 
-  return "";
+  return keySystems;
 }
 
 bool CWVDecrypter::OpenDRMSystem(std::string_view licenseURL,

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -101,14 +101,15 @@ bool CWVDecrypter::OpenDRMSystem(std::string_view licenseURL,
 }
 
 Adaptive_CencSingleSampleDecrypter* CWVDecrypter::CreateSingleSampleDecrypter(
-    std::vector<uint8_t>& pssh,
+    std::vector<uint8_t>& initData,
     std::string_view optionalKeyParameter,
     std::string_view defaultKeyId,
+    std::string_view licenseUrl,
     bool skipSessionMessage,
     CryptoMode cryptoMode)
 {
   CWVCencSingleSampleDecrypter* decrypter = new CWVCencSingleSampleDecrypter(
-      *m_WVCdmAdapter, pssh, defaultKeyId, skipSessionMessage, cryptoMode, this);
+      *m_WVCdmAdapter, initData, defaultKeyId, skipSessionMessage, cryptoMode, this);
   if (!decrypter->GetSessionId())
   {
     delete decrypter;

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -90,6 +90,11 @@ bool CWVDecrypter::OpenDRMSystem(std::string_view licenseURL,
                                  const std::vector<uint8_t>& serverCertificate,
                                  const uint8_t config)
 {
+  if (licenseURL.empty())
+  {
+    LOG::LogF(LOGERROR, "License Key property cannot be empty");
+    return false;
+  }
   m_WVCdmAdapter = new CWVCdmAdapter(licenseURL, serverCertificate, config, this);
 
   return m_WVCdmAdapter->GetCdmAdapter() != nullptr;

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -27,7 +27,7 @@ public:
 
   virtual bool Initialize() override;
 
-  virtual std::string SelectKeySytem(std::string_view keySystem) override;
+  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) override;
   virtual bool OpenDRMSystem(std::string_view licenseURL,
                              const std::vector<uint8_t>& serverCertificate,
                              const uint8_t config) override;

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -32,9 +32,10 @@ public:
                              const std::vector<uint8_t>& serverCertificate,
                              const uint8_t config) override;
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
-      std::vector<uint8_t>& pssh,
+      std::vector<uint8_t>& initData,
       std::string_view optionalKeyParameter,
       std::string_view defaultKeyId,
+      std::string_view licenseUrl,
       bool skipSessionMessage,
       CryptoMode cryptoMode) override;
   virtual void DestroySingleSampleDecrypter(Adaptive_CencSingleSampleDecrypter* decrypter) override;

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -41,7 +41,7 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm
 {
   SetParentIsOwner(false);
 
-  if (pssh.size() > 65535)
+  if (pssh.size() < 4 || pssh.size() > 65535)
   {
     LOG::LogF(LOGERROR, "PSSH init data with length %zu seems not to be cenc init data",
               pssh.size());

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -125,14 +125,15 @@ bool CWVDecrypterA::OpenDRMSystem(std::string_view licenseURL,
 }
 
 Adaptive_CencSingleSampleDecrypter* CWVDecrypterA::CreateSingleSampleDecrypter(
-    std::vector<uint8_t>& pssh,
+    std::vector<uint8_t>& initData,
     std::string_view optionalKeyParameter,
     std::string_view defaultKeyId,
+    std::string_view licenseUrl,
     bool skipSessionMessage,
     CryptoMode cryptoMode)
 {
   CWVCencSingleSampleDecrypterA* decrypter = new CWVCencSingleSampleDecrypterA(
-      *m_WVCdmAdapter, pssh, optionalKeyParameter, defaultKeyId, this);
+      *m_WVCdmAdapter, initData, optionalKeyParameter, defaultKeyId, this);
 
   {
     std::lock_guard<std::mutex> lk(m_decrypterListMutex);

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -8,6 +8,7 @@
 
 #include "WVDecrypter.h"
 
+#include "decrypters/Helpers.h"
 #include "WVCencSingleSampleDecrypter.h"
 #include "common/AdaptiveDecrypter.h"
 #include "jsmn.h"
@@ -82,26 +83,26 @@ void JNIThread(JavaVM* vm)
 }
 #endif
 
-std::string CWVDecrypterA::SelectKeySytem(std::string_view keySystem)
+std::vector<std::string_view> CWVDecrypterA::SelectKeySystems(std::string_view keySystem)
 {
-  LOG::Log(LOGDEBUG, "Key system request: %s", keySystem.data());
-  if (keySystem == "com.widevine.alpha")
+  LOG::Log(LOGDEBUG, "Key system request: %s", keySystem);
+  std::vector<std::string_view> keySystems;
+  if (keySystem == KS_WIDEVINE)
   {
     m_keySystem = WIDEVINE;
-    return "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
+    keySystems.push_back(URN_WIDEVINE);
   }
-  else if (keySystem == "com.huawei.wiseplay")
+  else if (keySystem == KS_WISEPLAY)
   {
     m_keySystem = WISEPLAY;
-    return "urn:uuid:3D5E6D35-9B9A-41E8-B843-DD3C6E72C42C";
+    keySystems.push_back(URN_WISEPLAY);
   }
-  else if (keySystem == "com.microsoft.playready")
+  else if (keySystem == KS_PLAYREADY)
   {
     m_keySystem = PLAYREADY;
-    return "urn:uuid:9A04F079-9840-4286-AB92-E65BE0885F95";
+    keySystems.push_back(URN_PLAYREADY);
   }
-
-  return "";
+  return keySystems;
 }
 
 bool CWVDecrypterA::OpenDRMSystem(std::string_view licenseURL,

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -112,6 +112,12 @@ bool CWVDecrypterA::OpenDRMSystem(std::string_view licenseURL,
   if (m_keySystem == NONE)
     return false;
 
+  if (licenseURL.empty())
+  {
+    LOG::LogF(LOGERROR, "License Key property cannot be empty");
+    return false;
+  }
+
   m_WVCdmAdapter = new CWVCdmAdapterA(m_keySystem, licenseURL, serverCertificate,
                                       m_mediaDrmEventListener.get(), this);
 

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -88,9 +88,10 @@ public:
                              const uint8_t config) override;
 
   virtual Adaptive_CencSingleSampleDecrypter* CreateSingleSampleDecrypter(
-      std::vector<uint8_t>& pssh,
+      std::vector<uint8_t>& initData,
       std::string_view optionalKeyParameter,
       std::string_view defaultKeyId,
+      std::string_view licenseUrl,
       bool skipSessionMessage,
       CryptoMode cryptoMode) override;
 

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -81,7 +81,7 @@ public:
   }
 #endif
 
-  virtual std::string SelectKeySytem(std::string_view keySystem) override;
+  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) override;
 
   virtual bool OpenDRMSystem(std::string_view licenseURL,
                              const std::vector<uint8_t>& serverCertificate,

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1302,7 +1302,7 @@ bool adaptive::CDashTree::GetProtectionData(
   const ProtectionScheme* protSelected = nullptr;
   const ProtectionScheme* protCommon = nullptr;
 
-  for (auto supportedKeySystem : m_supportedKeySystems)
+  for (std::string_view supportedKeySystem : m_supportedKeySystems)
   {
     for (const ProtectionScheme& protScheme : reprProtSchemes)
     {
@@ -1356,7 +1356,12 @@ bool adaptive::CDashTree::GetProtectionData(
   }
 
   if (!selectedPssh.empty())
-    pssh = BASE64::Decode(selectedPssh);
+  {
+    if (UTILS::BASE64::IsValidBase64(selectedPssh))
+      pssh = BASE64::Decode(selectedPssh);
+    else
+      std::copy(selectedPssh.begin(), selectedPssh.end(), std::back_inserter(pssh));   
+  }
 
   if (!selectedKid.empty())
   {

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -81,12 +81,14 @@ protected:
    * \param reprProtSchemes The protection schemes of the representation
    * \param pssh[OUT] The PSSH (if any) that match the supported systemid
    * \param kid[OUT] The KID (should be provided)
+   * \param licenseUrl[OUT] The license url (if any)
    * \return True if a protection has been found, otherwise false
    */
   bool GetProtectionData(const std::vector<PLAYLIST::ProtectionScheme>& adpProtSchemes,
                          const std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
                          std::vector<uint8_t>& pssh,
-                         std::string& kid);
+                         std::string& kid,
+                         std::string& licenseUrl);
 
   bool ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -35,7 +35,7 @@ public:
   CDashTree(const CDashTree& left);
 
   void Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                 std::string_view supportedKeySystem,
+                 std::vector<std::string_view> supportedKeySystems,
                  std::string_view manifestUpdParams) override;
 
   virtual TreeType GetTreeType() const override { return TreeType::DASH; }

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -36,7 +36,7 @@ public:
   virtual CHLSTree* Clone() const override { return new CHLSTree{*this}; }
 
   virtual void Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                         std::string_view supportedKeySystem,
+                         std::vector<std::string_view> supportedKeySystems,
                          std::string_view manifestUpdateParam) override;
 
   virtual bool Open(std::string_view url,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${BINARY}
     TestSmoothTree.cpp
     TestHelper.cpp
     TestUtils.cpp
+    ../decrypters/Helpers.cpp
     ../parser/DASHTree.cpp
     ../parser/HLSTree.cpp
     ../parser/SmoothTree.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(${BINARY}
     ../utils/Base64Utils.cpp
     ../utils/CharArrayParser.cpp
     ../utils/CurlUtils.cpp
+    ../utils/DigestMD5Utils.cpp
     ../utils/FileUtils.cpp
     ../utils/StringUtils.cpp
     ../utils/UrlUtils.cpp

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -6,13 +6,13 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "TestHelper.h"
-
+#include "../CompKodiProps.h"
+#include "../SrvBroker.h"
+#include "../decrypters/Helpers.h"
 #include "../utils/Base64Utils.h"
 #include "../utils/UrlUtils.h"
 #include "../utils/Utils.h"
-#include "../SrvBroker.h"
-#include "../CompKodiProps.h"
+#include "TestHelper.h"
 
 #include <gtest/gtest.h>
 
@@ -68,7 +68,7 @@ protected:
     // We set the download speed to calculate the initial network bandwidth
     m_reprChooser->SetDownloadSpeed(500000);
 
-    tree->Configure(m_reprChooser, "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED",
+    tree->Configure(m_reprChooser, std::vector<std::string_view>{DRM::URN_WIDEVINE},
                     manifestUpdParams);
 
     // Parse the manifest

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -212,8 +212,8 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
-  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
+  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
@@ -228,8 +228,8 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
       tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
-  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
+  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
@@ -241,7 +241,8 @@ TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl,
+            "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelative)
@@ -253,8 +254,8 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
-  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
+  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
@@ -271,8 +272,8 @@ TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
       tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string kidUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_kidUrl;
-  EXPECT_EQ(kidUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
+  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, PtsSetInMultiPeriod)

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -39,13 +39,13 @@ protected:
 
   bool OpenTestFileMaster(std::string filePath, std::string url)
   {
-    return OpenTestFileMaster(filePath, url, {}, "");
+    return OpenTestFileMaster(filePath, url, {}, std::vector<std::string_view>{});
   }
 
   bool OpenTestFileMaster(std::string filePath,
                           std::string url,
                           std::map<std::string, std::string> manifestHeaders,
-                          std::string_view supportedKeySystem)
+                          std::vector<std::string_view> supportedKeySystems)
   {
     testHelper::testFile = filePath;
 
@@ -64,7 +64,7 @@ protected:
     // We set the download speed to calculate the initial network bandwidth
     m_reprChooser->SetDownloadSpeed(500000);
 
-    tree->Configure(m_reprChooser, supportedKeySystem, "");
+    tree->Configure(m_reprChooser, supportedKeySystems, "");
 
     // Parse the manifest
     if (!tree->Open(resp.effectiveUrl, resp.headers, resp.data))
@@ -342,7 +342,7 @@ TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrmNoKSMaster)
   testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
   bool ret = OpenTestFileMaster("hls/encrypt_master_drm.m3u8",
-                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, "");
+                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, std::vector<std::string_view>{});
   EXPECT_EQ(ret, false);
 }
 
@@ -354,7 +354,7 @@ TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrmNoKS)
   testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
   bool ret = OpenTestFileMaster("hls/encrypt_master.m3u8",
-                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, "");
+                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, std::vector<std::string_view>{});
 
   EXPECT_EQ(ret, true);
 
@@ -380,7 +380,7 @@ TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrm)
   testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
   bool ret = OpenTestFileMaster("hls/encrypt_master_drm.m3u8",
-                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, UUID_WIDEVINE);
+    "https://baz.qux/hls/video/stream_name/master.m3u8", {}, std::vector<std::string_view>{URN_WIDEVINE});
 
   EXPECT_EQ(ret, true);
 

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -25,7 +25,7 @@
 //        this shortens the conversion needed
 using STR = std::string;
 
-constexpr std::string_view UUID_WIDEVINE = "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED";
+constexpr std::string_view URN_WIDEVINE = "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
 
 std::string GetEnv(const std::string& var);
 void SetFileName(std::string& file, const std::string name);

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -6,11 +6,11 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "TestHelper.h"
-
 #include "../CompKodiProps.h"
 #include "../SrvBroker.h"
+#include "../decrypters/Helpers.h"
 #include "../utils/UrlUtils.h"
+#include "TestHelper.h"
 
 #include <gtest/gtest.h>
 
@@ -59,7 +59,7 @@ protected:
     // We set the download speed to calculate the initial network bandwidth
     m_reprChooser->SetDownloadSpeed(500000);
 
-    tree->Configure(m_reprChooser, "urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED", "");
+    tree->Configure(m_reprChooser, std::vector<std::string_view>{DRM::URN_WIDEVINE}, "");
 
     // Parse the manifest
     if (!tree->Open(resp.effectiveUrl, resp.headers, resp.data))

--- a/src/utils/Base64Utils.cpp
+++ b/src/utils/Base64Utils.cpp
@@ -10,6 +10,8 @@
 
 #include "log.h"
 
+#include <regex>
+
 using namespace UTILS::BASE64;
 
 namespace
@@ -18,6 +20,7 @@ constexpr char PADDING{'='};
 constexpr std::string_view CHARACTERS{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                       "abcdefghijklmnopqrstuvwxyz"
                                       "0123456789+/"};
+constexpr std::string_view REGEX("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$");
 // clang-format off
 constexpr unsigned char BASE64_TABLE[] = {
     255,255,255,255, 255,255,255,255, 255,255,255,255, 255,255,255,255,
@@ -199,4 +202,10 @@ std::string UTILS::BASE64::DecodeToStr(std::string_view input)
   std::vector<uint8_t> output;
   Decode(input.data(), input.size(), output);
   return {output.begin(), output.end()};
+}
+
+bool UTILS::BASE64::IsValidBase64(const std::string& input)
+{
+  std::regex base64Regex(REGEX.data());
+  return std::regex_match(input, base64Regex);
 }

--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -28,5 +28,7 @@ void Decode(const char* input, const size_t length, std::vector<uint8_t>& output
 std::vector<uint8_t> Decode(std::string_view input);
 std::string DecodeToStr(std::string_view input);
 
+bool IsValidBase64(const std::string& input);
+
 } // namespace BASE64
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change implements ClearKey decrypter support, both the 'proper' ClearKey which supports signalling license servers in the manifest, and also just directly supplying keyid/key pairs. DASH and HLS support (no smoothstream atm).

We are aware that there are playlists (STRM, M3U8, etc) that use existing ISA properties (e.g. inputstream.adaptive.license_key) in a way that has never been supported or implemented in this add-on. These playlists will need to be adapted in some way (script etc.) and this is outside of the scope for this add-on.
Since this is a new feature we have therefore introduced the new DRM property. This property in the near future will replace most of the existing properties in order to make configuration more efficient and clear. 

The property introduced is inputstream.adaptive.drm and will be expanded upon in the future to accept further DRM configuration for streams. It accepts a JSON structure, examples can be seen below.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested in #811 and multiple other closed issues. 


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows only testing. Hoping all the users requesting this can help out on other platforms and streams.

Tested with 2 streams (1 DASH, 1 HLS) and both with the key/keyid supplied in the manifest, and also supplied in the stream properties:

HLS, using keys supplied in manifests:
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.license_type=org.w3.clearkey
https://storage.googleapis.com/shaka-demo-assets/angel-one-sample-aes-ctr-multiple-key/manifest.m3u8
```

HLS, using keys supplied to IA directly:
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.license_type=org.w3.clearkey
#KODIPROP:inputstream.adaptive.drm={"org.w3.clearkey":{"license":{"keyids":{"abba271e8bcf552bbd2e86a434a9a5d9":"abba271e8bcf552bbd2e86a434a9a5d9","a4631a153a443df9eed0593043db7519":"a4631a153a443df9eed0593043db7519"}}}}
https://storage.googleapis.com/shaka-demo-assets/angel-one-sample-aes-ctr-multiple-key/manifest.m3u8
```

DASH, using license server in manifest (note that the license server has an expired certificate, as described in code comment):
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.license_type=org.w3.clearkey
https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd
```

DASH, using keys supplied to IA directly (additional key that is not needed is added for testing purposes):
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.license_type=org.w3.clearkey
#KODIPROP:inputstream.adaptive.drm={"org.w3.clearkey":{"license":{"keyids":{"feedf00deedeadbeeff0baadf00dd00d":"00112233445566778899aabbccddeeff","1234f00deedeadbeeff0baadf00dd00d":"8899aabbccddeeff8899aabbccddeeff"}}}}
https://storage.googleapis.com/shaka-demo-assets/angel-one-clearkey/dash.mpd
```

### _EDIT PLEASE NOTE: --- Has been changed at later time the way to configure DRM ---_
To facilitate the future transition of old Kodi DRM properties, has been introduced
`inputstream.adaptive.drm_legacy`

This property can be used not only with ClearKey, but also with all other DRM's,
more detailed info and examples on PR #1604.

Anyway the above examples will be valid in the future when the new 'inputstream.adaptive.drm' property will be added.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
