### PR TITLE
[cmakelists] Symbol visibility hidden (-fvisibility=hidden)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ else()
   list(APPEND DEPLIBS ${CMAKE_DL_LIBS})
   # Required on some old linux platforms to use macro like PRIu64
   add_definitions(-D__STDC_FORMAT_MACROS)
+  # Force symbol visibility hidden by default for operative systems different than Windows,
+  # by default on Windows is hidden, on linux is the opposite, and lead to have singleton static objects
+  # stored in memory in a persistent way between all ISAdaptive instances (kodi core dlopen/dlclose)
+  add_compile_options(-fvisibility=hidden)
 endif()
 
 # Sources to build


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
User noticed weird behaviour under linux only
when you play a widevine video and after a clearkey video this last one dont works anymore resulting in various errors,
this is only an example but the problem is reproducible in several similar ways with different DRM's

the problem are the static variables, in particular there is a singleton, the service broker
https://github.com/xbmc/inputstream.adaptive/blob/68003021d71243fec3a1619c0c9dccb22017ae5f/src/SrvBroker.h#L59-L63

then problem raise because shared libraries under linux (opened by kodi core with dlopen/dlclose) by default export static data in order to be shared/linked to all instances of the library, this cause that the second time that you play a video the service broker contains the data of the first video played and so cause any kind of weirdness, errors, etc...

this problem under Windows dont happens because by default symbols are internal (hidden)

there are different ways to "hide" symbols i chosen to add compiler parameter `-fvisibility=hidden` to apply it globally

side note:
im not sure because i have not time to test it on a LibreELEC device but there is possibility that could fix #454 about "Permanent failure" error, see comment https://github.com/xbmc/inputstream.adaptive/issues/727#issuecomment-872103229, where seem that widevine library could have static variables

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1704
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
builded on ubuntu then,
1) play widevine video
2) play clearkey video
3) the second video must be played without problem

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
