### PR TITLE
[KodiProps] add common_headers property

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="drm|drm_legacy|license_type|license_key|license_url|license_url_append|license_data|license_flags|server_certificate|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|config|manifest_config"
+    listitemprops="drm|drm_legacy|license_type|license_key|license_url|license_url_append|license_data|license_flags|server_certificate|common_headers|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|config|manifest_config"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -39,6 +39,8 @@ constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_dat
 constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags"; //! @todo: to be deprecated
 constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate"; //! @todo: to be deprecated
 
+constexpr std::string_view PROP_COMMON_HEADERS = "inputstream.adaptive.common_headers";
+
 constexpr std::string_view PROP_MANIFEST_PARAMS = "inputstream.adaptive.manifest_params";
 constexpr std::string_view PROP_MANIFEST_HEADERS = "inputstream.adaptive.manifest_headers";
 constexpr std::string_view PROP_MANIFEST_UPD_PARAMS = "inputstream.adaptive.manifest_upd_params";
@@ -142,6 +144,11 @@ void ADP::KODI_PROPS::CCompKodiProps::Init(const std::map<std::string, std::stri
           "will be removed on next Kodi version. This because the PVR API bug has been fixed on "
           "Kodi v22. Please use the appropriate properties to set the DRM configuration.");
       licenseUrl += prop.second;
+    }
+    else if (prop.first == PROP_COMMON_HEADERS)
+    {
+      LogProp(prop.first, prop.second);
+      ParseHeaderString(m_commonHeaders, prop.second);
     }
     else if (prop.first == PROP_MANIFEST_UPD_PARAMS)
     {

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -122,6 +122,9 @@ public:
 
   void Init(const std::map<std::string, std::string>& props);
 
+  // \brief HTTP headers used for any HTTP request
+  const std::map<std::string, std::string>& GetCommonHeaders() const { return m_commonHeaders; }
+
   // \brief HTTP parameters used to download manifest updates
   std::string GetManifestUpdParams() const { return m_manifestUpdParams; }
   // \brief HTTP parameters used to download manifests
@@ -175,6 +178,7 @@ private:
 
   std::string m_manifestUpdParams;
   std::string m_manifestParams;
+  std::map<std::string, std::string> m_commonHeaders;
   std::map<std::string, std::string> m_manifestHeaders;
   std::string m_streamParams;
   std::map<std::string, std::string> m_streamHeaders;

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -194,6 +194,8 @@ UTILS::CURL::CUrl::CUrl(std::string_view url)
     if (!kodiProps.GetConfig().curlSSLVerifyPeer)
       m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "verifypeer", "false");
 
+    AddHeaders(kodiProps.GetCommonHeaders());
+
     // Add session cookies
     // NOTE: if kodi property inputstream.adaptive.stream_headers is set with "cookie" header
     // the cookies set by the property will replace these


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
add `inputstream.adaptive.common_headers` new property
example:

`#KODIPROP:inputstream.adaptive.common_headers=User-Agent=theuseragentstringencoded&other=encodedvalue`

to note that headers add to `common_headers` prop, can be overwritten by the other `stream_headers`, ...and all others, if they contains the same header name

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
make life easier to users/devs
over time it often happens that users do not read the wiki, or do not understand the difference between stream and manifest,
since we manage HTTP headers/parametes separately for
- manifest requests
- stream requests (audio/video/subs data)
- license requests

this lead to problems as e.g. #1684 #1686 

this separate header management has been implemented for special use cases,
but it is often the case that services require only “user-agent” as a prerequisite for all HTTP requests
so let's provide a way to set common headers for all cases above mentioned,
so without the needs to add them to each separate property

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
