### PR TITLE
[KodiProps] New drm_legacy, moved "keyids" to "license" dict

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="drm|license_type|license_key|license_url|license_url_append|license_data|license_flags|server_certificate|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|config|manifest_config"
+    listitemprops="drm|drm_legacy|license_type|license_key|license_url|license_url_append|license_data|license_flags|server_certificate|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|config|manifest_config"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -357,12 +357,17 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
       continue;
     }
 
-    if (jDictVal.HasMember("keyids") && jDictVal["keyids"].IsObject())
+    if (jDictVal.HasMember("license") && jDictVal["license"].IsObject())
     {
-      for (auto const& keyid : jDictVal["keyids"].GetObject())
+      auto& jDictLic = jDictVal["license"];
+
+      if (jDictLic.HasMember("keyids") && jDictLic["keyids"].IsArray())
       {
-        if (keyid.name.IsString() && keyid.value.IsString())
-          drmCfg.m_keys[keyid.name.GetString()] = (keyid.value.GetString());
+        for (auto const& keyid : jDictLic["keyids"].GetObject())
+        {
+          if (keyid.name.IsString() && keyid.value.IsString())
+            drmCfg.m_keys[keyid.name.GetString()] = (keyid.value.GetString());
+        }
       }
     }
   }

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -11,6 +11,7 @@
 #include "CompSettings.h"
 #include "decrypters/Helpers.h"
 #include "utils/StringUtils.h"
+#include "utils/UrlUtils.h"
 #include "utils/Utils.h"
 #include "utils/log.h"
 
@@ -53,6 +54,7 @@ constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_d
 
 constexpr std::string_view PROP_CONFIG = "inputstream.adaptive.config";
 constexpr std::string_view PROP_DRM = "inputstream.adaptive.drm";
+constexpr std::string_view PROP_DRM_LEGACY = "inputstream.adaptive.drm_legacy";
 
 // Chooser's properties
 constexpr std::string_view PROP_STREAM_SELECTION_TYPE = "inputstream.adaptive.stream_selection_type";
@@ -194,6 +196,14 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
       if (!ParseDrmConfig(prop.second))
         LOG::LogF(LOGERROR, "Cannot parse \"%s\" property, wrong or malformed data.",
           prop.first.c_str());
+
+      logPropValRedacted = true;
+    }
+    else if (prop.first == PROP_DRM_LEGACY && !prop.second.empty())
+    {
+      if (!ParseDrmLegacyConfig(prop.second))
+        LOG::LogF(LOGERROR, "Cannot parse \"%s\" property, wrong or malformed data.",
+                  prop.first.c_str());
 
       logPropValRedacted = true;
     }
@@ -372,5 +382,88 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
     }
   }
 
+  return true;
+}
+
+bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmLegacyConfig(const std::string& data)
+{
+  // Legacy way to configure a DRM.
+  // Designed to have a minimal configuration for the most common use cases using a single DRM.
+
+  /* Expected TEXT structure:
+   * [DRM KeySystem] | [License server URL or KeyId's] | [License server headers]
+   *
+   * From 1 to 3 fields, splitted by pipes
+   */
+
+  std::vector<std::string> pipedCfg = STRING::SplitToVec(data, '|');
+  if (pipedCfg.size() > 3)
+  {
+    LOG::LogF(LOGERROR, "Malformed value on the DRM legacy property");
+    return false;
+  }
+
+  std::string keySystem = STRING::Trim(pipedCfg[0]);
+
+  std::string licenseStr;
+  if (pipedCfg.size() > 1)
+    licenseStr = STRING::Trim(pipedCfg[1]);
+
+  std::string licenseHeaders;
+  if (pipedCfg.size() > 2)
+    licenseHeaders = STRING::Trim(pipedCfg[2]);
+
+  if (!DRM::IsKeySystemSupported(keySystem))
+  {
+    LOG::LogF(LOGERROR, "Unknown key system \"%s\" on DRM legacy property", keySystem.data());
+    return false;
+  }
+
+  m_licenseType = keySystem;
+
+  // Clear existing value to prevent possible mix with other similar properties
+  m_licenseKey.clear();
+
+  if (!licenseStr.empty())
+  {
+    if (URL::IsValidUrl(licenseStr)) // License server URL
+    {
+      m_licenseKey = licenseStr;
+    }
+    else // Assume are keyid's for ClearKey DRM
+    {
+      // Expected TEXT structure: "kid1:key1,kid2:key2,..."
+      DrmCfg& drmCfg = m_drmConfigs[keySystem];
+      std::vector<std::string> keyIdPair = STRING::SplitToVec(licenseStr, ',');
+
+      for (const std::string& keyPairStr : keyIdPair)
+      {
+        std::vector<std::string> keyPair = STRING::SplitToVec(keyPairStr, ':');
+        if (keyPair.size() != 2)
+        {
+          LOG::LogF(LOGERROR, "Ignored malformed ClearKey kid/key pair");
+          continue;
+        }
+        drmCfg.m_keys[STRING::Trim(keyPair[0])] = STRING::Trim(keyPair[1]);
+      }
+    }
+  }
+
+  //! @todo: temporary stored default DRM values here just for convenience
+  //! since we need to construct the "license key" string
+  //! these values are stored also on DRM's implementation,
+  //! they must be placed in an appropriate place with the future DRM config rework
+  if (licenseHeaders.empty())
+  {
+    if (keySystem == DRM::KS_WIDEVINE)
+      licenseHeaders = "Content-Type=application%2Foctet-stream";
+    else if (keySystem == DRM::KS_PLAYREADY)
+      licenseHeaders = "Content-Type=text%2Fxml&SOAPAction=http%3A%2F%2Fschemas.microsoft.com%"
+                       "2FDRM%2F2007%2F03%2Fprotocols%2FAcquireLicense";
+    else if (keySystem == DRM::KS_WISEPLAY)
+      licenseHeaders = "Content-Type=application/json";
+  }
+
+  m_licenseKey += "|" + licenseHeaders + "|R{SSM}|R";
   return true;
 }

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -232,7 +232,7 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
     LOG::Log(
       LOGERROR,
       "The \"inputstream.adaptive.license_key\" property cannot be used to configure ClearKey DRM,\n"
-      "use \"inputstream.adaptive.drm\" instead.\nSee Wiki integration page for more details.");
+      "use \"inputstream.adaptive.drm_legacy\" instead.\nSee Wiki integration page for more details.");
     m_licenseKey.clear();
   }
 }

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -126,6 +126,7 @@ private:
   void ParseManifestConfig(const std::string& data);
 
   bool ParseDrmConfig(const std::string& data);
