### PR TITLE
[AdaptiveUtils] Fix defaultkid to tenc atom on CreateMovieAtom

### DIFF
--- a/src/common/AdaptiveUtils.cpp
+++ b/src/common/AdaptiveUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "AdaptiveStream.h"
 #include "Representation.h"
+#include "decrypters/Helpers.h"
 #include "utils/log.h"
 #include "utils/Utils.h"
 
@@ -125,14 +126,14 @@ AP4_Movie* PLAYLIST::CreateMovieAtom(adaptive::AdaptiveStream& adStream,
     const PLAYLIST::CPeriod::PSSHSet& psshSet =
         adStream.getPeriod()->GetPSSHSets()[repr->GetPsshSetPos()];
 
-    const AP4_UI08* kid = nullptr;
+    std::vector<uint8_t> defaultKid;
     if (psshSet.defaultKID_.empty())
-      kid = DEFAULT_KEYID;
+      defaultKid.assign(DEFAULT_KEYID, DEFAULT_KEYID + 16);
     else
-      kid = reinterpret_cast<const AP4_UI08*>(psshSet.defaultKID_.data());
+      defaultKid = DRM::ConvertKidStrToBytes(psshSet.defaultKID_);
 
     AP4_ContainerAtom schi{AP4_ATOM_TYPE_SCHI};
-    schi.AddChild(new AP4_TencAtom(AP4_CENC_CIPHER_AES_128_CTR, 8, kid));
+    schi.AddChild(new AP4_TencAtom(AP4_CENC_CIPHER_AES_128_CTR, 8, defaultKid.data()));
     sampleDesc = new AP4_ProtectedSampleDescription(0, sampleDesc, 0,
                                                     AP4_PROTECTION_SCHEME_TYPE_PIFF, 0, "", &schi);
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
on cleanups of #1615 completely forgot about sinthetized movie atom used only for smoothstreaming
kid was add as string and so malformed causing decryption problems

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1632 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
