### PR TITLE
[DRM][ClearKey] Add license url by DRM config, CK as DRM replacement

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -463,6 +463,9 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmLegacyConfig(const std::string& da
 
     drmCfg.license.serverUrl = licenseUrl;
     ParseHeaderString(drmCfg.license.reqHeaders, licenseHeaders);
+    // Until the future DRM config rework only the ClearKey DRM use the new properties
+    // so return now to keep m_licenseKey empty
+    return true;
   }
   else if (licenseHeaders.empty())
   {

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -381,6 +381,12 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
     {
       auto& jDictLic = jDictVal["license"];
 
+      if (jDictLic.HasMember("server_url") && jDictLic["server_url"].IsString())
+        drmCfg.license.serverUrl = jDictLic["server_url"].GetString();
+
+      if (jDictLic.HasMember("req_headers") && jDictLic["req_headers"].IsString())
+        ParseHeaderString(drmCfg.license.reqHeaders, jDictLic["req_headers"].GetString());
+
       if (jDictLic.HasMember("keyids") && jDictLic["keyids"].IsArray())
       {
         for (auto const& keyid : jDictLic["keyids"].GetObject())

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -68,6 +68,20 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
 {
   std::string licenseUrl;
 
+  if (((STRING::KeyExists(props, PROP_LICENSE_TYPE) || STRING::KeyExists(props, PROP_LICENSE_KEY)) &&
+       (STRING::KeyExists(props, PROP_DRM_LEGACY) || STRING::KeyExists(props, PROP_DRM))) ||
+      (STRING::KeyExists(props, PROP_DRM_LEGACY) && STRING::KeyExists(props, PROP_DRM)))
+  {
+    LOG::Log(LOGERROR, "WRONG DRM CONFIGURATION. A mixed use of DRM properties are not supported.\n"
+                       "Please fix your configuration by setting only one of these:\n"
+                       " - Simple method: \"inputstream.adaptive.drm_legacy\"\n"
+                       " - Advanced method: \"inputstream.adaptive.license_type\" with optional "
+                       "\"inputstream.adaptive.license_key\"\n"
+                       " - NEW Advanced method (WIP, test only): \"inputstream.adaptive.drm\"\n"
+                       "For more details, see the Github Wiki Integration page.");
+    return;
+  }
+
   for (const auto& prop : props)
   {
     bool logPropValRedacted{false};
@@ -344,7 +358,8 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
    *                        "streams_pssh_data" : str,
    *                        "pre_init_data" : str,
    *                        "priority": int, 
-   *                        "keyids": list<dict>},
+   *                        "license": dict,
+   *                        ... },
    *   "keysystem_name_2" : { ... }}
    */
   rapidjson::Document jDoc;
@@ -367,6 +382,9 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
       continue;
     }
 
+    //! @todo: m_licenseType temporarily assigned, to remove with the DRM config rework
+    m_licenseType = keySystem;
+
     DrmCfg& drmCfg = m_drmConfigs[keySystem];
     auto& jDictVal = jChildObj.value;
 
@@ -387,7 +405,7 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
       if (jDictLic.HasMember("req_headers") && jDictLic["req_headers"].IsString())
         ParseHeaderString(drmCfg.license.reqHeaders, jDictLic["req_headers"].GetString());
 
-      if (jDictLic.HasMember("keyids") && jDictLic["keyids"].IsArray())
+      if (jDictLic.HasMember("keyids") && jDictLic["keyids"].IsObject())
       {
         for (auto const& keyid : jDictLic["keyids"].GetObject())
         {
@@ -396,6 +414,9 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
         }
       }
     }