+  bool ParseDrmLegacyConfig(const std::string& data);
 
   std::string m_licenseType;
   std::string m_licenseKey;

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -114,7 +114,7 @@ CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
     if (STRING::KeyExists(keys, hexDefKid))
       UTILS::STRING::ToHexBytes(keys.at(hexDefKid), hexKey);
     else
-      LOG::LogF(LOGERROR, "Missing KeyId \"%s\" on DRM configuration");
+      LOG::LogF(LOGERROR, "Missing KeyId \"%s\" on DRM configuration", defaultKeyId.data());
   }
 
   const AP4_UI08* ap4Key = reinterpret_cast<const AP4_UI08*>(hexKey.data());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
### 1° commit
"keyids" has been introduced on PR #1598
for the future drm properties rework i think it is appropriate to move all configurations for the licence request to a separate field
so move "keyids" to "license" dict

### 2° commit
oversight bug introduced from PR #1598 

### 3° commit
New property: `inputstream.adaptive.drm_legacy`

Reasons:
With the DRM properties PR rework there is the intention to deprecate all current properties to configure DRM,
this will inevitably lead to forcing the use `inputstream.adaptive.drm` that use a complex JSON.

Some users feedbacks was requesting an easier way to configure DRM for playlist files (e.g. STRM)
but in any case we do not want to continue to maintain the old properties on future kodi versions.

So the idea is to add `inputstream.adaptive.drm_legacy` that accept a simple TEXT string (in similar way of `inputstream.adaptive.license_key` with pipes) designed to have a minimal configuration for the most common use cases using a single DRM that should be enough for most live TV playlists. (act as replacement of `inputstream.adaptive.license_type` and `inputstream.adaptive.license_key`)

The value expect a TEXT structure:

`[DRM KeySystem] | [License server URL or KeyId's] | [License server headers]`

So from 1 to 3 fields (as needed), splitted by pipes
examples:
```
#KODIPROP:inputstream.adaptive.drm_legacy=com.widevine.alpha|https://vod.pl/playerapi/product/drm/widevine/7310932|User-Agent=Mozilla%2F5.0+%28Windows+NT+10.0%3B+Win64%3B+x64%29+AppleWebKit%2F537.36+%28KHTML%2C+like+Gecko%29+Chrome%2F106.0.0.0+Safari%2F537.36
```
```
#KODIPROP:inputstream.adaptive.drm_legacy=com.microsoft.playready
```
```
#KODIPROP:inputstream.adaptive.drm_legacy=org.w3.clearkey|000102030405060708090a0b0c0d0e0f:00112233445566778899aabbccddeeff

# for the keyid's format example: `kid1:key1,kid2:key2,kid3:key3,...`
```

Of course, as a minimum configuration there are no advanced configurations such as wrappers or other things,
for these cases (in future, not now yet) will be used `inputstream.adaptive.drm`

-----

This is a transitional behaviour for Kodi properties, expected from Kodi 21:

- `inputstream.adaptive.license_type` and `inputstream.adaptive.license_key` can be used as usual
- `inputstream.adaptive.drm_legacy` can be used for most common DRM use cases from Kodi 21 as replacement of `inputstream.adaptive.license_type` and `inputstream.adaptive.license_key`, and so _this can be the starting point for live TV playlists conversions_ since support also ClearKey DRM
- `inputstream.adaptive.drm` for addons to allow advanced multi DRM configurations (i hope on future v22)

thinking about all this again, i belive that introducing the `inputstream.adaptive.drm` on Kodi 21 is too early, and can be temporary disabled from Omega branch (since not released yet)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reworking ideas on DRM configurations between Kodi 21 / 22

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
