### PR TITLE
[HLS] Fix misaligned periods update for VOD and crash

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -937,6 +937,18 @@ std::string SESSION::CSession::GetCDMSession(unsigned int index)
   return m_cdmSessions[index].m_sessionId;
 }
 
+std::shared_ptr<Adaptive_CencSingleSampleDecrypter> SESSION::CSession::GetSingleSampleDecryptor(
+    unsigned int index) const
+{
+  if (index >= m_cdmSessions.size())
+  {
+    LOG::LogF(LOGERROR, "Index %u out of range, cannot get single sample decrypter", index);
+    return nullptr;
+  }
+
+  return m_cdmSessions[index].m_cencSingleSampleDecrypter;
+}
+
 uint64_t SESSION::CSession::PTSToElapsed(uint64_t pts)
 {
   if (m_timingStream)
@@ -1268,14 +1280,21 @@ bool SESSION::CSession::OnGetStream(int streamid, kodi::addon::InputstreamInfo& 
     if (psshSetPos != PSSHSET_POS_DEFAULT ||
         stream->m_adStream.getPeriod()->GetEncryptionState() == EncryptionState::NOT_SUPPORTED)
     {
-      if (!GetSingleSampleDecryptor(psshSetPos))
+      // NOTE "psshSetPos < m_cdmSessions.size()" CONDITION:
+      // is required because the GetNextRepresentation method called by AdaptiveStream "ensure segment" method
+      // can change stream quality that download new manifests, parsing new manifests may add new PSSH's,
+      // so there will be a higher psshSetPos value than m_cdmSessions
+      // this happens for HLS case because the m_cdmSessions is updated with OpenStream.
+      // On DEMUX_SPECIALID_STREAMCHANGE event Kodi query all streams by calling GetStream in advance
+      // than OpenStream so there is a higher psshSetPos value and GetSingleSampleDecryptor cannot get a ptr
+      if (psshSetPos < m_cdmSessions.size() && !GetSingleSampleDecryptor(psshSetPos))
       {
         // If the stream is protected with a unsupported DRM, we have to stop the playback,
         // since there are no ways to stop playback when Kodi request streams
         // we are forced to delete all CStream's here, so that when demux reader will starts
         // will have no data to process, and so stop the playback
         // (other streams may have been requested/opened before this one)
-        LOG::Log(LOGERROR, "GetStream(%d): Decrypter for the stream not found");
+        LOG::Log(LOGERROR, "GetStream(%d): Decrypter for the stream not found", streamid);
         DeleteStreams();
         return false;
       }

--- a/src/Session.h
+++ b/src/Session.h
@@ -136,10 +136,8 @@ public:
    *  \param index The index (psshSet number) of the cdm session
    *  \return The single sample decrypter
    */
-  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> GetSingleSampleDecryptor(unsigned int index) const
-  {
-    return m_cdmSessions[index].m_cencSingleSampleDecrypter;
-  }
+  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> GetSingleSampleDecryptor(
+      unsigned int index) const;
 
   /*! \brief Get the decrypter (DRM lib)
    *  \return The decrypter

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -447,6 +447,14 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
   size_t adpSetPos = GetPtrPosition(period->GetAdaptationSets(), adp);
   size_t reprPos = GetPtrPosition(adp->GetRepresentations(), rep);
 
+  if (!m_isLive)
+  {
+    // VOD streaming must be updated always from the first period
+    period = m_periods[0].get();
+    adp = period->GetAdaptationSets()[adpSetPos].get();
+    rep = adp->GetRepresentations()[reprPos].get();
+  }
+
   rep->SetBaseUrl(sourceUrl);
 
   EncryptionType currentEncryptionType = EncryptionType::NONE;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
### commit 1: Fix misaligned periods update
to reproduce easily the problem use HLS VOD with multiperiods
and set "Stream selection type" to "Manual OSD"
while in playback use kodi GUI to change video stream quality
you can see that when quality change the chapters increase and sometimes other oddities and errors in the log appear
even sometimes the playback becomes unstable,
imo it could be not the best fix, i do not currently have the patience to invest days to do something better, since i have pending other tasks

the problem is that ProcessChildManifest is called e.g. from OnStreamChange with current period/rep
this is ok for live stream but with VOD there are static periods, if you provide the current period e.g. 2
it start to parse manifest and update data from period 2 onwards but manifest periods start from 1, this cause big mess and misaligned periods data

### commit 2:
to reproduce the problem is needed an HLS VOD with multiperiods and DRM
and is required to have more streams with differents PSSH (so the use case of D+)
then set "Stream selection type" to "Test" in order to switch stream quality automatically to trigger the DEMUX_SPECIALID_STREAMCHANGE
I added the explanation of the problem in the code, because it is a particular case that might not be so straightforward to understand

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1707
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with D+ and user confirmed

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
