### PR TITLE
[DashTree] Fix lost repr common attribs data

### DIFF
--- a/src/common/Representation.cpp
+++ b/src/common/Representation.cpp
@@ -15,6 +15,48 @@
 using namespace PLAYLIST;
 using namespace UTILS;
 
+void PLAYLIST::CRepresentation::SetParent(CAdaptationSet* parent /* = nullptr */,
+                                          bool copyData /* = false */)
+{
+  CCommonSegAttribs::m_parentCommonSegAttribs = parent;
+
+  // If you change parent, you will loose pointer where CCommonAttribs have data stored
+  // so copy all data, and after replace CCommonAttribs
+  // this is a workaround for a more complex problem see CDashTree::MergeAdpSets todo
+  if (copyData && m_parentCommonAttributes)
+  {
+    if (m_parentCommonAttributes->GetContainerType() != ContainerType::NOTYPE &&
+        m_containerType == ContainerType::NOTYPE)
+      m_containerType = m_parentCommonAttributes->GetContainerType();
+
+    if (m_parentCommonAttributes->GetAspectRatio() != 0 && m_aspectRatio == 0)
+      m_aspectRatio = m_parentCommonAttributes->GetAspectRatio();
+
+    if (m_parentCommonAttributes->GetFrameRate() != 0 && m_frameRate == 0)
+      m_frameRate = m_parentCommonAttributes->GetFrameRate();
+
+    if (m_parentCommonAttributes->GetFrameRateScale() != 0 && m_frameRateScale == 0)
+      m_frameRateScale = m_parentCommonAttributes->GetFrameRateScale();
+
+    if (m_parentCommonAttributes->GetWidth() != 0 && m_resWidth == 0)
+      m_resWidth = m_parentCommonAttributes->GetWidth();
+
+    if (m_parentCommonAttributes->GetHeight() != 0 && m_resHeight == 0)
+      m_resHeight = m_parentCommonAttributes->GetHeight();
+
+    if (m_parentCommonAttributes->GetSampleRate() != 0 && m_sampleRate == 0)
+      m_sampleRate = m_parentCommonAttributes->GetSampleRate();
+
+    if (m_parentCommonAttributes->GetAudioChannels() != 0 && m_audioChannels == 0)
+      m_audioChannels = m_parentCommonAttributes->GetAudioChannels();
+
+    if (!m_parentCommonAttributes->GetMimeType().empty() && m_mimeType.empty())
+      m_mimeType = m_parentCommonAttributes->GetMimeType();
+  }
+
+  CCommonAttribs::m_parentCommonAttributes = parent;
+}
+
 void PLAYLIST::CRepresentation::AddCodecs(std::string_view codecs)
 {
   std::set<std::string> list = STRING::SplitToSet(codecs, ',');

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -47,11 +47,7 @@ public:
    *        To be used if you plan to set or move a representation to an AdptationSet or a different one.
    * \param parent[OPT] The parent AdaptationSet to link
    */
-  void SetParent(CAdaptationSet* parent = nullptr)
-  {
-    CCommonSegAttribs::m_parentCommonSegAttribs = parent;
-    CCommonAttribs::m_parentCommonAttributes = parent;
-  }
+  void SetParent(CAdaptationSet* parent = nullptr, bool copyData = false);
 
   // Share AdaptationSet common attribs
   static std::unique_ptr<CRepresentation> MakeUniquePtr(CAdaptationSet* parent = nullptr)

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1466,6 +1466,10 @@ uint32_t adaptive::CDashTree::ParseAudioChannelConfig(pugi::xml_node node)
   return channels;
 }
 
+//! @todo: MergeAdpSets its a kind of workaround
+//! its missing a middle interface where store "streams" (or media tracks) data in a form
+//! that is detached from "tree" interface, this would avoid the force
+//! change of CAdaptationSet data and its parent data (CRepresentation::SetParent)
 void adaptive::CDashTree::MergeAdpSets()
 {
   // NOTE: This method wipe out all properties of merged adaptation set
@@ -1501,7 +1505,7 @@ void adaptive::CDashTree::MergeAdpSets()
           for (auto itRepr = nextAdpSet->GetRepresentations().begin();
                itRepr < nextAdpSet->GetRepresentations().end(); ++itRepr)
           {
-            itRepr->get()->SetParent(adpSet);
+            itRepr->get()->SetParent(adpSet, true);
             adpSet->GetRepresentations().push_back(std::move(*itRepr));
           }
           itNextAdpSet = periodAdpSets.erase(itNextAdpSet);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
when `CDashTree::MergeAdpSets` merge adpsets the adpset will be deleted and his CCommonAttribs data lost
this copy the data to the representations relative to that adpset

this is another use case that could better managed by having a middle "streams/tracks" interface, where "tree" data remains untouched

this is the MPD manifest example [manifest_1720943882.txt](https://github.com/user-attachments/files/16216659/manifest_1720943882.txt)
where due to `urn:mpeg:dash:adaptation-set-switching:2016` and same codec will cause adpsets to merge

the problem has only been highlighted now because only a single adpset has width/height attributes

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
problem signaled on slack channels

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