+
+    //! @todo: temporary support only one DRM config
+    break;
   }
 
   return true;

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -64,7 +64,15 @@ struct ManifestConfig
 
 struct DrmCfg
 {
-  std::map<std::string, std::string> m_keys;
+  struct License
+  {
+    std::string serverUrl;
+    std::map<std::string, std::string> reqHeaders;
+
+    std::map<std::string, std::string> keys; // Clearkeys kid / key
+  };
+
+  License license; // The license configuration
 };
 
 class ATTR_DLL_LOCAL CCompKodiProps

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -440,9 +440,10 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
           // Use the init data provided by manifest (e.g. PSSH)
           initData = sessionPsshset.pssh_;
         }
-        else
+        else if (licenseType != DRM::KS_CLEARKEY)
         {
           // Try extract the PSSH/KID from the stream
+          // only if clearkeys are not used (use case e.g. Widevine manifest tested with ClearKey DRM)
           if (!ExtractStreamProtectionData(sessionPsshset, initData, m_adaptiveTree->m_supportedKeySystems))
             LOG::Log(LOGERROR, "License data: Cannot extract PSSH/KID data from the stream");
         }

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -178,8 +178,7 @@ std::string CClearKeyCencSingleSampleDecrypter::CreateLicenseRequest(
    * "type":"temporary" }
    */
 
-  std::string b64Kid = UTILS::BASE64::Encode(defaultKeyId);
-  UTILS::STRING::ReplaceAll(b64Kid, "=", "");
+  std::string b64Kid = UTILS::BASE64::Encode(defaultKeyId, false);
 
   rapidjson::Document jDoc;
   jDoc.SetObject();

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -26,7 +26,10 @@
 using namespace UTILS;
 
 CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
-    std::string_view licenseUrl, const std::vector<uint8_t>& defaultKeyId, CClearKeyDecrypter* host)
+    std::string_view licenseUrl,
+    const std::map<std::string, std::string>& licenseHeaders,
+    const std::vector<uint8_t>& defaultKeyId,
+    CClearKeyDecrypter* host)
   : m_host(host)
 {
   if (licenseUrl.empty())
@@ -47,6 +50,8 @@ CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
   CURL::CUrl curl{licenseUrl};
   curl.AddHeader("Accept", "application/json");
   curl.AddHeader("Content-Type", "application/json");
+  curl.AddHeaders(licenseHeaders);
+
   curl.AddHeader("postdata", UTILS::BASE64::Encode(postData));
 
   std::string response;

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -88,10 +88,10 @@ CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
     return;
   }
 
-  std::vector<uint8_t> keyBytes = BASE64::Decode(m_keyPairs[b64DefaultKeyId]);
+  const std::vector<uint8_t> keyBytes = BASE64::Decode(m_keyPairs[b64DefaultKeyId]);
   if (AP4_FAILED(AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, keyBytes.data(),
-                                                       16, 0, 0, nullptr, false,
-                                                       m_singleSampleDecrypter)))
+                                                       static_cast<AP4_Size>(keyBytes.size()), 0, 0,
+                                                       nullptr, false, m_singleSampleDecrypter)))
   {
     LOG::LogF(LOGERROR, "Failed to create AP4_CencSingleSampleDecrypter");
   }
@@ -122,9 +122,9 @@ CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
       LOG::LogF(LOGERROR, "Missing KeyId \"%s\" on DRM configuration", defaultKeyId.data());
   }
 
-  const AP4_UI08* ap4Key = reinterpret_cast<const AP4_UI08*>(hexKey.data());
-  AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, ap4Key, 16, 0, 0, nullptr,
-                                        false, m_singleSampleDecrypter);
+  AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, hexKey.data(),
+                                        static_cast<AP4_Size>(hexKey.size()), 0, 0, nullptr, false,
+                                        m_singleSampleDecrypter);
   SetParentIsOwner(false);
   AddSessionKey(defaultKeyId);
 }

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -47,12 +47,10 @@ CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
     FILESYS::SaveFile(debugFilePath, postData.c_str(), true);
   }
 
-  CURL::CUrl curl{licenseUrl};
+  CURL::CUrl curl{licenseUrl, postData};
   curl.AddHeader("Accept", "application/json");
   curl.AddHeader("Content-Type", "application/json");
   curl.AddHeaders(licenseHeaders);
