### PR TITLE
[Session] Use total segments duration to check the period

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -12,6 +12,7 @@
 #include "CompSettings.h"
 #include "SrvBroker.h"
 #include "aes_decrypter.h"
+#include "common/AdaptationSet.h"
 #include "common/AdaptiveDecrypter.h"
 #include "common/AdaptiveTreeFactory.h"
 #include "common/Chooser.h"
@@ -1120,7 +1121,7 @@ bool CSession::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
 
   for (; pi != m_adaptiveTree->m_periods.cend(); pi++)
   {
-    chapterTime += double((*pi)->GetDuration()) / (*pi)->GetTimescale();
+    chapterTime += double((*pi)->GetSegDuration()) / (*pi)->GetTimescale();
     if (chapterTime > seekTime)
       break;
   }
@@ -1128,7 +1129,7 @@ bool CSession::SeekTime(double seekTime, unsigned int streamId, bool preceeding)
   if (pi == m_adaptiveTree->m_periods.cend())
     --pi;
 
-  chapterTime -= double((*pi)->GetDuration()) / (*pi)->GetTimescale();
+  chapterTime -= double((*pi)->GetSegDuration()) / (*pi)->GetTimescale();
 
   if ((*pi).get() != m_adaptiveTree->m_currentPeriod)
   {
@@ -1369,7 +1370,7 @@ int64_t CSession::GetChapterPos(int ch) const
 
   for (; ch; --ch)
   {
-    sum += (m_adaptiveTree->m_periods[ch - 1]->GetDuration() * STREAM_TIME_BASE) /
+    sum += (m_adaptiveTree->m_periods[ch - 1]->GetSegDuration() * STREAM_TIME_BASE) /
            m_adaptiveTree->m_periods[ch - 1]->GetTimescale();
   }
 
@@ -1384,7 +1385,7 @@ uint64_t CSession::GetChapterStartTime() const
     if (p.get() == m_adaptiveTree->m_currentPeriod)
       break;
     else
-      start_time += (p->GetDuration() * STREAM_TIME_BASE) / p->GetTimescale();
+      start_time += (p->GetSegDuration() * STREAM_TIME_BASE) / p->GetTimescale();
   }
   return start_time;
 }

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -23,6 +23,17 @@ PLAYLIST::CPeriod::~CPeriod()
 {
 }
 
+uint64_t PLAYLIST::CPeriod::GetSegDuration()
+{
+  CAdaptationSet* adp = CAdaptationSet::FindByFirstAVStream(m_adaptationSets);
+  if (adp && !adp->GetRepresentations().empty())
+  {
+    auto& rep = adp->GetRepresentations().front();
+    return rep->Timeline().GetDuration() * m_timescale / rep->GetTimescale();
+  }
+  return 0;
+}
+
 void PLAYLIST::CPeriod::CopyHLSData(const CPeriod* other)
 {
   m_adaptationSets.reserve(other->m_adaptationSets.size());
@@ -99,3 +110,5 @@ void PLAYLIST::CPeriod::AddAdaptationSet(std::unique_ptr<CAdaptationSet>& adapta
 {
   m_adaptationSets.push_back(std::move(adaptationSet));
 }
+
+

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -57,7 +57,18 @@ public:
   void SetStart(uint64_t start) { m_start = start; }
 
   /*!
-   * \brief Get the duration, in timescale units.
+   * \brief Get a precise duration of all segments, in timescale units.
+   *        Value is taken from the first A/V representation timeline.
+   *        The value can differ from GetDuration, because GetDuration take in account
+   *        the duration from "start" time of period,
+   *        and may be affected by inaccurate estimates of ADS streams.
+   * \return The duration value.
+   */
+  uint64_t GetSegDuration();
+
+  /*!
+   * \brief Get the duration, in timescale units,
+   *        (value may be affected by inaccurate estimates of ADS streams).
    * \return The duration value.
    */
   uint64_t GetDuration() const { return m_duration; }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
On the issue ISA its not able to switch to the right period when you try to do a video seek
manifest case: [segtpl_multiperiod_ads.mpd.txt](https://github.com/user-attachments/files/16334134/segtpl_multiperiod_ads.mpd.txt)

from the manifest the ADS periods (marked with `urn:scte:scte35:2013:xml`) dont have the "duration" attribute but only "start" attrib.
with the parser we calculate the period duration by looking for the "start" attrib of the next period (by difference),
but if you calculate the duration, you can see that dont match with the total segments duration (of SegmentTemplate),
this seem to lead to in a segments hole in part of the period

It seems that Dash when periods are reported as ADS the period duration is not exact but estimated, but i have not yet found enough info to confirm this.

Then since there are parts of code that use "Period->GetDuration" lead to a wrong behaviour, as you can see on `CSession::SeekTime` try find the chapter on a wrong time

my idea is instead looking to each period duration, use total segments duration, that must be a safe value

todo:
1) need a feedback, i cant test it by myself atm since my only MPD multiperiod TV streaming is completely dead...
2) check for some regressions?
3) it would be useful to have confirmation from other streams that Dash period ADS have estimated and not precise durations

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
attempt to fix #1500
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NOT TESTED!

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
