### PR TITLE
[SampleReader][cleanups] Separate Get/Set stream id methods

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,13 +248,15 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
 
   ContainerType reprContainerType = rep->GetContainerType();
   uint32_t mask = (1U << stream->m_info.GetStreamType()) | m_session->GetIncludedStreamMask();
-  auto reader = ADP::CreateStreamReader(reprContainerType, stream, static_cast<uint32_t>(streamid), mask);
+  auto reader = ADP::CreateStreamReader(reprContainerType, stream, mask);
 
   if (!reader)
   {
     m_session->EnableStream(stream, false);
     return false;
   }
+
+  reader->SetStreamId(stream->m_info.GetStreamType(), streamid);
 
   uint16_t psshSetPos = stream->m_adStream.getRepresentation()->m_psshSetPos;
   reader->SetDecrypter(m_session->GetSingleSampleDecryptor(psshSetPos),

--- a/src/main.h
+++ b/src/main.h
@@ -57,7 +57,7 @@ public:
 
 private:
   std::shared_ptr<SESSION::CSession> m_session;
-  std::map<INPUTSTREAM_TYPE, unsigned int> m_IncludedStreams;
+  std::map<INPUTSTREAM_TYPE, int> m_IncludedStreams; // stream type - stream id
   int m_failedSeekTime = ~0;
   std::string m_chapterName;
   // The last PTS of the segment package fed to kodi.

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -10,10 +10,8 @@
 
 #include "AdaptiveByteStream.h"
 
-CADTSSampleReader::CADTSSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
-  : ADTSReader{input},
-    m_streamId{streamId},
-    m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)}
+CADTSSampleReader::CADTSSampleReader(AP4_ByteStream* input)
+  : ADTSReader{input}, m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)}
 {
 }
 

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -15,7 +15,7 @@ class CAdaptiveByteStream;
 class ATTR_DLL_LOCAL CADTSSampleReader : public ISampleReader, public ADTSReader
 {
 public:
-  CADTSSampleReader(AP4_ByteStream* input, AP4_UI32 streamId);
+  CADTSSampleReader(AP4_ByteStream* input);
 
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
@@ -32,7 +32,6 @@ public:
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 90000; }
-  AP4_UI32 GetStreamId() const override { return m_streamId; }
   AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
   const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
   uint64_t GetDuration() const override { return (ADTSReader::GetDuration() * 100) / 9; }
@@ -41,7 +40,6 @@ public:
 private:
   bool m_eos{false};
   bool m_started{false};
-  AP4_UI32 m_streamId;
   uint64_t m_pts{0};
   int64_t m_ptsDiff{0};
   uint64_t m_ptsOffs{~0ULL};

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -35,11 +35,8 @@ constexpr uint8_t MP4_TFRFBOX_UUID[] = {0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46
 
 CFragmentedSampleReader::CFragmentedSampleReader(AP4_ByteStream* input,
                                                  AP4_Movie* movie,
-                                                 AP4_Track* track,
-                                                 AP4_UI32 streamId)
-  : AP4_LinearReader{*movie, input},
-    m_track{track},
-    m_streamId{streamId}
+                                                 AP4_Track* track)
+  : AP4_LinearReader{*movie, input}, m_track{track}
 {
 }
 

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -18,10 +18,7 @@ class CodecHandler;
 class ATTR_DLL_LOCAL CFragmentedSampleReader : public ISampleReader, public AP4_LinearReader
 {
 public:
-  CFragmentedSampleReader(AP4_ByteStream* input,
-                         AP4_Movie* movie,
-                         AP4_Track* track,
-                         AP4_UI32 streamId);
+  CFragmentedSampleReader(AP4_ByteStream* input, AP4_Movie* movie, AP4_Track* track);
 
   ~CFragmentedSampleReader();
 
@@ -36,7 +33,6 @@ public:
   bool IsStarted() const override { return m_started; }
   uint64_t DTS() const override { return m_dts; }
   uint64_t PTS() const override { return m_pts; }
-  AP4_UI32 GetStreamId() const override { return m_streamId; }
   AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); }
   const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); }
   uint64_t GetDuration() const override;
