### PR TITLE
Moved extradata conversions to more appropriate places

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -701,24 +701,7 @@ void SESSION::CSession::UpdateStream(CStream& stream)
   stream.m_info.SetExtraData(nullptr, 0);
 
   if (!rep->GetCodecPrivateData().empty())
-  {
-    std::vector<uint8_t> annexb;
-    const std::vector<uint8_t>* extraData(&annexb);
-
-    const DRM::DecrypterCapabilites& caps{GetDecrypterCaps(rep->m_psshSetPos)};
-
-    if ((caps.flags & DRM::DecrypterCapabilites::SSD_ANNEXB_REQUIRED) &&
-        stream.m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
-    {
-      LOG::Log(LOGDEBUG, "UpdateStream: Convert avc -> annexb");
-      annexb = AvcToAnnexb(rep->GetCodecPrivateData());
-    }
-    else
-    {
-      extraData = &rep->GetCodecPrivateData();
-    }
-    stream.m_info.SetExtraData(extraData->data(), extraData->size());
-  }
+    stream.m_info.SetExtraData(rep->GetCodecPrivateData());
 
   stream.m_info.SetCodecFourCC(0);
   stream.m_info.SetBitRate(rep->GetBandwidth());

--- a/src/codechandler/AVCCodecHandler.h
+++ b/src/codechandler/AVCCodecHandler.h
@@ -13,7 +13,9 @@
 class ATTR_DLL_LOCAL AVCCodecHandler : public CodecHandler
 {
 public:
-  AVCCodecHandler(AP4_SampleDescription* sd);
+  AVCCodecHandler(AP4_SampleDescription* sd, bool isRequiredAnnexB);
+
+  bool CheckExtraData(std::vector<uint8_t>& extraData, bool isRequiredAnnexB) override;
   bool ExtraDataToAnnexB() override;
   void UpdatePPSId(const AP4_DataBuffer& buffer) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;

--- a/src/codechandler/CodecHandler.h
+++ b/src/codechandler/CodecHandler.h
@@ -34,6 +34,16 @@ public:
    */
   virtual bool GetInformation(kodi::addon::InputstreamInfo& info);
   virtual bool ExtraDataToAnnexB() { return false; };
+  /*!
+   * \brief Check for extradata data format, if needed it will be converted
+   * \param extraData The data
+   * \param isRequiredAnnexB If the extradata must be in annex b format
+   * \return True if data is changed, otherwise false
+   */
+  virtual bool CheckExtraData(std::vector<uint8_t>& extraData, bool isRequiredAnnexB)
+  {
+    return false;
+  }
   virtual STREAMCODEC_PROFILE GetProfile() { return STREAMCODEC_PROFILE::CodecProfileNotNeeded; };
   virtual bool Transform(AP4_UI64 pts, AP4_UI32 duration, AP4_DataBuffer& buf, AP4_UI64 timescale)
   {

--- a/src/codechandler/HEVCCodecHandler.h
+++ b/src/codechandler/HEVCCodecHandler.h
@@ -13,8 +13,9 @@
 class ATTR_DLL_LOCAL HEVCCodecHandler : public CodecHandler
 {
 public:
-  HEVCCodecHandler(AP4_SampleDescription* sd);
+  HEVCCodecHandler(AP4_SampleDescription* sd, bool isRequiredAnnexB);
 
+  bool CheckExtraData(std::vector<uint8_t>& extraData, bool isRequiredAnnexB) override;
   bool ExtraDataToAnnexB() override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
 };

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -747,8 +747,11 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
 
   // ISA custom attribute
   // No dash spec, looks like a custom Amazon video service implementation
-  repr->SetCodecPrivateData(
-      UTILS::AnnexbToAvc(XML::GetAttrib(nodeRepr, "codecPrivateData").data()));
+  std::string codecPrivateData;
+  if (XML::QueryAttrib(nodeRepr, "codecPrivateData", codecPrivateData))
+  {
+    repr->SetCodecPrivateData(STRING::HexToBytes(codecPrivateData));
+  }
 
   // ISA custom attribute
   repr->SetSampleRate(XML::GetAttribUint32(nodeRepr, "audioSamplingRate"));

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -323,14 +323,7 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
   std::string codecPrivateData;
   if (XML::QueryAttrib(nodeQI, "CodecPrivateData", codecPrivateData))
   {
-    const auto& codecs = repr->GetCodecs();
-    if (CODEC::Contains(codecs, CODEC::FOURCC_HEVC) ||
-        CODEC::Contains(codecs, CODEC::FOURCC_HEV1) || CODEC::Contains(codecs, CODEC::FOURCC_HVC1))
-    {
-      repr->SetCodecPrivateData(AnnexbToHvcc(codecPrivateData.c_str()));
-    }
-    else
-      repr->SetCodecPrivateData(AnnexbToAvc(codecPrivateData.c_str()));
+    repr->SetCodecPrivateData(STRING::HexToBytes(codecPrivateData));
   }
 
   if (CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_AACL) && repr->GetCodecPrivateData().empty())

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "StringUtils.h"
+#include "log.h"
 
 #include "kodi/tools/StringUtils.h"
 
@@ -332,4 +333,24 @@ std::string UTILS::STRING::Trim(std::string value)
 {
   StringUtils::Trim(value);
   return value;
+}
+
+std::vector<uint8_t> UTILS::STRING::HexToBytes(const std::string& hex)
+{
+  std::vector<uint8_t> bytes;
+  if (hex.size() % 2 != 0)
+  {
+    // Handle error for strings with an odd number of characters
+    LOG::LogF(LOGERROR, "Cannot convert hex to bytes, string length is not valid");
+    return bytes;
+  }
+
+  for (size_t i = 0; i < hex.size(); i += 2)
+  {
+    unsigned char highNibble = ToHexNibble(hex[i]);
+    unsigned char lowNibble = ToHexNibble(hex[i + 1]);
+    bytes.emplace_back((highNibble << 4) | lowNibble);
+  }
+
+  return bytes;
 }

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -283,5 +283,12 @@ std::string ToHexadecimal(const std::vector<uint8_t> data);
  */
 std::string Trim(std::string value);
 
+/*!
+ * \brief Convert a hex string to bytes.
+ * \param hex The hex string
+ * \return The string on its byte representation
+ */
+std::vector<uint8_t> HexToBytes(const std::string& hex);
+
 } // namespace STRING
 } // namespace UTILS

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -22,8 +22,9 @@ constexpr uint8_t DEFAULT_KEYID[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 // Placeholder for unknown AP4_Track id
 constexpr uint32_t AP4_TRACK_ID_UNKNOWN = -1;
 
-std::vector<uint8_t> AnnexbToHvcc(const char* b16Data);
-std::vector<uint8_t> AnnexbToAvc(const char* b16Data);
+std::vector<uint8_t> AnnexbToHvcc(const std::vector<uint8_t>& annexb);
+std::vector<uint8_t> AnnexbToAvc(const std::vector<uint8_t>& annexb);
+bool IsAnnexB(const std::vector<uint8_t>& data);
 std::vector<uint8_t> AvcToAnnexb(const std::vector<uint8_t>& avc);
 
 void ParseHeaderString(std::map<std::string, std::string>& headerMap, const std::string& header);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The main problem that has required these changes is that
following check for SSD_ANNEXB_REQUIRED require drm  to be already initialized
https://github.com/xbmc/inputstream.adaptive/blob/9d7d90a4e137a9d8bade808708ef197cb8b5cdfb/src/Session.cpp#L710-L716

reasons:
1) with HLS the DRM is initialized elsewhere, and this will not work at playback startup, this is not documented in the code and is difficult to understand without studying the whole messy things in depth, although it “should” never be used for HLS could be a difficult thing to check in future
2) with the future drm rework the DRM is always initialized in similar way as now happens with HLS, so a code change is required
3) avoid that parsers have the task to convert extradata, and leave this task to codec handlers when possible

other changes:
- on converters such as `AnnexbToHvcc` etc... has been moved out the hex conversion code in the HexToBytes method, which has nothing to do with them
- On smoothstreaming parser the CodecPrivateData was always converted from annexb to Avcc when the codec was not hevc, this was a bad behaviour that could lead to problems with other codecs, now removed

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleanups required for the future drm auto selection rework

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on ISA Samples addon i tested Smoothstreaming VOD  (without DRM) that have extradata on the manifest
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
