### PR TITLE
[Session] Reworked widevine pssh generation for smoothstreaming

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -382,7 +382,8 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
       if (sessionPsshset.adaptation_set_->GetStreamType() == StreamType::NOTYPE)
         continue;
 
-      std::string_view licenseData = CSrvBroker::GetKodiProps().GetLicenseData();
+      const std::vector<uint8_t> defaultKid = DRM::ConvertKidStrToBytes(sessionPsshset.defaultKID_);
+      std::string_view licenseDataStr = CSrvBroker::GetKodiProps().GetLicenseData();
 
       if (m_adaptiveTree->GetTreeType() == adaptive::TreeType::SMOOTH_STREAMING)
       {
@@ -392,17 +393,21 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
           //! @todo: CreateISMlicense accept placeholders {KID} and {UUID} but its not wiki documented
           //! we should continue allow create custom pssh with placeholders?
           //! see also todo's below
-          if (licenseData.empty())
+          std::vector<uint8_t> licenseData = BASE64::Decode(licenseDataStr);
+
+          if (DRM::IsValidPsshHeader(licenseData))
           {
-            LOG::Log(LOGDEBUG, "License data: Create Widevine PSSH for SmoothStreaming");
-            licenseData = "e0tJRH0="; // {KID}
+            initData = licenseData;
           }
           else
           {
-            LOG::Log(LOGDEBUG, "License data: Create Widevine PSSH for SmoothStreaming, based on "
-                               "license data property");
+            LOG::Log(LOGDEBUG, "License data: Create Widevine PSSH for SmoothStreaming %s",
+                     licenseData.empty() ? "" : "(with custom data)");
+
+            std::vector<uint8_t> wvPsshData;
+            if (DRM::MakeWidevinePsshData(defaultKid, licenseData, wvPsshData))
+              DRM::MakePssh(DRM::ID_WIDEVINE, wvPsshData, initData);
           }
-          DRM::CreateISMlicense(sessionPsshset.defaultKID_, licenseData, initData);
         }
         else if (licenseType == "com.microsoft.playready")
         {
@@ -416,16 +421,16 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
           //! As first decoupling things and allowing to have a way to set DRM optional parameters in a extensible way
           //! for future other use cases, and not limited to Playready only.
           //! To take in account that license_data property is also used on DASH parser to bypass ContentProtection tags.
-          drmOptionalKeyParam = licenseData;
+          drmOptionalKeyParam = licenseDataStr;
         }
       }
-      else if (!licenseData.empty())
+      else if (!licenseDataStr.empty())
       {
         // Custom license PSSH data provided from property
         // This can allow to initialize a DRM that could be also not specified
         // as supported in the manifest (e.g. missing DASH ContentProtection tags)
         LOG::Log(LOGDEBUG, "License data: Use PSSH data provided by the license data property");
-        initData = BASE64::Decode(licenseData);
+        initData = BASE64::Decode(licenseDataStr);
       }
 
       if (initData.empty() && sessionPsshset.m_licenseUrl.empty())
@@ -444,7 +449,6 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
       }
 
       CCdmSession& session{m_cdmSessions[ses]};