@@ -61,7 +57,6 @@ private:
 
   AP4_Track* m_track;
   AP4_UI32 m_poolId{0};
-  AP4_UI32 m_streamId;
   AP4_UI32 m_sampleDescIndex{1};
   DRM::DecrypterCapabilites m_decrypterCaps;
   unsigned int m_failCount{0};

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -77,13 +77,16 @@ public:
   virtual bool GetFragmentInfo(uint64_t& duration) { return false; }
 
   virtual uint32_t GetTimeScale() const = 0;
-  virtual AP4_UI32 GetStreamId() const = 0;
+
+  virtual int GetStreamId() const { return m_streamId; }
+  virtual void SetStreamId(INPUTSTREAM_TYPE type, int streamId) { m_streamId = streamId; }
+
   virtual AP4_Size GetSampleDataSize() const = 0;
   virtual const AP4_Byte* GetSampleData() const = 0;
   virtual uint64_t GetDuration() const = 0;
   virtual bool IsEncrypted() const = 0;
-  virtual void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) {};
-  virtual void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) {};
+  virtual void AddStreamType(INPUTSTREAM_TYPE type, int streamId) {}
+  virtual void SetStreamType(INPUTSTREAM_TYPE type, int streamId) {}
   virtual bool RemoveStreamType(INPUTSTREAM_TYPE type) { return true; };
   virtual bool IsStarted() const = 0;
   virtual CryptoInfo GetReaderCryptoInfo() const { return CryptoInfo(); }
@@ -123,4 +126,5 @@ protected:
 
 private:
   std::future<AP4_Result> m_readSampleAsyncState;
+  int m_streamId{0};
 };

--- a/src/samplereader/SampleReaderFactory.cpp
+++ b/src/samplereader/SampleReaderFactory.cpp
@@ -24,27 +24,25 @@ using namespace PLAYLIST;
 
 std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& containerType,
                                                        SESSION::CStream* stream,
-                                                       uint32_t streamId,
                                                        uint32_t includedStreamMask)
 {
   std::unique_ptr<ISampleReader> reader;
 
   if (containerType == ContainerType::TEXT)
   {
-    reader = std::make_unique<CSubtitleSampleReader>(streamId);
+    reader = std::make_unique<CSubtitleSampleReader>();
   }
   else if (containerType == ContainerType::TS)
   {
-    reader = std::make_unique<CTSSampleReader>(
-        stream->GetAdByteStream(), stream->m_info.GetStreamType(), streamId, includedStreamMask);
+    reader = std::make_unique<CTSSampleReader>(stream->GetAdByteStream(), includedStreamMask);
   }
   else if (containerType == ContainerType::ADTS)
   {
-    reader = std::make_unique<CADTSSampleReader>(stream->GetAdByteStream(), streamId);
+    reader = std::make_unique<CADTSSampleReader>(stream->GetAdByteStream());
   }
   else if (containerType == ContainerType::WEBM)
   {
-    reader = std::make_unique<CWebmSampleReader>(stream->GetAdByteStream(), streamId);
+    reader = std::make_unique<CWebmSampleReader>(stream->GetAdByteStream());
   }
   else if (containerType == ContainerType::MP4)
   {
@@ -85,8 +83,7 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
       return nullptr;
     }
 
-    reader = std::make_unique<CFragmentedSampleReader>(stream->GetAdByteStream(), movie, track,
-                                                       streamId);
+    reader = std::make_unique<CFragmentedSampleReader>(stream->GetAdByteStream(), movie, track);
   }
   else
   {
@@ -110,7 +107,7 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
       stream->m_adStream.getRepresentation()->SetContainerType(containerType);
 
       stream->GetAdByteStream()->Seek(0); // Seek because bytes are consumed from previous reader
-      reader = std::make_unique<CADTSSampleReader>(stream->GetAdByteStream(), streamId);
+      reader = std::make_unique<CADTSSampleReader>(stream->GetAdByteStream());
       if (!reader->Initialize(stream))
         reader.reset();
     }

