### PR TITLE
Fix build error with gcc 14

### DIFF
--- a/src/decrypters/Helpers.h
+++ b/src/decrypters/Helpers.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
## Description
This PR fixed a build error with gcc 14
```
src/decrypters/Helpers.h:55:13: error: 'uint8_t' was not declared in this scope
   55 | std::vector<uint8_t> ConvertKidStrToBytes(std::string_view kidStr);
```
## Motivation and context
Fix a build error with gcc 14

## How has this been tested?
Build-tested with gcc 14

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
