### PR TITLE
[FragmentedSampleReader] Check default_isProtected before add senc

### DIFF
--- a/src/common/AdaptiveUtils.cpp
+++ b/src/common/AdaptiveUtils.cpp
@@ -133,7 +133,10 @@ AP4_Movie* PLAYLIST::CreateMovieAtom(adaptive::AdaptiveStream& adStream,
       defaultKid = DRM::ConvertKidStrToBytes(psshSet.defaultKID_);
 
     AP4_ContainerAtom schi{AP4_ATOM_TYPE_SCHI};
-    schi.AddChild(new AP4_TencAtom(AP4_CENC_CIPHER_AES_128_CTR, 8, defaultKid.data()));
+    // Note TENC default_isProtected parameter is intentionally set to 0 (not encrypted)
+    // this is to prevent CFragmentedSampleReader::ProcessMoof from trying to create a SENC atom
+    // and so avoid decrypting with a CAdaptiveCencSampleDecrypter
+    schi.AddChild(new AP4_TencAtom(0, 8, defaultKid.data()));
     sampleDesc = new AP4_ProtectedSampleDescription(0, sampleDesc, 0,
                                                     AP4_PROTECTION_SCHEME_TYPE_PIFF, 0, "", &schi);
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
PR #1688 introduced a kind of workaround to add SENC box when missing
this caused a kind of problem with smoothstreaming

smoothstreaming as usual is a bit shitting format
since dont have initialization segment a custom MOOV box is created manually from
https://github.com/xbmc/inputstream.adaptive/blob/c77b4061214de2c41779a1516bab25f93d7c91bf/src/common/AdaptiveUtils.cpp#L76-L78

the problem is a bit wide, i think that FragmentedSampleReader code can be potentially improved
but its impossible to me make a good code cleanup and or a better fix
since atm i dont have at my hand all streams that i can use to test all use cases

this part of code is as cat and mice
https://github.com/xbmc/inputstream.adaptive/blob/c77b4061214de2c41779a1516bab25f93d7c91bf/src/samplereader/FragmentedSampleReader.cpp#L391-L409
we need to check for missing SENC before call `AP4_CencSampleInfoTable::Create` to prevent that Create method to fails
but on Issue thread the smoothstreaming (playready) manifest converted to widevine, must not use `CAdaptiveCencSampleDecrypter`,
since the video stream of the Issue dont have SAIZ/SAIO/SENC,  SENC is so created,
and if i understand correctly this seem to prevent the use of widevine decrypter from `CFragmentedSampleReader::ReadSample()`

as kind of solution i have set TENC `default_isProtected` parameter to 0 that means "not encrypted", this is not so clean solution, but i have no better ideas atm since i have no way to make tests for each use case

anyway TENC `default_isProtected` parameter is not so important to bento4 source code, and also we dont have code that depends from it, then should be a kind of solution that at least does not produce side effects

Sidenote: TENC `default_isProtected` on bento4 allow to have values different from 0 and 1, its weird,
looks like bento4 `default_isProtected` param support is a sort of custom implementation that dont follow the MP4 standard
at least im not able to find similar specs

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1708 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
user tested his SS video
and some segments are here [IssueSegments.zip](https://github.com/user-attachments/files/17588907/IssueSegments.zip)

another use case is from sample provided by PR #1688

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