--- a/src/samplereader/SampleReaderFactory.h
+++ b/src/samplereader/SampleReaderFactory.h
@@ -28,13 +28,11 @@ namespace ADP
  * \brief Create and initialize a sample stream reader for the specified container
  * \param containerType The type of stream container, the value could be changed if the type is wrong
  * \param stream The stream object that will use the reader
- * \param streamId The stream id
  * \param includedStreamMask The flags for included streams
  * \return The sample reader if has success, otherwise nullptr
  */
 std::unique_ptr<ISampleReader> CreateStreamReader(PLAYLIST::ContainerType& containerType,
                                                   SESSION::CStream* stream,
-                                                  uint32_t streamId,
                                                   uint32_t includedStreamMask);
 
 } // namespace ADP

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -27,10 +27,6 @@
 using namespace PLAYLIST;
 using namespace UTILS;
 
-CSubtitleSampleReader::CSubtitleSampleReader(AP4_UI32 streamId) : m_streamId{streamId}
-{
-}
-
 bool CSubtitleSampleReader::Initialize(SESSION::CStream* stream)
 {
 

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -27,7 +27,7 @@ class AdaptiveStream;
 class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
 {
 public:
-  CSubtitleSampleReader(AP4_UI32 streamId);
+  CSubtitleSampleReader() = default;
 
   virtual bool Initialize(SESSION::CStream* stream) override;
   bool IsStarted() const override { return m_started; }
@@ -44,7 +44,6 @@ public:
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   void SetPTSDiff(uint64_t pts) override;
   uint32_t GetTimeScale() const override { return 1000; }
-  AP4_UI32 GetStreamId() const override { return m_streamId; }
   AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); }
   const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); }
   uint64_t GetDuration() const override { return m_sample.GetDuration() * 1000; }
@@ -55,7 +54,6 @@ private:
 
   uint64_t m_pts{0};
   int64_t m_ptsDiff{0};
-  AP4_UI32 m_streamId;
   bool m_eos{false};
   bool m_started{false};
   std::unique_ptr<CodecHandler> m_codecHandler;

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -10,14 +10,14 @@
 
 #include "AdaptiveByteStream.h"
 
-CTSSampleReader::CTSSampleReader(AP4_ByteStream* input,
-                               INPUTSTREAM_TYPE type,
-                               AP4_UI32 streamId,
-                               uint32_t requiredMask)
-  : TSReader{input, requiredMask},
-    m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)},
-    m_typeMask{1U << type}
+CTSSampleReader::CTSSampleReader(AP4_ByteStream* input, uint32_t requiredMask)
+  : TSReader{input, requiredMask}, m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)}
 {
+}
+
+void CTSSampleReader::SetStreamId(INPUTSTREAM_TYPE type, int streamId)
+{
+  m_typeMask = 1U << type;
   m_typeMap[INPUTSTREAM_TYPE_NONE] = streamId;
   m_typeMap[type] = streamId;
 }
@@ -27,17 +27,17 @@ bool CTSSampleReader::Initialize(SESSION::CStream* stream)
   return TSReader::Initialize();
 }
 
-void CTSSampleReader::AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid)
+void CTSSampleReader::AddStreamType(INPUTSTREAM_TYPE type, int streamId)
 {
-  m_typeMap[type] = sid;
+  m_typeMap[type] = streamId;
   m_typeMask |= (1 << type);
   if (m_started)
     StartStreaming(m_typeMask);
 }
 
