### PR TITLE
[HelperPr] Fix string comparison compiler warning

### DIFF
--- a/src/decrypters/HelperPr.cpp
+++ b/src/decrypters/HelperPr.cpp
@@ -217,7 +217,7 @@ bool DRM::PRHeaderParser::Parse(const std::vector<uint8_t>& prHeader)
       xml_node nodeAlgid = nodePROTECTINFO.child("ALGID");
       if (nodeAlgid)
       {
-        auto algid = nodeAlgid.child_value();
+        std::string_view algid = nodeAlgid.child_value();
         if (algid == "AESCTR")
           m_encryption = EncryptionType::AESCTR;
         else if (algid == "AESCBC")
@@ -237,7 +237,7 @@ bool DRM::PRHeaderParser::Parse(const std::vector<uint8_t>& prHeader)
       {
         kidBase64 = nodeKID.attribute("VALUE").as_string();
 
-        auto algid = nodeKID.attribute("ALGID").as_string();
+        std::string_view algid = nodeKID.attribute("ALGID").as_string();
         if (algid == "AESCTR")
           m_encryption = EncryptionType::AESCTR;
         else if (algid == "AESCBC")
@@ -256,7 +256,7 @@ bool DRM::PRHeaderParser::Parse(const std::vector<uint8_t>& prHeader)
           {
             kidBase64 = nodeKID.attribute("VALUE").as_string();
 
-            auto algid = nodeKID.attribute("ALGID").as_string();
+            std::string_view algid = nodeKID.attribute("ALGID").as_string();
             if (algid == "AESCTR")
               m_encryption = EncryptionType::AESCTR;
             else if (algid == "AESCBC")


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
android compiler warnings
```
/home/jenkins/workspace/binary-addons/kodi-android-aarch64-Piers/tools/depends/target/binary-addons/inputstream.adaptive/src/decrypters/HelperPr.cpp:221:19: warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Wstring-compare]
        if (algid == "AESCTR")
                  ^  ~~~~~~~~
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