-
-  curl.AddHeader("postdata", UTILS::BASE64::Encode(postData));
 
   std::string response;
   int statusCode = curl.Open();

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
@@ -17,6 +17,7 @@ class CClearKeyCencSingleSampleDecrypter : public Adaptive_CencSingleSampleDecry
 {
 public:
   CClearKeyCencSingleSampleDecrypter(std::string_view licenseUrl,
+                                     const std::map<std::string, std::string>& licenseHeaders,
                                      const std::vector<uint8_t>& defaultKeyId,
                                      CClearKeyDecrypter* host);
   CClearKeyCencSingleSampleDecrypter(const std::vector<uint8_t>& initdata,

--- a/src/decrypters/clearkey/ClearKeyDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.cpp
@@ -40,15 +40,20 @@ Adaptive_CencSingleSampleDecrypter* CClearKeyDecrypter::CreateSingleSampleDecryp
     CryptoMode cryptoMode)
 {
   CClearKeyCencSingleSampleDecrypter* decrypter = nullptr;
-  auto& keys = CSrvBroker::GetKodiProps().GetDrmConfig(std::string(DRM::KS_CLEARKEY)).m_keys;
+  auto& cfgLic = CSrvBroker::GetKodiProps().GetDrmConfig(std::string(DRM::KS_CLEARKEY)).license;
 
-  if (!keys.empty() || !initData.empty()) // Keys provided from manifest or Kodi property
+  // If keys / license url are provided by Kodi property, those of the manifest will be overwritten
+
+  if (!cfgLic.serverUrl.empty())
+    licenseUrl = cfgLic.serverUrl;
+
+  if ((!cfgLic.keys.empty() || !initData.empty()) && cfgLic.serverUrl.empty()) // Keys provided from manifest or Kodi property
   {
-    decrypter = new CClearKeyCencSingleSampleDecrypter(initData, defaultkeyid, keys, this);
+    decrypter = new CClearKeyCencSingleSampleDecrypter(initData, defaultkeyid, cfgLic.keys, this);
   }
   else // Clearkey license server URL provided
   {
-    decrypter = new CClearKeyCencSingleSampleDecrypter(licenseUrl, defaultkeyid, this);
+    decrypter = new CClearKeyCencSingleSampleDecrypter(licenseUrl, cfgLic.reqHeaders, defaultkeyid, this);
   }
 
   if (!decrypter->HasKeys())

--- a/src/decrypters/clearkey/ClearKeyDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.cpp
@@ -12,6 +12,7 @@
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
 #include "decrypters/Helpers.h"
+#include "utils/log.h"
 
 std::vector<std::string_view> CClearKeyDecrypter::SelectKeySystems(std::string_view keySystem)
 {
@@ -39,6 +40,12 @@ Adaptive_CencSingleSampleDecrypter* CClearKeyDecrypter::CreateSingleSampleDecryp
     bool skipSessionMessage,
     CryptoMode cryptoMode)
 {
+  if (cryptoMode != CryptoMode::AES_CTR)
+  {
+    LOG::LogF(LOGERROR, "Cannot initialize ClearKey DRM. Only \"cenc\" encryption supported.");
+    return nullptr;
+  }
+
   CClearKeyCencSingleSampleDecrypter* decrypter = nullptr;
   auto& cfgLic = CSrvBroker::GetKodiProps().GetDrmConfig(std::string(DRM::KS_CLEARKEY)).license;
 

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -459,6 +459,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     }
 
     std::string encData{BASE64::Encode(blocks[2])};
+    //! @todo: inappropriate use of "postdata" header, use CURL::CUrl for post request
     file.AddHeader("postdata", encData.c_str());
   }
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1295,6 +1295,13 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
           m_currentPssh = STRING::ToVecUint8(resp.data);
       }
 