-void CTSSampleReader::SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid)
+void CTSSampleReader::SetStreamType(INPUTSTREAM_TYPE type, int streamId)
 {
-  m_typeMap[type] = sid;
+  m_typeMap[type] = streamId;
   m_typeMask = (1 << type);
 }
 

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -15,14 +15,11 @@ class CAdaptiveByteStream;
 class ATTR_DLL_LOCAL CTSSampleReader : public ISampleReader, public TSReader
 {
 public:
-  CTSSampleReader(AP4_ByteStream* input,
-                  INPUTSTREAM_TYPE type,
-                  AP4_UI32 streamId,
-                  uint32_t requiredMask);
+  CTSSampleReader(AP4_ByteStream* input, uint32_t requiredMask);
 
   bool Initialize(SESSION::CStream* stream) override;
-  void AddStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
-  void SetStreamType(INPUTSTREAM_TYPE type, uint32_t sid) override;
+  void AddStreamType(INPUTSTREAM_TYPE type, int streamId) override;
+  void SetStreamType(INPUTSTREAM_TYPE type, int streamId) override;
   bool RemoveStreamType(INPUTSTREAM_TYPE type) override;
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
@@ -39,15 +36,18 @@ public:
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 90000; }
-  AP4_UI32 GetStreamId() const override { return m_typeMap[GetStreamType()]; }
+
+  int GetStreamId() const override { return m_typeMap[GetStreamType()]; }
+  void SetStreamId(INPUTSTREAM_TYPE type, int streamId) override;
+
   AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
   const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
   uint64_t GetDuration() const override { return (TSReader::GetDuration() * 100) / 9; }
   bool IsEncrypted() const override { return false; }
 
 private:
-  uint32_t m_typeMask; //Bit representation of INPUTSTREAM_TYPES
-  uint32_t m_typeMap[16];
+  uint32_t m_typeMask{0}; //Bit representation of INPUTSTREAM_TYPES
+  int m_typeMap[16]{};
   uint64_t m_pts{0};
   uint64_t m_dts{0};
   uint64_t m_ptsOffs{~0ULL};

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -10,10 +10,8 @@
 
 #include "AdaptiveByteStream.h"
 
-CWebmSampleReader::CWebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId)
-  : WebmReader{input},
-    m_streamId{streamId},
-    m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)} {};
+CWebmSampleReader::CWebmSampleReader(AP4_ByteStream* input)
+  : WebmReader{input}, m_adByteStream{dynamic_cast<CAdaptiveByteStream*>(input)} {};
 
 bool CWebmSampleReader::Initialize(SESSION::CStream* stream)
 {

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -15,7 +15,7 @@ class CAdaptiveByteStream;
 class ATTR_DLL_LOCAL CWebmSampleReader : public ISampleReader, public WebmReader
 {
 public:
-  CWebmSampleReader(AP4_ByteStream* input, AP4_UI32 streamId);
+  CWebmSampleReader(AP4_ByteStream* input);
 
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
@@ -33,14 +33,12 @@ public:
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 1000; }
-  AP4_UI32 GetStreamId() const override { return m_streamId; }
   AP4_Size GetSampleDataSize() const override { return GetPacketSize(); }
   const AP4_Byte* GetSampleData() const override { return GetPacketData(); }
   uint64_t GetDuration() const override { return WebmReader::GetDuration() * 1000; }
   bool IsEncrypted() const override { return false; }
 
 private:
-  AP4_UI32 m_streamId;
   uint64_t m_pts{0};
   uint64_t m_dts{0};
   uint64_t m_ptsOffs{~0ULL};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Separate Get/Set stream id methods
so that its possible set streamid without use the factory

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
on the future drm rework for the drm autoselection im moving this code
https://github.com/xbmc/inputstream.adaptive/blob/397a0c1307bb138d7130e202d5434c2c2a9116cd/src/main.cpp#L246-L257
in to `Session::PrepareStream` (PrepareStream method will be used to initialize drm for all types of manifests)

this is required because currently there is CFragmentedSampleReader that needs `reader->SetDecrypter`
on the rework code GetSingleSampleDecryptor/GetDecrypterCaps dont exists anymore
and i need to get them by using session id that on main.cpp on new code cannot be achieved without adding additional methods which in my opinion are not necessary

along this change i changed all vars types by using int everywhere, since kodi interface use int only

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
