### PR TITLE
Cleanups to session / service broker / chooser interface

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -90,7 +90,7 @@ void LogDrmJsonDictKeys(std::string_view keyName,
 }
 } // unnamed namespace
 
-ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std::string>& props)
+void ADP::KODI_PROPS::CCompKodiProps::Init(const std::map<std::string, std::string>& props)
 {
   std::string licenseUrl;
 

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -117,8 +117,10 @@ struct DrmCfg
 class ATTR_DLL_LOCAL CCompKodiProps
 {
 public:
-  CCompKodiProps(const std::map<std::string, std::string>& props);
+  CCompKodiProps() = default;
   ~CCompKodiProps() = default;
+
+  void Init(const std::map<std::string, std::string>& props);
 
   // \brief HTTP parameters used to download manifest updates
   std::string GetManifestUpdParams() const { return m_manifestUpdParams; }

--- a/src/CompResources.h
+++ b/src/CompResources.h
@@ -16,6 +16,7 @@
 #include <kodi/AddonBase.h>
 #endif
 
+#include <atomic>
 #include <mutex>
 #include <string>
 #include <unordered_set>
@@ -30,6 +31,22 @@ namespace ADP
 {
 namespace RESOURCES
 {
+struct ScreenInfo
+{
+  ScreenInfo() = default;
+  ScreenInfo(int widthPx, int heightPx, int maxWidthPx, int maxHeightPx)
+  {
+    width = widthPx;
+    height = heightPx;
+    maxWidth = maxWidthPx;
+    maxHeight = maxHeightPx;
+  }
+  int width{0};
+  int height{0};
+  int maxWidth{0};
+  int maxHeight{0};
+};
+
 class ATTR_DLL_LOCAL CCompResources
 {
 public:
@@ -37,6 +54,18 @@ public:
   ~CCompResources() = default;
 
   void InitStage2(adaptive::AdaptiveTree* tree) { m_tree = tree; }
+
+  /*!
+   * \brief Get the current screen info.
+   * \return The screen info.
+   */
+  ScreenInfo GetScreenInfo() const { return m_screenInfo.load(); }
+
+  /*!
+   * \brief Set the screen info.
+   * \param screenInfo The scren info
+   */
+  void SetScreenInfo(const ScreenInfo& screenInfo) { m_screenInfo = screenInfo; }
 
   /*!
    * \brief Cookies that can be shared along with HTTP requests.
@@ -58,6 +87,7 @@ public:
   const adaptive::AdaptiveTree& GetTree() const { return *m_tree; }
 
 private:
+  std::atomic<ScreenInfo> m_screenInfo;
   std::unordered_set<UTILS::CURL::Cookie> m_cookies;
   std::mutex m_cookiesMutex;
   adaptive::AdaptiveTree* m_tree{nullptr};

--- a/src/Session.h
+++ b/src/Session.h
@@ -13,8 +13,6 @@
 #include "common/AdaptiveTree.h"
 #include "decrypters/IDecrypter.h"
 
-#include <bento4/Ap4.h>
-
 #if defined(ANDROID)
 #include <kodi/platform/android/System.h>
 #endif

--- a/src/Session.h
+++ b/src/Session.h
@@ -14,7 +14,6 @@
 #include "decrypters/IDecrypter.h"
 
 #include <bento4/Ap4.h>
-#include <kodi/tools/DllHelper.h>
 
 #if defined(ANDROID)
 #include <kodi/platform/android/System.h>
@@ -342,7 +341,6 @@ protected:
                                    const std::vector<std::string_view>& keySystems);
 
 private:
-  std::unique_ptr<kodi::tools::CDllHelper> m_dllHelper;
   std::shared_ptr<DRM::IDecrypter> m_decrypter;
 
   struct CCdmSession

--- a/src/Session.h
+++ b/src/Session.h
@@ -29,15 +29,16 @@ namespace SESSION
 class ATTR_DLL_LOCAL CSession : public adaptive::AdaptiveStreamObserver
 {
 public:
-  CSession(const std::string& manifestUrl);
+  CSession() = default;
   virtual ~CSession();
 
   void DeleteStreams();
 
   /*! \brief Initialize the session
+   *  \param manifestUrl The manifest URL
    *  \return True if has success, false otherwise
    */
-  bool Initialize();
+  bool Initialize(std::string manifestUrl);
 
   /*
    * \brief Check HDCP parameters to remove unplayable representations
@@ -206,11 +207,10 @@ public:
     return ret;
   };
 
-  /*! \brief To inform of Kodi's current screen resolution
-   *  \param width The width in pixels
-   *  \param height The height in pixels
+  /*!
+   * \brief Callback for screen resolution change.
    */
-  void SetVideoResolution(int width, int height, int maxWidth, int maxHeight);
+  void OnScreenResChange();
 
   /*! \brief Seek streams and readers to a specified time
    *  \param seekTime The seek time in seconds
@@ -342,7 +342,6 @@ protected:
                                    const std::vector<std::string_view>& keySystems);
 
 private:
-  std::string m_manifestUrl;
   std::unique_ptr<kodi::tools::CDllHelper> m_dllHelper;
   std::shared_ptr<DRM::IDecrypter> m_decrypter;
 
@@ -355,7 +354,7 @@ private:
   std::vector<CCdmSession> m_cdmSessions;
 
   adaptive::AdaptiveTree* m_adaptiveTree{nullptr};
-  CHOOSER::IRepresentationChooser* m_reprChooser;
+  CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
 
   std::vector<std::unique_ptr<CStream>> m_streams;
   CStream* m_timingStream{nullptr};

--- a/src/SrvBroker.cpp
+++ b/src/SrvBroker.cpp
@@ -14,14 +14,17 @@
 
 using namespace ADP;
 
-CSrvBroker::CSrvBroker() = default;
+CSrvBroker::CSrvBroker()
+{
+  m_compKodiProps = std::make_unique<KODI_PROPS::CCompKodiProps>();
+  m_compResources = std::make_unique<RESOURCES::CCompResources>();
+  m_compSettings = std::make_unique<SETTINGS::CCompSettings>();
+};
 CSrvBroker::~CSrvBroker() = default;
 
 void CSrvBroker::Init(const std::map<std::string, std::string>& kodiProps)
 {
-  m_compKodiProps = std::make_unique<KODI_PROPS::CCompKodiProps>(kodiProps);
-  m_compResources = std::make_unique<RESOURCES::CCompResources>();
-  m_compSettings = std::make_unique<SETTINGS::CCompSettings>();
+  m_compKodiProps->Init(kodiProps);
 }
 
 void CSrvBroker::InitStage2(adaptive::AdaptiveTree* tree)

--- a/src/common/Chooser.cpp
+++ b/src/common/Chooser.cpp
@@ -8,6 +8,7 @@
 
 #include "Chooser.h"
 
+#include "CompResources.h"
 #include "ChooserAskQuality.h"
 #include "ChooserDefault.h"
 #include "ChooserFixedRes.h"
@@ -70,6 +71,7 @@ IRepresentationChooser* CHOOSER::CreateRepresentationChooser()
   if (!reprChooser)
     reprChooser = new CRepresentationChooserDefault();
 
+  reprChooser->OnUpdateScreenRes();
   reprChooser->Initialize(props);
 
   return reprChooser;
@@ -84,14 +86,13 @@ CHOOSER::IRepresentationChooser::IRepresentationChooser()
     m_isAdjustRefreshRate = true;
 }
 
-void CHOOSER::IRepresentationChooser::SetScreenResolution(const int width,
-                                                          const int height,
-                                                          const int maxWidth,
-                                                          const int maxHeight)
+void CHOOSER::IRepresentationChooser::OnUpdateScreenRes()
 {
+  const auto sInfo = CSrvBroker::GetResources().GetScreenInfo();
+
   LOG::Log(LOGINFO,
            "[Repr. chooser] Resolution set: %dx%d, max allowed: %dx%d, Adjust refresh rate: %i",
-           width, height, maxWidth, maxHeight, m_isAdjustRefreshRate);
+           sInfo.width, sInfo.height, sInfo.maxWidth, sInfo.maxHeight, m_isAdjustRefreshRate);
 
   // Use case: User chooses to upscale Kodi GUI from TV instead of Kodi engine.
   // In this case "Adjust refresh rate" setting can be enabled and then
@@ -100,16 +101,16 @@ void CHOOSER::IRepresentationChooser::SetScreenResolution(const int width,
   // For example we can have the GUI at 1080p and when playback starts can be
   // auto-switched to 4k, but to allow Kodi do this we have to provide the
   // stream resolution that match the max allowed screen resolution.
-  if (m_isAdjustRefreshRate && width < maxWidth && height < maxHeight)
+  if (m_isAdjustRefreshRate && sInfo.width < sInfo.maxWidth && sInfo.height < sInfo.maxHeight)
   {
-    m_screenCurrentWidth = maxWidth;
-    m_screenCurrentHeight = maxHeight;
+    m_screenCurrentWidth = sInfo.maxWidth;
+    m_screenCurrentHeight = sInfo.maxHeight;
     m_isForceStartsMaxRes = true;
   }
   else
   {
-    m_screenCurrentWidth = width;
-    m_screenCurrentHeight = height;
+    m_screenCurrentWidth = sInfo.width;
+    m_screenCurrentHeight = sInfo.height;
   }
 }
 

--- a/src/common/Chooser.h
+++ b/src/common/Chooser.h
@@ -60,17 +60,9 @@ public:
   virtual void PostInit() {}
 
   /*!
-   * \brief Set the current screen resolution.
-   *        To be called every time the screen resolution change.
-   * \param width Width resolution
-   * \param height Height resolution
-   * \param maxWidth Max width resolution
-   * \param maxHeight Max height resolution
+   * \brief Callback to update screen resolution.
    */
-  void SetScreenResolution(const int width,
-                           const int height,
-                           const int maxWidth,
-                           const int maxHeight);
+  void OnUpdateScreenRes();
 
   /*!
    * \brief Set the current download speed.

--- a/src/main.h
+++ b/src/main.h
@@ -56,11 +56,7 @@ public:
   std::shared_ptr<SESSION::CSession> GetSession() { return m_session; };
 
 private:
-  std::shared_ptr<SESSION::CSession> m_session{nullptr};
-  int m_currentVideoWidth{0};
-  int m_currentVideoHeight{0};
-  int m_currentVideoMaxWidth{0};
-  int m_currentVideoMaxHeight{0};
+  std::shared_ptr<SESSION::CSession> m_session;
   std::map<INPUTSTREAM_TYPE, unsigned int> m_IncludedStreams;
   int m_failedSeekTime = ~0;
   std::string m_chapterName;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -53,7 +53,11 @@ add_executable(${BINARY}
     ../utils/XMLUtils.cpp
     )
 
-target_link_libraries(${BINARY} PRIVATE ${BENTO4_LIBRARIES} ${PUGIXML_LIBRARIES} ${GTEST_LIBRARIES} Threads::Threads ${CMAKE_DL_LIBS})
+if(LINUX)
+  SET(ADD_LINK_LIBS "atomic")
+endif()
+
+target_link_libraries(${BINARY} PRIVATE ${BENTO4_LIBRARIES} ${PUGIXML_LIBRARIES} ${GTEST_LIBRARIES} Threads::Threads ${CMAKE_DL_LIBS} ${ADD_LINK_LIBS})
 
 set(TEST_DATA_DIR "${CMAKE_SOURCE_DIR}/src/test/manifests")
 add_test(NAME manifest_tests COMMAND ${BINARY} "${TEST_DATA_DIR}")


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Reorganized better way code by using appropriate "init" methods and not constructors,
allowing to remove also some main/session members

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleanups while was continue future drm auto-selection devs
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