+      if (uriUrl.empty()) // No kid provided, assume key == kid
+        m_currentDefaultKID = STRING::ToHexadecimal(uriData);
+
+    }
+    else if (STRING::CompareNoCase(keyFormat, DRM::URN_WIDEVINE))
+    {
+      // Take only the KID
       if (STRING::KeyExists(attribs, "KEYID"))
       {
         std::string keyid = attribs["KEYID"];
@@ -1305,16 +1312,14 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
         else
           LOG::LogF(LOGERROR, "Incorret KEYID tag format");
       }
-      else if (uriUrl.empty()) // No kid provided, assume key == kid
-        m_currentDefaultKID = STRING::ToHexadecimal(uriData);
-
-      if (encryptMethod == "SAMPLE-AES-CTR")
-        m_cryptoMode = CryptoMode::AES_CTR;
-      else if (encryptMethod == "SAMPLE-AES")
-        m_cryptoMode = CryptoMode::AES_CBC;
-
-      return EncryptionType::CLEARKEY;
     }
+
+    if (encryptMethod == "SAMPLE-AES-CTR")
+      m_cryptoMode = CryptoMode::AES_CTR;
+    else if (encryptMethod == "SAMPLE-AES")
+      m_cryptoMode = CryptoMode::AES_CBC;
+
+    return EncryptionType::CLEARKEY;
   }
 
   // Unsupported encryption

--- a/src/utils/Base64Utils.cpp
+++ b/src/utils/Base64Utils.cpp
@@ -44,7 +44,10 @@ constexpr unsigned char BASE64_TABLE[] = {
 // clang-format on
 } // namespace
 
-void UTILS::BASE64::Encode(const uint8_t* input, const size_t length, std::string& output)
+void UTILS::BASE64::Encode(const uint8_t* input,
+                           const size_t length,
+                           std::string& output,
+                           const bool padding /* = true */)
 {
   if (input == nullptr || length == 0)
     return;
@@ -68,40 +71,45 @@ void UTILS::BASE64::Encode(const uint8_t* input, const size_t length, std::strin
       output.push_back(CHARACTERS[(l >> 0) & 0x3F]);
   }
 
-  int left = 3 - (length % 3);
-
-  if (length % 3)
+  if (padding)
   {
-    for (int i = 0; i < left; i++)
-      output.push_back(PADDING);
+    const int left = 3 - (length % 3);
+
+    if (length % 3)
+    {
+      for (int i = 0; i < left; ++i)
+        output.push_back(PADDING);
+    }
   }
 }
 
-std::string UTILS::BASE64::Encode(const uint8_t* input, const size_t length)
+std::string UTILS::BASE64::Encode(const uint8_t* input,
+                                  const size_t length,
+                                  const bool padding /* = true */)
 {
   std::string output;
-  Encode(input, length, output);
+  Encode(input, length, output, padding);
   return output;
 }
 
-std::string UTILS::BASE64::Encode(const std::vector<uint8_t>& input)
+std::string UTILS::BASE64::Encode(const std::vector<uint8_t>& input, const bool padding /* = true */)
 {
   std::string output;
-  Encode(input.data(), input.size(), output);
+  Encode(input.data(), input.size(), output, padding);
   return output;
 }
 
-std::string UTILS::BASE64::Encode(const std::vector<char>& input)
+std::string UTILS::BASE64::Encode(const std::vector<char>& input, const bool padding /* = true */)
 {
   std::string output;
-  Encode(reinterpret_cast<const uint8_t*>(input.data()), input.size(), output);
+  Encode(reinterpret_cast<const uint8_t*>(input.data()), input.size(), output, padding);
   return output;
 }
 
-std::string UTILS::BASE64::Encode(const std::string& inputStr)
+std::string UTILS::BASE64::Encode(const std::string& inputStr, const bool padding /* = true */)
 {
   std::string output;
-  Encode(reinterpret_cast<const uint8_t*>(inputStr.data()), inputStr.size(), output);
+  Encode(reinterpret_cast<const uint8_t*>(inputStr.data()), inputStr.size(), output, padding);
   return output;
 }
 

