### PR TITLE
[DashTree] Improved clearkey defaultkid workaround

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -65,7 +65,7 @@ CSession::CSession(const std::string& manifestUrl) : m_manifestUrl(manifestUrl)
 CSession::~CSession()
 {
   LOG::Log(LOGDEBUG, "CSession::~CSession()");
-  m_streams.clear();
+  DeleteStreams();
   DisposeDecrypter();
 
   if (m_adaptiveTree)
@@ -77,6 +77,12 @@ CSession::~CSession()
 
   delete m_reprChooser;
   m_reprChooser = nullptr;
+}
+
+void SESSION::CSession::DeleteStreams()
+{
+  LOG::Log(LOGDEBUG, "CSession::DeleteStreams()");
+  m_streams.clear();
 }
 
 void CSession::SetSupportedDecrypterURN(std::vector<std::string_view>& keySystems)

--- a/src/Session.h
+++ b/src/Session.h
@@ -30,6 +30,8 @@ public:
   CSession(const std::string& manifestUrl);
   virtual ~CSession();
 
+  void DeleteStreams();
+
   /*! \brief Initialize the session
    *  \return True if has success, false otherwise
    */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Better handle missing kid, this will cover use case of manifest provided on #1646
it works because the manifest provide the playready scheme where the kid is extracted from the data header, then if a manifest dont provide playready will fails

I will make no further changes for this because its needed implementing in right way the kid extraction from mp4 box, that will cover the other use cases, but this at least from my part will be done in future but only after the DRM property rework

--

commit 2: fix corrupted playback when you play HLS with unsupported encryption, so kodi player still starts, for example because there is video encrypted but subtitles are unencrypted and are hoverer initialized, the kodi demuxer starts read in any case the subitles packets, nothing prevent to stop streams

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #1646
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
