### PR TITLE
[ADTSReader] Return false when id3tagparser fails due to eos

### DIFF
--- a/src/demuxers/ADTSReader.cpp
+++ b/src/demuxers/ADTSReader.cpp
@@ -429,7 +429,7 @@ bool ADTSReader::ReadPacket()
     if ((id3Ret = m_id3TagParser.parse(m_stream)) == ID3TAG::PARSE_SUCCESS)
       continue;
     else if (id3Ret == ID3TAG::PARSE_FAIL)
-      break;
+      return false;
 
     if (m_id3TagParser.getPts(m_basePts))
       m_frameParser.resetFrameCount();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Use case of HLS+AAC audio

CADTSSampleReader::ReadSample call ADTSReader::ReadPacket each time kodi request buffer data but when the stream buffer reach the end the m_id3TagParser.parse cannot read data from m_stream by returning ID3TAG::PARSE_FAIL
this was breaking the while loop and return true

since return true was causing that CADTSSampleReader::ReadSample to return AP4_SUCCESS with bad data
where instead was needed to check for waitingForSegment and mark the m_eos as true, this to allow stop the playback and so avoid flooding kodi demuxer of bad package data

seem weird to me that its needed return true also when the audio data is not parsed
it come from the initial ISA implementation so it could be a very old oversight or a workaround for other problems

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1629 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sample stream provided in pvt by user and other 2 hls+aac

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