--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -18,11 +18,11 @@ namespace UTILS
 namespace BASE64
 {
 
-void Encode(const uint8_t* input, const size_t length, std::string& output);
-std::string Encode(const uint8_t* input, const size_t length);
-std::string Encode(const std::vector<uint8_t>& input);
-std::string Encode(const std::vector<char>& input);
-std::string Encode(const std::string& input);
+void Encode(const uint8_t* input, const size_t length, std::string& output, const bool padding = true);
+std::string Encode(const uint8_t* input, const size_t length, const bool padding = true);
+std::string Encode(const std::vector<uint8_t>& input, const bool padding = true);
+std::string Encode(const std::vector<char>& input, const bool padding = true);
+std::string Encode(const std::string& input, const bool padding = true);
 
 void Decode(const char* input, const size_t length, std::vector<uint8_t>& output);
 std::vector<uint8_t> Decode(std::string_view input);

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "CurlUtils.h"
 
+#include "Base64Utils.h"
 #include "StringUtils.h"
 #include "UrlUtils.h"
 #include "Utils.h"
@@ -198,6 +199,14 @@ UTILS::CURL::CUrl::CUrl(std::string_view url)
     // the cookies set by the property will replace these
     if (kodiProps.GetConfig().internalCookies)
       m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "cookie", GetCookies(url));
+  }
+}
+
+UTILS::CURL::CUrl::CUrl(std::string_view url, const std::string& postData) : CUrl::CUrl(url)
+{
+  if (m_file.IsOpen() && !postData.empty())
+  {
+    m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "postdata", BASE64::Encode(postData));
   }
 }
 

--- a/src/utils/CurlUtils.h
+++ b/src/utils/CurlUtils.h
@@ -42,6 +42,13 @@ public:
   * \param url The url of the file to download
   */
   CUrl(std::string_view url);
+
+ /*!
+  * \brief Create CUrl for POST request, if the data are empty, GET will be performed.
+  * \param url The request url
+  * \param postData The data for the POST request
+  */
+  CUrl(std::string_view url, const std::string& postData);
   ~CUrl();
 
  /*!

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -27,6 +27,12 @@ bool KeyExists(const T& container, const Key& key)
   return container.find(key) != std::end(container);
 }
 
+template<typename T>
+bool KeyExists(const T& container, const std::string_view key)
+{
+  return container.find(key.data()) != std::end(container);
+}
+
 /*!
  * \brief Get map value of the specified key
  * \param map The map where find the value


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1) Add support to set license server url from property, example:
`#KODIPROP:inputstream.adaptive.drm_legacy=org.w3.clearkey|https://server/AcquireLicense`

2) Add support to pass http headers to license server request
3) Tested DASH Widevine stream, used with ClearKey as DRM replacement, as requested on #811 and #1637.
~The only limitation is that the manifest must provide the ContentProtection with `urn:mpeg:dash:mp4protection:2011` containing the `default_KID`~
4) Add support "ClearKey as DRM replacement" for HLS, but not tested since i havent found any stream
5) Add code to prevent a mixed misuse of DRM properties
6) Some code cleanups

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #1637 
closes #811

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested MPD widevine protected by using ClearKey license server url provided by DRM config property, the tested MPD does not provide the ClearKey `ContentProtection` tag, as follow:
```
        <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="**7B7D**-565C-4**3-B**F-**C33**654**" xmlns:cenc="urn:mpeg:cenc:2013"/>
        <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
          <cenc:pssh xmlns:cenc="urn:mpeg:cenc:2013">redacted</cenc:pssh>
        </ContentProtection>
        <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
          <cenc:pssh xmlns:cenc="urn:mpeg:cenc:2013">redacted</cenc:pssh>
        </ContentProtection>
```
i cant publish here the test stream used

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
