### PR TITLE
[Session][CDM] Dont initialize already initialized sessions

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -381,6 +381,17 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
     // cdmSession 0 is reserved for unencrypted streams
     for (size_t ses{1}; ses < m_cdmSessions.size(); ++ses)
     {
+      CCdmSession& session{m_cdmSessions[ses]};
+
+      // Check if the decrypter has been previously initialized, if so skip it,
+      // sessions are collected and never removed and InitializeDRM can be called more times
+      // depending on how it is used:
+      // 1) CSession::Initialize->InitializePeriod->InitializeDRM - Used by DASH/SS (single call)
+      // 2) CInputStreamAdaptive::DemuxRead->m_session->InitializePeriod()->InitializeDRM - On chapter change (single call)
+      // 3) CInputStreamAdaptive::OpenStream->m_session->PrepareStream->InitializeDRM - Used by HLS (a call for each stream)
+      if (session.m_cencSingleSampleDecrypter)
+        continue;
+
       std::vector<uint8_t> initData;
       std::string drmOptionalKeyParam;
 
@@ -455,8 +466,6 @@ bool CSession::InitializeDRM(bool addDefaultKID /* = false */)
             LOG::Log(LOGERROR, "License data: Cannot extract PSSH/KID data from the stream");
         }
       }
-
-      CCdmSession& session{m_cdmSessions[ses]};
 
       if (addDefaultKID && ses == 1 && session.m_cencSingleSampleDecrypter)
       {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix a very old bug, at least i assume it as a bug, where each session on `m_cdmSessions` are initialized more times

`InitializeDRM` can be called more times depends on use cases:
1) CSession::Initialize->InitializePeriod->InitializeDRM - Used by DASH/SS  --> single call
2) CInputStreamAdaptive::DemuxRead->m_session->InitializePeriod()->InitializeDRM - On chapter change --> single call
3) CInputStreamAdaptive::OpenStream->m_session->PrepareStream->InitializeDRM - Used by HLS --> a call for each stream

the `m_cdmSessions` is every time resized but existing sessions are permanent
and when they are once time initialized, when `InitializeDRM` is called again for any reason, the loop 
`for (size_t ses{1}; ses < m_cdmSessions.size(); ++ses)`
will "reinitialize" every session

i find a bit weird this thing, and i assume that its a bug

this can be clearily visible with this widevine HLS sample stream
```
#KODIPROP:mimetype=application/vnd.apple.mpegurl
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
#KODIPROP:inputstream.adaptive.license_key=https://cwip-shaka-proxy.appspot.com/no_auth||R{SSM}|
https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine-hls/hls.m3u8
```
Here the log before the changes [log_before.txt](https://github.com/user-attachments/files/16729470/log_before.txt)
Here the log after the changes [log_after.txt](https://github.com/user-attachments/files/16729478/log_after.txt)

you can see that the old behaviour sessions are initialized 4 times !!
look at `Initializing stream with KID:` log prints

---

while i was writing this, a question arose to me,
what happens if at chapter/period change the pssh change and KIDs change?
seem that at least for DASH usually the protection between periods should be the same (in theory)
but if change, by following the code on InitializeDRM, the decrypter is kept and seem nothing do a real reinitialization,
i think this is an unhandled situation that can lead to problems

---

backport later times, just to see that there are no new bad feedbacks

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have never given too much weight to this until now that i am making big changes
while playing with ClearKey i noticed a weird thing
multiple `Initializing stream with KID:` was printed on log where should not, so investigated better

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see above
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
