### PR TITLE
Prevent pipe char uses on manifest url and params

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -173,6 +173,7 @@ bool CSession::Initialize()
   }
 
   std::string manifestUrl = m_manifestUrl;
+  URL::RemovePipePart(manifestUrl); // No pipe char uses, must be used Kodi properties only
 
   URL::AppendParameters(manifestUrl, kodiProps.GetManifestParams());
 

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -205,7 +205,7 @@ std::string UTILS::URL::GetUrlPath(std::string url)
 
 void UTILS::URL::AppendParameters(std::string& url, std::string_view params)
 {
-  if (params.empty())
+  if (params.empty() || params.front() == '|')
     return;
 
   params.remove_prefix(params.front() == '&' || params.front() == '?' ? 1 : 0);
@@ -326,4 +326,11 @@ void UTILS::URL::EnsureEndingBackslash(std::string& url)
 {
   if (!url.empty() && url.back() != '/')
     url += "/";
+}
+
+void UTILS::URL::RemovePipePart(std::string& url)
+{
+  const size_t urlPipePos = url.find("|");
+  if (urlPipePos != std::string::npos)
+    url.erase(urlPipePos);
 }

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -93,5 +93,11 @@ std::string Join(std::string baseUrl, std::string relativeUrl);
  */
 void EnsureEndingBackslash(std::string& url);
 
+/*!
+ * \brief Remove the part of the URL that starts with the pipe char "|".
+ * \param url[IN][OUT] An URL.
+ */
+void RemovePipePart(std::string& url);
+
 } // namespace URL
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Prevent pipe char uses on manifest url and params
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More times is happened that users dont read Wiki integration page, and make use of pipe "|" char along manifest url to set headers,
this works because Kodi core Curl is able to parse it, but
1) ISA is not aware of it and manifest updates on live contents will not works
2) if Kodi core make a change it stop to works
3) ISA already provide the appropriate properties to set HTTP headers

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