-      const std::vector<uint8_t> defaultKid = DRM::ConvertKidStrToBytes(sessionPsshset.defaultKID_);
 
       if (addDefaultKID && ses == 1 && session.m_cencSingleSampleDecrypter)
       {

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -71,15 +71,6 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
 
   m_wvCdmAdapter.insertssd(this);
 
-  if (CSrvBroker::GetSettings().IsDebugLicense())
-  {
-    std::string debugFilePath = FILESYS::PathCombine(m_host->GetLibraryPath(),
-                                                     "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
-
-    std::string data{reinterpret_cast<const char*>(pssh.data()), pssh.size()};
-    UTILS::FILESYS::SaveFile(debugFilePath, data, true);
-  }
-
   // No cenc init data with PSSH box format, create one
   if (memcmp(pssh.data() + 4, "pssh", 4) != 0)
   {
@@ -107,6 +98,15 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(CWVCdmAdapter& drm,
     psshAtom[2] = static_cast<uint8_t>(psshAtom.size() >> 8);
     psshAtom[3] = static_cast<uint8_t>(psshAtom.size());
     m_pssh = psshAtom;
+  }
+
+  if (CSrvBroker::GetSettings().IsDebugLicense())
+  {
+    std::string debugFilePath =
+        FILESYS::PathCombine(m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
+
+    std::string data{reinterpret_cast<const char*>(m_pssh.data()), m_pssh.size()};
+    UTILS::FILESYS::SaveFile(debugFilePath, data, true);
   }
 
   drm.GetCdmAdapter()->CreateSessionAndGenerateRequest(m_promiseId++, cdm::SessionType::kTemporary,

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -49,14 +49,6 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm
     return;
   }
 
-  if (CSrvBroker::GetSettings().IsDebugLicense())
-  {
-    std::string debugFilePath =
-        FILESYS::PathCombine(m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
-    std::string data{reinterpret_cast<const char*>(pssh.data()), pssh.size()};
-    FILESYS::SaveFile(debugFilePath, data, true);
-  }
-
   m_pssh = pssh;
   // No cenc init data with PSSH box format, create one
   if (memcmp(pssh.data() + 4, "pssh", 4) != 0)
@@ -79,6 +71,15 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(CWVCdmAdapterA& drm
     psshAtom[3] = static_cast<uint8_t>(psshAtom.size());
     m_pssh = psshAtom;
   }
+
+  if (CSrvBroker::GetSettings().IsDebugLicense())
+  {
+    std::string debugFilePath =
+        FILESYS::PathCombine(m_host->GetLibraryPath(), "EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED.init");
+    std::string data{reinterpret_cast<const char*>(m_pssh.data()), m_pssh.size()};
+    FILESYS::SaveFile(debugFilePath, data, true);
+  }
+
   m_initialPssh = m_pssh;
 
   if (!optionalKeyParameter.empty())

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -129,8 +129,11 @@ public:
 
   virtual void ResetVideo() override {}
 
-  virtual void SetLibraryPath(std::string_view libraryPath) override {}
-  virtual std::string_view GetLibraryPath() const override { return ""; }
+  virtual void SetLibraryPath(std::string_view libraryPath) override
+  {
+    m_libraryPath = libraryPath;
+  }
+  virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
 
   virtual void OnMediaDrmEvent(const CJNIMediaDrm& mediaDrm,
                                const std::vector<char>& sessionId,
@@ -139,6 +142,7 @@ public:
                                const std::vector<char>& data) override;
 
 private:
+  std::string m_libraryPath;
   kodi::platform::CInterfaceAndroidSystem m_androidSystem;
   std::unique_ptr<CMediaDrmOnEventListener> m_mediaDrmEventListener;
   WV_KEYSYSTEM m_keySystem;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The `CreateISMlicense` code was used to construct only a single part of the PSSH data (the WidevinePsshData structure that has been never specified) that also was not including the PSSH box.

I reworked whole code, in a very simplified way

by verifing the PSSH generated by using axinom PSSH Box decoder, reported the lack of data from `content_id` field of WidevinePsshData data structure, it could be a bug introduced from Kodi 20 (i have not check kodi<=19), now fixed

axinom PSSH Box decoder also report a lack of `protection_scheme` field, but i found constraining docs on the net about this field, where often is signed as not mandatory field, i made some attempts to add it but i failed to constructing the correct protobuf for that field, due to different data type

i removed the limitation where the `{KID}` is must appears before the `{UUID}`.

i have add a little check to prevent that if a PSSH box is set on license_data property cannot be injected on the `content_id` field, but will be used directly.

_Signed as backport needed, to do at later time after merged, i want to see if there are complaining, should not because the data is correct, i think there are few addons that use this SmoothStreaming mixture_

--

Add also two more commits that i used to debug it

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the DRM config rework i was looking to this ugly code
that was needed some cleanups in advance to understand how better proceeds

The use case for this code is:
Use a SmoothStreaming manifest, PlayReady protected, with a service that provide also the Widevine license server url
then the configuration to allow ISA to generate a Widevine PSSH for SS will be as:
```
#KODIPROP:mimetype=application/vnd.ms-sstr+xml
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://widevinelicenseserverurl
https://playready.server.com/media/example.ism.smoothstreaming/manifest
```
optionally is possible provide set a custom `content_id` field data by using license_data prop:
```
#KODIPROP:inputstream.adaptive.license_data="your base64 data" (placeholders if used must be encoded base64 with the raw data)
```

Plus on the inputstream.adaptive.license_data, for this use case, can be used two placeholders to inject data to the custom data:
`{KID}` to inject the KID as bytes
`{UUID}` to inject the KID as UUID string
a limitation: the `{KID}` is must appears before the `{UUID}` or the generation fails
a problem: if a user try to set a real PSSH box on the license_data, will cause unexpected behaviours

all this has been never documented on Wiki due to missing test streams

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested directly, i forced a playready smoothstreaming, without playback

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
