### PR TITLE
[AdaptiveTree] IsLastSegment return false if period is the last one

### DIFF
--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -197,6 +197,10 @@ namespace adaptive
 
     if (IsLive())
     {
+      // Assume that if the period is the last, it never ends until segments can no longer be downloaded
+      if (m_periods.back().get() == segPeriod)
+        return false;
+
       if (segPeriod->GetDuration() > 0 && segPeriod->GetStart() != NO_VALUE)
       {
         const uint64_t pDurMs = segPeriod->GetDuration() * 1000 / segPeriod->GetTimescale();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
PR #1586 change set the duration to all periods
this has lead to a different behaviour of `AdaptiveTree::IsLastSegment`

seem there is no a specific rule that dash use to signal a end of live playback
therefore we continue to insert segments until the downloads fail

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1614 at least for dash case (hls should be not related)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Dash live inserts, single period:
http://daserstedash.akamaized.net/dash/live/2103597/daserste/dvbt2/manifest.mpd (germany geolock)
Dash live inserts, multiple periods: (at period change segments (numbers) downloaded must be exact)
https://livesim2.dashif.org/livesim2/ato_10/testpic_2s/Manifest.mpd

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
