### PR TITLE
Implement DRM auto-selection

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -164,14 +164,7 @@ msgctxt "#30171"
 msgid "Defines the initial bandwidth when it cannot be automatically determined. This value can be overridden by the minimum bandwidth setting."
 msgstr ""
 
-msgctxt "#30172"
-msgid "Ignore HDCP status"
-msgstr ""
-
-#. Description of setting with label #30172
-msgctxt "#30173"
-msgid "Some DRM-protected HD / UHD videos may only be played if the HDCP status is ignored."
-msgstr ""
+#empty strings from id 30171 to 30173
 
 #. To set the stream selection type (refer to RepresentationChooser's)
 msgctxt "#30174"

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -161,13 +161,6 @@
           </control>
         </setting>
       </group>
-      <group id="misc">
-        <setting id="HDCPOVERRIDE" type="boolean" label="30172" help="30173">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-      </group>
     </category>
     <category id="expert" label="30120">
       <group id="misc">

--- a/plugin.video.isasamples/menu_data.py
+++ b/plugin.video.isasamples/menu_data.py
@@ -353,7 +353,7 @@ menu_data = {
                     'drm': '{"org.w3.clearkey": {"license": {"keyids": {"feedf00deedeadbeeff0baadf00dd00d": "00112233445566778899aabbccddeeff", "1234f00deedeadbeeff0baadf00dd00d": "8899aabbccddeeff8899aabbccddeeff"}}}}',
                 }
             },
-            'Bitmovin art of motion [widevine to clear key, keys on property]': {
+            'Bitmovin art of motion [WV to CK, keys on property]': {
                 SI_ENCRYPT: 'DRMCK',
                 SI_INFO: 'Override widevine content protection to use clear key',
                 SI_CONFIG: {
@@ -585,6 +585,15 @@ menu_data = {
                     'license_key': 'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(persist:false,sl:150)',
                     'drm_legacy': 'com.microsoft.playready|https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(persist:false,sl:150)',
                     'drm': '{"com.microsoft.playready": {"license": {"server_url": "https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(persist:false,sl:150)"}}}'
+                }
+            },
+            'Microsoft tears of steel 4k [PR to CK, keys on property]': {
+                SI_ENCRYPT: 'DRMCK',
+                SI_INFO: 'Override PlayReady content protection to use ClearKey',
+                SI_CONFIG: {
+                    'manifest_url': 'https://test.playready.microsoft.com/media/profficialsite/tearsofsteel_4k.ism.smoothstreaming/manifest',
+                    'drm_legacy': 'org.w3.clearkey|6f651ae1dbe44434bcb4690d1564c41c:88da852ae4fa2e1e36aeb2d5c94997b1',
+                    'drm': '{"org.w3.clearkey": {"license": {"keyids": {"6f651ae1dbe44434bcb4690d1564c41c": "88da852ae4fa2e1e36aeb2d5c94997b1"}}}}',
                 }
             },
         },

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -21,12 +21,13 @@
 #include <rapidjson/document.h>
 
 using namespace UTILS;
+using namespace ADP::KODI_PROPS;
 
 namespace
 {
 // clang-format off
-constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type"; //! @todo: to be deprecated
-constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"; //! @todo: to be deprecated
+constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type"; //! @todo: deprecated to be removed on Kodi 23
+constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"; //! @todo: deprecated to be removed on Kodi 23
 // PROP_LICENSE_URL and PROP_LICENSE_URL_APPEND has been added as workaround for Kodi PVR API bug
 // where limit property values to max 1024 chars, if exceeds the string is truncated.
 // Since some services provide license urls that exceeds 1024 chars,
@@ -36,9 +37,9 @@ constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"
 // -> this problem has been fixed on Kodi 22
 constexpr std::string_view PROP_LICENSE_URL = "inputstream.adaptive.license_url"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_LICENSE_URL_APPEND = "inputstream.adaptive.license_url_append"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data"; //! @todo: to be deprecated
-constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags"; //! @todo: to be deprecated
-constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate"; //! @todo: to be deprecated
+constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data"; //! @todo: deprecated to be removed on Kodi 23
+constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags"; //! @todo: deprecated to be removed on Kodi 23
+constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate"; //! @todo: deprecated to be removed on Kodi 23
 
 constexpr std::string_view PROP_COMMON_HEADERS = "inputstream.adaptive.common_headers";
 
@@ -53,7 +54,7 @@ constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_he
 constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: to be deprecated
+constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: deprecated to be removed on Kodi 23
 
 constexpr std::string_view PROP_CONFIG = "inputstream.adaptive.config";
 constexpr std::string_view PROP_DRM = "inputstream.adaptive.drm";
@@ -280,9 +281,23 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
     else
     {
       auto first = m_drmConfigs.begin();
-      first->second.license.serverUrl = licenseUrl;
+      first->second.license.serverUri = licenseUrl;
     }
   }
+}
+
+bool ADP::KODI_PROPS::CCompKodiProps::HasDrmConfig(std::string_view keySystem) const
+{
+  return STRING::KeyExists(m_drmConfigs, keySystem);
+}
+
+const ADP::KODI_PROPS::DrmCfg ADP::KODI_PROPS::CCompKodiProps::GetDrmConfig(
+    std::string_view keySystem) const
+{
+  if (STRING::KeyExists(m_drmConfigs, keySystem))
+    return m_drmConfigs.at(keySystem.data());
+
+  return {}; // default values
 }
 
 void ADP::KODI_PROPS::CCompKodiProps::ParseConfig(const std::string& data)
@@ -313,6 +328,38 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseConfig(const std::string& data)
     else if (configName == "internal_cookies" && jDictVal.IsBool())
     {
       m_config.internalCookies = jDictVal.GetBool();
+    }
+    else if (configName == "check_hdcp" && jDictVal.IsString())
+    {
+      std::string_view value = jDictVal.GetString();
+
+      if (value.empty() || value == "default")
+        m_config.hdcpCheck = HdcpCheckType::DEFAULT;
+      else if (value == "license")
+        m_config.hdcpCheck = HdcpCheckType::LICENSE;
+      else
+        LOG::LogF(LOGERROR, "Value \"%s\" isnt supported on \"%s\" config of \"%s\" property",
+                  value.data(), configName.c_str(), PROP_MANIFEST_CONFIG.data());
+    }
+    else if (configName == "resolution_limit" && jDictVal.IsString())
+    {
+      std::string_view value = jDictVal.GetString();
+      if (!value.empty())
+      {
+        auto pos = value.find('x');
+        if (pos != std::string_view::npos)
+        {
+          const int width = STRING::ToInt32(value.substr(0, pos));
+          const int height = STRING::ToInt32(value.substr(pos + 1));
+          m_config.resolutionLimit = width * height;
+        }
+        else
+        {
+          LOG::LogF(LOGERROR,
+                    "Invalid resolution format \"%s\" on \"%s\" config of \"%s\" property",
+                    value.data(), configName.c_str(), PROP_MANIFEST_CONFIG.data());
+        }
+      }
     }
     else
     {
@@ -379,9 +426,7 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
 
   if (!STRING::KeyExists(props, PROP_LICENSE_TYPE))
     return;
-  /*
-   *! @todo: TO UNCOMMENT WHEN DRM AUTO-SELECTION WILL BE FULL IMPLEMENTED
-   *
+
   LOG::Log(LOGWARNING, "<<<<<<<<< DEPRECATION NOTICE >>>>>>>>>\n"
                        "DEPRECATED PROPERTIES HAS BEEN USED TO SET THE DRM CONFIGURATION.\n"
                        "THE FOLLOWING PROPERTIES WILL BE REMOVED FROM FUTURE KODI VERSIONS:\n"
@@ -392,11 +437,11 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
                        "- inputstream.adaptive.server_certificate\n"
                        "- inputstream.adaptive.pre_init_data\n"
                        "YOU SHOULD CONSIDER MIGRATING TO THE NEW PROPERTIES:\n"
-                       "- inputstream.adaptive.drm\n"
                        "- inputstream.adaptive.drm_legacy\n"
+                       "- inputstream.adaptive.drm\n"
                        "FOR MORE INFO, PLEASE READ THE WIKI PAGE: "
                        "https://github.com/xbmc/inputstream.adaptive/wiki/Integration-DRM");
-  */
+
   std::string drmKeySystem{DRM::KS_NONE};
   if (STRING::KeyExists(props, PROP_LICENSE_TYPE))
     drmKeySystem = props.at(PROP_LICENSE_TYPE.data());
@@ -426,6 +471,8 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
 
   // As legacy behaviour its expected to force the unique drm configuration available
   drmCfg.priority = 1;
+  // As legacy behaviour force single session (as in the old ISA versions <= v21)
+  drmCfg.isForceSingleSession = true;
 
   // Parse DRM properties
   const bool isRedacted = !CSrvBroker::GetSettings().IsDebugVerbose();
@@ -485,7 +532,7 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
     {
       // Field 1: License server url
       if (fieldCount >= 1)
-        drmCfg.license.serverUrl = fields[0];
+        drmCfg.license.serverUri = fields[0];
 
       // Field 2: HTTP request headers
       if (fieldCount >= 2)
@@ -567,8 +614,8 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
             // Position 2: The dict Key name to get HDCP value (optional)
             if (jPaths.size() >= 2)
             {
-              drmCfg.license.unwrapperParams["path_hdcp_traverse"] = "true";
-              drmCfg.license.unwrapperParams["path_hdcp"] = jPaths[1];
+              drmCfg.license.unwrapperParams["path_hdcp_res_traverse"] = "true";
+              drmCfg.license.unwrapperParams["path_hdcp_res"] = jPaths[1];
             }
           }
         }
@@ -608,7 +655,7 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
       continue;
     }
 
-    DrmCfg& drmCfg = m_drmConfigs[keySystem];
+    DrmCfg& drmCfg = m_drmConfigs[keySystem]; // create new configuration
     auto& jDictVal = jChildObj.value;
 
     if (!jDictVal.IsObject())
@@ -621,6 +668,9 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
     // Parse main DRM config
 
     LogDrmJsonDictKeys("main", jDictVal, keySystem);
+
+    if (jDictVal.HasMember("force_single_session") && jDictVal["force_single_session"].IsBool())
+      drmCfg.isForceSingleSession = jDictVal["force_single_session"].GetBool();
 
     if (jDictVal.HasMember("persistent_storage") && jDictVal["persistent_storage"].IsBool())
       drmCfg.isPersistentStorage = jDictVal["persistent_storage"].GetBool();
@@ -663,7 +713,7 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
         drmCfg.license.serverCert = jDictLic["server_certificate"].GetString();
 
       if (jDictLic.HasMember("server_url") && jDictLic["server_url"].IsString())
-        drmCfg.license.serverUrl = jDictLic["server_url"].GetString();
+        drmCfg.license.serverUri = jDictLic["server_url"].GetString();
 
       if (jDictLic.HasMember("use_http_get_request") && jDictLic["use_http_get_request"].IsBool())
         drmCfg.license.isHttpGetRequest = jDictLic["use_http_get_request"].GetBool();
@@ -687,11 +737,21 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
       {
         for (auto& jPairUnwrap : jDictLic["unwrapper_params"].GetObject()) // Iterate JSON dict
         {
-          if (jPairUnwrap.name.IsString() && jPairUnwrap.value.IsString())
+          if (!jPairUnwrap.name.IsString() ||
+              !(jPairUnwrap.value.IsString() || jPairUnwrap.value.IsBool()))
           {
-            drmCfg.license.unwrapperParams.emplace(jPairUnwrap.name.GetString(),
-                                                   jPairUnwrap.value.GetString());
+            LOG::LogF(LOGERROR,
+                      "The license parameter \"unwrapper_params\" contains invalid values");
+            break;
           }
+
+          std::string value;
+          if (jPairUnwrap.value.IsString())
+            value = jPairUnwrap.value.GetString();
+          else if (jPairUnwrap.value.IsBool())
+            value = jPairUnwrap.value.GetBool() ? "true" : "false";
+
+          drmCfg.license.unwrapperParams.emplace(jPairUnwrap.name.GetString(), value);
         }
       }
 
@@ -704,9 +764,6 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmConfig(const std::string& data)
         }
       }
     }
-
-    //! @todo: temporary support only one DRM config, must be reworked the CSession for DRM auto-selection
-    break;
   }
 
   return true;
@@ -752,9 +809,9 @@ bool ADP::KODI_PROPS::CCompKodiProps::ParseDrmLegacyConfig(const std::string& da
 
   if (!licenseStr.empty())
   {
-    if (URL::IsValidUrl(licenseStr)) // License server URL
+    if (URL::IsValidUrl(licenseStr) || URL::IsValidUri(licenseStr)) // License server URI
     {
-      drmCfg.license.serverUrl = licenseStr;
+      drmCfg.license.serverUri = licenseStr;
     }
     else // Assume are keyid's for ClearKey DRM
     {

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -35,6 +35,12 @@ struct ChooserProps
   std::pair<int, int> m_resolutionSecureMax; // Res. limit for DRM protected videos (values 0 means auto)
 };
 
+enum class HdcpCheckType
+{
+  DEFAULT,
+  LICENSE, // To check HDCP values from DRM license response
+};
+
 // Generic add-on configuration
 struct Config
 {
@@ -43,6 +49,10 @@ struct Config
   bool curlSSLVerifyPeer{true};
   // Determines if cookies are internally handled by InputStream Adaptive add-on
   bool internalCookies{false};
+  // Determines how HDCP should be checked
+  HdcpCheckType hdcpCheck{HdcpCheckType::DEFAULT};
+  // Force limit resolutions of manifest streams to the specified value included (value in px, height x width)
+  int resolutionLimit{0};
 };
 
 struct ManifestConfig
@@ -78,13 +88,15 @@ struct DrmCfg
   std::optional<bool> isSecureDecoderEnabled;
   // Optional parameters to make the CDM key request (CDM specific parameters)
   std::map<std::string, std::string> optKeyReqParams;
+  // Enforce the use of a single session (license is assumed to return all keys in one request)
+  bool isForceSingleSession{false};
 
   struct License
   {
     // The license server certificate encoded as base64
     std::string serverCert;
-    // The license server url
-    std::string serverUrl;
+    // The license server uri
+    std::string serverUri;
     // To force an HTTP GET request, instead that POST request
     bool isHttpGetRequest{false};
     // HTTP request headers
@@ -152,20 +164,13 @@ public:
   // \brief Specifies the manifest configuration
   const ManifestConfig& GetManifestConfig() const { return m_manifestConfig; }
 
+  // \brief Checks whether there is a DRM configuration for the specified key system
+  bool HasDrmConfig(std::string_view keySystem) const;
 
-  //! @todo: temporary method, for future rework
-  const std::string GetDrmKeySystem()
-  {
-    return m_drmConfigs.empty() ? "" : m_drmConfigs.begin()->first;
-  }
-  //! @todo: temporary method, for future rework
-  const DrmCfg& GetDrmConfig() { return m_drmConfigs[GetDrmKeySystem()]; }
+  // \brief Gets the DRM configuration for the specified keysystem. If not found, returns default values.
+  const DrmCfg GetDrmConfig(std::string_view keySystem) const;
 
-
-  // \brief Get DRM configuration for specified keysystem, if not found will return default values
-  const DrmCfg& GetDrmConfig(const std::string& keySystem) { return m_drmConfigs[keySystem]; }
-  const DrmCfg& GetDrmConfig(std::string_view keySystem) { return m_drmConfigs[std::string(keySystem)]; }
-
+  // \brief Gets the DRM configurations (Key System, DRM config)
   const std::map<std::string, DrmCfg>& GetDrmConfigs() const { return m_drmConfigs; }
 
 private:

--- a/src/CompSettings.cpp
+++ b/src/CompSettings.cpp
@@ -18,11 +18,6 @@
 using namespace ADP::SETTINGS;
 using namespace UTILS;
 
-bool ADP::SETTINGS::CCompSettings::IsHdcpOverride() const
-{
-  return kodi::addon::GetSettingBoolean("HDCPOVERRIDE");
-}
-
 StreamSelMode ADP::SETTINGS::CCompSettings::GetStreamSelMode() const
 {
   const std::string mode = kodi::addon::GetSettingString("adaptivestream.streamselection.mode");

--- a/src/CompSettings.h
+++ b/src/CompSettings.h
@@ -42,8 +42,6 @@ public:
   CCompSettings() = default;
   ~CCompSettings() = default;
 
-  bool IsHdcpOverride() const;
-
   // Chooser's settings
 
   StreamSelMode GetStreamSelMode() const;

--- a/src/Iaes_decrypter.h
+++ b/src/Iaes_decrypter.h
@@ -26,7 +26,7 @@ public:
                        size_t dstOffset,
                        size_t& dataSize,
                        bool lastChunk) = 0;
-  virtual std::string convertIV(const std::string& input) = 0;
+  virtual std::vector<uint8_t> convertIV(const std::string& input) = 0;
   virtual void ivFromSequence(uint8_t* buffer, uint64_t sid) = 0;
   // virtual const std::string& getLicenseKey() const = 0;
   // virtual bool RenewLicense(const std::string& pluginUrl) = 0;

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -15,8 +15,10 @@
 #include "common/AdaptiveDecrypter.h"
 #include "common/AdaptiveTreeFactory.h"
 #include "common/Chooser.h"
+#include "common/ReprSelector.h"
 #include "decrypters/DrmFactory.h"
 #include "decrypters/Helpers.h"
+#include "samplereader/SampleReaderFactory.h"
 #include "utils/Base64Utils.h"
 #include "utils/CurlUtils.h"
 #include "utils/StringUtils.h"
@@ -33,7 +35,7 @@ SESSION::CSession::~CSession()
 {
   LOG::Log(LOGDEBUG, "CSession::~CSession()");
   DeleteStreams();
-  DisposeDecrypter();
+  m_drmEngine.Dispose();
 
   if (m_adaptiveTree)
   {
@@ -50,48 +52,7 @@ void SESSION::CSession::DeleteStreams()
 {
   LOG::Log(LOGDEBUG, "CSession::DeleteStreams()");
   m_streams.clear();
-}
-
-void SESSION::CSession::SetSupportedDecrypterURN(std::vector<std::string_view>& keySystems)
-{
-  std::string decrypterPath = CSrvBroker::GetSettings().GetDecrypterPath();
-  if (decrypterPath.empty())
-  {
-    LOG::Log(LOGWARNING, "Decrypter path not set in the add-on settings");
-    return;
-  }
-
-  const std::string keySystem = CSrvBroker::GetKodiProps().GetDrmKeySystem();
-  m_decrypter = DRM::FACTORY::GetDecrypter(GetCryptoKeySystem(keySystem));
-  if (!m_decrypter)
-    return;
-
-  if (!m_decrypter->Initialize())
-  {
-    LOG::Log(LOGERROR, "The decrypter library cannot be initialized.");
-    return;
-  }
-
-  keySystems = m_decrypter->SelectKeySystems(keySystem);
-  m_decrypter->SetLibraryPath(decrypterPath);
-}
-
-void SESSION::CSession::DisposeSampleDecrypter()
-{
-  if (m_decrypter)
-  {
-    for (auto& cdmSession : m_cdmSessions)
-    {
-      cdmSession.m_sessionId.clear();
-      cdmSession.m_cencSingleSampleDecrypter = nullptr;
-    }
-  }
-}
-
-void SESSION::CSession::DisposeDecrypter()
-{
-  DisposeSampleDecrypter();
-  m_decrypter = nullptr;
+  m_timingStream = nullptr;
 }
 
 /*----------------------------------------------------------------------
@@ -119,37 +80,18 @@ bool SESSION::CSession::Initialize(std::string manifestUrl)
   }
 
   auto& kodiProps = CSrvBroker::GetKodiProps();
-
-  // Get URN's wich are supported by this addon
-  std::vector<std::string_view> supportedKeySystems;
-  if (!kodiProps.GetDrmKeySystem().empty())
-  {
-    SetSupportedDecrypterURN(supportedKeySystems);
-    for (std::string_view keySystem : supportedKeySystems)
-    {
-      LOG::Log(LOGDEBUG, "Supported URN: %s", keySystem.data());
-    }
-  }
-
   std::map<std::string, std::string> manifestHeaders = kodiProps.GetManifestHeaders();
-  bool isSessionOpened{false};
 
-  // Preinitialize the DRM, if pre-initialisation data are provided
-  if (!kodiProps.GetDrmConfig().preInitData.empty())
+  m_drmEngine.Initialize();
+
+  DRM::DRMSession session;
+  // Pre-initialize the DRM allow to generate the challenge and session ID data
+  // used to make licensed manifest requests
+  if (m_drmEngine.PreInitializeDRM(session))
   {
-    std::string challengeB64;
-    std::string sessionId;
-    // Pre-initialize the DRM allow to generate the challenge and session ID data
-    // used to make licensed manifest requests (via proxy callback)
-    if (PreInitializeDRM(challengeB64, sessionId, isSessionOpened))
-    {
-      manifestHeaders["challengeB64"] = STRING::URLEncode(challengeB64);
-      manifestHeaders["sessionId"] = sessionId;
-    }
-    else
-    {
-      return false;
-    }
+    // The following are custom headers that must be handled through a proxy server
+    manifestHeaders["challengeB64"] = STRING::URLEncode(session.challenge);
+    manifestHeaders["sessionId"] = session.id;
   }
 
   URL::RemovePipePart(manifestUrl); // No pipe char uses, must be used Kodi properties only
@@ -175,7 +117,7 @@ bool SESSION::CSession::Initialize(std::string manifestUrl)
   if (!m_adaptiveTree)
     return false;
 
-  m_adaptiveTree->Configure(m_reprChooser, supportedKeySystems, kodiProps.GetManifestUpdParams());
+  m_adaptiveTree->Configure(m_reprChooser, kodiProps.GetManifestUpdParams());
 
   if (!m_adaptiveTree->Open(manifestResp.effectiveUrl, manifestResp.headers, manifestResp.data))
   {
@@ -188,380 +130,148 @@ bool SESSION::CSession::Initialize(std::string manifestUrl)
 
   CSrvBroker::GetInstance()->InitStage2(m_adaptiveTree);
 
-  return InitializePeriod(isSessionOpened);
+  InitializePeriod();
+
+  return true;
 }
 
-void SESSION::CSession::CheckHDCP()
+bool SESSION::CSession::CheckPlayableStreams()
 {
-  //! @todo: is needed to implement an appropriate CP check to
-  //! remove HDCPOVERRIDE setting workaround
-  if (m_cdmSessions.empty())
-    return;
+  auto& kodiPropCfg = CSrvBroker::GetKodiProps().GetConfig();
 
-  std::vector<DRM::DecrypterCapabilites> decrypterCaps;
-
-  for (const auto& cdmsession : m_cdmSessions)
+  /*! @todo: Code commented, see todo below about: "Secure path on audio stream is not implemented"
+   *
+  if (kodiPropCfg.resolutionLimit == 0 &&
+      kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::DEFAULT)
   {
-    decrypterCaps.emplace_back(cdmsession.m_decrypterCaps);
+    return;
   }
-
+  */
   uint32_t adpIndex{0};
   CAdaptationSet* adp{nullptr};
 
   while ((adp = m_adaptiveTree->GetAdaptationSet(adpIndex++)))
   {
-    if (adp->GetStreamType() != StreamType::VIDEO)
-      continue;
-
-    for (auto itRepr = adp->GetRepresentations().begin();
-         itRepr != adp->GetRepresentations().end();)
+    for (auto& repr : adp->GetRepresentations())
     {
-      CRepresentation* repr = (*itRepr).get();
-
-      const DRM::DecrypterCapabilites& ssd_caps = decrypterCaps[repr->m_psshSetPos];
-
-      if (repr->GetHdcpVersion() > ssd_caps.hdcpVersion ||
-          (ssd_caps.hdcpLimit > 0 && repr->GetWidth() * repr->GetHeight() > ssd_caps.hdcpLimit))
+      //! @todo: Code changed, see todo below about: "Secure path on audio stream is not implemented"
+      // if (kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::LICENSE &&
+      //     !m_adaptiveTree->IsReqPrepareStream())
+      if (!m_adaptiveTree->IsReqPrepareStream())
       {
-        LOG::Log(LOGDEBUG, "Representation ID \"%s\" removed as not HDCP compliant",
-                 repr->GetId().data());
-        itRepr = adp->GetRepresentations().erase(itRepr);
-      }
-      else
-        itRepr++;
-    }
-  }
-}
-
-bool SESSION::CSession::PreInitializeDRM(std::string& challengeB64,
-                                         std::string& sessionId,
-                                         bool& isSessionOpened)
-{
-  auto& drmPropCfg = CSrvBroker::GetKodiProps().GetDrmConfig();
-
-  std::string psshData;
-  std::string kidData;
-  // Parse the PSSH/KID data
-  size_t posSplitter = drmPropCfg.preInitData.find("|");
-  if (posSplitter != std::string::npos)
-  {
-    psshData = drmPropCfg.preInitData.substr(0, posSplitter);
-    kidData = drmPropCfg.preInitData.substr(posSplitter + 1);
-  }
-
-  if (psshData.empty() || kidData.empty())
-  {
-    LOG::LogF(LOGERROR, "Invalid DRM pre-init data, must be as: {PSSH as base64}|{KID as base64}");
-    return false;
-  }
-
-  m_cdmSessions.resize(2);
-
-  // Try to initialize an SingleSampleDecryptor
-  LOG::LogF(LOGDEBUG, "Entering encryption section");
-
-  if (!m_decrypter)
-  {
-    LOG::LogF(LOGERROR, "No decrypter found for encrypted stream");
-    return false;
-  }
-
-  if (!m_decrypter->IsInitialised())
-  {
-    DRM::Config drmCfg = DRM::CreateDRMConfig(DRM::KS_WIDEVINE, drmPropCfg);
-    if (!m_decrypter->OpenDRMSystem(drmCfg))
-    {
-      LOG::LogF(LOGERROR, "OpenDRMSystem failed");
-      return false;
-    }
-  }
-
-  std::vector<uint8_t> initData;
-
-  // Set the provided PSSH
-  initData = BASE64::Decode(psshData);
-
-  // Decode the provided KID
-  const std::vector<uint8_t> decKid = BASE64::Decode(kidData);
-
-  CCdmSession& session(m_cdmSessions[1]);
-
-  std::string hexKid{STRING::ToHexadecimal(decKid)};
-  LOG::LogF(LOGDEBUG, "Initializing session with KID: %s", hexKid.c_str());
-
-  if (m_decrypter && (session.m_cencSingleSampleDecrypter =
-                          m_decrypter->CreateSingleSampleDecrypter(initData, decKid, "", true,
-                                                                   CryptoMode::AES_CTR)) != nullptr)
-  {
-    session.m_sessionId = session.m_cencSingleSampleDecrypter->GetSessionId();
-    sessionId = session.m_sessionId;
-    challengeB64 = m_decrypter->GetChallengeB64Data(session.m_cencSingleSampleDecrypter);
-  }
-  else
-  {
-    LOG::LogF(LOGERROR, "Initialize failed (SingleSampleDecrypter)");
-    session.m_cencSingleSampleDecrypter = nullptr;
-    return false;
-  }
-#if defined(ANDROID)
-  // On android is not possible add the default KID key
-  // then we cannot re-use same session
-  DisposeSampleDecrypter();
-#else
-  isSessionOpened = true;
-#endif
-  return true;
-}
-
-bool SESSION::CSession::InitializeDRM(bool addDefaultKID /* = false */)
-{
-  bool isSecureVideoSession{false};
-  m_cdmSessions.resize(m_adaptiveTree->m_currentPeriod->GetPSSHSets().size());
-
-  // Try to initialize an SingleSampleDecryptor
-  if (m_adaptiveTree->m_currentPeriod->GetEncryptionState() == EncryptionState::ENCRYPTED_DRM)
-  {
-    const std::string keySystem = CSrvBroker::GetKodiProps().GetDrmKeySystem();
-    auto& drmPropCfg = CSrvBroker::GetKodiProps().GetDrmConfig();
-
-    DRM::Config drmCfg = DRM::CreateDRMConfig(keySystem, drmPropCfg);
-
-    if (drmCfg.license.serverUrl.empty())
-      drmCfg.license.serverUrl = m_adaptiveTree->GetLicenseUrl();
-
-    LOG::Log(LOGDEBUG, "Entering encryption section");
-
-    if (!m_decrypter)
-    {
-      LOG::Log(LOGERROR, "No decrypter found for encrypted stream");
-      return false;
-    }
-
-    if (!m_decrypter->IsInitialised())
-    {
-      if (!m_decrypter->OpenDRMSystem(drmCfg))
-      {
-        LOG::Log(LOGERROR, "OpenDRMSystem failed");
-        return false;
-      }
-    }
-
-    // cdmSession 0 is reserved for unencrypted streams
-    for (size_t ses{1}; ses < m_cdmSessions.size(); ++ses)
-    {
-      CCdmSession& session{m_cdmSessions[ses]};
-
-      // Check if the decrypter has been previously initialized, if so skip it,
-      // sessions are collected and never removed and InitializeDRM can be called more times
-      // depending on how it is used:
-      // 1) CSession::Initialize->InitializePeriod->InitializeDRM - Used by DASH/SS (single call)
-      // 2) CInputStreamAdaptive::DemuxRead->m_session->InitializePeriod()->InitializeDRM - On chapter change (single call)
-      // 3) CInputStreamAdaptive::OpenStream->m_session->PrepareStream->InitializeDRM - Used by HLS (a call for each stream)
-      if (session.m_cencSingleSampleDecrypter)
-        continue;
-
-      const CPeriod::PSSHSet& sessionPsshset = m_adaptiveTree->m_currentPeriod->GetPSSHSets()[ses];
-
-      if (sessionPsshset.adaptation_set_->GetStreamType() == StreamType::NOTYPE)
-        continue;
-
-      std::vector<uint8_t> initData = sessionPsshset.pssh_;
-      std::string defaultKidStr = sessionPsshset.defaultKID_;
-
-      std::vector<uint8_t> customInitData = BASE64::Decode(drmPropCfg.initData);
-
-      if (m_adaptiveTree->GetTreeType() == adaptive::TreeType::SMOOTH_STREAMING &&
-          keySystem == DRM::KS_WIDEVINE)
-      {
-        if (DRM::IsValidPsshHeader(customInitData))
+        // The LICENSE method assume that a service provide in the license response the HDCP parameters
+        // currently a comparison is made between the license HDCP values and the one provided by the manifest.
+        // To do it you have to initialize the DRM to handle all streams,
+        // this could be expensive to do since you can request a license for each stream
+        if (!repr->DrmInfos().empty())
         {
-          initData = customInitData;
-        }
-        else
-        {
-          LOG::Log(LOGDEBUG, "License data: Create Widevine PSSH for SmoothStreaming %s",
-                   customInitData.empty() ? "" : "(with custom data)");
+          kodi::addon::InputstreamInfo isInfo;
+          DRM::DRMInfo initDrmInfo;
 
-          initData =
-              DRM::PSSH::MakeWidevine({DRM::ConvertKidStrToBytes(defaultKidStr)}, customInitData);
-        }
-      }
-      else if (!customInitData.empty())
-      {
-        // Custom license PSSH data provided from property
-        // This can allow to initialize a DRM that could be also not specified
-        // as supported in the manifest (e.g. missing DASH ContentProtection tags)
-        LOG::Log(LOGDEBUG, "License data: Use PSSH data provided by the license data property");
-        initData = customInitData;
-      }
-
-      // If no KID, but init data, extract the KID from init data
-      if (!initData.empty() && defaultKidStr.empty())
-      {
-        DRM::PSSH parser;
-        if (parser.Parse(initData) && !parser.GetKeyIds().empty())
-        {
-          LOG::Log(LOGDEBUG, "Default KID parsed from init data");
-          defaultKidStr = STRING::ToHexadecimal(parser.GetKeyIds()[0]);
-        }
-      }
-
-      //! @todo: as is implemented InitializeDRM will initialize all PSSHSet's also when are not used,
-      //!   therefore ExtractStreamProtectionData can perform many (not needed) downloads of mp4 init files
-      if ((initData.empty() && keySystem != DRM::KS_CLEARKEY) || defaultKidStr.empty())
-      {
-        // Try extract the PSSH/KID from the stream
-        ExtractStreamProtectionData(sessionPsshset, defaultKidStr, initData,
-                                    m_adaptiveTree->m_supportedKeySystems);
-      }
-
-      const std::vector<uint8_t> defaultKid = DRM::ConvertKidStrToBytes(defaultKidStr);
-
-      if (addDefaultKID && ses == 1 && session.m_cencSingleSampleDecrypter)
-      {
-        // If the CDM has been pre-initialized, on non-android systems
-        // we use the same session opened then we have to add the current KID
-        // because the session has been opened with a different PSSH/KID
-        session.m_cencSingleSampleDecrypter->AddKeyId(defaultKid);
-        session.m_cencSingleSampleDecrypter->SetDefaultKeyId(defaultKid);
-      }
-
-      if (!defaultKid.empty())
-      {
-        LOG::Log(LOGDEBUG, "Initializing stream with KID: %s", defaultKidStr.c_str());
-
-        // If a decrypter has the default KID, re-use the same decrypter for also this session
-        for (size_t i{1}; i < ses; ++i)
-        {
-          if (m_decrypter->HasLicenseKey(m_cdmSessions[i].m_cencSingleSampleDecrypter, defaultKid))
+          if (m_drmEngine.InitializeSession(repr->DrmInfos(), DRM::DRMMediaType::VIDEO,
+                                            m_adaptiveTree->m_currentPeriod->IsSecureDecodeNeeded(),
+                                            isInfo, repr.get(), adp, false, initDrmInfo))
           {
-            session.m_cencSingleSampleDecrypter = m_cdmSessions[i].m_cencSingleSampleDecrypter;
-            break;
+            if (!isInfo.GetCryptoSession().GetSessionId().empty())
+            {
+              const auto session = m_drmEngine.GetSession(isInfo.GetCryptoSession().GetSessionId(),
+                                                          initDrmInfo.defaultKid);
+              if (session)
+              {
+                //! @todo: HACK REQUIRED BECAUSE ---> Secure path on audio stream is not implemented for CDM Widevine ONLY (non-android) <---
+                //! since audio streams that require Secure path decoder cannot be played
+                //! we have no way to distinguish which ones they are other than to do a KID test with the DRM for each stream,
+                //! this is an expensive method that could open many DRM sessions which will not be unused for playback.
+                //! When in a future this will be implemented, all this code should be cleanup and removed
+                //! and then leave it to CInputStreamAdaptive::OpenStream -> PrepareStream
+                //! the task to initialize DRM session only to the requested streams.
+                //! It can be tested e.g. with some Am@zon videos
+                auto& caps = session->capabilities;
+
+                if (!session->drm->IsSecureDecoderAudioSupported() &&
+                    adp->GetStreamType() == StreamType::AUDIO &&
+                    caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH)
+                {
+                  LOG::Log(LOGWARNING,
+                           "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", "
+                           "Secure path decoder on audio stream is not supported",
+                           repr->GetId().data(), adp->GetId().data());
+                  repr->isPlayable = false;
+                  continue;
+                }
+
+                // Note to HDCP check:
+                // HDCP check should be done by the DRM where in case of problems should block key's
+                // for example with Widevine you will get "output-restricted" to key status
+                // the following it's an additional check for custom manifest's
+                if (kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::LICENSE)
+                {
+                  if (repr->GetHdcpVersion() > caps.hdcpVersion ||
+                      (caps.hdcpLimit > 0 && repr->GetWidth() * repr->GetHeight() > caps.hdcpLimit))
+                  {
+                    LOG::Log(
+                        LOGWARNING,
+                        "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", as not HDCP compliant",
+                        repr->GetId().data(), adp->GetId().data());
+                    repr->isPlayable = false;
+                    continue;
+                  }
+
+                }
+              }
+            }
+          }
+          else
+          {
+            if (m_drmEngine.GetStatus() == DRM::EngineStatus::DRM_ERROR ||
+                m_drmEngine.GetStatus() == DRM::EngineStatus::DECRYPTER_ERROR)
+            {
+              return false; // return here, a bad status dont allow you to play streams
+            }
           }
         }
       }
-      else if (defaultKid.empty())
+      // Limit streams resolutions available on the manifest,
+      // some video services apply protections that limit playable resolutions,
+      // this is a kind of workaround to avoid playback errors or black screen,
+      //! @todo: these situations should be better handled in the DRM/session implementation
+      if (kodiPropCfg.resolutionLimit > 0)
       {
-        for (size_t i{1}; i < ses; ++i)
+        if (repr->GetWidth() * repr->GetHeight() > kodiPropCfg.resolutionLimit)
         {
-          if (sessionPsshset.pssh_ == m_adaptiveTree->m_currentPeriod->GetPSSHSets()[i].pssh_)
-          {
-            session.m_cencSingleSampleDecrypter = m_cdmSessions[i].m_cencSingleSampleDecrypter;
-            break;
-          }
+          LOG::Log(LOGWARNING,
+                   "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", it exceeds the resolution limits",
+                   repr->GetId().data(), adp->GetId().data());
+          repr->isPlayable = false;
         }
-        if (!session.m_cencSingleSampleDecrypter)
-        {
-          LOG::Log(LOGWARNING, "Initializing stream with unknown KID!");
-        }
-      }
-
-      if (session.m_cencSingleSampleDecrypter ||
-          (session.m_cencSingleSampleDecrypter = m_decrypter->CreateSingleSampleDecrypter(
-               initData, defaultKid, sessionPsshset.m_licenseUrl, false,
-               sessionPsshset.m_cryptoMode == CryptoMode::NONE ? CryptoMode::AES_CTR
-                                                               : sessionPsshset.m_cryptoMode)) !=
-              nullptr)
-      {
-        m_decrypter->GetCapabilities(session.m_cencSingleSampleDecrypter, defaultKid,
-                                     sessionPsshset.media_, session.m_decrypterCaps);
-
-        session.m_sessionId = session.m_cencSingleSampleDecrypter->GetSessionId();
-
-        if (session.m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_INVALID)
-        {
-          m_adaptiveTree->m_currentPeriod->RemovePSSHSet(static_cast<std::uint16_t>(ses));
-        }
-        else if (session.m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH)
-        {
-          isSecureVideoSession = true;
-
-          // Allow to disable the secure decoder
-          bool disableSecureDecoder = CSrvBroker::GetSettings().IsDisableSecureDecoder();
-          // but, DRM config can override it
-          if (drmPropCfg.isSecureDecoderEnabled.has_value())
-            disableSecureDecoder = !*drmPropCfg.isSecureDecoderEnabled;
-          // but, manifest config can override all others
-          if (m_adaptiveTree->m_currentPeriod->IsSecureDecodeNeeded().has_value())
-            disableSecureDecoder = !*m_adaptiveTree->m_currentPeriod->IsSecureDecodeNeeded();
-          if (disableSecureDecoder)
-          {
-            LOG::Log(LOGDEBUG, "Initialize DRM: Configured with secure decoder disabled");
-            session.m_decrypterCaps.flags &= ~DRM::DecrypterCapabilites::SSD_SECURE_DECODER;
-          }
-        }
-      }
-      else
-      {
-        LOG::Log(LOGERROR, "Initialize failed (SingleSampleDecrypter)");
-        for (size_t i(ses); i < m_cdmSessions.size(); ++i)
-          m_cdmSessions[i].m_cencSingleSampleDecrypter = nullptr;
-
-        return false;
       }
     }
   }
-
-  bool isHdcpOverride = CSrvBroker::GetSettings().IsHdcpOverride();
-  if (isHdcpOverride)
-    LOG::Log(LOGDEBUG, "Ignore HDCP status is enabled");
-
-  if (!isHdcpOverride)
-    CheckHDCP();
-
-  m_reprChooser->SetSecureSession(isSecureVideoSession);
 
   return true;
 }
 
-bool SESSION::CSession::InitializePeriod(bool isSessionOpened /* = false */)
+void SESSION::CSession::InitializePeriod()
 {
-  bool isPsshChanged{true};
-  bool isReusePssh{true};
-
   if (m_adaptiveTree->IsChangingPeriod())
   {
-    isPsshChanged =
-        !(m_adaptiveTree->m_currentPeriod->GetPSSHSets() == m_adaptiveTree->m_nextPeriod->GetPSSHSets());
-    isReusePssh = !isPsshChanged && m_adaptiveTree->m_nextPeriod->GetEncryptionState() ==
-                                       EncryptionState::ENCRYPTED_DRM;
+    // Complete the transition into the new period
     m_adaptiveTree->m_currentPeriod = m_adaptiveTree->m_nextPeriod;
+    m_adaptiveTree->OnPeriodChange();
   }
 
   m_chapterStartTime = GetChapterStartTime();
 
-  if (m_adaptiveTree->m_currentPeriod->GetEncryptionState() == EncryptionState::NOT_SUPPORTED)
-  {
-    LOG::LogF(LOGERROR, "Unhandled encrypted stream.");
-    return false;
-  }
-
-  // create SESSION::STREAM objects. One for each AdaptationSet
+  // Clean to create new SESSION::STREAM objects. One for each AdaptationSet/Representation
   m_streams.clear();
 
-  if (!isPsshChanged)
-  {
-    if (isReusePssh)
-      LOG::Log(LOGDEBUG, "Reusing DRM psshSets for new period!");
-  }
-  else
-  {
-    if (isSessionOpened)
-    {
-      LOG::Log(LOGDEBUG, "New period, reinitialize by using same session");
-    }
-    else
-    {
-      LOG::Log(LOGDEBUG, "New period, dispose sample decrypter and reinitialize");
-      DisposeSampleDecrypter();
-    }
-
-    if (!InitializeDRM(isSessionOpened))
-      return false;
-  }
+  // Note: this could initialize DRM on all streams right here, instead of CInputStreamAdaptive::OpenStream
+  if (!CheckPlayableStreams())
+    return;
 
   uint32_t adpIndex{0};
   CAdaptationSet* adp{nullptr};
+
   CHOOSER::StreamSelection streamSelectionMode = m_reprChooser->GetStreamSelectionMode();
   //! @todo: GetAudioLangOrig property should be reworked to allow override or set
   //! manifest a/v and subtitles streams attributes such as default/original etc..
@@ -569,6 +279,11 @@ bool SESSION::CSession::InitializePeriod(bool isSessionOpened /* = false */)
   //! and some video services dont follow exactly the specs so can lead to wrong Kodi flags sets.
   //! An idea is add/move these override of attributes on post manifest parsing.
   std::string audioLanguageOrig = CSrvBroker::GetKodiProps().GetAudioLangOrig();
+
+  // For multi-codec manifests, determine which codec to use by default,
+  // then choose the appropriate AdaptationSet. It may also depend on the Chooser behavior.
+  CAdaptationSet* defVideoAdpSet = m_reprChooser->GetPreferredVideoAdpSet(
+      m_adaptiveTree->m_currentPeriod, DetermineDefaultAdpSet());
 
   while ((adp = m_adaptiveTree->GetAdaptationSet(adpIndex++)))
   {
@@ -589,7 +304,7 @@ bool SESSION::CSession::InitializePeriod(bool isSessionOpened /* = false */)
       isManualStreamSelection = streamSelectionMode == CHOOSER::StreamSelection::MANUAL;
 
     // Get the default initial stream repr. based on "adaptive repr. chooser"
-    auto defaultRepr{m_reprChooser->GetRepresentation(adp)};
+    CRepresentation* defaultRepr{m_reprChooser->GetRepresentation(adp)};
 
     if (isManualStreamSelection)
     {
@@ -601,7 +316,10 @@ bool SESSION::CSession::InitializePeriod(bool isSessionOpened /* = false */)
         uniqueId |= reprIndex << 16;
 
         CRepresentation* currentRepr = adp->GetRepresentations()[i].get();
-        bool isDefaultRepr{currentRepr == defaultRepr};
+        if (!currentRepr->isPlayable)
+          continue;
+
+        const bool isDefaultRepr{adp == defVideoAdpSet && currentRepr == defaultRepr}; // meant for video only
 
         AddStream(adp, currentRepr, isDefaultRepr, uniqueId, audioLanguageOrig);
       }
@@ -609,15 +327,18 @@ bool SESSION::CSession::InitializePeriod(bool isSessionOpened /* = false */)
     else
     {
       // Add the default stream representation only
+      if (!defaultRepr->isPlayable)
+        continue;
+
       size_t reprIndex{adp->GetRepresentations().size()};
       uint32_t uniqueId{adpIndex};
       uniqueId |= reprIndex << 16;
 
-      AddStream(adp, defaultRepr, true, uniqueId, audioLanguageOrig);
+      const bool isDefaultRepr{adp == defVideoAdpSet}; // meant for video only
+
+      AddStream(adp, defaultRepr, isDefaultRepr, uniqueId, audioLanguageOrig);
     }
   }
-
-  return true;
 }
 
 void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
@@ -703,7 +424,6 @@ void SESSION::CSession::UpdateStream(CStream& stream)
     return;
   }
 
-  stream.m_isEncrypted = rep->GetPsshSetPos() != PSSHSET_POS_DEFAULT;
   stream.m_info.SetExtraData(nullptr, 0);
 
   if (!rep->GetCodecPrivateData().empty())
@@ -860,29 +580,84 @@ void SESSION::CSession::UpdateStream(CStream& stream)
   stream.m_info.SetCodecInternalName(codecStr);
 }
 
-void SESSION::CSession::PrepareStream(CStream* stream)
+bool SESSION::CSession::PrepareStream(CStream* stream, uint64_t startPts)
 {
-  if (!m_adaptiveTree->IsReqPrepareStream())
-    return;
-
-  CRepresentation* repr = stream->m_adStream.getRepresentation();
   const EVENT_TYPE startEvent = stream->m_adStream.GetStartEvent();
+  CPeriod* period = stream->m_adStream.getPeriod();
+  CAdaptationSet* adp = stream->m_adStream.getAdaptationSet();
+  CRepresentation* repr = stream->m_adStream.getRepresentation();
 
   // Prepare the representation when the period change usually its not needed,
   // because the timeline is always already updated
-  if ((!m_adaptiveTree->IsChangingPeriod() || repr->Timeline().IsEmpty()) &&
-      (startEvent == EVENT_TYPE::STREAM_START || startEvent == EVENT_TYPE::STREAM_ENABLE))
+  if (m_adaptiveTree->IsReqPrepareStream())
   {
-    m_adaptiveTree->PrepareRepresentation(stream->m_adStream.getPeriod(),
-                                          stream->m_adStream.getAdaptationSet(), repr);
+    if ((!m_adaptiveTree->IsChangingPeriod() || repr->Timeline().IsEmpty()) &&
+        (startEvent == EVENT_TYPE::STREAM_START || startEvent == EVENT_TYPE::STREAM_ENABLE))
+    {
+      if (!m_adaptiveTree->PrepareRepresentation(period, adp, repr))
+        return false;
+    }
   }
 
-  if (stream->m_adStream.getPeriod()->GetEncryptionState() == EncryptionState::ENCRYPTED_DRM)
+  DRM::DRMInfo initDrmInfo;
+
+  if (!repr->DrmInfos().empty())
   {
-    InitializeDRM();
+    DRM::DRMMediaType drmMediaType{DRM::DRMMediaType::UNKNOWN};
+    const StreamType sType = adp->GetStreamType();
+
+    if (sType == StreamType::VIDEO || sType == StreamType::VIDEO_AUDIO)
+      drmMediaType = DRM::DRMMediaType::VIDEO;
+    else if (sType == StreamType::AUDIO)
+      drmMediaType = DRM::DRMMediaType::AUDIO;
+    else
+    {
+      LOG::LogF(LOGWARNING, "Stream media type \"%i\" is not supported by the DRM engine", sType);
+      return false;
+    }
+
+    if (!m_drmEngine.InitializeSession(repr->DrmInfos(), drmMediaType,
+                                       period->IsSecureDecodeNeeded(), stream->m_info, repr, adp,
+                                       m_adaptiveTree->IsChangingPeriod(), initDrmInfo))
+    {
+      return false;
+    }
   }
 
-  stream->m_isEncrypted = repr->GetPsshSetPos() != PSSHSET_POS_DEFAULT;
+  stream->m_adStream.start_stream(startPts);
+  stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
+
+  ContainerType reprContainerType = repr->GetContainerType();
+  uint32_t mask = (1U << stream->m_info.GetStreamType()) | GetIncludedStreamMask();
+  auto reader = ADP::CreateStreamReader(reprContainerType, stream, mask);
+
+  if (!reader)
+    return false;
+
+  const auto session = m_drmEngine.GetSession(stream->m_info.GetCryptoSession().GetSessionId(),
+                                              initDrmInfo.defaultKid);
+
+  if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::VIDEO_AUDIO)
+  {
+    m_reprChooser->SetSecureSession(session && session->capabilities.flags &
+                                                   DRM::DecrypterCapabilites::SSD_SECURE_PATH);
+  }
+
+  if (session)
+    reader->SetDecrypter(session->decrypter, session->capabilities);
+
+  stream->SetReader(std::move(reader));
+
+  if (reprContainerType == ContainerType::TS)
+  {
+    // With TS streams the elapsed time would be calculated incorrectly as during the tree refresh,
+    // nextSegment would be deleted by the FreeSegments/newsegments swap. Do this now before the tree refresh.
+    // Also, when reopening a stream (switching reps) the elapsed time would be incorrectly set until the
+    // second segment plays, now force a correct calculation at the start of the stream.
+    OnSegmentChanged(&stream->m_adStream);
+  }
+
+  return true;
 }
 
 void CSession::EnableStream(CStream* stream, bool enable)
@@ -901,40 +676,6 @@ void CSession::EnableStream(CStream* stream, bool enable)
 
     stream->Disable();
   }
-}
-
-bool SESSION::CSession::IsCDMSessionSecurePath(size_t index)
-{
-  if (index >= m_cdmSessions.size())
-  {
-    LOG::LogF(LOGERROR, "No CDM session at index %u", index);
-    return false;
-  }
-
-  return (m_cdmSessions[index].m_decrypterCaps.flags &
-          DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0;
-}
-
-std::string SESSION::CSession::GetCDMSession(unsigned int index)
-{
-  if (index >= m_cdmSessions.size())
-  {
-    LOG::LogF(LOGERROR, "No CDM session at index %u", index);
-    return {};
-  }
-  return m_cdmSessions[index].m_sessionId;
-}
-
-std::shared_ptr<Adaptive_CencSingleSampleDecrypter> SESSION::CSession::GetSingleSampleDecryptor(
-    unsigned int index) const
-{
-  if (index >= m_cdmSessions.size())
-  {
-    LOG::LogF(LOGERROR, "Index %u out of range, cannot get single sample decrypter", index);
-    return nullptr;
-  }
-
-  return m_cdmSessions[index].m_cencSingleSampleDecrypter;
 }
 
 uint64_t SESSION::CSession::PTSToElapsed(uint64_t pts)
@@ -1082,6 +823,9 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
 {
   bool ret{false};
 
+  if (m_streams.empty())
+    return false;
+
   //we don't have pts < 0 here and work internally with uint64
   if (seekTime < 0)
     seekTime = 0;
@@ -1194,7 +938,7 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
           double destTime{static_cast<double>(PTSToElapsed(streamReader->PTS())) /
                           STREAM_TIME_BASE};
           LOG::Log(LOGINFO,
-                   "Seek time %0.1lf for stream: %u (physical index %u) continues at %0.1lf "
+                   "Seek time %0.1lf for stream: %i (physical index %u) continues at %0.1lf "
                    "(PTS: %llu)",
                    seekTime, streamReader->GetStreamId(), stream->m_info.GetPhysicalIndex(),
                    destTime, streamReader->PTS());
@@ -1260,51 +1004,27 @@ void SESSION::CSession::OnStreamChange(adaptive::AdaptiveStream* adStream)
 
 bool SESSION::CSession::OnGetStream(int streamid, kodi::addon::InputstreamInfo& info)
 {
-  CStream* stream(GetStream(streamid - GetPeriodId() * 1000));
-
-  if (stream)
+  if (m_drmEngine.GetStatus() == DRM::EngineStatus::DRM_ERROR ||
+      m_drmEngine.GetStatus() == DRM::EngineStatus::DECRYPTER_ERROR)
   {
-    const uint16_t psshSetPos = stream->m_adStream.getRepresentation()->m_psshSetPos;
-    if (psshSetPos != PSSHSET_POS_DEFAULT ||
-        stream->m_adStream.getPeriod()->GetEncryptionState() == EncryptionState::NOT_SUPPORTED)
-    {
-      // NOTE "psshSetPos < m_cdmSessions.size()" CONDITION:
-      // is required because the GetNextRepresentation method called by AdaptiveStream "ensure segment" method
-      // can change stream quality that download new manifests, parsing new manifests may add new PSSH's,
-      // so there will be a higher psshSetPos value than m_cdmSessions
-      // this happens for HLS case because the m_cdmSessions is updated with OpenStream.
-      // On DEMUX_SPECIALID_STREAMCHANGE event Kodi query all streams by calling GetStream in advance
-      // than OpenStream so there is a higher psshSetPos value and GetSingleSampleDecryptor cannot get a ptr
-      if (psshSetPos < m_cdmSessions.size() && !GetSingleSampleDecryptor(psshSetPos))
-      {
-        // If the stream is protected with a unsupported DRM, we have to stop the playback,
-        // since there are no ways to stop playback when Kodi request streams
-        // we are forced to delete all CStream's here, so that when demux reader will starts
-        // will have no data to process, and so stop the playback
-        // (other streams may have been requested/opened before this one)
-        LOG::Log(LOGERROR, "GetStream(%d): Decrypter for the stream not found", streamid);
-        DeleteStreams();
-        return false;
-      }
-    }
+    // If the stream is protected with a unsupported DRM, we have to stop the playback,
+    // since there are no ways to stop playback when Kodi request streams
+    // we are forced to delete all CStream's here, so that when demux reader will starts
+    // will have no data to process, and so stop the playback
+    // (other streams may have been requested/opened before this one)
+    DeleteStreams();
+    return false;
+  }
+  else
+  {
+    CStream* stream = GetStream(streamid - GetPeriodId() * 1000);
+    if (!stream)
+      return false;
 
     info = stream->m_info;
-    return true;
   }
 
-  return false;
-}
-
-std::shared_ptr<Adaptive_CencSingleSampleDecrypter> SESSION::CSession::GetSingleSampleDecrypter(
-    std::string sessionId)
-{
-  for (std::vector<CCdmSession>::iterator b(m_cdmSessions.begin() + 1), e(m_cdmSessions.end());
-       b != e; ++b)
-  {
-    if (sessionId == b->m_sessionId)
-      return b->m_cencSingleSampleDecrypter;
-  }
-  return nullptr;
+  return true;
 }
 
 uint32_t SESSION::CSession::GetIncludedStreamMask() const
@@ -1445,98 +1165,33 @@ bool SESSION::CSession::SeekChapter(int ch)
   return false;
 }
 
-void SESSION::CSession::ExtractStreamProtectionData(const PLAYLIST::CPeriod::PSSHSet& psshSet,
-                                                    std::string& defaultKid,
-                                                    std::vector<uint8_t>& initData,
-                                                    const std::vector<std::string_view>& keySystems)
+PLAYLIST::CAdaptationSet* SESSION::CSession::DetermineDefaultAdpSet()
 {
-  auto initialRepr = m_reprChooser->GetRepresentation(psshSet.adaptation_set_);
+  //! @todo: this is a rough first implementation that have a fixed codec priority order,
+  //! and only for video streams. In the future it should be improved
+  //! for example check if hardware have capabilities and made it customizable,
+  //! since low-end devices may prefer older codecs such as H264 since they
+  //! do not require high-performance hardware to process the decoding.
+  //! The current sorting is intended just to limit bandwidth consumption
+  //! by prioritizing video codecs with high efficiency
+  const std::vector<std::string> videoCodecOrder = {
+      CODEC::FOURCC_DVHE, CODEC::FOURCC_HEV1, CODEC::FOURCC_DVH1, CODEC::FOURCC_HVC1,
+      CODEC::FOURCC_HEVC, CODEC::FOURCC_AV01, CODEC::NAME_AV1,    CODEC::FOURCC_VP09,
+      CODEC::NAME_VP9,    CODEC::FOURCC_AVC_, CODEC::FOURCC_H264};
 
-  if (initialRepr->GetContainerType() != ContainerType::MP4)
-    return;
-
-  LOG::LogF(LOGDEBUG, "Parse protection data from stream");
-  CStream stream{m_adaptiveTree, psshSet.adaptation_set_, initialRepr};
-
-  stream.m_isEnabled = true;
-  stream.m_adStream.start_stream();
-  stream.SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream.m_adStream));
-  stream.SetStreamFile(std::make_unique<AP4_File>(*stream.GetAdByteStream(),
-                                                  AP4_DefaultAtomFactory::Instance_, true));
-  AP4_Movie* movie{stream.GetStreamFile()->GetMovie()};
-  if (!movie)
+  for (auto& codecCC : videoCodecOrder)
   {
-    LOG::LogF(LOGERROR, "No MOOV atom in stream");
-    stream.Disable();
-    return;
-  }
-
-  AP4_Track* track =
-      movie->GetTrack(static_cast<AP4_Track::Type>(stream.m_adStream.GetTrackType()));
-
-  if (track) // Try extract the default KID from tenc / piff mp4 box
-  {
-    AP4_ProtectedSampleDescription* protSampleDesc =
-        static_cast<AP4_ProtectedSampleDescription*>(track->GetSampleDescription(0));
-
-    if (protSampleDesc)
+    CAdaptationSet* currAdp{nullptr};
+    uint32_t adpIndex{0};
+    while ((currAdp = m_adaptiveTree->GetAdaptationSet(adpIndex++)))
     {
-      AP4_ProtectionSchemeInfo* psi = protSampleDesc->GetSchemeInfo();
-      if (psi)
-      {
-        AP4_ContainerAtom* schi = protSampleDesc->GetSchemeInfo()->GetSchiAtom();
-        if (schi)
-        {
-          AP4_TencAtom* tenc =
-              AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0));
-          if (tenc)
-          {
-            defaultKid = STRING::ToHexadecimal(tenc->GetDefaultKid(), 16);
-          }
-          else
-          {
-            AP4_PiffTrackEncryptionAtom* piff =
-                AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom,
-                                 schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0));
-            if (piff)
-            {
-              defaultKid = STRING::ToHexadecimal(piff->GetDefaultKid(), 16);
-            }
-          }
-        }
-      }
+      if (currAdp->GetRepresentations().empty() || currAdp->GetStreamType() != StreamType::VIDEO)
+        continue;
+
+      if (CODEC::Contains(currAdp->GetCodecs(), codecCC))
+        return currAdp;
     }
   }
 
-  if (initData.empty() || defaultKid.empty())
-  {
-    const std::vector<std::string> systemIds = DRM::UrnsToSystemIds(keySystems);
-    AP4_Array<AP4_PsshAtom>& pssh{movie->GetPsshAtoms()};
-
-    for (unsigned int i = 0; i < pssh.ItemCount(); ++i)
-    {
-      AP4_PsshAtom& psshAtom = pssh[i];
-
-      std::string systemId = STRING::ToHexadecimal(psshAtom.GetSystemId(), 16);
-
-      // Check if the system id is supported
-      if (std::find(systemIds.cbegin(), systemIds.cend(), systemId) != systemIds.cend())
-      {
-        const AP4_DataBuffer& dataBuf = psshAtom.GetData();
-        const std::vector<uint8_t> psshData{dataBuf.GetData(),
-                                            dataBuf.GetData() + dataBuf.GetDataSize()};
-
-        initData = DRM::PSSH::Make(psshAtom.GetSystemId(), {}, psshData);
-
-        if (psshAtom.GetKid(0))
-        {
-          defaultKid = STRING::ToHexadecimal(pssh[i].GetKid(0), 16);
-        }
-
-        break;
-      }
-    }
-  }
-
-  stream.Disable();
+  return nullptr;
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -11,6 +11,7 @@
 #include "Stream.h"
 #include "common/AdaptiveStream.h"
 #include "common/AdaptiveTree.h"
+#include "decrypters/DrmEngine.h"
 #include "decrypters/IDecrypter.h"
 
 #if defined(ANDROID)
@@ -37,31 +38,12 @@ public:
    */
   bool Initialize(std::string manifestUrl);
 
-  /*
-   * \brief Check HDCP parameters to remove unplayable representations
-   */
-  void CheckHDCP();
+  bool CheckPlayableStreams();
 
-  /*! \brief Pre-Initialize the DRM
-   *  \param challengeB64 [OUT] Provide the challenge data as base64
-   *  \param sessionId [OUT] Provide the session ID
-   *  \param isSessionOpened [OUT] Will be true if the DRM session has been opened
-   *  \return True if has success, false otherwise
+  /*!
+   * \brief Initialize adaptive tree period
    */
-  bool PreInitializeDRM(std::string& challengeB64, std::string& sessionId, bool& isSessionOpened);
-
-  /*! \brief Initialize the DRM
-   *  \param addDefaultKID Set True to add the default KID to the first session
-   *  \return True if has success, false otherwise
-   */
-  bool InitializeDRM(bool addDefaultKID = false);
-
-  /*! \brief Initialize adaptive tree period
-   *  \param isSessionOpened Set True to kept and re-use the DRM session opened,
-   *         otherwise False to reinitialize the DRM session
-   *  \return True if has success, false otherwise
-   */
-  bool InitializePeriod(bool isSessionOpened = false);
+  void InitializePeriod();
 
   /*! \brief Get the sample reader of the next sample stream. This also set flags
    *         if the stream has changed, use CheckChange method to check it.
@@ -93,7 +75,7 @@ public:
    * \brief Update stream's InputstreamInfo
    * \param stream The stream to prepare
    */
-  void PrepareStream(CStream* stream);
+  bool PrepareStream(CStream* stream, uint64_t startPts);
 
   /*! \brief Get a stream by index (starting at 1)
    *  \param sid The one-indexed stream id
@@ -115,49 +97,10 @@ public:
    */
   unsigned int GetStreamCount() const { return static_cast<unsigned int>(m_streams.size()); }
 
-  /*!
-   * \brief Determines if the CDM session at specified index require Secure Path (TEE).
-   * \return True if Secure Path is required, otherwise false.
-   */
-  bool IsCDMSessionSecurePath(size_t index);
-
-  /*! \brief Get a session string (session id) by index from the cdm sessions
-   *  \param index The index (psshSet number) of the cdm session
-   *  \return The session string
-   */
-  std::string GetCDMSession(unsigned int index);
-
   /*! \brief Get the media type mask
    *  \return The media type mask
    */
   uint8_t GetMediaTypeMask() const { return m_mediaTypeMask; }
-
-  /*! \brief Get a single sample decrypter by index from the cdm sessions
-   *  \param index The index (psshSet number) of the cdm session
-   *  \return The single sample decrypter
-   */
-  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> GetSingleSampleDecryptor(
-      unsigned int index) const;
-
-  /*! \brief Get the decrypter (DRM lib)
-   *  \return The decrypter
-   */
-  DRM::IDecrypter* GetDecrypter() { return m_decrypter.get(); }
-
-  /*! \brief Get a single sample decrypter matching the session id provided
-   *  \param sessionId The session id string to match
-   *  \return The single sample decrypter
-   */
-  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> GetSingleSampleDecrypter(std::string sessionId);
-
-  /*! \brief Get decrypter capabilities for a single sample decrypter
-   *  \param index The index (psshSet number) of the cdm session
-   *  \return The single sample decrypter capabilities
-   */
-  const DRM::DecrypterCapabilites& GetDecrypterCaps(unsigned int index) const
-  {
-    return m_cdmSessions[index].m_decrypterCaps;
-  };
 
   /*! \brief Get the total time in ms of the stream
    *  \return The total time in ms of the stream
@@ -324,36 +267,18 @@ public:
    */
   bool OnGetStream(int streamid, kodi::addon::InputstreamInfo& info);
 
+  const DRM::CDRMEngine& GetDRMEngine() const { return m_drmEngine; }
+
 protected:
-  /*! \brief Check for and load decrypter module matching the supplied key system
-   *  \param key_system [OUT] Will be assigned to if a decrypter is found matching
-   *                    the set license type
+  /*!
+   * \brief Determine the AdaptationSet that should be the default to be played,
+   *        the behavior is mainly based on codec types
+   * \return The AdaptationSet, or nullptr if unhandled
    */
-  void SetSupportedDecrypterURN(std::vector<std::string_view>& keySystems);
-
-  /*! \brief Destroy all CencSingleSampleDecrypter instances
-   */
-  void DisposeSampleDecrypter();
-
-  /*! \brief Destroy the decrypter module instance
-   */
-  void DisposeDecrypter();
-
-  void ExtractStreamProtectionData(const PLAYLIST::CPeriod::PSSHSet& psshSet,
-                                   std::string& defaultKid,
-                                   std::vector<uint8_t>& initData,
-                                   const std::vector<std::string_view>& keySystems);
+  PLAYLIST::CAdaptationSet* DetermineDefaultAdpSet();
 
 private:
-  std::shared_ptr<DRM::IDecrypter> m_decrypter;
-
-  struct CCdmSession
-  {
-    DRM::DecrypterCapabilites m_decrypterCaps;
-    std::shared_ptr<Adaptive_CencSingleSampleDecrypter> m_cencSingleSampleDecrypter;
-    std::string m_sessionId;
-  };
-  std::vector<CCdmSession> m_cdmSessions;
+  DRM::CDRMEngine m_drmEngine;
 
   adaptive::AdaptiveTree* m_adaptiveTree{nullptr};
   CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -26,7 +26,6 @@ void CStream::Disable()
     Reset();
 
     m_isEnabled = false;
-    m_isEncrypted = false;
   }
 }
 

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -23,14 +23,11 @@ public:
   CStream(adaptive::AdaptiveTree* tree,
           PLAYLIST::CAdaptationSet* adp,
           PLAYLIST::CRepresentation* initialRepr)
-    : m_isEnabled{false},
-      m_isEncrypted{false},
-      m_mainId{0},
-      m_adStream{tree, adp, initialRepr},
-      m_isValid{true} {};
+    : m_isEnabled{false}, m_mainId{0}, m_adStream{tree, adp, initialRepr}, m_isValid{true}
+  {
+  }
 
-
-  ~CStream() { Disable(); };
+  ~CStream() { Disable(); }
 
   /*!
    * \brief Stop/disable the AdaptiveStream and reset
@@ -82,7 +79,6 @@ public:
   }
 
   bool m_isEnabled;
-  bool m_isEncrypted;
   uint16_t m_mainId;
   adaptive::AdaptiveStream m_adStream;
   kodi::addon::InputstreamInfo m_info;

--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -44,16 +44,16 @@ void AESDecrypter::decrypt(const AP4_UI08* aes_key,
   dst.resize(dstOffset + dataSize);
 }
 
-std::string AESDecrypter::convertIV(const std::string &input)
+std::vector<uint8_t> AESDecrypter::convertIV(const std::string& input)
 {
-  std::string result;
+  std::vector<uint8_t> result;
   result.resize(16);
   AP4_Result ret(AP4_ERROR_INVALID_FORMAT);
 
   if (input.size() == 34)
-    ret = AP4_ParseHex(input.c_str() + 2, reinterpret_cast<unsigned char*>(&result[0]), 16);
+    ret = AP4_ParseHex(input.c_str() + 2, &result[0], 16);
   else if (input.size() == 32)
-    ret = AP4_ParseHex(input.c_str(), reinterpret_cast<unsigned char*>(&result[0]), 16);
+    ret = AP4_ParseHex(input.c_str(), &result[0], 16);
   if (!AP4_SUCCEEDED(ret))
     result.clear();
   return result;

--- a/src/aes_decrypter.h
+++ b/src/aes_decrypter.h
@@ -35,7 +35,7 @@ public:
                size_t dstOffset,
                size_t& dataSize,
                bool lastChunk);
-  std::string convertIV(const std::string& input);
+  std::vector<uint8_t> convertIV(const std::string& input);
   void ivFromSequence(uint8_t* buffer, uint64_t sid);
   // const std::string& getLicenseKey() const { return m_licenseKey; };
   // bool RenewLicense(const std::string& pluginUrl);

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -55,5 +55,9 @@ public:
 
   virtual AP4_UI32 AddPool() { return 0; }
   virtual void RemovePool(AP4_UI32 poolId) {}
-  virtual std::string GetSessionId() { return {}; }
+
+  /*!
+   * \brief The session ID, is mandatory to distinguish sessions.
+   */
+  virtual std::string GetSessionId() = 0;
 };

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -176,7 +176,8 @@ bool adaptive::AdaptiveStream::DownloadImpl(const DownloadInfo& downloadInfo,
             std::vector<uint8_t>& segmentBuffer = downloadInfo.m_segmentBuffer->buffer;
 
             m_tree->OnDataArrived(downloadInfo.m_segmentBuffer->segment_number,
-                                  downloadInfo.m_segmentBuffer->segment.pssh_set_, m_decrypterIv,
+                                  downloadInfo.m_segmentBuffer->segment.AESKeyInfo(),
+                                  m_decrypterIv,
                                   bufferData.data(), bytesRead, segmentBuffer, segmentBuffer.size(),
                                   isLastChunk);
           }

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -40,7 +40,6 @@ namespace adaptive
     m_manifestParams = left.m_manifestParams;
     m_manifestHeaders = left.m_manifestHeaders;
     m_settings = left.m_settings;
-    m_supportedKeySystems = left.m_supportedKeySystems;
     m_pathSaveManifest = left.m_pathSaveManifest;
     stream_start_ = left.stream_start_;
 
@@ -49,11 +48,9 @@ namespace adaptive
   }
 
   void AdaptiveTree::Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                               std::vector<std::string_view> supportedKeySystems,
                                std::string_view manifestUpdParams)
   {
     m_reprChooser = reprChooser;
-    m_supportedKeySystems = supportedKeySystems;
 
     auto srvBroker = CSrvBroker::GetInstance();
 
@@ -112,19 +109,14 @@ namespace adaptive
              m_isLive ? "live" : "VOD");
   }
 
-  void AdaptiveTree::FreeSegments(CPeriod* period, CRepresentation* repr)
+  void AdaptiveTree::FreeSegments(CRepresentation* repr)
   {
-    for (const CSegment& segment : repr->Timeline())
-    {
-      period->DecreasePSSHSetUsageCount(segment.pssh_set_);
-    }
-
     repr->Timeline().Clear();
     repr->current_segment_ = nullptr;
   }
 
   void AdaptiveTree::OnDataArrived(uint64_t segNum,
-                                   uint16_t psshSet,
+                                   std::optional<CAesKeyInfo>& aesKey,
                                    uint8_t iv[16],
                                    const uint8_t* srcData,
                                    size_t srcDataSize,
@@ -133,34 +125,6 @@ namespace adaptive
                                    bool isLastChunk)
   {
     segBuffer.insert(segBuffer.end(), srcData, srcData + srcDataSize);
-  }
-
-  uint16_t AdaptiveTree::InsertPsshSet(PLAYLIST::StreamType streamType,
-                                       PLAYLIST::CPeriod* period,
-                                       PLAYLIST::CAdaptationSet* adp,
-                                       const std::vector<uint8_t>& pssh,
-                                       std::string_view defaultKID,
-                                       std::string_view licenseUrl /* = "" */,
-                                       std::string_view iv /* = "" */)
-  {
-    CPeriod::PSSHSet psshSet;
-    psshSet.pssh_ = pssh;
-    psshSet.defaultKID_ = defaultKID;
-    psshSet.m_licenseUrl = licenseUrl;
-    psshSet.iv = iv;
-    psshSet.m_cryptoMode = m_cryptoMode;
-    psshSet.adaptation_set_ = adp;
-
-    if (streamType == StreamType::VIDEO)
-      psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO;
-    else if (streamType == StreamType::VIDEO_AUDIO)
-      psshSet.media_ = CPeriod::PSSHSet::MEDIA_VIDEO | CPeriod::PSSHSet::MEDIA_AUDIO;
-    else if (streamType == StreamType::AUDIO)
-      psshSet.media_ = CPeriod::PSSHSet::MEDIA_AUDIO;
-    else
-      psshSet.media_ = CPeriod::PSSHSet::MEDIA_UNSPECIFIED;
-
-    return period->InsertPSSHSet(psshSet);
   }
 
   void AdaptiveTree::SortTree()

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "utils/CryptoUtils.h"
 #include "AdaptationSet.h"
 #include "Period.h"
 #include "Representation.h"
@@ -73,10 +72,7 @@ public:
   uint64_t available_time_{0}; // in ms
   uint64_t m_liveDelay{0}; // Apply a delay in seconds from the live edge
 
-  std::vector<std::string_view> m_supportedKeySystems;
   std::string location_;
-
-  CryptoMode m_cryptoMode{CryptoMode::NONE};
 
   AdaptiveTree() = default;
   AdaptiveTree(const AdaptiveTree& left);
@@ -86,11 +82,10 @@ public:
 
   /*!
    * \brief Configure the adaptive tree.
-   * \param kodiProps The Kodi properties
+   * \param reprChooser The representation chooser
    * \param manifestUpdParams Parameters to be add to manifest request url, depends on manifest implementation
    */
   virtual void Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                         std::vector<std::string_view> supportedKeySystems,
                          std::string_view manifestUpdParams);
 
   /*
@@ -137,7 +132,7 @@ public:
   }
 
   virtual void OnDataArrived(uint64_t segNum,
-                             uint16_t psshSet,
+                             std::optional<CAesKeyInfo>& aesKey,
                              uint8_t iv[16],
                              const uint8_t* srcData,
                              size_t srcDataSize,
@@ -172,7 +167,12 @@ public:
   {
   }
 
-  void FreeSegments(PLAYLIST::CPeriod* period, PLAYLIST::CRepresentation* repr);
+  /*!
+   * \brief Callback done when the period has been changed.
+   */
+  virtual void OnPeriodChange() {}
+
+  void FreeSegments(PLAYLIST::CRepresentation* repr);
 
   /*!
    * \brief Some types of live manifests do not include segments, so the client must create them,
@@ -208,15 +208,6 @@ public:
   {
     return false;
   }
-
-  // Insert a PSSHSet to the specified Period and return the position
-  uint16_t InsertPsshSet(PLAYLIST::StreamType streamType,
-                         PLAYLIST::CPeriod* period,
-                         PLAYLIST::CAdaptationSet* adp,
-                         const std::vector<uint8_t>& pssh,
-                         std::string_view defaultKID,
-                         std::string_view licenseUrl = "",
-                         std::string_view iv = "");
 
   PLAYLIST::CAdaptationSet* GetAdaptationSet(size_t pos) const
   {
@@ -328,12 +319,6 @@ public:
   TreeUpdateThread& GetTreeUpdMutex() { return m_updThread; };
 
   /*!
-   * \brief Get the license URL, some DRM-encrypted manifests (e.g. SmoothStreaming) can provide it.
-   * \return The license URL if found, otherwise empty string.
-   */
-  std::string_view GetLicenseUrl() { return m_licenseUrl; }
-
-  /*!
    * \brief Specifies if TTML subtitle time is relative to sample time.
    * \return True if relative to sample time, otherwise false.
    */
@@ -396,8 +381,6 @@ protected:
 
   // Provide the path where the manifests will be saved, if debug enabled
   std::string m_pathSaveManifest;
-
-  std::string m_licenseUrl;
 
   bool m_isTTMLTimeRelative{false};
   bool m_isReqPrepareStream{false};

--- a/src/common/AdaptiveUtils.cpp
+++ b/src/common/AdaptiveUtils.cpp
@@ -136,16 +136,15 @@ AP4_Movie* PLAYLIST::CreateMovieAtom(adaptive::AdaptiveStream& adStream,
     sampleDesc = new AP4_SampleDescription(AP4_SampleDescription::TYPE_UNKNOWN, 0, 0);
   }
 
-  if (repr->GetPsshSetPos() != PSSHSET_POS_DEFAULT)
+  if (!repr->DrmInfos().empty())
   {
-    const PLAYLIST::CPeriod::PSSHSet& psshSet =
-        adStream.getPeriod()->GetPSSHSets()[repr->GetPsshSetPos()];
+    DRM::DRMInfo& drmInfo = repr->DrmInfos()[0];
 
     std::vector<uint8_t> defaultKid;
-    if (psshSet.defaultKID_.empty())
+    if (drmInfo.defaultKid.empty())
       defaultKid.assign(DEFAULT_KEYID, DEFAULT_KEYID + 16);
     else
-      defaultKid = DRM::ConvertKidStrToBytes(psshSet.defaultKID_);
+      defaultKid = DRM::ConvertKidStrToBytes(drmInfo.defaultKid);
 
     AP4_ContainerAtom schi{AP4_ATOM_TYPE_SCHI};
     // Note TENC default_isProtected parameter is intentionally set to 0 (not encrypted)

--- a/src/common/AdaptiveUtils.h
+++ b/src/common/AdaptiveUtils.h
@@ -27,10 +27,6 @@ class InputstreamInfo;
 
 namespace PLAYLIST
 {
-// Marker for the default psshset position
-constexpr uint16_t PSSHSET_POS_DEFAULT = 0;
-// Marker for not valid psshset position
-constexpr uint16_t PSSHSET_POS_INVALID = std::numeric_limits<uint16_t>::max();
 // Marker for not set/not found segment position
 constexpr size_t SEGMENT_NO_POS = std::numeric_limits<size_t>::max();
 // Marker for not set/not found segment number

--- a/src/common/Chooser.h
+++ b/src/common/Chooser.h
@@ -19,8 +19,9 @@
 // forwards
 namespace PLAYLIST
 {
-class CRepresentation;
+class CPeriod;
 class CAdaptationSet;
+class CRepresentation;
 }
 
 namespace ADP::KODI_PROPS
@@ -94,6 +95,19 @@ public:
       PLAYLIST::CAdaptationSet* adp)
   {
     return GetNextRepresentation(adp, nullptr);
+  }
+
+  /*!
+   * \brief Get the preferred adaptation set from a period
+   *        (a representation may be preselected internally the Chooser)
+   * \param period The period where choose the adaptation set / representation
+   * \param adpSetPreferred The preferred adaptation set
+   * \return The adaptation set or nullptr, the behaviour depend on Chooser implementation
+   */
+  virtual PLAYLIST::CAdaptationSet* GetPreferredVideoAdpSet(
+      PLAYLIST::CPeriod* period, PLAYLIST::CAdaptationSet* adpSetPreferred)
+  {
+    return adpSetPreferred;
   }
 
   /*!

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -13,6 +13,7 @@
 #include "ReprSelector.h"
 #include "Representation.h"
 #include "SrvBroker.h"
+#include "Period.h"
 #include "kodi/tools/StringUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/Utils.h"
@@ -58,43 +59,53 @@ void CRepresentationChooserAskQuality::PostInit()
 {
 }
 
-PLAYLIST::CRepresentation* CRepresentationChooserAskQuality::GetNextRepresentation(
-    PLAYLIST::CAdaptationSet* adp, PLAYLIST::CRepresentation* currentRep)
+PLAYLIST::CAdaptationSet* CHOOSER::CRepresentationChooserAskQuality::GetPreferredVideoAdpSet(
+    PLAYLIST::CPeriod* period, PLAYLIST::CAdaptationSet* adpSetPreferred)
 {
-  if (currentRep)
-    return currentRep;
-
-  if (adp->GetStreamType() != StreamType::VIDEO)
+  // If the dialog box has already been displayed, then the period has changed
+  if (m_isDialogShown)
   {
-    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
-    return selector.HighestBw(adp);
-  }
-
-  //! @todo: currently we dont handle in any way a codec priority and selection
-  //! that can happens when a manifest have multi-codec videos, therefore
-  //! we sent to Kodi the video stream of each codec, but only the
-  //! first one (in index order) will be choosen for the playback
-  //! with the potential to poorly manage a bandwidth optimisation.
-  //! So we ask to the user to select the quality only for the first video
-  //! AdaptationSet and we try to select the same quality (resolution)
-  //! on all other video AdaptationSet's (codecs)
-  if (!m_isDialogShown)
-  {
-    // We find the best quality for the current resolution, to pre-select this entry
-    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
-    CRepresentation* bestRep{selector.Highest(adp)};
-
-    std::vector<std::string> entries;
-    int preselIndex{-1};
-    int selIndex{0};
-    const size_t reprSize = adp->GetRepresentations().size();
-
-    if (reprSize > 1)
+    // Try find the adaptation set with same codec or fallback to the preferred
+    PLAYLIST::CAdaptationSet* selAdpSet = adpSetPreferred;
+    for (auto& adpSet : period->GetAdaptationSets())
     {
-      // Add available qualities
-      for (auto itRep = adp->GetRepresentations().begin(); itRep  !=  adp->GetRepresentations().end(); itRep++)
+      if (adpSet->GetStreamType() != StreamType::VIDEO || adpSet->GetRepresentations().size() == 0)
+        continue;
+
+      if (CODEC::GetVideoDesc(adpSet->GetCodecs()) != m_selectedVideoCodecDesc)
+        continue;
+    
+      selAdpSet = adpSet.get();
+      break;
+    }
+
+    return selAdpSet;
+  }
+  else
+  {
+    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
+    std::vector<std::string> entries;
+    std::vector<std::pair<CAdaptationSet*, CRepresentation*>> entriesOjb;
+    int preselIndex{-1}; // Preselected list item
+    int selIndex{0};
+
+    for (auto& adpSet : period->GetAdaptationSets())
+    {
+      if (adpSet->GetStreamType() != StreamType::VIDEO || adpSet->GetRepresentations().size() == 0)
+        continue;
+
+      CRepresentation* bestRep{nullptr};
+
+      // preferred adaptation set, in order to have a preferred codec for multi-codec manifests
+      if (adpSetPreferred == adpSet.get())
       {
-        CRepresentation* repr = (*itRep).get();
+        bestRep = selector.Highest(adpSetPreferred);
+      }
+
+      for (auto& repr : adpSet->GetRepresentations())
+      {
+        if (!repr->isPlayable)
+          continue;
 
         std::string entryName{kodi::addon::GetLocalizedString(30232)};
         STRING::ReplaceFirst(entryName, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
@@ -112,36 +123,58 @@ PLAYLIST::CRepresentation* CRepresentationChooserAskQuality::GetNextRepresentati
         quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
         STRING::ReplaceFirst(entryName, "{quality}", quality);
 
-        if (repr == bestRep)
-          preselIndex = static_cast<int>(std::distance(adp->GetRepresentations().begin(), itRep));
+        entries.emplace_back(entryName);
+        entriesOjb.emplace_back(adpSet.get(), repr.get());
 
-        entries.emplace_back(entryName);        
+        if (repr.get() == bestRep)
+          preselIndex = static_cast<int>(entries.size()) - 1;
       }
-      
+    }
+
+    if (entries.size() > 1)
+    {
       selIndex = kodi::gui::dialogs::Select::Show(kodi::addon::GetLocalizedString(30231), entries,
                                                   preselIndex, 10000);
     }
 
-    CRepresentation* selRep{bestRep};
+    if (!entries.empty())
+    {
+      CAdaptationSet* selAdpSet{entriesOjb[preselIndex].first};
+      CRepresentation* selRep{entriesOjb[preselIndex].second};
 
-    if (selIndex >= 0) // If was <0 has been cancelled by the user
-      selRep = adp->GetRepresentations()[selIndex].get();
+      if (selIndex >= 0) // If selIndex is <0 has been cancelled by the user
+      {
+        selAdpSet = entriesOjb[selIndex].first;
+        selRep = entriesOjb[selIndex].second;
+      }
 
-    m_selectedResWidth = selRep->GetWidth();
-    m_selectedResHeight = selRep->GetHeight();
-    m_isDialogShown = true;
+      m_selectedResWidth = selRep->GetWidth();
+      m_selectedResHeight = selRep->GetHeight();
+      // Convert codec to description, as the codec string may be slightly different
+      // when using ISO BMFF format, and the comparison may fail
+      m_selectedVideoCodecDesc = CODEC::GetVideoDesc(selAdpSet->GetCodecs());
 
-    LogDetails(nullptr, selRep);
-    return selRep;
+      m_isDialogShown = true;
+
+      LogDetails(nullptr, selRep);
+      return selAdpSet;
+    }
   }
-  else
+  return adpSetPreferred;
+}
+
+PLAYLIST::CRepresentation* CRepresentationChooserAskQuality::GetNextRepresentation(
+    PLAYLIST::CAdaptationSet* adp, PLAYLIST::CRepresentation* currentRep)
+{
+  if (currentRep)
+    return currentRep;
+
+  if (adp->GetStreamType() != StreamType::VIDEO)
   {
-    // We fall here when:
-    // - First start, but we have a multi-codec manifest (workaround)
-    //   then we have to try select the same resolution for each other video codec
-    //   these streams will be choosable for now via Kodi OSD video settings.
-    // - Switched to next period, then we try select the same resolution
-    CRepresentationSelector selector{m_selectedResWidth, m_selectedResHeight};
-    return selector.Highest(adp);
+    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
+    return selector.HighestBw(adp);
   }
+
+  CRepresentationSelector selector{m_selectedResWidth, m_selectedResHeight};
+  return selector.Highest(adp);
 }

--- a/src/common/ChooserAskQuality.h
+++ b/src/common/ChooserAskQuality.h
@@ -25,6 +25,9 @@ public:
 
   void PostInit() override;
 
+  PLAYLIST::CAdaptationSet* GetPreferredVideoAdpSet(
+      PLAYLIST::CPeriod* period, PLAYLIST::CAdaptationSet* adpSetPreferred) override;
+
   PLAYLIST::CRepresentation* GetNextRepresentation(PLAYLIST::CAdaptationSet* adp,
                                                    PLAYLIST::CRepresentation* currentRep) override;
 
@@ -32,6 +35,7 @@ private:
   bool m_isDialogShown{false};
   int m_selectedResWidth{0};
   int m_selectedResHeight{0};
+  std::string m_selectedVideoCodecDesc;
 };
 
 } // namespace CHOOSER

--- a/src/common/ChooserDefault.cpp
+++ b/src/common/ChooserDefault.cpp
@@ -202,6 +202,9 @@ PLAYLIST::CRepresentation* CRepresentationChooserDefault::GetNextRepresentation(
 
   for (auto& rep : adp->GetRepresentations())
   {
+    if (!rep->isPlayable)
+      continue;
+
     int score{std::abs(rep->GetWidth() * rep->GetHeight() - m_screenWidth * m_screenHeight)};
 
     if (!m_isForceStartsMaxRes)

--- a/src/common/Period.cpp
+++ b/src/common/Period.cpp
@@ -16,7 +16,6 @@ using namespace PLAYLIST;
 
 PLAYLIST::CPeriod::CPeriod() : CCommonSegAttribs()
 {
-  m_psshSets.emplace_back(PSSHSet());
 }
 
 PLAYLIST::CPeriod::~CPeriod()
@@ -37,62 +36,6 @@ void PLAYLIST::CPeriod::CopyHLSData(const CPeriod* other)
   m_id = other->m_id;
   m_timescale = other->m_timescale;
   m_includedStreamType = other->m_includedStreamType;
-}
-
-uint16_t PLAYLIST::CPeriod::InsertPSSHSet(const PSSHSet& psshSet)
-{
-  auto itPssh = m_psshSets.end();
-
-  if (psshSet.m_licenseUrl.empty())
-  {
-    // Find the psshSet by skipping the first one of the list (for unencrypted streams)
-    // note that PSSHSet struct has a custom comparator for std::find
-    itPssh = std::find(m_psshSets.begin() + 1, m_psshSets.end(), psshSet);
-  }
-
-  if (itPssh != m_psshSets.end() && itPssh->m_usageCount == 0)
-  {
-    // If the existing psshSet is not used, replace it with the new one
-    *itPssh = psshSet;
-  }
-  else
-  {
-    // Add a new PsshSet
-    itPssh = m_psshSets.insert(m_psshSets.end(), psshSet);
-  }
-
-  itPssh->m_usageCount++;
-
-  return static_cast<uint16_t>(itPssh - m_psshSets.begin());
-}
-
-void PLAYLIST::CPeriod::RemovePSSHSet(uint16_t pssh_set)
-{
-  for (std::unique_ptr<PLAYLIST::CAdaptationSet>& adpSet : m_adaptationSets)
-  {
-    auto& reps = adpSet->GetRepresentations();
-
-    for (auto itRepr = reps.begin(); itRepr != reps.end();)
-    {
-      if ((*itRepr)->m_psshSetPos == pssh_set)
-        itRepr = reps.erase(itRepr);
-      else
-        itRepr++;
-    }
-  }
-}
-
-void PLAYLIST::CPeriod::DecreasePSSHSetUsageCount(uint16_t pssh_set)
-{
-  if (pssh_set >= m_psshSets.size())
-  {
-    LOG::LogF(LOGERROR, "Cannot decrease PSSH usage, PSSHSet position %u exceeds the container size", pssh_set);
-    return;
-  }
-
-  PSSHSet& psshSet = m_psshSets[pssh_set];
-  if (psshSet.m_usageCount > 0)
-    psshSet.m_usageCount--;
 }
 
 void PLAYLIST::CPeriod::AddAdaptationSet(std::unique_ptr<CAdaptationSet>& adaptationSet)

--- a/src/common/Period.h
+++ b/src/common/Period.h
@@ -10,7 +10,6 @@
 
 #include "CommonSegAttribs.h"
 #include "SegTemplate.h"
-#include "utils/CryptoUtils.h"
 
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "test/KodiStubs.h"
@@ -78,9 +77,6 @@ public:
    */
   void SetTimescale(uint32_t timescale) { m_timescale = timescale; }
 
-  EncryptionState GetEncryptionState() const { return m_encryptionState; }
-  void SetEncryptionState(EncryptionState encryptState) { m_encryptionState = encryptState; }
-
   // Force the use of secure decoder only when parsed manifest specify it
   std::optional<bool> IsSecureDecodeNeeded() const { return m_isSecureDecoderNeeded; }
   void SetSecureDecodeNeeded(std::optional<bool> isSecureDecoderNeeded)
@@ -96,43 +92,11 @@ public:
   void AddAdaptationSet(std::unique_ptr<CAdaptationSet>& adaptationSet);
   std::vector<std::unique_ptr<CAdaptationSet>>& GetAdaptationSets() { return m_adaptationSets; }
 
-  struct ATTR_DLL_LOCAL PSSHSet
-  {
-    static constexpr uint32_t MEDIA_UNSPECIFIED = 0;
-    static constexpr uint32_t MEDIA_VIDEO = 1;
-    static constexpr uint32_t MEDIA_AUDIO = 2;
-
-    // Custom comparator for std::find
-    bool operator==(const PSSHSet& other) const
-    {
-      return media_ == other.media_ && pssh_ == other.pssh_ && defaultKID_ == other.defaultKID_ &&
-             iv == other.iv;
-    }
-
-    //! @todo: create getter/setters
-    std::vector<uint8_t> pssh_; // Data as bytes (not base64)
-    std::string m_licenseUrl; // License server URL
-    std::string defaultKID_;
-    std::string iv;
-    uint32_t media_{0};
-    // Specify how many times the same PSSH is used between AdaptationSets or Representations
-    uint32_t m_usageCount{0};
-    CryptoMode m_cryptoMode{CryptoMode::NONE};
-    CAdaptationSet* adaptation_set_{nullptr};
-  };
-
-  uint16_t InsertPSSHSet(const PSSHSet& pssh);
-  void RemovePSSHSet(uint16_t pssh_set);
-  void DecreasePSSHSetUsageCount(uint16_t pssh_set);
-  std::vector<PSSHSet>& GetPSSHSets() { return m_psshSets; }
-
   // Make use of PLAYLIST::StreamType flags
   uint32_t m_includedStreamType{0}; //! @todo: part of this need a rework
 
 protected:
   std::vector<std::unique_ptr<CAdaptationSet>> m_adaptationSets;
-  
-  std::vector<PSSHSet> m_psshSets;
 
   std::string m_id;
   std::string m_baseUrl;
@@ -140,7 +104,7 @@ protected:
   uint32_t m_sequence{0};
   uint64_t m_start{NO_VALUE};
   uint64_t m_duration{0};
-  EncryptionState m_encryptionState{EncryptionState::UNENCRYPTED};
+
   std::optional<bool> m_isSecureDecoderNeeded;
   std::vector<uint32_t> m_segmentTimelineDuration;
 };

--- a/src/common/ReprSelector.cpp
+++ b/src/common/ReprSelector.cpp
@@ -36,6 +36,9 @@ PLAYLIST::CRepresentation* CRepresentationSelector::Highest(
 
   for (auto& rep : adaptSet->GetRepresentations())
   {
+    if (!rep->isPlayable)
+      continue;
+
     if (rep->GetWidth() <= m_screenWidth && rep->GetHeight() <= m_screenHeight)
     {
       if (!highestRep || (highestRep->GetWidth() <= rep->GetWidth() &&
@@ -60,6 +63,9 @@ PLAYLIST::CRepresentation* CRepresentationSelector::HighestBw(
 
   for (auto& rep : adaptSet->GetRepresentations())
   {
+    if (!rep->isPlayable)
+      continue;
+
     if (!repHigherBw || rep->GetBandwidth() > repHigherBw->GetBandwidth())
     {
       repHigherBw = rep.get();
@@ -73,8 +79,9 @@ PLAYLIST::CRepresentation* CRepresentationSelector::Higher(PLAYLIST::CAdaptation
                                                            PLAYLIST::CRepresentation* currRep) const
 {
   auto reps = adaptSet->GetRepresentationsPtr();
-  auto repIt{
-      std::upper_bound(reps.begin(), reps.end(), currRep, CRepresentation::CompareBandwidthPtr)};
+  auto repIt = std::find_if(
+      reps.begin(), reps.end(), [currRep](const auto& rep)
+      { return rep->isPlayable && CRepresentation::CompareBandwidthPtr(rep, currRep); });
 
   if (repIt == reps.end())
     return currRep;

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -15,6 +15,7 @@
 #include "SegmentBase.h"
 #include "SegTemplate.h"
 #include "SegmentList.h"
+#include "decrypters/DrmEngineDefines.h"
 
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "test/KodiStubs.h"
@@ -96,6 +97,10 @@ public:
   uint32_t GetBandwidth() const { return m_bandwidth; }
   void SetBandwidth(uint32_t bandwidth) { m_bandwidth = bandwidth; }
 
+  /*!
+   * \brief Get the HDCP version required.
+   *        The value is concatenated, example HDCP 2.2 value is 22.
+   */
   uint16_t GetHdcpVersion() const { return m_hdcpVersion; }
   void SetHdcpVersion(uint16_t hdcpVersion) { m_hdcpVersion = hdcpVersion; }
 
@@ -158,6 +163,9 @@ public:
   bool IsIncludedStream() const { return m_isIncludedStream; }
   void SetIsIncludedStream(bool isIncludedStream) { m_isIncludedStream = isIncludedStream; }
 
+  std::vector<DRM::DRMInfo>& DrmInfos() { return m_drmInfo; }
+  void AddDrmInfo(DRM::DRMInfo drmInfo) { m_drmInfo.emplace_back(drmInfo); }
+
   void CopyHLSData(const CRepresentation* other);
 
   static bool CompareBandwidth(std::unique_ptr<CRepresentation>& left,
@@ -170,9 +178,6 @@ public:
   {
     return left->m_bandwidth < right->m_bandwidth;
   }
-
-  uint16_t m_psshSetPos{PSSHSET_POS_DEFAULT}; // Index position of the PSSHSet
-  const uint16_t GetPsshSetPos() const { return m_psshSetPos; }
 
   size_t expired_segments_{0};
 
@@ -211,6 +216,8 @@ public:
   uint32_t assured_buffer_duration_{0};
   uint32_t max_buffer_duration_{0};
 
+  bool isPlayable{true}; //! @todo: decouple "adaptivetree" with a kind of new streams interface could remove it
+
 protected:
   std::string m_id;
   std::string m_sourceUrl;
@@ -239,6 +246,7 @@ protected:
   bool m_isWaitForSegment{false};
 
   bool m_isIncludedStream{false};
+  std::vector<DRM::DRMInfo> m_drmInfo;
 };
 
 } // namespace PLAYLIST

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "AdaptiveUtils.h"
+#include "utils/CryptoUtils.h"
 
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "test/KodiStubs.h"
@@ -18,6 +19,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -40,7 +42,6 @@ public:
 
   uint64_t startPTS_ = NO_PTS_VALUE; // The start PTS, in timescale units
   uint64_t m_endPts = NO_PTS_VALUE; // The end PTS, in timescale units
-  uint16_t pssh_set_ = PSSHSET_POS_DEFAULT;
 
   uint64_t m_time{0}; // Timestamp
   uint64_t m_number{SEGMENT_NO_NUMBER};
@@ -58,8 +59,12 @@ public:
    */
   bool HasByteRange() const { return range_begin_ != NO_VALUE || range_end_ != NO_VALUE; }
 
+  std::optional<CAesKeyInfo>& AESKeyInfo() { return m_aesKey; }
+  const std::optional<CAesKeyInfo>& AESKeyInfo() const { return m_aesKey; }
+
 private:
   bool m_isInitialization{false};
+  std::optional<CAesKeyInfo> m_aesKey;
 };
 
 class ATTR_DLL_LOCAL CSegContainer

--- a/src/decrypters/CMakeLists.txt
+++ b/src/decrypters/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+  DrmEngine.cpp
   DrmFactory.cpp
   Helpers.cpp
   HelperPr.cpp
@@ -6,6 +7,8 @@ set(SOURCES
 )
 
 set(HEADERS
+  DrmEngine.h
+  DrmEngineDefines.h
   DrmFactory.h
   Helpers.h
   HelperPr.h

--- a/src/decrypters/DrmEngine.cpp
+++ b/src/decrypters/DrmEngine.cpp
@@ -1,0 +1,767 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DrmEngine.h"
+
+#include "CompKodiProps.h"
+#include "CompResources.h"
+#include "CompSettings.h"
+#include "DrmFactory.h"
+#include "Helpers.h"
+#include "SrvBroker.h"
+#include "Stream.h"
+#include "common/AdaptationSet.h"
+#include "common/AdaptiveDecrypter.h"
+#include "common/Representation.h"
+#include "utils/Base64Utils.h"
+#include "utils/StringUtils.h"
+#include "utils/UrlUtils.h"
+#include "utils/log.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+using namespace DRM;
+using namespace UTILS;
+
+namespace
+{
+STREAM_CRYPTO_KEY_SYSTEM KSToCryptoKeySystem(std::string_view keySystem)
+{
+  if (keySystem == DRM::KS_WIDEVINE)
+    return STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE;
+  else if (keySystem == DRM::KS_WISEPLAY)
+    return STREAM_CRYPTO_KEY_SYSTEM_WISEPLAY;
+  else if (keySystem == DRM::KS_PLAYREADY)
+    return STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY;
+  else if (keySystem == DRM::KS_CLEARKEY)
+    return STREAM_CRYPTO_KEY_SYSTEM_CLEARKEY;
+  else
+    return STREAM_CRYPTO_KEY_SYSTEM_NONE;
+}
+
+std::shared_ptr<DRM::IDecrypter> CreateDRM(std::string_view keySystem)
+{
+  std::string decrypterPath = CSrvBroker::GetSettings().GetDecrypterPath();
+  if (decrypterPath.empty())
+  {
+    LOG::Log(LOGWARNING,
+             "Cannot create the decrypter, the decrypter path is not set in the add-on settings");
+    return nullptr;
+  }
+
+  std::shared_ptr<DRM::IDecrypter> drm;
+
+  drm = DRM::FACTORY::GetDecrypter(KSToCryptoKeySystem(keySystem));
+
+  if (!drm)
+  {
+    LOG::LogF(LOGERROR, "Unable to create the DRM decrypter");
+    return nullptr;
+  }
+
+  drm->SetLibraryPath(decrypterPath);
+
+  if (!drm->Initialize())
+  {
+    LOG::Log(LOGERROR, "The DRM decrypter cannot be initialized");
+    return nullptr;
+  }
+
+  return drm;
+}
+
+/*!
+ * \brief Get a DRMInfo by Key System
+ * \param drmInfos The manifest DRM info
+ * \param keySystem The Key System to search
+ * \return The DRMInfo if found, otherwise nullptr
+ */
+DRM::DRMInfo* GetDRMInfoByKS(std::vector<DRM::DRMInfo>& drmInfos, std::string_view keySystem)
+{
+  // If no key system is provided its assumend CENC content compatible with any DRM
+  auto itDrmInfo = std::find_if(drmInfos.begin(), drmInfos.end(), [&](const DRMInfo& info)
+                                { return info.keySystem == keySystem || info.keySystem.empty(); });
+
+  if (itDrmInfo != drmInfos.end())
+    return &(*itDrmInfo);
+
+  return nullptr;
+}
+
+// \brief Query DRM decrypter to get capabilities and set it to session.
+// \return True if has success, otherwise false.
+bool GetCapabilities(const std::optional<bool> isForceSecureDecoder,
+                     const std::optional<bool> drmCfgIsSecureDecoderEnabled,
+                     const std::vector<uint8_t>& defaultKid,
+                     DRMSession& session)
+{
+  const uint32_t dMedia = session.mediaType == DRM::DRMMediaType::VIDEO
+                              ? DecrypterCapabilites::SSD_MEDIA_VIDEO
+                              : DecrypterCapabilites::SSD_MEDIA_AUDIO;
+
+  auto& caps = session.capabilities;
+  session.drm->GetCapabilities(session.decrypter, defaultKid, dMedia, caps);
+
+  if (caps.flags & DRM::DecrypterCapabilites::SSD_INVALID)
+  {
+    return false;
+  }
+  else if (caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH)
+  {
+    // Allow to disable the secure decoder
+    bool disableSecureDecoder = CSrvBroker::GetSettings().IsDisableSecureDecoder();
+    // but, DRM config can override it
+    if (drmCfgIsSecureDecoderEnabled.has_value())
+      disableSecureDecoder = !*drmCfgIsSecureDecoderEnabled;
+    // but, external config can override all others (e.g. manifest)
+    if (isForceSecureDecoder.has_value())
+      disableSecureDecoder = !*isForceSecureDecoder;
+    if (disableSecureDecoder)
+    {
+      LOG::Log(LOGDEBUG, "DRM configured with secure decoder disabled");
+      caps.flags &= ~DRM::DecrypterCapabilites::SSD_SECURE_DECODER;
+    }
+  }
+
+  return true;
+}
+} // unnamed namespace
+
+void DRM::CDRMEngine::Initialize()
+{
+  // Build the list of the supported DRM's by KeySystem,
+  // the list depends on the operative system used,
+  // the order of addition also defines the DRM priority (always prefer real DRM's over ClearKey)
+  // in future could be improved to take in account also the DRM capability on the target system
+
+  // Widevine currently always preferred as first because on android can reach 4k on L1 devices
+  m_supportedKs.emplace_back(KS_WIDEVINE);
+#if ANDROID
+  m_supportedKs.emplace_back(KS_PLAYREADY);
+  m_supportedKs.emplace_back(KS_WISEPLAY);
+#endif
+  m_supportedKs.emplace_back(KS_CLEARKEY);
+
+  // Sort key systems based on priorities
+  const auto& kodiProps = CSrvBroker::GetKodiProps();
+
+  for (auto& [ks, cfg] : kodiProps.GetDrmConfigs())
+  {
+    if (cfg.priority.has_value() && *cfg.priority != 0)
+    {
+      auto it = std::find(m_supportedKs.begin(), m_supportedKs.end(), ks);
+      if (it != m_supportedKs.end())
+      {
+        m_supportedKs.erase(it);
+
+        size_t index = *cfg.priority - 1;
+        if (index >= m_supportedKs.size())
+          index = m_supportedKs.size() - 1;
+
+        m_supportedKs.insert(m_supportedKs.begin() + index, ks);
+      }
+    }
+  }
+}
+
+bool DRM::CDRMEngine::PreInitializeDRM(DRMSession& session)
+{
+  auto& kodiProps = CSrvBroker::GetKodiProps();
+
+  // Pre-initialize the DRM is available for Widevine only.
+  // Since the manifest will be downloaded later its assumed that
+  // the manifest support the DRM and that the priority is set to 1.
+  if (std::find(m_supportedKs.cbegin(), m_supportedKs.cend(), KS_WIDEVINE) == m_supportedKs.cend())
+    return false;
+
+  const auto propDrmCfg = kodiProps.GetDrmConfig(KS_WIDEVINE);
+
+  if (!propDrmCfg.priority.has_value() || propDrmCfg.priority != 1 || propDrmCfg.preInitData.empty())
+    return false;
+
+  LOG::Log(LOGDEBUG, "Pre-initialize crypto session");
+  std::vector<uint8_t> initData;
+  std::vector<uint8_t> kidData;
+  // Parse the init data (PSSH, KID)
+  size_t posSplitter = propDrmCfg.preInitData.find("|");
+  if (posSplitter != std::string::npos)
+  {
+    initData = BASE64::Decode(propDrmCfg.preInitData.substr(0, posSplitter));
+    kidData = BASE64::Decode(propDrmCfg.preInitData.substr(posSplitter + 1));
+  }
+
+  if (initData.empty() || kidData.empty())
+  {
+    LOG::LogF(LOGERROR, "Invalid \"pre_init_data\" parameter, the data have this format: "
+                        "{PSSH as base64}|{KID as base64}");
+    m_status = EngineStatus::DRM_ERROR;
+    return false;
+  }
+
+  m_keySystem = KS_WIDEVINE;
+
+  auto drm = CreateDRM(m_keySystem);
+  if (!drm)
+  {
+    m_status = EngineStatus::DRM_ERROR;
+    return false;
+  }
+
+  DRM::Config drmCfg = CreateDRMConfig(m_keySystem, kodiProps.GetDrmConfig(m_keySystem));
+
+  if (!drm->OpenDRMSystem(drmCfg))
+  {
+    LOG::LogF(LOGERROR, "Failed to open the DRM");
+    m_status = EngineStatus::DRM_ERROR;
+    return false;
+  }
+
+  LOG::LogF(LOGDEBUG, "Initializing session with KID: %s", STRING::ToHexadecimal(kidData).c_str());
+
+  auto dec = drm->CreateSingleSampleDecrypter(initData, kidData, "", true, CryptoMode::AES_CTR);
+
+  if (!dec)
+  {
+    LOG::LogF(LOGERROR, "Failed to initialize the decrypter");
+    m_status = EngineStatus::DECRYPTER_ERROR;
+    return false;
+  }
+
+  m_drms.emplace(m_keySystem, drm);
+
+  session.id = dec->GetSessionId();
+  session.challenge = drm->GetChallengeB64Data(dec);
+  session.drm = drm;
+  session.decrypter = dec;
+#ifndef ANDROID
+  // On android is not possible add the default KID key used to open DRM
+  // then dont add this DRM session, since must be reinitialized
+  m_sessions.emplace_back(session);
+#endif
+
+  m_isPreinitialized = true;
+
+  return true;
+}
+
+bool DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
+                                        DRM::DRMMediaType mediaType,
+                                        std::optional<bool> isForceSecureDecoder,
+                                        kodi::addon::InputstreamInfo& streamInfo,
+                                        PLAYLIST::CRepresentation* repr,
+                                        PLAYLIST::CAdaptationSet* adp,
+                                        bool canCleanupSessions,
+                                        DRM::DRMInfo& initDrmInfo)
+{
+  if (drmInfos.empty())
+    return false;
+
+  LOG::Log(LOGDEBUG, "Initialize crypto session");
+
+  ConfigureClearKey(drmInfos);
+
+  auto& kodiProps = CSrvBroker::GetKodiProps();
+
+  // This is a kind of hack,
+  // some services use manifests (usually SmoothStreaming) with PlayReady DRM only,
+  // but they have also a Widevine license server that allow to play same stream with Widevine,
+  // this will allow to force change the manifest DRMInfo KeySytem to Widevine and replace the init data
+  bool isPRtoWVKeySystem{false};
+  if (HasKeySystemSupport(KS_WIDEVINE) && drmInfos.size() == 1 &&
+      drmInfos[0].keySystem == KS_PLAYREADY && kodiProps.GetDrmConfigs().size() == 1 &&
+      kodiProps.HasDrmConfig(KS_WIDEVINE))
+  {
+    drmInfos[0].keySystem = KS_WIDEVINE;
+    isPRtoWVKeySystem = true;
+  }
+
+  if (!SelectDRM(drmInfos))
+  {
+    LOG::LogF(LOGERROR, "The stream is encrypted with a DRM not supported by this system");
+    m_status = EngineStatus::DRM_ERROR;
+    return false;
+  }
+
+  // Find a compatible DRM info
+  auto pDrmInfo = GetDRMInfoByKS(drmInfos, m_keySystem);
+
+  if (!pDrmInfo)
+  {
+    LOG::LogF(LOGERROR, "The Key System \"%s\" does not match any DRMInfo", m_keySystem.c_str());
+    m_status = EngineStatus::DRM_ERROR;
+    return false;
+  }
+
+  DRM::DRMInfo& drmInfo = *pDrmInfo;
+  const auto drmPropCfg = kodiProps.GetDrmConfig(m_keySystem);
+
+  // Set custom init data PSSH provided from property,
+  // can allow to initialize a DRM that could be also not specified
+  // as supported in the manifest (e.g. missing DASH ContentProtection tags)
+  if (!drmPropCfg.initData.empty() || isPRtoWVKeySystem)
+  {
+    drmInfo.initData.clear();
+
+    std::vector<uint8_t> customInitData = BASE64::Decode(drmPropCfg.initData);
+
+    if (DRM::IsValidPsshHeader(customInitData))
+    {
+      LOG::Log(LOGDEBUG, "Use custom init PSSH provided by the \"license\" property");
+      drmInfo.initData = customInitData;
+    }
+    else if (m_keySystem == DRM::KS_WIDEVINE) // Try to create a PSSH box, KID should be provided by manifest
+    {
+      LOG::Log(LOGDEBUG, "Make a Widevine init PSSH to replace PlayReady init data");
+      drmInfo.initData =
+          DRM::PSSH::MakeWidevine({DRM::ConvertKidStrToBytes(drmInfo.defaultKid)}, customInitData);
+    }
+
+    if (drmInfo.initData.empty())
+      LOG::LogF(LOGERROR, "The custom init PSSH contains no data");
+  }
+
+  // If no KID, but init data, extract the KID from init data
+  if (!drmInfo.initData.empty() && drmInfo.defaultKid.empty() &&
+      DRM::IsValidPsshHeader(drmInfo.initData))
+  {
+    DRM::PSSH parser;
+    if (parser.Parse(drmInfo.initData) && !parser.GetKeyIds().empty())
+    {
+      LOG::Log(LOGDEBUG, "Default KID parsed from init data");
+      drmInfo.defaultKid = STRING::ToLower(STRING::ToHexadecimal(parser.GetKeyIds()[0]));
+    }
+  }
+
+  if ((drmInfo.initData.empty() && m_keySystem != DRM::KS_CLEARKEY) || drmInfo.defaultKid.empty())
+  {
+    // Try extract the PSSH/KID from the stream, as last resort because its expensive
+    ExtractStreamProtectionData(repr, adp, drmInfo);
+  }
+
+  // Create the DRM decrypter
+  if (!STRING::KeyExists(m_drms, m_keySystem))
+  {
+    //! @todo: to test a way to preinitialize DRM when manifest is downloaded/parsed
+    //! in the hoping to have a more smoother playback transition
+    //! this can be tested with multiperiods video where first period is unencrypted and second one DRM crypted
+    auto drm = CreateDRM(m_keySystem);
+    if (!drm)
+    {
+      m_status = EngineStatus::DRM_ERROR;
+      return false;
+    }
+    m_drms.emplace(m_keySystem, drm);
+  }
+
+  const std::vector<uint8_t> drmInfoKidBytes = DRM::ConvertKidStrToBytes(drmInfo.defaultKid);
+
+  if (m_isPreinitialized && m_sessions.size() == 1)
+  {
+    // Widevine only, when the CDM is preinitialized for non-android systems
+    // the session has been created with a custom PSSH/KID and it should
+    // be assumed that there is a single session for all streams.
+    // In order to reuse this session is needed to add the current KID.
+    if (!m_sessions[0].drm->HasLicenseKey(m_sessions[0].decrypter, drmInfoKidBytes))
+    {
+      m_sessions[0].decrypter->AddKeyId(drmInfoKidBytes);
+      m_sessions[0].decrypter->SetDefaultKeyId(drmInfoKidBytes);
+    }
+  }
+
+  // Check whether it is possible to reuse an existing DRM session
+  // its recommended to use separate sessions when a/v media types have different KIDs
+  // to avoid possible decryption problems that usually affect android devices (corrupted/pixellated video)
+  DRMSession* session{nullptr};
+  for (DRMSession& s : m_sessions)
+  {
+    bool isReuseSession{false};
+    const std::optional<bool> hasKey = s.drm->HasLicenseKey(s.decrypter, drmInfoKidBytes);
+
+    // forced single session, allow to share same session (also with different media types)
+    if (drmPropCfg.isForceSingleSession && (!hasKey.has_value() || *hasKey))
+    {
+      isReuseSession = true;
+    }
+    // share same session when: KID is the same, otherwise check if there is license key by media type
+    else if ((!s.kid.empty() && s.kid == drmInfo.defaultKid) ||
+             (hasKey.has_value() && *hasKey && s.mediaType == mediaType))
+    {
+      isReuseSession = true;
+    }
+    if (isReuseSession)
+    {
+      session = &s;
+      break;
+    }
+  }
+
+  // No reausable DRM session, create a new one
+  if (!session)
+  {
+    if (canCleanupSessions)
+      DeleteSessionsByType(mediaType);
+
+    DRMSession newSes;
+    newSes.drm = m_drms[m_keySystem];
+    newSes.mediaType = mediaType;
+    newSes.kid = drmInfo.defaultKid;
+
+    if (!newSes.drm->IsInitialised())
+    {
+      DRM::Config drmCfg = DRM::CreateDRMConfig(m_keySystem, drmPropCfg);
+      if (!newSes.drm->OpenDRMSystem(drmCfg))
+      {
+        LOG::LogF(LOGERROR, "Failed to open the DRM");
+        m_status = EngineStatus::DRM_ERROR;
+        return false;
+      }
+    }
+
+    newSes.decrypter = newSes.drm->CreateSingleSampleDecrypter(
+        drmInfo.initData, drmInfoKidBytes, drmInfo.licenseServerUri, false,
+        drmInfo.cryptoMode == CryptoMode::NONE ? CryptoMode::AES_CTR : drmInfo.cryptoMode);
+    if (!newSes.decrypter)
+    {
+      LOG::Log(LOGERROR, "Failed to initialize the decrypter");
+      m_status = EngineStatus::DECRYPTER_ERROR;
+      return false;
+    }
+
+    newSes.id = newSes.decrypter->GetSessionId();
+
+    if (!GetCapabilities(isForceSecureDecoder, drmPropCfg.isSecureDecoderEnabled, drmInfoKidBytes,
+                         newSes))
+    {
+      m_status = EngineStatus::DECRYPTER_ERROR;
+      return false;
+    }
+
+    m_sessions.emplace_back(newSes);
+    session = &m_sessions.back();
+    LOG::Log(LOGDEBUG, "Initialized new DRM session (ID: %s, KID: %s)", session->id.c_str(),
+             drmInfo.defaultKid.c_str());
+  }
+  else
+  {
+    // Although we reuse the same session (and decryptor) this create each time a new DRMSession,
+    // with the only purpose of differentiating (and caching) the "capabilities", since different KIDs can
+    // correspond to different "capabilities", access to capabilities could be improved in the future,
+    // perhaps by moving them within the decryptor itself and make an appropriate query inteface so that
+    // also other components can query e.g. FragmentedSampleReader, there are potentials to clean various code
+    DRMSession newSes;
+    newSes.id = session->id;
+    newSes.drm = session->drm;
+    newSes.decrypter = session->decrypter;
+    newSes.mediaType = mediaType;
+    newSes.kid = drmInfo.defaultKid;
+
+    if (drmInfo.defaultKid == session->kid) // Same KID same capabilities
+    {
+      newSes.capabilities = session->capabilities;
+    }
+    else
+    {
+      if (!GetCapabilities(isForceSecureDecoder, drmPropCfg.isSecureDecoderEnabled, drmInfoKidBytes,
+                           newSes))
+      {
+        m_status = EngineStatus::DECRYPTER_ERROR;
+        return false;
+      }
+    }
+
+    m_sessions.emplace_back(newSes);
+    session = &m_sessions.back();
+    LOG::Log(LOGDEBUG, "Reused existing DRM session (ID: %s, KID: %s)", session->id.c_str(),
+             drmInfo.defaultKid.c_str());
+  }
+
+  auto& caps = session->capabilities;
+
+  // Create crypto session
+  kodi::addon::StreamCryptoSession cryptoSession;
+
+  cryptoSession.SetSessionId(session->id);
+  // Set the key system will enable the crypto session to kodi decoders (e.g. ffmpeg)
+  if (caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH)
+    cryptoSession.SetKeySystem(KSToCryptoKeySystem(m_keySystem));
+
+  if (caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH &&
+      caps.flags & DRM::DecrypterCapabilites::SSD_SUPPORTS_DECODING)
+  {
+    LOG::Log(LOGDEBUG, "Secure crypto session enabled to DRM session (ID: %s)",
+             session->id.c_str());
+    streamInfo.SetFeatures(INPUTSTREAM_FEATURE_DECODE);
+  }
+  else
+    streamInfo.SetFeatures(INPUTSTREAM_FEATURE_NONE);
+
+  if (caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH &&
+      caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_DECODER)
+  {
+    // Enable the ISA VideoCodecAdaptive decoder
+    LOG::Log(LOGDEBUG, "Secure crypto decoder enabled to DRM session (ID: %s)",
+             session->id.c_str());
+    cryptoSession.SetFlags(STREAM_CRYPTO_FLAG_SECURE_DECODER);
+  }
+  else
+    cryptoSession.SetFlags(STREAM_CRYPTO_FLAG_NONE);
+
+  streamInfo.SetCryptoSession(cryptoSession);
+
+  initDrmInfo = drmInfo;
+  return true;
+}
+
+const DRMSession* DRM::CDRMEngine::GetSession(const std::string& id) const
+{
+  if (id.empty())
+    return nullptr;
+
+  for (const auto& session : m_sessions)
+  {
+    if (session.id == id)
+      return &session;
+  }
+  return nullptr;
+}
+
+const DRMSession* DRM::CDRMEngine::GetSession(const std::string& id, const std::string& kid) const
+{
+  if (id.empty())
+    return nullptr;
+
+  for (const auto& session : m_sessions)
+  {
+    if (session.id == id && session.kid == kid)
+      return &session;
+  }
+  return nullptr;
+}
+
+bool DRM::CDRMEngine::ConfigureClearKey(std::vector<DRM::DRMInfo>& drmInfos)
+{
+  const auto& kodiProps = CSrvBroker::GetKodiProps();
+
+  if (!kodiProps.HasDrmConfig(KS_CLEARKEY) || drmInfos.empty())
+    return false;
+
+  const ADP::KODI_PROPS::DrmCfg& drmCfg = kodiProps.GetDrmConfig(KS_CLEARKEY);
+
+  // The ClearKey configuration can add (or replace) CK DRMInfo when
+  // it finds a custom license uri or keys
+  if (drmCfg.license.serverUri.empty() && drmCfg.license.keys.empty())
+    return false;
+
+  // Get info from any drm info item, since should be the same
+  const CryptoMode cryptoMode = drmInfos[0].cryptoMode;
+  const std::string defaultKid = drmInfos[0].defaultKid;
+
+  if (kodiProps.GetDrmConfigs().size() == 1) // Single config (CK)
+  {
+    // Delete all the DRMInfo, so you can force CK even if the manifest uses a different DRM
+    drmInfos.clear();
+  }
+  else // More configs, behavior based on "priority" its needed to preserve DRMInfos
+  {
+    drmInfos.erase(std::remove_if(drmInfos.begin(), drmInfos.end(), [](const DRM::DRMInfo& info)
+                                  { return info.keySystem == KS_CLEARKEY; }),
+                   drmInfos.end());
+  }
+
+  std::string licenseUri;
+
+  if (drmCfg.license.keys.empty())
+  {
+    licenseUri = drmCfg.license.serverUri;
+  }
+  else // Create license uri with jwkSets
+  {
+    rapidjson::Document jDoc;
+    jDoc.SetObject();
+    auto& allocator = jDoc.GetAllocator();
+
+    rapidjson::Value jwkSets{rapidjson::kArrayType};
+
+    for (auto& [kid, key] : drmCfg.license.keys)
+    {
+      const std::string kVal =
+          BASE64::UrlSafeEncode(BASE64::Encode(DRM::ConvertKidStrToBytes(key), false));
+      const std::string kidVal =
+          BASE64::UrlSafeEncode(BASE64::Encode(DRM::ConvertKidStrToBytes(kid), false));
+
+      rapidjson::Value jwkSet{rapidjson::kObjectType};
+      jwkSet.AddMember("k", rapidjson::Value(kVal.c_str(), allocator), allocator);
+      jwkSet.AddMember("kid", rapidjson::Value(kidVal.c_str(), allocator), allocator);
+      jwkSet.AddMember("kty", "oct", allocator);
+      jwkSets.PushBack(jwkSet, allocator);
+    }
+
+    jDoc.AddMember("keys", jwkSets, allocator);
+    jDoc.AddMember("type", "temporary", allocator);
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer{buffer};
+    jDoc.Accept(writer);
+
+    licenseUri =
+        "data:application/json;base64," + BASE64::Encode(buffer.GetString(), buffer.GetSize());
+  }
+
+  DRM::DRMInfo drmInfo;
+  drmInfo.keySystem = KS_CLEARKEY;
+  drmInfo.cryptoMode = cryptoMode;
+  drmInfo.defaultKid = defaultKid;
+  drmInfo.licenseServerUri = licenseUri;
+  drmInfos.emplace_back(drmInfo);
+
+  return true;
+}
+
+bool DRM::CDRMEngine::SelectDRM(std::vector<DRM::DRMInfo>& drmInfos)
+{
+  if (!m_keySystem.empty())
+    return true;
+
+  // Iterate supported DRM Key System's to find a match with the drmInfo's,
+  // the supported DRM's are ordered by priority
+  // the lower index have the higher priority
+  for (const std::string& ks : m_supportedKs)
+  {
+    const DRM::DRMInfo* drmInfo = GetDRMInfoByKS(drmInfos, ks);
+
+    if (drmInfo)
+    {
+      m_keySystem = ks;
+      break;
+    }
+  }
+
+  return !m_keySystem.empty();
+}
+
+//! @todo: to remove requirements for CRepresentation CAdaptationSet vars
+//! see also todo comment below
+void DRM::CDRMEngine::ExtractStreamProtectionData(PLAYLIST::CRepresentation* repr,
+                                                  PLAYLIST::CAdaptationSet* adp,
+                                                  DRM::DRMInfo& drmInfo)
+{
+  if (repr->GetContainerType() != PLAYLIST::ContainerType::MP4)
+    return;
+
+  LOG::LogF(LOGDEBUG, "Parse MP4 protection data from stream");
+
+  //! @todo: AdaptiveTree* const_cast its not good thing to do, it should be removed
+  //! with a code rework, for example by reusing the CStream created by OpenStream
+  //! and/or maybe create a way to avoid involve DRMEngine with CStream directly
+  SESSION::CStream stream{
+      const_cast<adaptive::AdaptiveTree*>(&CSrvBroker::GetResources().GetTree()), adp, repr};
+
+  stream.m_isEnabled = true;
+  stream.m_adStream.start_stream();
+  stream.SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream.m_adStream));
+  stream.SetStreamFile(std::make_unique<AP4_File>(*stream.GetAdByteStream(),
+                                                  AP4_DefaultAtomFactory::Instance_, true));
+  AP4_Movie* movie{stream.GetStreamFile()->GetMovie()};
+  if (!movie)
+  {
+    LOG::LogF(LOGERROR, "No MOOV atom in stream");
+    stream.Disable();
+    return;
+  }
+
+  AP4_Track* track =
+      movie->GetTrack(static_cast<AP4_Track::Type>(stream.m_adStream.GetTrackType()));
+
+  if (track) // Try extract the default KID from tenc / piff mp4 box
+  {
+    AP4_ProtectedSampleDescription* protSampleDesc =
+        static_cast<AP4_ProtectedSampleDescription*>(track->GetSampleDescription(0));
+
+    if (protSampleDesc)
+    {
+      AP4_ProtectionSchemeInfo* psi = protSampleDesc->GetSchemeInfo();
+      if (psi)
+      {
+        AP4_ContainerAtom* schi = protSampleDesc->GetSchemeInfo()->GetSchiAtom();
+        if (schi)
+        {
+          AP4_TencAtom* tenc =
+              AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0));
+          if (tenc)
+          {
+            drmInfo.defaultKid = STRING::ToLower(STRING::ToHexadecimal(tenc->GetDefaultKid(), 16));
+          }
+          else
+          {
+            AP4_PiffTrackEncryptionAtom* piff =
+                AP4_DYNAMIC_CAST(AP4_PiffTrackEncryptionAtom,
+                                 schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0));
+            if (piff)
+            {
+              drmInfo.defaultKid = STRING::ToLower(STRING::ToHexadecimal(piff->GetDefaultKid(), 16));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (drmInfo.initData.empty() || drmInfo.defaultKid.empty())
+  {
+    AP4_Array<AP4_PsshAtom>& pssh{movie->GetPsshAtoms()};
+    const uint8_t* currSystemId = DRM::KeySystemToUUID(m_keySystem);
+
+    for (unsigned int i = 0; i < pssh.ItemCount(); ++i)
+    {
+      AP4_PsshAtom& psshAtom = pssh[i];
+
+      // Try find the system id
+      if (std::memcmp(psshAtom.GetSystemId(), currSystemId, 16) == 0)
+      {
+        const AP4_DataBuffer& dataBuf = psshAtom.GetData();
+        const std::vector<uint8_t> psshData{dataBuf.GetData(),
+                                            dataBuf.GetData() + dataBuf.GetDataSize()};
+
+        drmInfo.initData = DRM::PSSH::Make(psshAtom.GetSystemId(), {}, psshData);
+
+        if (psshAtom.GetKid(0))
+        {
+          drmInfo.defaultKid = STRING::ToLower(STRING::ToHexadecimal(pssh[i].GetKid(0), 16));
+        }
+
+        break;
+      }
+    }
+  }
+
+  stream.Disable();
+}
+
+void DRM::CDRMEngine::DeleteSessionsByType(const DRMMediaType mediaType)
+{
+  // Despite this will delete sessions, the shared IDecrypter/Adaptive_CencSingleSampleDecrypter
+  // might still be in use, for example on CVideoCodecAdaptive, so shared uses can be deleted at later time
+  m_sessions.erase(std::remove_if(m_sessions.begin(), m_sessions.end(),
+                                  [mediaType](const DRMSession& session)
+                                  { return session.mediaType == mediaType; }),
+                   m_sessions.end());
+}
+
+bool DRM::CDRMEngine::HasKeySystemSupport(std::string_view keySystem) const
+{
+  return std::find(m_supportedKs.cbegin(), m_supportedKs.cend(), keySystem) != m_supportedKs.cend();
+}
+
+void DRM::CDRMEngine::Dispose()
+{
+  LOG::Log(LOGDEBUG, "Dispose DRM Engine");
+  m_sessions.clear();
+  m_drms.clear();
+}

--- a/src/decrypters/DrmEngine.h
+++ b/src/decrypters/DrmEngine.h
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "DrmEngineDefines.h"
+#include "IDecrypter.h"
+#include "utils/CryptoUtils.h"
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "test/KodiStubs.h"
+#else
+#include <kodi/addon-instance/Inputstream.h>
+#endif
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// forwards
+namespace PLAYLIST
+{
+class CRepresentation;
+class CAdaptationSet;
+} // namespace PLAYLIST
+
+namespace DRM
+{
+
+class ATTR_DLL_LOCAL CDRMEngine
+{
+public:
+  CDRMEngine() = default;
+  virtual ~CDRMEngine() = default;
+
+  /*!
+   * \brief Initialize the DRM engine.
+   */
+  void Initialize();
+
+  /*!
+   * \brief Pre-initialize a DRM before to download a manifest and create a session.
+   * \param session[OUT] The opened session
+   * \return True if has been pre-initialized, otherwise false
+   */
+  bool PreInitializeDRM(DRMSession& session);
+
+  /*!
+   * \brief Initialize a DRM (if needed), then create or reuse a session.
+   * \param drmInfos The DRM info provided by a manifest
+   * \param mediaType The type of media involved in the session
+   * \param isForceSecureDecoder[OPT] To force the Secure Decoder, this setting coming from the manifest
+   * \param streamInfo The InputstreamInfo where set the DRM configuration
+   * \param repr The representation of the stream refer to drmInfos
+   * \param adp The adaptation set of the representation
+   * \param canCleanupSessions Delete existing sessions before to create a new one
+   * \param initDrmInfo[OUT] Set the DRMInfo used to initialize, otherwise the value is unchanged
+   * \return True if has success, otherwise false
+   */
+  bool InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
+                         DRM::DRMMediaType mediaType,
+                         std::optional<bool> isForceSecureDecoder,
+                         kodi::addon::InputstreamInfo& streamInfo,
+                         PLAYLIST::CRepresentation* repr,
+                         PLAYLIST::CAdaptationSet* adp,
+                         bool canCleanupSessions,
+                         DRM::DRMInfo& initDrmInfo);
+
+  /*!
+   * \brief Get the session by ID (dont take in account KID).
+   * \param id The session ID
+   * \return The session, otherwise nullptr if not found
+   */
+  const DRMSession* GetSession(const std::string& id) const;
+
+  /*!
+   * \brief Get the session by ID that match the specified KID.
+   * \param id The session ID
+   * \return The session, otherwise nullptr if not found
+   */
+  const DRMSession* GetSession(const std::string& id, const std::string& kid) const;
+
+
+  /*!
+   * \brief Get the current engine status. The state can change after each call to InitializeSession.
+   * \return The current status
+   */
+  EngineStatus GetStatus() const { return m_status; }
+
+  /*!
+   * \brief Unload DRM engine resources.
+   */
+  void Dispose();
+
+private:
+  /*!
+   * \brief Configure DRM ClearKey, by replacing manifest DRM info when needed.
+   */
+  bool ConfigureClearKey(std::vector<DRM::DRMInfo>& drmInfos);
+
+  /*!
+   * \brief Select and set a DRM compatible with a DRM info.
+   * \param drmInfos The manifest DRM info
+   * \return True if a match was found, otherwise false
+   */
+  bool SelectDRM(std::vector<DRM::DRMInfo>& drmInfos);
+
+  void ExtractStreamProtectionData(PLAYLIST::CRepresentation* repr,
+                                   PLAYLIST::CAdaptationSet* adp,
+                                   DRM::DRMInfo& drmInfo);
+
+  // \brief Delete all sessions by media type
+  void DeleteSessionsByType(const DRMMediaType type);
+
+  // \brief Check if a Key System is supported
+  bool HasKeySystemSupport(std::string_view keySystem) const;
+
+  std::vector<std::string> m_supportedKs; // Supported key systems, the lower index has higher priority
+  std::string m_keySystem; // Choosen key system
+  std::map<std::string, std::shared_ptr<DRM::IDecrypter>> m_drms; // KeySystem - DRM instance
+  std::vector<DRMSession> m_sessions;
+
+  EngineStatus m_status{EngineStatus::NONE};
+  bool m_isPreinitialized{false};
+};
+
+} // namespace DRM

--- a/src/decrypters/DrmEngineDefines.h
+++ b/src/decrypters/DrmEngineDefines.h
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/CryptoUtils.h"
+
+#include <cstdint>
+#include <memory>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+// forwards
+class Adaptive_CencSingleSampleDecrypter;
+namespace DRM
+{
+class IDecrypter;
+}
+
+namespace DRM
+{
+
+constexpr uint16_t HDCP_V_NONE = 0;
+constexpr uint16_t HDCP_V_MAX = 9999;
+
+struct DecrypterCapabilites
+{
+  static const uint32_t SSD_SUPPORTS_DECODING = 1;
+  static const uint32_t SSD_SECURE_PATH = 2;
+  static const uint32_t SSD_ANNEXB_REQUIRED = 4;
+  static const uint32_t SSD_HDCP_RESTRICTED = 8;
+  static const uint32_t SSD_SINGLE_DECRYPT = 16;
+  static const uint32_t SSD_SECURE_DECODER = 32;
+  static const uint32_t SSD_INVALID = 64;
+
+  static const uint32_t SSD_MEDIA_VIDEO = 1;
+  static const uint32_t SSD_MEDIA_AUDIO = 2;
+
+  uint16_t flags{0};
+
+  /* The following 2 fields are set as followed:
+     - If licenseresponse return hdcp information, hdcpversion is 0 and
+       hdcplimit either 0 (if hdcp is supported) or given value (if hdcpversion is not supported)
+     - if no hdcp information is passed in licenseresponse, we set hdcpversion to the value we support
+       manifest / representation have to check if they are allowed to be played.
+  */
+  uint16_t hdcpVersion{HDCP_V_NONE}; //The HDCP version streams has to be restricted 0,10,20,21,22.....
+  int hdcpLimit{0}; // If set (> 0) streams that are greater than the multiplication of "Width x Height" cannot be played.
+};
+
+struct Config
+{
+  // The Key System used to initialize DRM
+  std::string keySystem;
+  // To enable persistent state CDM behaviour
+  bool isPersistentStorage{false};
+  // Optional parameters to make the CDM key request (CDM specific parameters)
+  std::map<std::string, std::string> optKeyReqParams;
+
+  struct License
+  {
+    // The license server certificate
+    std::vector<uint8_t> serverCert;
+    // The license server uri
+    std::string serverUri;
+    // To force an HTTP GET request, instead that POST request
+    bool isHttpGetRequest{false};
+    // HTTP request headers
+    std::map<std::string, std::string> reqHeaders;
+    // HTTP parameters to append to the url
+    std::string reqParams;
+    // Custom license data encoded as base64 to make the HTTP license request
+    std::string reqData;
+    // License data wrappers
+    // Multiple wrappers supported e.g. "base64,json", the name order defines the order
+    // in which data will be wrapped, (1) base64 --> (2) url
+    std::string wrapper;
+    // License data unwrappers
+    // Multiple un-wrappers supported e.g. "base64,json", the name order defines the order
+    // in which data will be unwrapped, (1) base64 --> (2) json
+    std::string unwrapper;
+    // License data unwrappers parameters
+    std::map<std::string, std::string> unwrapperParams;
+    // Clear key's for ClearKey DRM (KID / KEY pair)
+    std::map<std::string, std::string> keys;
+  };
+
+  // The license configuration
+  License license;
+  // Specifies if has been parsed the new DRM config ("drm" or "drm_legacy" kodi property)
+  //! @todo: to remove when deprecated DRM properties will be removed
+  bool isNewConfig{true};
+};
+
+constexpr std::string_view ROBUSTNESS_HW_SECDEC = "HW_SECURE_DECODE";
+
+enum class EngineStatus
+{
+  NONE,
+  DRM_ERROR, // Unsupported DRM, or a problem in the initialization of DRM
+  DECRYPTER_ERROR, // A DRM decrypter error
+};
+
+enum class DRMMediaType
+{
+  UNKNOWN,
+  VIDEO,
+  AUDIO
+};
+
+struct DRMInfo
+{
+  std::string keySystem; // Key system, empty if CENC
+  CryptoMode cryptoMode = CryptoMode::NONE; // Encryption scheme
+  std::string robustness;
+  std::vector<uint8_t> initData;
+  std::string defaultKid;
+  std::string licenseServerUri;
+  std::vector<uint8_t> serverCert; // Server certificate
+};
+
+struct DRMSession
+{
+  std::string id; // DRM session ID
+  std::shared_ptr<DRM::IDecrypter> drm; // DRM instance
+  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter; // DRM Decrypter instance
+  DRM::DecrypterCapabilites capabilities;
+  std::string kid;
+  std::string challenge; // Key request (Challenge) as base64
+  DRMMediaType mediaType{DRMMediaType::UNKNOWN};
+};
+
+} // namespace DRM

--- a/src/decrypters/DrmFactory.cpp
+++ b/src/decrypters/DrmFactory.cpp
@@ -68,6 +68,7 @@ DRM::Config DRM::CreateDRMConfig(std::string_view keySystem, const ADP::KODI_PRO
 {
   DRM::Config cfg;
 
+  cfg.keySystem = keySystem;
   cfg.isPersistentStorage = propCfg.isPersistentStorage;
   cfg.optKeyReqParams = propCfg.optKeyReqParams;
   cfg.isNewConfig = propCfg.isNewConfig;
@@ -76,7 +77,7 @@ DRM::Config DRM::CreateDRMConfig(std::string_view keySystem, const ADP::KODI_PRO
   auto& licCfg = cfg.license;
 
   licCfg.serverCert = BASE64::Decode(propLicCfg.serverCert);
-  licCfg.serverUrl = propLicCfg.serverUrl;
+  licCfg.serverUri = propLicCfg.serverUri;
   licCfg.isHttpGetRequest = propLicCfg.isHttpGetRequest;
 
   if (!propLicCfg.reqData.empty() && !BASE64::IsValidBase64(propLicCfg.reqData) &&

--- a/src/decrypters/HelperPr.cpp
+++ b/src/decrypters/HelperPr.cpp
@@ -194,7 +194,6 @@ bool DRM::PRHeaderParser::Parse(const std::vector<uint8_t>& prHeader)
   }
 
   std::string_view ver = XML::GetAttrib(nodeWRM, "version");
-  LOG::Log(LOGDEBUG, "Parsing Playready header version %s", ver.data());
 
   xml_node nodeDATA = nodeWRM.child("DATA");
   if (!nodeDATA)

--- a/src/decrypters/HelperWv.cpp
+++ b/src/decrypters/HelperWv.cpp
@@ -428,7 +428,8 @@ bool DRM::WvUnwrapLicense(std::string_view wrapper,
                           std::string_view contentType,
                           std::string data,
                           std::string& dataOut,
-                          int& hdcpLimit)
+                          int& hdcpResLimit,
+                          uint16_t& hdcpVerLimit)
 {
   // The license response must be in binary data format
   // but many services have a proprietary implementations therefore
@@ -528,31 +529,88 @@ bool DRM::WvUnwrapLicense(std::string_view wrapper,
 
       data = jDataObjValue->GetString();
 
-      if (STRING::KeyExists(params, "path_hdcp"))
+      if (STRING::KeyExists(params, "path_hdcp_res"))
       {
         bool isJsonHdcpTraverse{false};
-        if (STRING::KeyExists(params, "path_hdcp_traverse"))
-          isJsonHdcpTraverse = STRING::ToLower(params.at("path_hdcp_traverse")) == "true";
+        if (STRING::KeyExists(params, "path_hdcp_res_traverse"))
+          isJsonHdcpTraverse = STRING::ToLower(params.at("path_hdcp_res_traverse")) == "true";
 
         const rapidjson::Value* jHdcpObjValue;
         if (isJsonHdcpTraverse)
-          jHdcpObjValue = JSON::GetValueTraversePaths(jDoc, params.at("path_hdcp"));
+          jHdcpObjValue = JSON::GetValueTraversePaths(jDoc, params.at("path_hdcp_res"));
         else
-          jHdcpObjValue = JSON::GetValueAtPath(jDoc, params.at("path_hdcp"));
+          jHdcpObjValue = JSON::GetValueAtPath(jDoc, params.at("path_hdcp_res"));
 
         if (!jHdcpObjValue)
         {
-          LOG::LogF(LOGERROR, "Unable to parse JSON HDCP value, path \"%s\" not found",
-                    params.at("path_hdcp").c_str());
+          LOG::LogF(LOGWARNING, "Unable to parse JSON HDCP resolution, path \"%s\" not found",
+                    params.at("path_hdcp_res").c_str());
         }
-        else if (!jHdcpObjValue->IsInt())
+        else if (jHdcpObjValue->IsInt())
         {
-          LOG::LogF(LOGERROR,
-                    "Unable to parse JSON HDCP value, value with wrong data type on path \"%s\"",
-                    params.at("path_hdcp").c_str());
+          hdcpResLimit = jHdcpObjValue->GetInt();
+        }
+        else if (jHdcpObjValue->IsDouble())
+        {
+          hdcpResLimit = static_cast<int>(jHdcpObjValue->GetDouble());
+        }
+        else if (jHdcpObjValue->IsString())
+        {
+          std::string_view resValue = jHdcpObjValue->GetString();
+
+          auto pos = resValue.find('x');
+          if (pos != std::string_view::npos) // Expected format width x height (e.g. "1280x720")
+          {
+            const int width = STRING::ToInt32(resValue.substr(0, pos));
+            const int height = STRING::ToInt32(resValue.substr(pos + 1));
+            hdcpResLimit = width * height;
+          }
+          else // Expected format multiplication of width x height (e.g. 921600 stands for "1280x720")
+          {
+            hdcpResLimit = STRING::ToInt32(resValue);
+          }
         }
         else
-          hdcpLimit = jHdcpObjValue->GetInt();
+          LOG::LogF(LOGERROR,
+                    "Unable to parse JSON HDCP resolution, wrong data type on path \"%s\"",
+                    params.at("path_hdcp_res").c_str());
+      }
+
+      if (STRING::KeyExists(params, "path_hdcp_ver"))
+      {
+        bool isJsonHdcpTraverse{false};
+        if (STRING::KeyExists(params, "path_hdcp_ver_traverse"))
+          isJsonHdcpTraverse = STRING::ToLower(params.at("path_hdcp_ver_traverse")) == "true";
+
+        const rapidjson::Value* jHdcpObjValue;
+        if (isJsonHdcpTraverse)
+          jHdcpObjValue = JSON::GetValueTraversePaths(jDoc, params.at("path_hdcp_ver"));
+        else
+          jHdcpObjValue = JSON::GetValueAtPath(jDoc, params.at("path_hdcp_ver"));
+
+        if (!jHdcpObjValue)
+        {
+          LOG::LogF(LOGWARNING, "Unable to parse JSON HDCP version, path \"%s\" not found",
+                    params.at("path_hdcp_ver").c_str());
+        }
+        else if (jHdcpObjValue->IsInt())
+        {
+          hdcpVerLimit = jHdcpObjValue->GetInt();
+        }
+        else if (jHdcpObjValue->IsDouble())
+        {
+          hdcpVerLimit = static_cast<int>(jHdcpObjValue->GetDouble() * 10);
+        }
+        else if (jHdcpObjValue->IsString())
+        {
+          // Try convert the string value e.g. "HDCP_NONE" --> 0, "HDCP_V2_2" --> 22
+          hdcpVerLimit = STRING::GetNumbers(jHdcpObjValue->GetString());
+        }
+        else
+        {
+          LOG::LogF(LOGERROR, "Unable to parse JSON HDCP version, wrong data type on path \"%s\"",
+                    params.at("path_hdcp_ver").c_str());
+        }
       }
 
       if (isAuto && BASE64::IsValidBase64(data))
@@ -656,5 +714,32 @@ void DRM::TranslateLicenseUrlPh(std::string& url,
     md5.Update(challenge.data(), static_cast<uint32_t>(challenge.size()));
     md5.Finalize();
     STRING::ReplaceFirst(url, "{CHA-MD5}", md5.HexDigest());
+  }
+}
+
+int DRM::ParseXLimitVideoHeader(std::string_view value)
+{
+  if (value.empty())
+    return 0;
+
+  // Only supported "max" parameter
+  if (!STRING::StartsWith(value, "max="))
+  {
+    LOG::LogF(LOGERROR, "Cannot parse \"X-Limit-Video\" header, missing \"max\" parameter");
+    return 0;
+  }
+
+  value.remove_prefix(4);
+
+  auto pos = value.find('x');
+  if (pos != std::string_view::npos) // Expected format width x height (e.g. "1280x720")
+  {
+    const int width = STRING::ToInt32(value.substr(0, pos));
+    const int height = STRING::ToInt32(value.substr(pos + 1));
+    return width * height;
+  }
+  else // Expected format multiplication of width x height (e.g. 921600 stands for "1280x720"), backward compatibility Kodi <= 21
+  {
+    return STRING::ToInt32(value);
   }
 }

--- a/src/decrypters/HelperWv.h
+++ b/src/decrypters/HelperWv.h
@@ -124,10 +124,18 @@ bool WvUnwrapLicense(std::string_view wrapper,
                      std::string_view contentType,
                      std::string data,
                      std::string& dataOut,
-                     int& hdcpLimit);
+                     int& hdcpResLimit,
+                     uint16_t& hdcpVerLimit);
 
 void TranslateLicenseUrlPh(std::string& url,
                            const std::vector<uint8_t>& challenge,
                            const bool isNewConfig);
+
+/*!
+ * \brief Parse the value of "X-Limit-Video" HTTP header.
+ * \param value The header value
+ * \return The value of "max" parameter, otherwise 0
+ */
+int ParseXLimitVideoHeader(std::string_view value);
 
 } // namespace DRM

--- a/src/decrypters/Helpers.cpp
+++ b/src/decrypters/Helpers.cpp
@@ -94,6 +94,20 @@ std::vector<std::string> DRM::UrnsToSystemIds(const std::vector<std::string_view
   return sids;
 }
 
+std::string_view DRM::UrnToKeySystem(std::string_view urn)
+{
+  if (urn == URN_WIDEVINE)
+    return KS_WIDEVINE;
+  else if (urn == URN_PLAYREADY)
+    return KS_PLAYREADY;
+  else if (urn == URN_WISEPLAY)
+    return KS_WISEPLAY;
+  else if (urn == URN_CLEARKEY || urn == URN_COMMON)
+    return KS_CLEARKEY;
+  else
+    return "";
+}
+
 std::string DRM::KeySystemToDrmName(std::string_view ks)
 {
   if (ks == KS_WIDEVINE)

--- a/src/decrypters/Helpers.h
+++ b/src/decrypters/Helpers.h
@@ -78,6 +78,13 @@ std::string UrnToSystemId(std::string_view urn);
 std::vector<std::string> UrnsToSystemIds(const std::vector<std::string_view>& urns);
 
 /*!
+ * \brief Convert DRM URN to Key System.
+ * \param urn The URN
+ * \return The Key System, otherwise empty if fails.
+ */
+std::string_view UrnToKeySystem(std::string_view urn);
+
+/*!
  * \brief Convert a hexdecimal KeyId of 32 chars to 16 bytes.
  * \param kidStr The hexdecimal KeyId
  * \return KeyId as bytes, otherwise empty if fails.

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "DrmEngineDefines.h"
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -21,73 +23,6 @@ enum class CryptoMode;
 
 namespace DRM
 {
-struct DecrypterCapabilites
-{
-  static const uint32_t SSD_SUPPORTS_DECODING = 1;
-  static const uint32_t SSD_SECURE_PATH = 2;
-  static const uint32_t SSD_ANNEXB_REQUIRED = 4;
-  static const uint32_t SSD_HDCP_RESTRICTED = 8;
-  static const uint32_t SSD_SINGLE_DECRYPT = 16;
-  static const uint32_t SSD_SECURE_DECODER = 32;
-  static const uint32_t SSD_INVALID = 64;
-
-  static const uint32_t SSD_MEDIA_VIDEO = 1;
-  static const uint32_t SSD_MEDIA_AUDIO = 2;
-
-  uint16_t flags{0};
-
-  /* The following 2 fields are set as followed:
-     - If licenseresponse return hdcp information, hdcpversion is 0 and
-       hdcplimit either 0 (if hdcp is supported) or given value (if hdcpversion is not supported)
-     - if no hdcp information is passed in licenseresponse, we set hdcpversion to the value we support
-       manifest / representation have to check if they are allowed to be played.
-  */
-  uint16_t hdcpVersion{0}; //The HDCP version streams has to be restricted 0,10,20,21,22.....
-  int hdcpLimit{0}; // If set (> 0) streams that are greater than the multiplication of "Width x Height" cannot be played.
-};
-
-struct Config
-{
-  // To enable persistent state CDM behaviour
-  bool isPersistentStorage{false};
-  // Optional parameters to make the CDM key request (CDM specific parameters)
-  std::map<std::string, std::string> optKeyReqParams;
-
-  struct License
-  {
-    // The license server certificate
-    std::vector<uint8_t> serverCert;
-    // The license server url
-    std::string serverUrl;
-    // To force an HTTP GET request, instead that POST request
-    bool isHttpGetRequest{false};
-    // HTTP request headers
-    std::map<std::string, std::string> reqHeaders;
-    // HTTP parameters to append to the url
-    std::string reqParams;
-    // Custom license data encoded as base64 to make the HTTP license request
-    std::string reqData;
-    // License data wrappers
-    // Multiple wrappers supported e.g. "base64,json", the name order defines the order
-    // in which data will be wrapped, (1) base64 --> (2) url
-    std::string wrapper;
-    // License data unwrappers
-    // Multiple un-wrappers supported e.g. "base64,json", the name order defines the order
-    // in which data will be unwrapped, (1) base64 --> (2) json
-    std::string unwrapper;
-    // License data unwrappers parameters
-    std::map<std::string, std::string> unwrapperParams;
-    // Clear key's for ClearKey DRM (KID / KEY pair)
-    std::map<std::string, std::string> keys;
-  };
-
-  // The license configuration
-  License license;
-  // Specifies if has been parsed the new DRM config ("drm" or "drm_legacy" kodi property)
-  //! @todo: to remove when deprecated DRM properties will be removed
-  bool isNewConfig{true};
-};
-
 class IDecrypter
 {
 public:
@@ -100,13 +35,6 @@ public:
    * \return True if has success, otherwise false
    */
   virtual bool Initialize() { return true; }
-
-  /**
-   * \brief Used to ensure the correct key system is selected
-   * \param keySystem The URN to be matched
-   * \return Supported URN if type matches to capabilities, otherwise null
-   */
-  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) = 0;
 
   /**
    * \brief Initialise the DRM system
@@ -143,14 +71,19 @@ public:
                                uint32_t media,
                                DecrypterCapabilites& caps) = 0;
 
-  /**
-   * \brief Check if the supplied KeyID has a license in the decrypter
+  /*
+   * \brief Check if the supplied KID has a license in the decrypter,
+   *        this feature depends on implementation of decrypter, so it will return null if its not implemented.
    * \param decrypter The single sample decrypter to use for this check
    * \param keyid The KeyID to check for a valid license
-   * \return True if the KeyID has a license otherwise false
+   * \return True if the license contains the KID, otherwise false. Null if not implemented.
    */
-  virtual bool HasLicenseKey(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
-                             const std::vector<uint8_t>& keyId) = 0;
+  virtual std::optional<bool> HasLicenseKey(
+      std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
+      const std::vector<uint8_t>& keyId)
+  {
+    return std::nullopt;
+  }
 
   /**
    * \brief Check if the decrypter has been initialised (OpenDRMSystem called)
@@ -208,6 +141,16 @@ public:
    * \return The auxillary library path
    */
   virtual std::string_view GetLibraryPath() const = 0;
+
+  /*
+   * \brief Unload resources.
+   */
+  virtual void Dispose() {}
+
+  /*
+   * \brief Workaround to missing secure decoder implementation.
+   */
+  virtual bool IsSecureDecoderAudioSupported() { return true; }
 
 };
 }; // namespace DRM

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -15,6 +15,7 @@
 #include "utils/CurlUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/UrlUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -25,121 +26,111 @@
 
 using namespace UTILS;
 
-namespace
-{
-void CkB64Encode(std::string& str)
-{
-  STRING::ReplaceAll(str, "+", "-");
-  STRING::ReplaceAll(str, "/", "_");
-}
-
-void CkB64Decode(std::string& str)
-{
-  STRING::ReplaceAll(str, "-", "+");
-  STRING::ReplaceAll(str, "_", "/");
-}
-}
+uint32_t CClearKeyCencSingleSampleDecrypter::g_sessionIdCount = 1;
 
 CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
-    std::string_view licenseUrl,
+    std::string_view licenseUri,
     const std::map<std::string, std::string>& licenseHeaders,
     const std::vector<uint8_t>& defaultKeyId,
     CClearKeyDecrypter* host)
   : m_host(host)
 {
-  if (licenseUrl.empty())
+  if (licenseUri.empty())
   {
-    LOG::LogF(LOGERROR, "License server URL not found");
+    LOG::LogF(LOGERROR, "Cannot decrypt, the license server URI is missing");
     return;
   }
 
-  const std::string postData = CreateLicenseRequest(defaultKeyId);
+  std::string licenseData;
+  std::vector<uint8_t> uriData;
 
-  if (CSrvBroker::GetSettings().IsDebugLicense())
+  if (URL::GetUriByteData(licenseUri, uriData)) // Provided license data in URI format
   {
-    const std::string debugFilePath =
-        FILESYS::PathCombine(m_host->GetLibraryPath(), "ClearKey.init");
-    FILESYS::SaveFile(debugFilePath, postData.c_str(), true);
+    licenseData.assign(uriData.begin(), uriData.end());
+  }
+  else // Make the request to the server by using URL
+  {
+    const std::string postData = CreateLicenseRequest(defaultKeyId);
+
+    if (CSrvBroker::GetSettings().IsDebugLicense())
+    {
+      const std::string debugFilePath =
+          FILESYS::PathCombine(m_host->GetLibraryPath(), "ClearKey.init");
+      FILESYS::SaveFile(debugFilePath, postData.c_str(), true);
+    }
+
+    CURL::CUrl curl{licenseUri, postData};
+    curl.AddHeader("Accept", "application/json");
+    curl.AddHeader("Content-Type", "application/json");
+    curl.AddHeaders(licenseHeaders);
+
+    std::string response;
+    int statusCode = curl.Open();
+    if (statusCode == -1 || statusCode >= 400)
+    {
+      LOG::Log(LOGERROR, "License server returned failure (HTTP error %i)", statusCode);
+      return;
+    }
+
+    if (curl.Read(response) != CURL::ReadStatus::IS_EOF)
+    {
+      LOG::LogF(LOGERROR, "Could not read the license server response");
+      return;
+    }
+
+    if (CSrvBroker::GetSettings().IsDebugLicense())
+    {
+      const std::string debugFilePath =
+          FILESYS::PathCombine(m_host->GetLibraryPath(), "ClearKey.response");
+      FILESYS::SaveFile(debugFilePath, response, true);
+    }
+
+    licenseData = response;
   }
 
-  CURL::CUrl curl{licenseUrl, postData};
-  curl.AddHeader("Accept", "application/json");
-  curl.AddHeader("Content-Type", "application/json");
-  curl.AddHeaders(licenseHeaders);
-
-  std::string response;
-  int statusCode = curl.Open();
-  if (statusCode == -1 || statusCode >= 400)
+  if (!ParseLicenseResponse(licenseData))
   {
-    LOG::Log(LOGERROR, "License server returned failure (HTTP error %i)", statusCode);
-    return;
-  }
-
-  if (curl.Read(response) != CURL::ReadStatus::IS_EOF)
-  {
-    LOG::LogF(LOGERROR, "Could not read the license server response");
-    return;
-  }
-
-  if (CSrvBroker::GetSettings().IsDebugLicense())
-  {
-    const std::string debugFilePath =
-        FILESYS::PathCombine(m_host->GetLibraryPath(), "ClearKey.response");
-    FILESYS::SaveFile(debugFilePath, response, true);
-  }
-
-  if (!ParseLicenseResponse(response))
-  {
-    LOG::LogF(LOGERROR, "Could not parse the license server response");
+    LOG::LogF(LOGERROR, "Could not parse the license data");
     return;
   }
 
   const std::string b64DefaultKeyId = BASE64::Encode(defaultKeyId);
   if (!STRING::KeyExists(m_keyPairs, b64DefaultKeyId))
   {
-    LOG::LogF(LOGERROR, "Key not found on license server response");
+    LOG::LogF(LOGERROR, "Key not found on license data");
     return;
   }
 
   const std::vector<uint8_t> keyBytes = BASE64::Decode(m_keyPairs[b64DefaultKeyId]);
-  if (AP4_FAILED(AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, keyBytes.data(),
-                                                       static_cast<AP4_Size>(keyBytes.size()), 0, 0,
-                                                       nullptr, false, m_singleSampleDecrypter)))
-  {
-    LOG::LogF(LOGERROR, "Failed to create AP4_CencSingleSampleDecrypter");
-  }
-  SetParentIsOwner(false);
-  AddSessionKey(defaultKeyId);
+
+  InitDecrypter(defaultKeyId, keyBytes);
 }
 
 CClearKeyCencSingleSampleDecrypter::CClearKeyCencSingleSampleDecrypter(
     const std::vector<uint8_t>& initData,
     const std::vector<uint8_t>& defaultKeyId,
-    const std::map<std::string, std::string>& keys,
     CClearKeyDecrypter* host)
   : m_host(host)
 {
   std::vector<uint8_t> hexKey;
+  // Currently HLS manifest only support this
+  // and the init data should contain only the key
+  hexKey = initData;
 
-  if (keys.empty()) // Assume key is provided from the manifest
-  {
-    hexKey = initData;
-  }
-  else // Key provided in Kodi props
-  {
-    const std::string hexDefKid = STRING::ToHexadecimal(defaultKeyId);
+  InitDecrypter(defaultKeyId, hexKey);
+}
 
-    if (STRING::KeyExists(keys, hexDefKid))
-      STRING::ToHexBytes(keys.at(hexDefKid), hexKey);
-    else
-      LOG::LogF(LOGERROR, "Missing KeyId \"%s\" on DRM configuration", defaultKeyId.data());
-  }
-
-  AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, hexKey.data(),
-                                        static_cast<AP4_Size>(hexKey.size()), 0, 0, nullptr, false,
+void CClearKeyCencSingleSampleDecrypter::InitDecrypter(const std::vector<uint8_t>& defaultKeyId,
+                                                         const std::vector<uint8_t>& key)
+{
+  AP4_CencSingleSampleDecrypter::Create(AP4_CENC_CIPHER_AES_128_CTR, key.data(),
+                                        static_cast<AP4_Size>(key.size()), 0, 0, nullptr, false,
                                         m_singleSampleDecrypter);
   SetParentIsOwner(false);
   AddSessionKey(defaultKeyId);
+
+  // Define a session id
+  m_sessionId = "ck_" + std::to_string(g_sessionIdCount++);
 }
 
 void CClearKeyCencSingleSampleDecrypter::AddSessionKey(const std::vector<uint8_t>& keyId)
@@ -191,8 +182,7 @@ std::string CClearKeyCencSingleSampleDecrypter::CreateLicenseRequest(
    * "type":"temporary" }
    */
 
-  std::string b64Kid = BASE64::Encode(defaultKeyId, false);
-  CkB64Encode(b64Kid);
+  std::string b64Kid = BASE64::UrlSafeEncode(BASE64::Encode(defaultKeyId, false));
 
   rapidjson::Document jDoc;
   jDoc.SetObject();
@@ -255,7 +245,6 @@ bool CClearKeyCencSingleSampleDecrypter::ParseLicenseResponse(std::string data)
 
     if (keyName == "keys" && jDictVal.IsArray())
     {
-      // NOTE: for now we assume that one key only is requested and one only will come in the license response
       for (auto const& jArrayKey : jDictVal.GetArray())
       {
         if (jArrayKey.IsObject())
@@ -269,14 +258,13 @@ bool CClearKeyCencSingleSampleDecrypter::ParseLicenseResponse(std::string data)
 
         if (!b64Key.empty() && !b64KeyId.empty())
         {
-          CkB64Decode(b64Key);
+          b64Key = BASE64::UrlSafeDecode(b64Key);
           BASE64::AddPadding(b64Key);
 
-          CkB64Decode(b64KeyId);
+          b64KeyId = BASE64::UrlSafeDecode(b64KeyId);
           BASE64::AddPadding(b64KeyId);
 
           m_keyPairs.emplace(b64KeyId, b64Key);
-          break;
         }
       }
     }

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
@@ -16,13 +16,12 @@ class CClearKeyDecrypter;
 class CClearKeyCencSingleSampleDecrypter : public Adaptive_CencSingleSampleDecrypter
 {
 public:
-  CClearKeyCencSingleSampleDecrypter(std::string_view licenseUrl,
+  CClearKeyCencSingleSampleDecrypter(std::string_view licenseUri,
                                      const std::map<std::string, std::string>& licenseHeaders,
                                      const std::vector<uint8_t>& defaultKeyId,
                                      CClearKeyDecrypter* host);
   CClearKeyCencSingleSampleDecrypter(const std::vector<uint8_t>& initdata,
                                      const std::vector<uint8_t>& defaultKeyId,
-                                     const std::map<std::string, std::string>& keys,
                                      CClearKeyDecrypter* host);
   virtual ~CClearKeyCencSingleSampleDecrypter(){};
   void AddSessionKey(const std::vector<uint8_t>& keyId);
@@ -48,12 +47,18 @@ public:
   void SetDefaultKeyId(const std::vector<uint8_t>& keyId) override{};
   void AddKeyId(const std::vector<uint8_t>& keyId) override{};
   bool HasKeys() { return !m_keyIds.empty(); }
+  std::string GetSessionId() override { return m_sessionId; }
 
 private:
+  void InitDecrypter(const std::vector<uint8_t>& defaultKeyId, const std::vector<uint8_t>& key);
+
   AP4_CencSingleSampleDecrypter* m_singleSampleDecrypter{nullptr};
   std::string m_strSession;
   std::string m_licenceDefaultKeyId;
   std::vector<std::vector<uint8_t>> m_keyIds;
   std::map<std::string, std::string> m_keyPairs;
   CClearKeyDecrypter* m_host;
+
+  std::string m_sessionId;
+  static uint32_t g_sessionIdCount;
 };

--- a/src/decrypters/clearkey/ClearKeyDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.cpp
@@ -12,17 +12,6 @@
 #include "decrypters/Helpers.h"
 #include "utils/log.h"
 
-std::vector<std::string_view> CClearKeyDecrypter::SelectKeySystems(std::string_view keySystem)
-{
-  std::vector<std::string_view> keySystems;
-  if (keySystem == KS_CLEARKEY)
-  {
-    keySystems.emplace_back(URN_CLEARKEY);
-    keySystems.emplace_back(URN_COMMON);
-  }
-  return keySystems;
-}
-
 bool CClearKeyDecrypter::OpenDRMSystem(const DRM::Config& config)
 {
   m_config = config;
@@ -44,22 +33,20 @@ std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CClearKeyDecrypter::CreateSi
   }
 
   std::shared_ptr<CClearKeyCencSingleSampleDecrypter> decrypter;
+
+  // NOTE: dont look at m_config.license configuration, since CDRMEngine::ConfigureClearKey takes care of that
   const DRM::Config::License& licConfig = m_config.license;
 
-  // If keys / license url are provided by Kodi property, those of the manifest will be overwritten
-
-  if (!licConfig.serverUrl.empty())
-    licenseUrl = licConfig.serverUrl;
-
-  if ((!licConfig.keys.empty() || !initData.empty()) && licConfig.serverUrl.empty()) // Keys provided from manifest or Kodi property
+  if (initData.empty())
   {
-    decrypter = std::make_shared<CClearKeyCencSingleSampleDecrypter>(initData, defaultkeyid,
-                                                                     licConfig.keys, this);
+    // Assume that the license URI is provided by manifest or Kodi properties (props can be with keys or URL)
+    decrypter = std::make_shared<CClearKeyCencSingleSampleDecrypter>(
+        licenseUrl, licConfig.reqHeaders, defaultkeyid, this);
   }
-  else // Clearkey license server URL provided
+  else
   {
-    decrypter = std::make_shared<CClearKeyCencSingleSampleDecrypter>(licenseUrl, licConfig.reqHeaders,
-                                                                     defaultkeyid, this);
+    // Keys should be provided by the manifest
+    decrypter = std::make_shared<CClearKeyCencSingleSampleDecrypter>(initData, defaultkeyid, this);
   }
 
   if (!decrypter->HasKeys())
@@ -69,7 +56,7 @@ std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CClearKeyDecrypter::CreateSi
   return decrypter;
 }
 
-bool CClearKeyDecrypter::HasLicenseKey(
+std::optional<bool> CClearKeyDecrypter::HasLicenseKey(
     std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
     const std::vector<uint8_t>& keyId)
 {

--- a/src/decrypters/clearkey/ClearKeyDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.h
@@ -16,7 +16,6 @@ class CClearKeyDecrypter : public IDecrypter
 public:
   CClearKeyDecrypter(){};
   virtual ~CClearKeyDecrypter() override{};
-  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) override;
   virtual bool OpenDRMSystem(const DRM::Config& config) override;
   virtual std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CreateSingleSampleDecrypter(
       const std::vector<uint8_t>& initData,
@@ -31,8 +30,9 @@ public:
                                DRM::DecrypterCapabilites& caps) override
   {
   }
-  virtual bool HasLicenseKey(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
-                             const std::vector<uint8_t>& keyid) override;
+  virtual std::optional<bool> HasLicenseKey(
+      std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
+      const std::vector<uint8_t>& keyid) override;
   virtual bool IsInitialised() override { return m_isInitialized; }
   virtual std::string GetChallengeB64Data(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter) override
   {

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -42,7 +42,7 @@ CWVCdmAdapter::CWVCdmAdapter(const DRM::Config& config, CWVDecrypter* host)
 
   // The license url come from license_key kodi property
   // we have to kept only the url without the parameters specified after pipe "|" char
-  std::string licUrl = m_config.license.serverUrl;
+  std::string licUrl = m_config.license.serverUri;
   const size_t urlPipePos = licUrl.find('|');
   if (urlPipePos != std::string::npos)
     licUrl.erase(urlPipePos);

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -48,9 +48,6 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(
     CryptoMode cryptoMode)
   : m_cdmAdapter(cdmAdapter),
     m_pssh(pssh),
-    m_hdcpVersion(99),
-    m_hdcpLimit(0),
-    m_resolutionLimit(0),
     m_promiseId(1),
     m_isDrained(true),
     m_defaultKeyId(defaultKeyId),
@@ -116,6 +113,7 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
   if (m_strSession.empty())
   {
     LOG::LogF(LOGDEBUG, "Session empty");
+    caps.flags = DecrypterCapabilites::SSD_INVALID;
     return;
   }
 
@@ -124,6 +122,7 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
   if (m_keys.empty())
   {
     LOG::LogF(LOGDEBUG, "Keys empty");
+    caps.flags = DecrypterCapabilites::SSD_INVALID;
     return;
   }
 
@@ -172,17 +171,14 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
       if (DecryptSampleData(poolId, in, out, iv, 1, clearBytes, encryptedBytes) != AP4_SUCCESS)
       {
         LOG::LogF(LOGDEBUG, "Single decrypt failed, secure path only");
-        if (media == DecrypterCapabilites::SSD_MEDIA_VIDEO)
-          caps.flags |= (DecrypterCapabilites::SSD_SECURE_PATH |
-                         DecrypterCapabilites::SSD_ANNEXB_REQUIRED);
-        else
-          caps.flags = DecrypterCapabilites::SSD_INVALID;
+        caps.flags |=
+            (DecrypterCapabilites::SSD_SECURE_PATH | DecrypterCapabilites::SSD_ANNEXB_REQUIRED);
       }
       else
       {
         LOG::LogF(LOGDEBUG, "Single decrypt possible");
         caps.flags |= DecrypterCapabilites::SSD_SINGLE_DECRYPT;
-        caps.hdcpVersion = 99;
+        caps.hdcpVersion = DRM::HDCP_V_MAX;
         caps.hdcpLimit = m_resolutionLimit;
       }
     }
@@ -197,6 +193,7 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
   else
   {
     LOG::LogF(LOGDEBUG, "Decoding not supported");
+    caps.flags = DecrypterCapabilites::SSD_INVALID;
   }
 }
 
@@ -284,7 +281,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     UTILS::FILESYS::SaveFile(debugFilePath, reqData, true);
   }
 
-  std::string url = licConfig.serverUrl;
+  std::string url = licConfig.serverUri;
   DRM::TranslateLicenseUrlPh(url, challenge, drmCfg.isNewConfig);
 
   CURL::CUrl cUrl{url, reqData};
@@ -308,12 +305,10 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   const std::string resLimit = cUrl.GetResponseHeader("X-Limit-Video"); // Custom header
   const std::string respContentType = cUrl.GetResponseHeader("Content-Type");
 
-  if (!resLimit.empty())
+  if (m_cdmAdapter->GetKeySystem() == DRM::KS_WIDEVINE)
   {
-    // To force limit playable streams resolutions
-    size_t posMax = resLimit.find("max=");
-    if (posMax != std::string::npos)
-      m_resolutionLimit = std::atoi(resLimit.data() + (posMax + 4));
+    // Force limit playable streams resolutions
+    m_resolutionLimit = DRM::ParseXLimitVideoHeader(resLimit);
   }
 
   // The first request could be the license certificate request
@@ -323,8 +318,6 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
       m_challenge.GetDataSize() == 2 && respContentType == "application/octet-stream";
   m_challenge.SetDataSize(0);
 
-  int hdcpLimit{0};
-
   // Unwrap license response
   if (!licConfig.unwrapper.empty() && m_cdmAdapter->GetKeySystem() == DRM::KS_WIDEVINE)
   {
@@ -333,7 +326,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     // Here we provide a built-in way to unwrap the license data received, this avoid force add-ons to integrate
     // a HTTP server proxy to manage the license data request/response, and so use Kodi properties to set wrappers.
     if (!DRM::WvUnwrapLicense(licConfig.unwrapper, licConfig.unwrapperParams, respContentType,
-                              respData, unwrappedData, hdcpLimit))
+                              respData, unwrappedData, m_hdcpLimit, m_hdcpVersion))
     {
       return false;
     }

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -103,9 +103,9 @@ private:
   };
   std::vector<WVSKEY> m_keys;
 
-  AP4_UI16 m_hdcpVersion;
-  int m_hdcpLimit;
-  int m_resolutionLimit;
+  uint16_t m_hdcpVersion{DRM::HDCP_V_MAX};
+  int m_hdcpLimit{0};
+  int m_resolutionLimit{0};
 
   AP4_DataBuffer m_decryptIn;
   AP4_DataBuffer m_decryptOut;

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -74,18 +74,9 @@ bool CWVDecrypter::Initialize()
   return true;
 }
 
-std::vector<std::string_view> CWVDecrypter::SelectKeySystems(std::string_view keySystem)
-{
-  std::vector<std::string_view> keySystems;
-  if (keySystem == KS_WIDEVINE)
-    keySystems.push_back(URN_WIDEVINE);
-
-  return keySystems;
-}
-
 bool CWVDecrypter::OpenDRMSystem(const DRM::Config& config)
 {
-  if (config.license.serverUrl.empty())
+  if (config.license.serverUri.empty())
   {
     LOG::LogF(LOGERROR, "The DRM license server url has not been specified");
     return false;
@@ -131,8 +122,9 @@ void CWVDecrypter::GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecr
     LOG::LogF(LOGFATAL, "Cannot cast the decrypter shared pointer.");
 }
 
-bool CWVDecrypter::HasLicenseKey(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
-                                 const std::vector<uint8_t>& keyId)
+std::optional<bool> CWVDecrypter::HasLicenseKey(
+    std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
+    const std::vector<uint8_t>& keyId)
 {
   auto wvDecrypter = std::dynamic_pointer_cast<CWVCencSingleSampleDecrypter>(decrypter);
   if (wvDecrypter)
@@ -201,10 +193,12 @@ VIDEOCODEC_RETVAL CWVDecrypter::VideoFrameDataToPicture(
 void CWVDecrypter::ResetVideo()
 {
   if (m_decodingDecrypter)
-  {
     m_decodingDecrypter->ResetVideo();
-    m_decodingDecrypter = nullptr;
-  }
+}
+
+void CWVDecrypter::Dispose()
+{
+  m_decodingDecrypter = nullptr;
 }
 
 void CWVDecrypter::SetLibraryPath(std::string_view libraryPath)

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -19,7 +19,6 @@ public:
 
   virtual bool Initialize() override;
 
-  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) override;
   virtual bool OpenDRMSystem(const DRM::Config& config) override;
   virtual std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CreateSingleSampleDecrypter(
       const std::vector<uint8_t>& initData,
@@ -32,8 +31,9 @@ public:
                                const std::vector<uint8_t>& keyId,
                                uint32_t media,
                                DRM::DecrypterCapabilites& caps) override;
-  virtual bool HasLicenseKey(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
-                             const std::vector<uint8_t>& keyId) override;
+  virtual std::optional<bool> HasLicenseKey(
+      std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
+      const std::vector<uint8_t>& keyId) override;
   virtual bool IsInitialised() override { return m_WVCdmAdapter != nullptr; }
   virtual std::string GetChallengeB64Data(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter) override;
   virtual bool OpenVideoDecoder(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
@@ -43,10 +43,14 @@ public:
   virtual VIDEOCODEC_RETVAL VideoFrameDataToPicture(kodi::addon::CInstanceVideoCodec* codecInstance,
                                                     VIDEOCODEC_PICTURE* picture) override;
   virtual void ResetVideo() override;
+  virtual void Dispose() override;
   virtual void SetLibraryPath(std::string_view libraryPath) override;
   virtual bool GetBuffer(void* instance, VIDEOCODEC_PICTURE& picture);
   virtual void ReleaseBuffer(void* instance, void* buffer);
   virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
+
+  //! @todo: Secure path for audio is not implemented
+  virtual bool IsSecureDecoderAudioSupported() override { return false; }
 
 private:
   std::shared_ptr<CWVCdmAdapter> m_WVCdmAdapter;

--- a/src/decrypters/widevineandroid/WVCdmAdapter.cpp
+++ b/src/decrypters/widevineandroid/WVCdmAdapter.cpp
@@ -44,7 +44,7 @@ CWVCdmAdapterA::CWVCdmAdapterA(std::string_view keySystem,
 {
   // The license url come from license_key kodi property
   // we have to kept only the url without the parameters specified after pipe "|" char
-  std::string licUrl = m_config.license.serverUrl;
+  std::string licUrl = m_config.license.serverUri;
   const size_t urlPipePos = licUrl.find('|');
   if (urlPipePos != std::string::npos)
     licUrl.erase(urlPipePos);

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -34,8 +34,6 @@ CWVCencSingleSampleDecrypterA::CWVCencSingleSampleDecrypterA(
     m_pssh(pssh),
     m_isProvisioningRequested(false),
     m_isKeyUpdateRequested(false),
-    m_hdcpLimit(0),
-    m_resolutionLimit(0),
     m_defaultKeyId{defaultKeyId}
 {
   SetParentIsOwner(false);
@@ -168,20 +166,13 @@ std::vector<uint8_t> CWVCencSingleSampleDecrypterA::GetChallengeData()
   return m_keyRequestData;
 }
 
-bool CWVCencSingleSampleDecrypterA::HasLicenseKey(const std::vector<uint8_t>& keyId)
-{
-  // true = one session for all streams, false = one sessions per stream
-  // false fixes pixaltion issues on some devices when manifest has multiple encrypted streams
-  return true;
-}
-
 void CWVCencSingleSampleDecrypterA::GetCapabilities(const std::vector<uint8_t>& keyId,
                                                     uint32_t media,
                                                     DRM::DecrypterCapabilites& caps)
 {
   caps = {DRM::DecrypterCapabilites::SSD_SECURE_PATH |
               DRM::DecrypterCapabilites::SSD_ANNEXB_REQUIRED,
-          0, m_hdcpLimit};
+          m_hdcpVersion, m_hdcpLimit};
 
   if (caps.hdcpLimit == 0)
     caps.hdcpLimit = m_resolutionLimit;
@@ -195,8 +186,6 @@ void CWVCencSingleSampleDecrypterA::GetCapabilities(const std::vector<uint8_t>& 
     caps.flags |= DRM::DecrypterCapabilites::SSD_SECURE_DECODER;
   }
   LOG::LogF(LOGDEBUG, "hdcpLimit: %i", caps.hdcpLimit);
-
-  caps.hdcpVersion = 99;
 }
 
 void CWVCencSingleSampleDecrypterA::OnNotify(const CdmMessage& message)
@@ -381,7 +370,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<uint8_t
     UTILS::FILESYS::SaveFile(debugFilePath, reqData, true);
   }
 
-  std::string url = licConfig.serverUrl;
+  std::string url = licConfig.serverUri;
   DRM::TranslateLicenseUrlPh(url, challenge, drmCfg.isNewConfig);
 
   CURL::CUrl cUrl{url, reqData};
@@ -405,19 +394,15 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<uint8_t
   const std::string resLimit = cUrl.GetResponseHeader("X-Limit-Video"); // Custom header
   const std::string respContentType = cUrl.GetResponseHeader("Content-Type");
 
-  if (!resLimit.empty())
+  if (m_cdmAdapter->GetKeySystem() == DRM::KS_WIDEVINE)
   {
-    // To force limit playable streams resolutions
-    size_t posMax = resLimit.find("max=");
-    if (posMax != std::string::npos)
-      m_resolutionLimit = std::atoi(resLimit.data() + (posMax + 4));
+    // Force limit playable streams resolutions
+    m_resolutionLimit = DRM::ParseXLimitVideoHeader(resLimit);
   }
 
   // The first request could be the license certificate request
   // this request is done by sending a challenge of 2 bytes, 0x08 0x04 (CAQ=)
   const bool isCertRequest = challenge.size() == 2 && challenge[0] == 0x08 && challenge[1] == 0x04;
-
-  int hdcpLimit{0};
 
   // Unwrap license response
   if (!licConfig.unwrapper.empty() && m_cdmAdapter->GetKeySystem() == DRM::KS_WIDEVINE)
@@ -427,7 +412,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<uint8_t
     // Here we provide a built-in way to unwrap the license data received, this avoid force add-ons to integrate
     // a HTTP server proxy to manage the license data request/response, and so use Kodi properties to set wrappers.
     if (!DRM::WvUnwrapLicense(licConfig.unwrapper, licConfig.unwrapperParams, respContentType,
-                              respData, unwrappedData, hdcpLimit))
+                              respData, unwrappedData, m_hdcpLimit, m_hdcpVersion))
     {
       return false;
     }

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.h
@@ -33,7 +33,6 @@ public:
 
   virtual std::string GetSessionId() override;
   std::vector<uint8_t> GetChallengeData();
-  virtual bool HasLicenseKey(const std::vector<uint8_t>& keyId);
 
   virtual AP4_Result SetFragmentInfo(AP4_UI32 poolId,
                                      const std::vector<uint8_t>& keyId,
@@ -100,6 +99,8 @@ private:
     AP4_DataBuffer m_annexbSpsPps;
   };
   std::vector<FINFO> m_fragmentPool;
-  int m_hdcpLimit;
-  int m_resolutionLimit;
+
+  uint16_t m_hdcpVersion{DRM::HDCP_V_MAX};
+  int m_hdcpLimit{0};
+  int m_resolutionLimit{0};
 };

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -52,39 +52,15 @@ void JNIThread(JavaVM* vm)
 }
 #endif
 
-std::vector<std::string_view> CWVDecrypterA::SelectKeySystems(std::string_view keySystem)
-{
-  LOG::Log(LOGDEBUG, "Key system request: %s", keySystem);
-
-  if (keySystem == KS_WIDEVINE)
-  {
-    m_keySystem = keySystem;
-    return {URN_WIDEVINE};
-  }
-  else if (keySystem == KS_WISEPLAY)
-  {
-    m_keySystem = keySystem;
-    return {URN_WISEPLAY};
-  }
-  else if (keySystem == KS_PLAYREADY)
-  {
-    m_keySystem = keySystem;
-    return {URN_PLAYREADY};
-  }
-
-  m_keySystem.clear();
-  return {};
-}
-
 bool CWVDecrypterA::OpenDRMSystem(const DRM::Config& config)
 {
-  if (config.license.serverUrl.empty())
+  if (config.license.serverUri.empty())
   {
     LOG::LogF(LOGERROR, "The DRM license server url has not been specified");
     return false;
   }
 
-  m_WVCdmAdapter = std::make_shared<CWVCdmAdapterA>(m_keySystem, config, m_classLoader, this);
+  m_WVCdmAdapter = std::make_shared<CWVCdmAdapterA>(config.keySystem, config, m_classLoader, this);
 
   return m_WVCdmAdapter->GetCDM() != nullptr;
 }
@@ -124,20 +100,6 @@ void CWVDecrypterA::GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDec
   }
   else
     LOG::LogF(LOGFATAL, "Cannot cast the decrypter shared pointer.");
-}
-
-bool CWVDecrypterA::HasLicenseKey(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
-                                  const std::vector<uint8_t>& keyId)
-{
-  auto wvDecrypter = std::dynamic_pointer_cast<CWVCencSingleSampleDecrypterA>(decrypter);
-  if (wvDecrypter)
-  {
-    return wvDecrypter->HasLicenseKey(keyId);
-  }
-  else
-    LOG::LogF(LOGFATAL, "Cannot cast the decrypter shared pointer.");
-
-  return false;
 }
 
 std::string CWVDecrypterA::GetChallengeB64Data(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter)

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -44,8 +44,6 @@ public:
   }
 #endif
 
-  virtual std::vector<std::string_view> SelectKeySystems(std::string_view keySystem) override;
-
   virtual bool OpenDRMSystem(const DRM::Config& config) override;
 
   virtual std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CreateSingleSampleDecrypter(
@@ -59,9 +57,6 @@ public:
                                const std::vector<uint8_t>& keyId,
                                uint32_t media,
                                DRM::DecrypterCapabilites& caps) override;
-
-  virtual bool HasLicenseKey(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
-                             const std::vector<uint8_t>& keyId) override;
 
   virtual std::string GetChallengeB64Data(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter) override;
 
@@ -96,7 +91,6 @@ public:
 private:
   std::string m_libraryPath;
   kodi::platform::CInterfaceAndroidSystem m_androidSystem;
-  std::string m_keySystem;
   std::shared_ptr<CWVCdmAdapterA> m_WVCdmAdapter;
   std::shared_ptr<jni::CJNIClassLoader> m_classLoader;
   std::string m_retvalHelper;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,6 @@
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
 #include "Stream.h"
-#include "samplereader/SampleReaderFactory.h"
 #include "utils/ThreadPool.h"
 #include "utils/log.h"
 
@@ -82,7 +81,6 @@ bool CInputStreamAdaptive::GetStreamIds(std::vector<unsigned int>& ids)
         continue;
       }
 
-      uint8_t cdmId(static_cast<uint8_t>(stream->m_adStream.getRepresentation()->m_psshSetPos));
       if (stream->m_isValid && (m_session->GetMediaTypeMask() &
                                 static_cast<uint8_t>(1) << static_cast<int>(stream->m_adStream.GetStreamType())))
       {
@@ -138,6 +136,18 @@ bool CInputStreamAdaptive::GetStream(int streamid, kodi::addon::InputstreamInfo&
   // Kodi core will continue to request another stream of same type (a/v)
   // as long as one is successful
   return m_session->OnGetStream(streamid, info);
+
+  //! @todo: Kodi VideoPlayer stream fallback bug / problem:
+  //! if a video stream for some reason does not start (OpenStream/GetStream fails) VideoPlayer has no logic to open the next video stream based of stream ID
+  //! this is a big problem (can be reproduced using "Stream selection type" to "Manual OSD" and hack a bit the code)
+  //! because VP seem to always take the first stream ID (1001) in index order, instead to continue with the next stream ID.
+  //! For example if you are playing stream ID 1022 and fails, VP try to play always 1001 instead of 1023.
+  //! This causes the following problems:
+  //! - impossibility to keep a consistent video codec to be used
+  //! - impossibility to have a stable video quality fallback in a decreasing manner. We could sort the list of streams decreasingly by resolution and bandwidth
+  //!   but dont solve in full the problem in case of multicodec's because VP will mix all.
+  //!   I'm talking about "decreasing manner" quality also because with DRM if 4k / FULLHD doesn't work you need a fallback to lower quality.
+  //! this needs to be fixed in the Kodi core VP
 }
 
 void CInputStreamAdaptive::UnlinkIncludedStreams(CStream* stream)
@@ -245,37 +255,13 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     return false;
   }
 
-  m_session->PrepareStream(stream);
-
-  stream->m_adStream.start_stream(m_lastPts);
-  stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
-
-  ContainerType reprContainerType = rep->GetContainerType();
-  uint32_t mask = (1U << stream->m_info.GetStreamType()) | m_session->GetIncludedStreamMask();
-  auto reader = ADP::CreateStreamReader(reprContainerType, stream, mask);
-
-  if (!reader)
+  if (!m_session->PrepareStream(stream, m_lastPts))
   {
     m_session->EnableStream(stream, false);
     return false;
   }
 
-  reader->SetStreamId(stream->m_info.GetStreamType(), streamid);
-
-  uint16_t psshSetPos = stream->m_adStream.getRepresentation()->m_psshSetPos;
-  reader->SetDecrypter(m_session->GetSingleSampleDecryptor(psshSetPos),
-                       m_session->GetDecrypterCaps(psshSetPos));
-
-  stream->SetReader(std::move(reader));
-
-  if (reprContainerType == ContainerType::TS)
-  {
-    // With TS streams the elapsed time would be calculated incorrectly as during the tree refresh,
-    // nextSegment would be deleted by the FreeSegments/newsegments swap. Do this now before the tree refresh.
-    // Also, when reopening a stream (switching reps) the elapsed time would be incorrectly set until the
-    // second segment plays, now force a correct calculation at the start of the stream.
-    m_session->OnSegmentChanged(&stream->m_adStream);
-  }
+  stream->GetReader()->SetStreamId(stream->m_info.GetStreamType(), streamid);
 
   if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
   {
@@ -296,43 +282,14 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       }
     }
   }
+
   m_session->EnableStream(stream, true);
 
-  bool isInfoChanged = stream->GetReader()->GetInformation(stream->m_info);
-
-  uint16_t cdmSessionIndex = stream->m_adStream.getRepresentation()->m_psshSetPos;
-
-  if (stream->m_isEncrypted && m_session->IsCDMSessionSecurePath(cdmSessionIndex))
-  {
-    LOG::Log(LOGDEBUG, "OpenStream(%d): Create secure crypto session", streamid);
-
-    // StreamCryptoSession enable the use of ISA VideoCodecAdaptive decoder
-    kodi::addon::StreamCryptoSession cryptoSession;
-
-    const std::string keySystem = CSrvBroker::GetKodiProps().GetDrmKeySystem();
-    cryptoSession.SetKeySystem(m_session->GetCryptoKeySystem(keySystem));
-
-    cryptoSession.SetSessionId(m_session->GetCDMSession(cdmSessionIndex));
-
-    if (m_session->GetDecrypterCaps(cdmSessionIndex).flags &
-        DRM::DecrypterCapabilites::SSD_SUPPORTS_DECODING)
-      stream->m_info.SetFeatures(INPUTSTREAM_FEATURE_DECODE);
-    else
-      stream->m_info.SetFeatures(INPUTSTREAM_FEATURE_NONE);
-
-    if (m_session->GetDecrypterCaps(cdmSessionIndex).flags &
-        DRM::DecrypterCapabilites::SSD_SECURE_DECODER)
-      cryptoSession.SetFlags(STREAM_CRYPTO_FLAG_SECURE_DECODER);
-    else
-      cryptoSession.SetFlags(STREAM_CRYPTO_FLAG_NONE);
-
-    stream->m_info.SetCryptoSession(cryptoSession);
-    isInfoChanged = true;
-  }
-
+  // If stream use DRM always update stream info
+  const bool isInfoChanged = stream->GetReader()->GetInformation(stream->m_info) ||
+                             !stream->m_info.GetCryptoSession().GetSessionId().empty();
   return isInfoChanged;
 }
-
 
 DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
 {
@@ -548,13 +505,18 @@ CVideoCodecAdaptive::CVideoCodecAdaptive(const kodi::addon::IInstanceInfo& insta
 
 CVideoCodecAdaptive::~CVideoCodecAdaptive()
 {
+  // When the addon is about to be terminated
+  // CVideoCodecAdaptive instance will be destroyed before of CInputStreamAdaptive::Close() call
+  LOG::Log(LOGDEBUG, "CVideoCodecAdaptive::~CVideoCodecAdaptive");
+  m_drm->Dispose();
+  m_drm = nullptr;
 }
 
 bool CVideoCodecAdaptive::Open(const kodi::addon::VideoCodecInitdata& initData)
 {
-  if (!m_session || !m_session->GetDecrypter())
+  if (!m_session)
     return false;
- 
+
   if ((initData.GetCodecType() == VIDEOCODEC_H264 || initData.GetCodecType() == VIDEOCODEC_AV1) &&
       !initData.GetExtraDataSize() && !(m_state & STATE_WAIT_EXTRADATA))
   {
@@ -586,11 +548,17 @@ bool CVideoCodecAdaptive::Open(const kodi::addon::VideoCodecInitdata& initData)
   }
   m_name += ".decoder";
 
-  std::string sessionId = initData.GetCryptoSession().GetSessionId();
-  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd(m_session->GetSingleSampleDecrypter(sessionId));
+  const std::string sessionId = initData.GetCryptoSession().GetSessionId();
 
-  return m_session->GetDecrypter()->OpenVideoDecoder(
-      ssd, initData.GetCStructure());
+  auto drmSession = m_session->GetDRMEngine().GetSession(sessionId);
+  if (!drmSession)
+  {
+    LOG::LogF(LOGERROR, "Cannot get DRM session id: %s", sessionId.c_str());
+    return false;
+  }
+
+  m_drm = drmSession->drm;
+  return m_drm->OpenVideoDecoder(drmSession->decrypter, initData.GetCStructure());
 }
 
 bool CVideoCodecAdaptive::Reconfigure(const kodi::addon::VideoCodecInitdata& initData)
@@ -600,32 +568,32 @@ bool CVideoCodecAdaptive::Reconfigure(const kodi::addon::VideoCodecInitdata& ini
 
 bool CVideoCodecAdaptive::AddData(const DEMUX_PACKET& packet)
 {
-  if (!m_session || !m_session->GetDecrypter())
+  if (!m_drm)
     return false;
 
-  return m_session->GetDecrypter()->DecryptAndDecodeVideo(
-             dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this), &packet) != VC_ERROR;
+  return m_drm->DecryptAndDecodeVideo(dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this),
+                                      &packet) != VC_ERROR;
 }
 
 VIDEOCODEC_RETVAL CVideoCodecAdaptive::GetPicture(VIDEOCODEC_PICTURE& picture)
 {
-  if (!m_session || !m_session->GetDecrypter())
+  if (!m_drm)
     return VIDEOCODEC_RETVAL::VC_ERROR;
 
   static VIDEOCODEC_RETVAL vrvm[] = {VIDEOCODEC_RETVAL::VC_NONE, VIDEOCODEC_RETVAL::VC_ERROR,
                                      VIDEOCODEC_RETVAL::VC_BUFFER, VIDEOCODEC_RETVAL::VC_PICTURE,
                                      VIDEOCODEC_RETVAL::VC_EOF};
 
-  return vrvm[m_session->GetDecrypter()->VideoFrameDataToPicture(
-      dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this), &picture)];
+  return vrvm[m_drm->VideoFrameDataToPicture(dynamic_cast<kodi::addon::CInstanceVideoCodec*>(this),
+                                             &picture)];
 }
 
 void CVideoCodecAdaptive::Reset()
 {
-  if (!m_session || !m_session->GetDecrypter())
+  if (!m_drm)
     return;
 
-  m_session->GetDecrypter()->ResetVideo();
+  m_drm->ResetVideo();
 }
 
 /*****************************************************************************************************/

--- a/src/main.h
+++ b/src/main.h
@@ -92,6 +92,7 @@ private:
   };
 
   std::shared_ptr<SESSION::CSession> m_session;
+  std::shared_ptr<DRM::IDecrypter> m_drm;
   unsigned int m_state;
   std::string m_name;
 };

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -102,15 +102,12 @@ std::string DetectCodecFromMimeType(std::string_view mimeType)
 
 adaptive::CDashTree::CDashTree(const CDashTree& left) : AdaptiveTree(left)
 {
-  m_isCustomInitPssh = left.m_isCustomInitPssh;
 }
 
 void adaptive::CDashTree::Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                                    std::vector<std::string_view> supportedKeySystems,
                                     std::string_view manifestUpdParams)
 {
-  AdaptiveTree::Configure(reprChooser, supportedKeySystems, manifestUpdParams);
-  m_isCustomInitPssh = !CSrvBroker::GetKodiProps().GetDrmConfig().initData.empty();
+  AdaptiveTree::Configure(reprChooser, manifestUpdParams);
 }
 
 bool adaptive::CDashTree::Open(std::string_view url,
@@ -654,7 +651,6 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
   // Parse <ContentProtection> child tags
   if (nodeAdp.child("ContentProtection"))
   {
-    period->SetEncryptionState(EncryptionState::NOT_SUPPORTED);
     ParseTagContentProtection(nodeAdp, adpSet->ProtectionSchemes());
     period->SetSecureDecodeNeeded(ParseTagContentProtectionSecDec(nodeAdp));
   }
@@ -947,40 +943,13 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   // Parse <ContentProtection> child tags
   if (nodeRepr.child("ContentProtection"))
   {
-    period->SetEncryptionState(EncryptionState::NOT_SUPPORTED);
     ParseTagContentProtection(nodeRepr, repr->ProtectionSchemes());
   }
 
   // Store the protection data
   if (adpSet->HasProtectionSchemes() || repr->HasProtectionSchemes())
   {
-    std::vector<uint8_t> pssh;
-    std::string kid;
-    std::string licenseUrl;
-    // If a custom init PSSH is provided, should mean that a certain content protection tag
-    // is missing, in this case we ignore the content protection tags and we add a PsshSet without data
-    if (m_isCustomInitPssh || GetProtectionData(adpSet->ProtectionSchemes(),
-                                                repr->ProtectionSchemes(), pssh, kid, licenseUrl))
-    {
-      period->SetEncryptionState(EncryptionState::ENCRYPTED_DRM);
-
-      uint16_t psshSetPos =
-          InsertPsshSet(adpSet->GetStreamType(), period, adpSet, pssh, kid, licenseUrl);
-
-      if (psshSetPos == PSSHSET_POS_INVALID)
-      {
-        LOG::LogF(LOGWARNING, "Skipped representation with id: \"%s\", due to not valid PSSH",
-                  repr->GetId().data());
-        return;
-      }
-      repr->m_psshSetPos = psshSetPos;
-
-      if (ParseTagContentProtectionSecDec(nodeRepr).has_value())
-      {
-        LOG::LogF(LOGERROR, "The <ContentProtection><widevine:license> tag must be child of "
-                            "the <AdaptationSet> tag.");
-      }
-    }
+    GetProtectionData(adpSet->ProtectionSchemes(), repr->ProtectionSchemes(), *repr.get());
   }
 
   // Parse <AudioChannelConfiguration> tag
@@ -1274,10 +1243,10 @@ void adaptive::CDashTree::ParseTagContentProtection(
   // Parse each ContentProtection tag to collect encryption schemes
   for (xml_node nodeCP : nodeParent.children("ContentProtection"))
   {
-    std::string_view schemeIdUri = XML::GetAttrib(nodeCP, "schemeIdUri");
+    const std::string schemeIdUri{XML::GetAttrib(nodeCP, "schemeIdUri")};
 
     ProtectionScheme protScheme;
-    protScheme.idUri = schemeIdUri;
+    protScheme.idUri = STRING::ToLower(schemeIdUri);
     protScheme.value = XML::GetAttrib(nodeCP, "value");
 
     // Get optional default KID
@@ -1302,139 +1271,98 @@ void adaptive::CDashTree::ParseTagContentProtection(
       }
       else if (childName == "mspr:pro" || childName == "pro")
       {
-        if (protScheme.kid.empty() || protScheme.pssh.empty())
+        DRM::PRHeaderParser parser;
+        if (parser.Parse(node.child_value()))
         {
-          DRM::PRHeaderParser parser;
-          if (parser.Parse(node.child_value()))
-          {
-            protScheme.kid = STRING::ToHexadecimal(parser.GetKID());
-            protScheme.pssh =
-                BASE64::Encode(DRM::PSSH::Make(DRM::ID_PLAYREADY, {}, parser.GetInitData()));
-          }
+          protScheme.kid = STRING::ToHexadecimal(parser.GetKID());
+          protScheme.pssh =
+              BASE64::Encode(DRM::PSSH::Make(DRM::ID_PLAYREADY, {}, parser.GetInitData()));
+          protScheme.licenseUrl = parser.GetLicenseURL();
+
+          auto encryptionType = parser.GetEncryption();
+          if (encryptionType == DRM::PRHeaderParser::EncryptionType::AESCTR)
+            protScheme.value = "cenc";
+          else if (encryptionType == DRM::PRHeaderParser::EncryptionType::AESCBC)
+            protScheme.value = "cbcs";
         }
       }
     }
+
+    // There are no constraints on the Kid format, it is recommended to be as UUID but not mandatory
+    STRING::ReplaceAll(protScheme.kid, "-", "");
+    protScheme.kid = STRING::ToLower(protScheme.kid);
 
     protSchemes.emplace_back(protScheme);
   }
 }
 
-bool adaptive::CDashTree::GetProtectionData(
+void adaptive::CDashTree::GetProtectionData(
     const std::vector<PLAYLIST::ProtectionScheme>& adpProtSchemes,
-    const std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
-    std::vector<uint8_t>& pssh,
-    std::string& kid,
-    std::string& licenseUrl)
+    std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
+    PLAYLIST::CRepresentation& repr)
 {
-  // Try find a protection scheme compatible for the current systemid
-  const ProtectionScheme* protSelected = nullptr;
-  const ProtectionScheme* protCommon = nullptr;
+  reprProtSchemes.insert(reprProtSchemes.end(), adpProtSchemes.begin(), adpProtSchemes.end());
 
-  for (std::string_view supportedKeySystem : m_supportedKeySystems)
+  CryptoMode cryptoMode = CryptoMode::AES_CTR; // default cenc
+  bool isCencSchemeOnly{false}; // ContentProtection with cenc only, no DRM scheme provided
+
+  // Find the encryption scheme
+  for (const ProtectionScheme& protScheme : reprProtSchemes)
   {
-    for (const ProtectionScheme& protScheme : reprProtSchemes)
+    if (protScheme.idUri == "urn:mpeg:dash:mp4protection:2011")
     {
-      if (STRING::CompareNoCase(protScheme.idUri, supportedKeySystem))
-      {
-        protSelected = &protScheme;
-      }
-      else if (protScheme.idUri == "urn:mpeg:dash:mp4protection:2011")
-      {
-        protCommon = &protScheme;
-      }
-    }
+      std::string_view encryptionScheme = protScheme.value;
+      if (encryptionScheme == "cenc")
+        cryptoMode = CryptoMode::AES_CTR;
+      else if (encryptionScheme == "cbcs")
+        cryptoMode = CryptoMode::AES_CBC;
+      else if (!encryptionScheme.empty())
+        LOG::LogF(LOGERROR, "Unsupported encryption scheme: %s", encryptionScheme.data());
 
-    if (!protSelected || !protCommon)
-    {
-      for (const ProtectionScheme& protScheme : adpProtSchemes)
-      {
-        if (!protSelected && STRING::CompareNoCase(protScheme.idUri, supportedKeySystem))
-        {
-          protSelected = &protScheme;
-        }
-        else if (!protCommon && protScheme.idUri == "urn:mpeg:dash:mp4protection:2011")
-        {
-          protCommon = &protScheme;
-        }
-      }
+      isCencSchemeOnly = reprProtSchemes.size() == 1;
+      break;
     }
   }
 
-  // Workaround for ClearKey:
-  // if license type ClearKey is set and a manifest dont contains ClearKey protection scheme
-  // in any case the KID is required to allow decryption (with clear keys or license URLs provided by Kodi props)
-  //! @todo: this should not be a task of parser, moreover missing an appropriate KID extraction from mp4 box
-  auto& kodiProps = CSrvBroker::GetKodiProps();
-  ProtectionScheme ckProtScheme;
-  if (kodiProps.GetDrmKeySystem() == DRM::KS_CLEARKEY)
+  // Find the default KeyId, if there are multiple they must be all the same
+  std::set<std::string> keyIds;
+  for (const ProtectionScheme& protScheme : reprProtSchemes)
   {
-    std::string_view defaultKid;
-    if (protSelected)
-      defaultKid = protSelected->kid;
-    if (defaultKid.empty() && protCommon)
-      defaultKid = protCommon->kid;
+    if (!protScheme.kid.empty())
+      keyIds.emplace(protScheme.kid);
+  }
 
-    if (defaultKid.empty())
+  if (keyIds.size() > 1)
+  {
+    LOG::LogF(LOGERROR, "Conflicting KeyId's on ContentProtection tags");
+    return;
+  }
+
+  for (const ProtectionScheme& protScheme : reprProtSchemes)
+  {
+    std::string_view keySystem = DRM::UrnToKeySystem(protScheme.idUri);
+
+    if (!keySystem.empty() || isCencSchemeOnly)
     {
-      for (const ProtectionScheme& protScheme : reprProtSchemes)
-      {
-        if (!protScheme.kid.empty())
-        {
-          defaultKid = protScheme.kid;
-          break;
-        }
-      }
-      if (defaultKid.empty())
-      {
-        for (const ProtectionScheme& protScheme : adpProtSchemes)
-        {
-          if (!protScheme.kid.empty())
-          {
-            defaultKid = protScheme.kid;
-            break;
-          }
-        }
-      }
-      if (protCommon)
-        ckProtScheme = *protCommon;
+      DRM::DRMInfo drmInfo;
+      drmInfo.keySystem = keySystem;
 
-      ckProtScheme.kid = defaultKid;
-      protCommon = &ckProtScheme;
+      std::vector<uint8_t> initData = BASE64::Decode(protScheme.pssh);
+      if (!keySystem.empty() && !initData.empty() && !DRM::IsValidPsshHeader(initData))
+      {
+        // Fix missing PSSH box (e.g. Amazon video service dont provide a CENC PSSH on ContentProtection)
+        initData = DRM::PSSH::Make(DRM::KeySystemToUUID(keySystem), {}, initData);
+      }
+
+      drmInfo.initData = initData;
+      drmInfo.licenseServerUri = protScheme.licenseUrl;
+      drmInfo.cryptoMode = cryptoMode;
+      if (!keyIds.empty())
+        drmInfo.defaultKid = *keyIds.begin();
+
+      repr.AddDrmInfo(drmInfo);
     }
   }
-
-  bool isEncrypted{false};
-  std::string selectedKid;
-  std::string selectedPssh;
-
-  if (protSelected)
-  {
-    isEncrypted = true;
-    selectedKid = protSelected->kid;
-    selectedPssh = protSelected->pssh;
-    licenseUrl = protSelected->licenseUrl;
-  }
-  if (protCommon)
-  {
-    isEncrypted = true;
-    if (selectedKid.empty())
-      selectedKid = protCommon->kid;
-
-    // Set crypto mode
-    if (protCommon->value == "cenc")
-      m_cryptoMode = CryptoMode::AES_CTR;
-    else if (protCommon->value == "cbcs")
-      m_cryptoMode = CryptoMode::AES_CBC;
-  }
-
-  if (!selectedPssh.empty())
-    pssh = BASE64::Decode(selectedPssh);
-
-  // There are no constraints on the Kid format, it is recommended to be as UUID but not mandatory
-  STRING::ReplaceAll(selectedKid, "-", "");
-  kid = selectedKid;
-
-  return isEncrypted;
 }
 
 std::optional<bool> adaptive::CDashTree::ParseTagContentProtectionSecDec(pugi::xml_node nodeParent)
@@ -1549,7 +1477,7 @@ void adaptive::CDashTree::MergeAdpSets()
         CAdaptationSet* nextAdpSet = itNextAdpSet->get();
         // IsMergeable:
         //  Some services (e.g. amazon) may have several AdaptationSets of the exact same audio track
-        //  the only difference is in the ContentProtection selectedKid/selectedPssh and the base url,
+        //  the only difference is in the ContentProtection kid/pssh and the base url,
         //  in order not to show several identical audio tracks in the Kodi GUI, we must merge adaptation sets
         // CompareSwitchingId:
         //  Some services can provide switchable video adp sets, these could havedifferent codecs, and could be
@@ -1559,12 +1487,6 @@ void adaptive::CDashTree::MergeAdpSets()
         //  we cannot merge adp sets with different codecs otherwise playback will not work
         if (adpSet->CompareSwitchingId(nextAdpSet) || adpSet->IsMergeable(nextAdpSet))
         {
-          // Sanitize adaptation set references to selectedPssh sets
-          for (CPeriod::PSSHSet& psshSet : period->GetPSSHSets())
-          {
-            if (psshSet.adaptation_set_ == nextAdpSet)
-              psshSet.adaptation_set_ = adpSet;
-          }
           // Move representations to the first switchable adaptation set
           for (auto itRepr = nextAdpSet->GetRepresentations().begin();
                itRepr < nextAdpSet->GetRepresentations().end(); ++itRepr)

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -35,7 +35,6 @@ public:
   CDashTree(const CDashTree& left);
 
   void Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                 std::vector<std::string_view> supportedKeySystems,
                  std::string_view manifestUpdParams) override;
 
   virtual TreeType GetTreeType() const override { return TreeType::DASH; }
@@ -84,11 +83,9 @@ protected:
    * \param licenseUrl[OUT] The license url (if any)
    * \return True if a protection has been found, otherwise false
    */
-  bool GetProtectionData(const std::vector<PLAYLIST::ProtectionScheme>& adpProtSchemes,
-                         const std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
-                         std::vector<uint8_t>& pssh,
-                         std::string& kid,
-                         std::string& licenseUrl);
+  void GetProtectionData(const std::vector<PLAYLIST::ProtectionScheme>& adpProtSchemes,
+                         std::vector<PLAYLIST::ProtectionScheme>& reprProtSchemes,
+                         PLAYLIST::CRepresentation& repr);
 
   std::optional<bool> ParseTagContentProtectionSecDec(pugi::xml_node nodeParent);
 
@@ -122,8 +119,5 @@ protected:
   uint64_t m_mediaPresDuration{0}; // MPD Media presentation duration attribute value, in ms (may be not provided)
 
   uint64_t m_minimumUpdatePeriod{PLAYLIST::NO_VALUE}; // in seconds, NO_VALUE if not set
-
-  // Determines if a custom PSSH initialization license data is provided
-  bool m_isCustomInitPssh{false};
 };
 } // namespace adaptive

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -162,10 +162,9 @@ adaptive::CHLSTree::CHLSTree(const CHLSTree& left) : AdaptiveTree(left)
 }
 
 void adaptive::CHLSTree::Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                                   std::vector<std::string_view> supportedKeySystems,
                                    std::string_view manifestUpdateParam)
 {
-  AdaptiveTree::Configure(reprChooser, supportedKeySystems, manifestUpdateParam);
+  AdaptiveTree::Configure(reprChooser, manifestUpdateParam);
   m_decrypter = std::make_unique<AESDecrypter>();
 }
 
@@ -486,8 +485,9 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
   CSegContainer newSegments;
   std::optional<CSegment> newSegment;
 
-  // Pssh set used between segments
-  uint16_t psshSetPos = PSSHSET_POS_DEFAULT;
+  // Encryptions used between segments
+  std::unordered_map<std::string_view, DRM::DRMInfo> drmInfos; // Key System - DRM info
+  std::optional<CAesKeyInfo> aesKey;
 
   uint32_t discontCount{0};
 
@@ -522,54 +522,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
     {
       auto attribs = ParseTagAttributes(tagValue);
       // NOTE: Multiple EXT-X-KEYs can be parsed sequentially
-      const EncryptionType encryptType = ProcessEncryption(rep->GetBaseUrl(), attribs);
-      switch (encryptType)
-      {
-        case EncryptionType::NONE:
-          currentEncryptionType = EncryptionType::NONE;
-          period->SetEncryptionState(EncryptionState::UNENCRYPTED);
-          psshSetPos = PSSHSET_POS_DEFAULT;
-          break;
-        case EncryptionType::AES128:
-          if (period->GetEncryptionState() != EncryptionState::ENCRYPTED_DRM)
-          {
-            currentEncryptionType = EncryptionType::AES128;
-            period->SetEncryptionState(EncryptionState::ENCRYPTED_CK);
-            psshSetPos = PSSHSET_POS_DEFAULT;
-          }
-          break;
-        case EncryptionType::WIDEVINE:
-        case EncryptionType::PLAYREADY:
-          if (period->GetEncryptionState() != EncryptionState::ENCRYPTED_CK)
-          {
-            currentEncryptionType = encryptType;
-            period->SetEncryptionState(EncryptionState::ENCRYPTED_DRM);
-            rep->m_psshSetPos = InsertPsshSet(adp->GetStreamType(), period, adp, m_currentPssh,
-                                              m_currentDefaultKID, m_currentKidUrl, m_currentIV);
-          }
-          break;
-        case EncryptionType::CLEARKEY:
-          if (period->GetEncryptionState() != EncryptionState::ENCRYPTED_CK)
-          {
-            currentEncryptionType = EncryptionType::CLEARKEY;
-            period->SetEncryptionState(EncryptionState::ENCRYPTED_DRM);
-            rep->m_psshSetPos = InsertPsshSet(adp->GetStreamType(), period, adp, m_currentPssh,
-              m_currentDefaultKID, m_currentKidUrl, m_currentIV);
-          }
-          break;
-        case EncryptionType::NOT_SUPPORTED:
-          // Set only if a supported encryption has not previously been parsed
-          if (period->GetEncryptionState() != EncryptionState::ENCRYPTED_DRM &&
-              period->GetEncryptionState() != EncryptionState::ENCRYPTED_CK)
-          {
-            currentEncryptionType = EncryptionType::NOT_SUPPORTED;
-            period->SetEncryptionState(EncryptionState::NOT_SUPPORTED);
-          }
-          break;
-        default:
-          LOG::LogF(LOGFATAL, "Unhandled EncryptionType");
-          break;
-      }
+      ProcessEncryption(rep->GetBaseUrl(), attribs, aesKey, drmInfos);
     }
     else if (tagName == "#EXT-X-MAP")
     {
@@ -589,7 +542,6 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
         segInit.SetIsInitialization(true);
         segInit.url = attribs["URI"];
         segInit.startPTS_ = NO_PTS_VALUE;
-        segInit.pssh_set_ = PSSHSET_POS_DEFAULT;
         rep->SetInitSegment(segInit);
         rep->SetContainerType(ContainerType::MP4);
       }
@@ -722,16 +674,8 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
       newSegment->url = line;
 
       // The EXT-X-KEY tag might appear before or after the EXTINF tag
-      // so its needed process it just before add the segment to timeline
-      if (currentEncryptionType == EncryptionType::AES128 && psshSetPos == PSSHSET_POS_DEFAULT)
-      {
-        if (!m_currentKidUrl.empty())
-        {
-          psshSetPos = InsertPsshSet(StreamType::NOTYPE, period, adp, m_currentPssh,
-                                     m_currentDefaultKID, m_currentKidUrl, m_currentIV);
-        }
-      }
-      newSegment->pssh_set_ = psshSetPos;
+      // so its needed set the encryption info just before add the segment to timeline
+      newSegment->AESKeyInfo() = aesKey;
 
       newSegments.Add(*newSegment);
       newSegment.reset();
@@ -804,6 +748,12 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
     {
       if (!newSegments.IsEmpty() && !isSkipUntilDiscont)
       {
+        // Set the DRM info
+        for (const auto& info : drmInfos)
+        {
+          rep->AddDrmInfo(info.second);
+        }
+
         period->SetSequence(m_discontSeq + discontCount);
 
         rep->SetDuration(newSegments.GetDuration());
@@ -815,7 +765,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
           period->SetDuration(periodDuration);
         }
 
-        FreeSegments(period, rep);
+        FreeSegments(rep);
 
         rep->SetStartNumber(mediaSequenceNbr);
 
@@ -856,17 +806,6 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
       {
         newRep->SetInitSegment(*rep->GetInitSegment());
         newRep->SetContainerType(rep->GetContainerType());
-      }
-
-      // Copy encryption data from previous period/representation
-      // it must persist until overrided by a new EXT-X-KEY tag
-      newPeriod->SetEncryptionState(period->GetEncryptionState());
-      if (currentEncryptionType == EncryptionType::WIDEVINE ||
-          currentEncryptionType == EncryptionType::PLAYREADY)
-      {
-        newRep->m_psshSetPos =
-            InsertPsshSet(newAdpSet->GetStreamType(), newPeriod, newAdpSet, m_currentPssh,
-                          m_currentDefaultKID, m_currentKidUrl, m_currentIV);
       }
 
       // Set the new period as current
@@ -914,7 +853,13 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
     return ParseStatus::ERROR;
   }
 
-  FreeSegments(period, rep);
+  // Set the DRM info
+  for (const auto& info : drmInfos)
+  {
+    rep->AddDrmInfo(info.second);
+  }
+
+  FreeSegments(rep);
   rep->Timeline().Swap(newSegments);
   rep->SetStartNumber(mediaSequenceNbr);
 
@@ -983,7 +928,7 @@ void adaptive::CHLSTree::PrepareSegments(PLAYLIST::CPeriod* period,
 }
 
 void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
-                                       uint16_t psshSet,
+                                       std::optional<CAesKeyInfo>& aesKey,
                                        uint8_t iv[16],
                                        const uint8_t* srcData,
                                        size_t srcDataSize,
@@ -991,47 +936,28 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
                                        size_t segBufferSize,
                                        bool isLastChunk)
 {
-  if (psshSet && m_currentPeriod->GetEncryptionState() == EncryptionState::ENCRYPTED_CK)
+  if (aesKey.has_value()) // Encrypted media, decrypt it
   {
     std::lock_guard<TreeUpdateThread> lckUpdTree(GetTreeUpdMutex());
 
-    std::vector<CPeriod::PSSHSet>& psshSets = m_currentPeriod->GetPSSHSets();
-
-    if (psshSet >= psshSets.size())
+    if (aesKey->key.empty())
     {
-      LOG::LogF(LOGERROR, "Cannot get PSSHSet at position %u", psshSet);
-      return;
-    }
+      if (STRING::KeyExists(m_aesUrlKeyCache, aesKey->keyUrl))
+        aesKey->key = m_aesUrlKeyCache[aesKey->keyUrl];
 
-    CPeriod::PSSHSet& pssh = psshSets[psshSet];
-
-    //Encrypted media, decrypt it
-    if (pssh.defaultKID_.empty())
-    {
-      if (!pssh.m_licenseUrl.empty())
+      if (aesKey->key.empty())
       {
-        // Try check if we already obtained KID from this KID URL
-        for (const CPeriod::PSSHSet& psshSet : m_currentPeriod->GetPSSHSets())
-        {
-          if (!psshSet.defaultKID_.empty() && psshSet.m_licenseUrl == pssh.m_licenseUrl)
-          {
-            pssh.defaultKID_ = psshSet.defaultKID_;
-            break;
-          }
-        }
-      }
-
-      if (pssh.defaultKID_.empty())
-      {
-      // RETRY:
-        auto& drmCfgProp = CSrvBroker::GetKodiProps().GetDrmConfig(DRM::KS_NONE);
+        // RETRY:
+        auto drmCfgProp = CSrvBroker::GetKodiProps().GetDrmConfig(DRM::KS_NONE);
 
         CURL::HTTPResponse resp;
 
-        if (DownloadKey(pssh.m_licenseUrl, drmCfgProp.license.reqHeaders, {}, resp))
+        if (DownloadKey(aesKey->keyUrl, drmCfgProp.license.reqHeaders, {}, resp))
         {
-          pssh.defaultKID_ = resp.data;
+          aesKey->key.assign(resp.data.begin(), resp.data.end());
+          m_aesUrlKeyCache[aesKey->keyUrl] = aesKey->key;
         }
+
         /*
          *! @todo: unclear if could be used by some old addon,
          *!        for now all related code has been commented for a future removal
@@ -1049,6 +975,7 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
         */
       }
     }
+
     /*
     if (pssh.defaultKID_ == "0")
     {
@@ -1059,26 +986,26 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
     */
     if (!segBufferSize)
     {
-      if (pssh.iv.empty())
+      if (aesKey->iv.empty())
         m_decrypter->ivFromSequence(iv, segNum);
       else
       {
         memset(iv, 0, 16);
-        memcpy(iv, pssh.iv.data(), pssh.iv.size() < 16 ? pssh.iv.size() : 16);
+        memcpy(iv, aesKey->iv.data(), aesKey->iv.size() < 16 ? aesKey->iv.size() : 16);
       }
     }
 
     // Decrypter needs preallocated data
     segBuffer.resize(segBufferSize + srcDataSize);
 
-    m_decrypter->decrypt(reinterpret_cast<const uint8_t*>(pssh.defaultKID_.data()), iv,
+    m_decrypter->decrypt(aesKey->key.data(), iv,
                          reinterpret_cast<const AP4_UI08*>(srcData), segBuffer, segBufferSize,
                          srcDataSize, isLastChunk);
     if (srcDataSize >= 16)
       memcpy(iv, srcData + (srcDataSize - 16), 16);
   }
   else
-    AdaptiveTree::OnDataArrived(segNum, psshSet, iv, srcData, srcDataSize, segBuffer, segBufferSize,
+    AdaptiveTree::OnDataArrived(segNum, aesKey, iv, srcData, srcDataSize, segBuffer, segBufferSize,
                                 isLastChunk);
 }
 
@@ -1107,6 +1034,12 @@ void adaptive::CHLSTree::OnRequestSegments(PLAYLIST::CPeriod* period,
   const uint64_t segNumber = rep->GetCurrentSegNumber();
 
   ProcessChildManifest(period, adp, rep, segNumber);
+}
+
+void adaptive::CHLSTree::OnPeriodChange()
+{
+  if (m_isLive)
+    m_aesUrlKeyCache.clear();
 }
 
 bool adaptive::CHLSTree::DownloadKey(std::string_view url,
@@ -1219,10 +1152,22 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
   return true;
 }
 
-PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
-    std::string_view baseUrl, std::map<std::string, std::string>& attribs)
+void adaptive::CHLSTree::ProcessEncryption(
+    std::string baseUrl,
+    std::map<std::string, std::string>& attribs,
+    std::optional<CAesKeyInfo>& aesKey,
+    std::unordered_map<std::string_view, DRM::DRMInfo>& drmInfos)
 {
   std::string_view encryptMethod = attribs["METHOD"];
+
+  // NO ENCRYPTION
+  if (encryptMethod == "NONE")
+  {
+    aesKey.reset();
+    drmInfos.clear();
+    return;
+  }
+
   // According to specs KEYFORMAT is optional and if not specified defaults implicitly to "identity"
   const std::string keyFormat = attribs["KEYFORMAT"].empty() ? "identity" : attribs["KEYFORMAT"];
 
@@ -1231,45 +1176,40 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
 
   if (STRING::KeyExists(attribs, "URI"))
   {
-    if (!GetUriByteData(attribs["URI"], uriData))
+    if (!URL::GetUriByteData(attribs["URI"], uriData))
     {
       // No URI with data format, but an URL
       uriUrl = attribs["URI"];
     }
   }
 
-  // NO ENCRYPTION
-  if (encryptMethod == "NONE")
-  {
-    m_currentPssh.clear();
-
-    return EncryptionType::NONE;
-  }
-
   // AES-128
   if (encryptMethod == "AES-128")
   {
+    aesKey = CAesKeyInfo();
+
     if (!uriData.empty())
     {
-      std::vector<uint8_t> kid = UTILS::ZeroPadding(uriData, 16);
-      m_currentDefaultKID = std::string(kid.begin(), kid.end());
+      aesKey->key = UTILS::ZeroPadding(uriData, 16);
     }
 
-    m_currentKidUrl = uriUrl;
-    if (URL::IsUrlRelative(m_currentKidUrl))
-      m_currentKidUrl = URL::Join(baseUrl.data(), m_currentKidUrl);
+    if (!uriUrl.empty())
+    {
+      if (URL::IsUrlRelative(uriUrl))
+        uriUrl = URL::Join(baseUrl, uriUrl);
 
-    m_currentIV = m_decrypter->convertIV(attribs["IV"]);
+      aesKey->keyUrl = uriUrl;
+    }
 
-    return EncryptionType::AES128;
+    aesKey->iv = m_decrypter->convertIV(attribs["IV"]);
   }
-
   // WIDEVINE
-  if (STRING::CompareNoCase(keyFormat, DRM::URN_WIDEVINE) &&
-      (std::find(m_supportedKeySystems.begin(), m_supportedKeySystems.end(), DRM::URN_WIDEVINE) !=
-          m_supportedKeySystems.end()))
+  else if (STRING::CompareNoCase(keyFormat, DRM::URN_WIDEVINE))
   {
-    m_currentPssh = uriData;
+    
+    DRM::DRMInfo& drmInfo = drmInfos[DRM::KS_WIDEVINE]; // Create or update
+    drmInfo.keySystem = DRM::KS_WIDEVINE;
+    drmInfo.initData = uriData;
 
     if (STRING::KeyExists(attribs, "KEYID"))
     {
@@ -1277,129 +1217,78 @@ PLAYLIST::EncryptionType adaptive::CHLSTree::ProcessEncryption(
       STRING::ToLower(keyid);
 
       if (STRING::StartsWith(keyid, "0x"))
-        m_currentDefaultKID = keyid.substr(2); // To remove "0x"
+      {
+        keyid.erase(0, 2); // To remove "0x"
+        STRING::ReplaceAll(keyid, "-", ""); // UUID format should not be allowed
+        drmInfo.defaultKid = keyid;
+      }
       else
         LOG::LogF(LOGERROR, "Incorrect KEYID tag format");
     }
 
     if (encryptMethod == "SAMPLE-AES-CTR")
-      m_cryptoMode = CryptoMode::AES_CTR;
+      drmInfo.cryptoMode = CryptoMode::AES_CTR;
     else if (encryptMethod == "SAMPLE-AES")
-      m_cryptoMode = CryptoMode::AES_CBC;
-
-    return EncryptionType::WIDEVINE;
+      drmInfo.cryptoMode = CryptoMode::AES_CBC;
   }
-
   // PLAYREADY
-  if (STRING::CompareNoCase(keyFormat, DRM::KS_PLAYREADY) &&
-      (std::find(m_supportedKeySystems.begin(), m_supportedKeySystems.end(), DRM::URN_PLAYREADY) !=
-       m_supportedKeySystems.end()))
+  else if (STRING::CompareNoCase(keyFormat, DRM::KS_PLAYREADY))
   {
     if (uriData.empty())
     {
       LOG::LogF(LOGERROR, "Incorrect or unsupported URI tag format");
-      return EncryptionType::NOT_SUPPORTED;
+      return;
     }
 
-    m_currentPssh = DRM::PSSH::Make(DRM::ID_PLAYREADY, {}, uriData);
+    DRM::DRMInfo& drmInfo = drmInfos[DRM::KS_PLAYREADY]; // Create or update
+    drmInfo.keySystem = DRM::KS_PLAYREADY;
+    drmInfo.initData = DRM::PSSH::Make(DRM::ID_PLAYREADY, {}, uriData);
 
     DRM::PRHeaderParser parser;
 
     if (parser.Parse(uriData) && !parser.GetKID().empty())
     {
-      m_licenseUrl = parser.GetLicenseURL();
-      m_currentDefaultKID = STRING::ToHexadecimal(parser.GetKID());
+      drmInfo.licenseServerUri = parser.GetLicenseURL();
+      drmInfo.defaultKid = STRING::ToLower(STRING::ToHexadecimal(parser.GetKID()));
 
       auto encryptionType = parser.GetEncryption();
       if (encryptionType == DRM::PRHeaderParser::EncryptionType::AESCTR)
-        m_cryptoMode = CryptoMode::AES_CTR;
+        drmInfo.cryptoMode = CryptoMode::AES_CTR;
       else if (encryptionType == DRM::PRHeaderParser::EncryptionType::AESCBC)
-        m_cryptoMode = CryptoMode::AES_CBC;
+        drmInfo.cryptoMode = CryptoMode::AES_CBC;
     }
     else
       LOG::LogF(LOGERROR, "Cannot parse Playready header");
-
-    return EncryptionType::PLAYREADY;
   }
-
   // CLEARKEY
-  if (std::find(m_supportedKeySystems.begin(), m_supportedKeySystems.end(), DRM::URN_CLEARKEY) !=
-      m_supportedKeySystems.end() && std::find(m_supportedKeySystems.begin(), m_supportedKeySystems.end(), DRM::URN_COMMON) !=
-    m_supportedKeySystems.end())
+  else if (STRING::CompareNoCase(keyFormat, "identity"))
   {
-    if (STRING::CompareNoCase(keyFormat, "identity"))
+    DRM::DRMInfo& drmInfo = drmInfos[DRM::KS_CLEARKEY]; // Create or update
+    drmInfo.keySystem = DRM::KS_CLEARKEY;
+
+    if (uriUrl.empty())
     {
-      if (uriUrl.empty())
-      {
-        m_currentPssh = uriData;
-      }
-      else
-      {
-        if (URL::IsUrlRelative(uriUrl))
-          uriUrl = URL::Join(baseUrl.data(), uriUrl);
-
-        UTILS::CURL::HTTPResponse resp;
-        if (DownloadKey(uriUrl, {}, {}, resp))
-          m_currentPssh = STRING::ToVecUint8(resp.data);
-      }
-
-      if (uriUrl.empty()) // No kid provided, assume key == kid
-        m_currentDefaultKID = STRING::ToHexadecimal(uriData);
-
+      drmInfo.initData = uriData;
     }
-    else if (STRING::CompareNoCase(keyFormat, DRM::URN_WIDEVINE))
+    else
     {
-      // Take only the KID
-      if (STRING::KeyExists(attribs, "KEYID"))
-      {
-        std::string keyid = attribs["KEYID"];
-        STRING::ToLower(keyid);
+      if (URL::IsUrlRelative(uriUrl))
+        uriUrl = URL::Join(baseUrl, uriUrl);
 
-        if (STRING::StartsWith(keyid, "0x"))
-          m_currentDefaultKID = keyid.substr(2); // To remove "0x"
-        else
-          LOG::LogF(LOGERROR, "Incorret KEYID tag format");
-      }
+      UTILS::CURL::HTTPResponse resp;
+      if (DownloadKey(uriUrl, {}, {}, resp))
+        drmInfo.initData = STRING::ToVecUint8(resp.data);
     }
 
     if (encryptMethod == "SAMPLE-AES-CTR")
-      m_cryptoMode = CryptoMode::AES_CTR;
+      drmInfo.cryptoMode = CryptoMode::AES_CTR;
     else if (encryptMethod == "SAMPLE-AES")
-      m_cryptoMode = CryptoMode::AES_CBC;
-
-    return EncryptionType::CLEARKEY;
+      drmInfo.cryptoMode = CryptoMode::AES_CBC;
   }
-
-  // Unsupported encryption
-  LOG::Log(LOGDEBUG, "Unsupported EXT-X-KEY keyformat \"%s\"", keyFormat.c_str());
-  return EncryptionType::NOT_SUPPORTED;
-}
-
-bool adaptive::CHLSTree::GetUriByteData(std::string_view uri, std::vector<uint8_t>& data)
-{
-  // Uri data format: "data:[media type][;attribute=value][;base64],<data>"
-  std::vector<std::string> colonSplit = STRING::SplitToVec(uri, ':');
-  if (colonSplit.size() == 2 && colonSplit[0] == "data")
+  else // Unsupported encryption
   {
-    std::vector<std::string> semiColonSplit = STRING::SplitToVec(colonSplit[1], ';');
-    if (semiColonSplit.size() > 0)
-    {
-      std::vector<std::string> comSplit = STRING::SplitToVec(semiColonSplit.back(), ',');
-      if (comSplit.size() == 2)
-      {
-        const bool isBase64 = comSplit[0] == "base64";
-        const std::string dataStr = comSplit[1];
-        if (isBase64)
-          data = BASE64::Decode(dataStr);
-        else
-          data = STRING::ToVecUint8(dataStr);
-        return true;
-      }
-    }
-    LOG::Log(LOGERROR, "Cannot parse URI: %s", uri.data());
-    return true;
+    LOG::LogF(LOGDEBUG, "Unsupported EXT-X-KEY keyformat \"%s\"", keyFormat.c_str());
   }
-  return false;
 }
 
 bool adaptive::CHLSTree::ParseRenditon(const Rendition& r,
@@ -1463,7 +1352,6 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
 {
   std::stringstream streamData{data};
   MultivariantPlaylist pl;
-  std::vector<EncryptionType> encryptionTypes;
 
   // Parse text data
 
@@ -1569,22 +1457,6 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
 
       pl.m_variants.emplace_back(var);
     }
-    else if (tagName == "#EXT-X-SESSION-KEY")
-    {
-      auto attribs = ParseTagAttributes(tagValue);
-      encryptionTypes.emplace_back(ProcessEncryption(base_url_, attribs));
-    }
-  }
-
-  if (!encryptionTypes.empty())
-  {
-    // Check if there is at least one EXT-X-SESSION-KEY supported
-    bool isNotSupported =
-        std::all_of(encryptionTypes.begin(), encryptionTypes.end(),
-                    [](EncryptionType type) { return type == EncryptionType::NOT_SUPPORTED; });
-
-    if (isNotSupported)
-      return false;
   }
 
   // Create Period / Adaptation sets / Representations

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -13,6 +13,8 @@
 #include "common/AdaptiveUtils.h"
 #include "utils/CurlUtils.h"
 
+#include <unordered_map>
+
 namespace adaptive
 {
 
@@ -36,7 +38,6 @@ public:
   virtual CHLSTree* Clone() const override { return new CHLSTree{*this}; }
 
   virtual void Configure(CHOOSER::IRepresentationChooser* reprChooser,
-                         std::vector<std::string_view> supportedKeySystems,
                          std::string_view manifestUpdateParam) override;
 
   virtual bool Open(std::string_view url,
@@ -48,7 +49,7 @@ public:
                                      PLAYLIST::CRepresentation* rep) override;
 
   virtual void OnDataArrived(uint64_t segNum,
-                             uint16_t psshSet,
+                             std::optional<CAesKeyInfo>& aesKey,
                              uint8_t iv[16],
                              const uint8_t* srcData,
                              size_t srcDataSize,
@@ -64,6 +65,8 @@ public:
   virtual void OnRequestSegments(PLAYLIST::CPeriod* period,
                                  PLAYLIST::CAdaptationSet* adp,
                                  PLAYLIST::CRepresentation* rep) override;
+
+  virtual void OnPeriodChange() override;
 
 protected:
   // \brief Rendition features
@@ -169,10 +172,10 @@ protected:
 
   virtual bool ParseManifest(const std::string& stream);
 
-  PLAYLIST::EncryptionType ProcessEncryption(std::string_view baseUrl,
-                                             std::map<std::string, std::string>& attribs);
-
-  bool GetUriByteData(std::string_view uri, std::vector<uint8_t>& data);
+  void ProcessEncryption(std::string baseUrl,
+                         std::map<std::string, std::string>& attribs,
+                         std::optional<CAesKeyInfo>& aesKey,
+                         std::unordered_map<std::string_view, DRM::DRMInfo>& drmInfos);
 
   /*!
    * \brief Parse a rendition and set the data to the AdaptationSet and Representation.
@@ -196,8 +199,10 @@ protected:
                             const std::string& data,
                             std::string_view info);
 
-
   std::unique_ptr<IAESDecrypter> m_decrypter;
+
+  // Temporary cache to store the downloaded AES KEY's
+  std::unordered_map<std::string, std::vector<uint8_t>> m_aesUrlKeyCache;
 
 private:
   /*!
@@ -245,11 +250,6 @@ private:
   uint8_t m_segmentIntervalSec = 4;
   bool m_hasDiscontSeq = false;
   uint32_t m_discontSeq = 0;
-
-  std::vector<uint8_t> m_currentPssh; // Last processed encryption PSSH from URI
-  std::string m_currentDefaultKID; // Last processed encryption KID
-  std::string m_currentKidUrl; // Last processed encryption KID URI
-  std::string m_currentIV; // Last processed encryption IV
 };
 
 } // namespace

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -91,34 +91,48 @@ bool adaptive::CSmoothTree::ParseManifest(const std::string& data)
 
   // Parse <Protection> tag
   DRM::PRHeaderParser protParser;
+  std::vector<DRM::DRMInfo> drmInfos;
   xml_node nodeProt = nodeSSM.child("Protection");
   if (nodeProt)
   {
-    period->SetEncryptionState(EncryptionState::NOT_SUPPORTED);
     period->SetSecureDecodeNeeded(true);
 
-    pugi::xml_node nodeProtHead = nodeProt.child("ProtectionHeader");
-    if (nodeProtHead)
+    for (xml_node nodePH : nodeProt.children("ProtectionHeader"))
     {
       // SystemID can be wrapped by {}
-      if (STRING::Contains(XML::GetAttrib(nodeProtHead, "SystemID"),
-                           "9A04F079-9840-4286-AB92-E65BE0885F95"))
+      std::string_view systemId = XML::GetAttrib(nodePH, "SystemID");
+      if (STRING::Contains(systemId, "9A04F079-9840-4286-AB92-E65BE0885F95"))
       {
-        if (protParser.Parse(nodeProtHead.child_value()))
+        if (protParser.Parse(nodePH.child_value()))
         {
-          period->SetEncryptionState(EncryptionState::ENCRYPTED_DRM);
-          m_licenseUrl = protParser.GetLicenseURL();
+          DRM::DRMInfo drmInfo;
+          drmInfo.keySystem = DRM::KS_PLAYREADY;
+          drmInfo.licenseServerUri = protParser.GetLicenseURL();
+          drmInfo.initData = DRM::PSSH::Make(DRM::ID_PLAYREADY, {}, protParser.GetInitData());
+          drmInfo.defaultKid = STRING::ToLower(STRING::ToHexadecimal(protParser.GetKID()));
+
+          auto encryptionType = protParser.GetEncryption();
+          if (encryptionType == DRM::PRHeaderParser::EncryptionType::AESCTR)
+            drmInfo.cryptoMode = CryptoMode::AES_CTR;
+          else if (encryptionType == DRM::PRHeaderParser::EncryptionType::AESCBC)
+            drmInfo.cryptoMode = CryptoMode::AES_CBC;
+
+          drmInfos.emplace_back(drmInfo);
         }
       }
-      else
-        LOG::LogF(LOGERROR, "Protection header with a SystemID not supported or not implemented.");
+      else // Several SystemID's should be supported, but it is not clear which ones
+      {
+        LOG::LogF(LOGWARNING,
+                  "Not implemented or unsupported \"ProtectionHeader\" with SystemID \"%s\"",
+                  systemId.data());
+      }
     }
   }
 
   // Parse <StreamIndex> tags
   for (xml_node node : nodeSSM.children("StreamIndex"))
   {
-    ParseTagStreamIndex(node, period.get(), protParser);
+    ParseTagStreamIndex(node, period.get(), drmInfos);
   }
 
   if (period->GetAdaptationSets().empty())
@@ -134,7 +148,7 @@ bool adaptive::CSmoothTree::ParseManifest(const std::string& data)
 
 void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
                                                 PLAYLIST::CPeriod* period,
-                                                const DRM::PRHeaderParser& protParser)
+                                                const std::vector<DRM::DRMInfo>& drmInfos)
 {
   std::unique_ptr<CAdaptationSet> adpSet = CAdaptationSet::MakeUniquePtr(period);
 
@@ -183,17 +197,6 @@ void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
       adpSet->SetIsImpaired(true);
     }
     adpSet->SetStreamType(StreamType::SUBTITLE);
-  }
-
-  uint16_t psshSetPos = PSSHSET_POS_DEFAULT;
-
-  if (protParser.HasProtection() && (adpSet->GetStreamType() == StreamType::VIDEO ||
-                                     adpSet->GetStreamType() == StreamType::AUDIO))
-  {
-    const std::vector<uint8_t> initData = DRM::PSSH::Make(DRM::ID_PLAYREADY, {}, protParser.GetInitData());
-
-    psshSetPos = InsertPsshSet(StreamType::VIDEO_AUDIO, period, adpSet.get(), initData,
-                               STRING::ToHexadecimal(protParser.GetKID()));
   }
 
   // Language code format ISO 639-2
@@ -271,13 +274,18 @@ void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
   // Parse <QualityLevel> tags
   for (xml_node node : nodeSI.children("QualityLevel"))
   {
-    ParseTagQualityLevel(node, adpSet.get(), timescale, psshSetPos);
+    ParseTagQualityLevel(node, adpSet.get(), timescale, drmInfos);
   }
 
   if (adpSet->GetRepresentations().empty())
   {
     LOG::LogF(LOGDEBUG, "No generated representations, adaptation set skipped.");
     return;
+  }
+
+  if (adpSet->GetCodecs().empty())
+  {
+    adpSet->AddCodecs(adpSet->GetRepresentations().front()->GetCodecs());
   }
 
   if (m_ptsBase == NO_PTS_VALUE || adpSet->GetStartPTS() < m_ptsBase)
@@ -289,7 +297,7 @@ void adaptive::CSmoothTree::ParseTagStreamIndex(pugi::xml_node nodeSI,
 void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
                                                  PLAYLIST::CAdaptationSet* adpSet,
                                                  const uint32_t timescale,
-                                                 const uint16_t psshSetPos)
+                                                 const std::vector<DRM::DRMInfo>& drmInfos)
 {
   std::unique_ptr<CRepresentation> repr = CRepresentation::MakeUniquePtr(adpSet);
 
@@ -306,7 +314,13 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
   if (XML::QueryAttrib(nodeQI, "FourCC", fourCc))
     repr->AddCodecs(fourCc);
 
-  repr->m_psshSetPos = psshSetPos;
+  if (!drmInfos.empty())
+  {
+    for (auto& drmInfo : drmInfos)
+    {
+      repr->AddDrmInfo(drmInfo);
+    }
+  }
 
   repr->SetResWidth(XML::GetAttribInt(nodeQI, "MaxWidth"));
   repr->SetResHeight(XML::GetAttribInt(nodeQI, "MaxHeight"));

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -48,11 +48,11 @@ protected:
 
   void ParseTagStreamIndex(pugi::xml_node nodeSI,
                            PLAYLIST::CPeriod* period,
-                           const DRM::PRHeaderParser& protParser);
+                           const std::vector<DRM::DRMInfo>& drmInfos);
   void ParseTagQualityLevel(pugi::xml_node nodeQI,
                             PLAYLIST::CAdaptationSet* adpSet,
                             const uint32_t timescale,
-                            const uint16_t psshSetPos);
+                            const std::vector<DRM::DRMInfo>& drmInfos);
   void CreateSegmentTimeline();
 
   uint64_t m_ptsBase{PLAYLIST::NO_PTS_VALUE}; // The lower start PTS time between all StreamIndex tags

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -69,8 +69,7 @@ protected:
     // We set the download speed to calculate the initial network bandwidth
     m_reprChooser->SetDownloadSpeed(500000);
 
-    tree->Configure(m_reprChooser, std::vector<std::string_view>{DRM::URN_WIDEVINE},
-                    manifestUpdParams);
+    tree->Configure(m_reprChooser, manifestUpdParams);
 
     // Parse the manifest
     if (!tree->Open(resp.effectiveUrl, resp.headers, resp.data))
@@ -394,14 +393,58 @@ TEST_F(DASHTreeTest, CalculatePsshDefaultKid)
 {
   OpenTestFile("mpd/pssh_default_kid.mpd");
 
+  const std::string kid1 = "0101f49e117cec8ed60627d7cb46ae38";
   const std::vector<uint8_t> pssh1 = BASE64::Decode("AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQblodJidXR9eARuql0dNLWg==");
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].pssh_, pssh1);
+  auto& adp1repr1 = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0];
+  
+  EXPECT_EQ(adp1repr1->DrmInfos().size(), 1);
   // The following KID on manifest is represented as UUID and dashes must be deleted (string size 36 to 32)
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[1].defaultKID_.size(), 32);
+  EXPECT_EQ(adp1repr1->DrmInfos()[0].defaultKid.size(), 32);
+  EXPECT_EQ(adp1repr1->DrmInfos()[0].defaultKid, kid1);
+  EXPECT_EQ(adp1repr1->DrmInfos()[0].initData, pssh1);
 
+  const std::string kid2 = "01004b6f0835b8079098c070dc30a6c7";
   const std::vector<uint8_t> pssh2 = BASE64::Decode("AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQnrQFDeRLSAKTLifXUIPiZg==");
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].pssh_, pssh2);
-  EXPECT_EQ(tree->m_periods[0]->GetPSSHSets()[2].defaultKID_.size(), 32);
+  auto& adp2repr1 = tree->m_periods[0]->GetAdaptationSets()[1]->GetRepresentations()[0];
+
+  EXPECT_EQ(adp2repr1->DrmInfos().size(), 1);
+  EXPECT_EQ(adp2repr1->DrmInfos()[0].defaultKid.size(), 32);
+  EXPECT_EQ(adp2repr1->DrmInfos()[0].defaultKid, kid2);
+  EXPECT_EQ(adp2repr1->DrmInfos()[0].initData, pssh2);
+}
+
+TEST_F(DASHTreeTest, PsshNoCenc)
+{
+  OpenTestFile("mpd/adaptation_set_merge.mpd");
+
+  // This manifest provides on ContentProtection the PSSH data without using the CENC PSSH format,
+  // on parsing the PSSH is expected to be converted to the CENC standard
+
+  const std::string kidCommon = "16b2ee1ac691450ea19c84e40f8e6221";
+  const std::vector<uint8_t> psshWidevine = BASE64::Decode("AAAAeXBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAFkIARIQFrLuGsaRRQ6hnITkD45iIRoGYW1hem9uIjVjaWQ6RnJMdUdzYVJSUTZobklUa0Q0NWlJUT09LDgwdVhRbEhiVENTenI1K25RcU5MclE9PSoCU0QyAA==");
+  const std::vector<uint8_t> psshPlayready = BASE64::Decode("AAACjHBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAmxsAgAAAQABAGICPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBHAHUANgB5AEYAcABIAEcARABrAFcAaABuAEkAVABrAEQANAA1AGkASQBRAD0APQA8AC8ASwBJAEQAPgA8AEMASABFAEMASwBTAFUATQA+AFAAUwBFAFEAcQA1ADAASgAzAHcAZwA9ADwALwBDAEgARQBDAEsAUwBVAE0APgA8AEwAQQBfAFUAUgBMAD4AaAB0AHQAcABzADoALwAvAHAAcgBsAHMALgBhAHQAdgAtAHAAcwAuAGEAbQBhAHoAbwBuAC4AYwBvAG0ALwBjAGQAcAA8AC8ATABBAF8AVQBSAEwAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==");
+  auto& adp1repr1 = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0];
+
+  EXPECT_EQ(adp1repr1->DrmInfos().size(), 2);
+  for (auto& drmInfo : adp1repr1->DrmInfos())
+  {
+    if (drmInfo.keySystem == DRM::KS_WIDEVINE)
+    {
+      EXPECT_EQ(drmInfo.defaultKid.size(), 32);
+      EXPECT_EQ(drmInfo.defaultKid, kidCommon);
+      EXPECT_EQ(drmInfo.initData, psshWidevine);
+    }
+    else if (drmInfo.keySystem == DRM::KS_PLAYREADY)
+    {
+      EXPECT_EQ(drmInfo.defaultKid.size(), 32);
+      EXPECT_EQ(drmInfo.defaultKid, kidCommon);
+      EXPECT_EQ(drmInfo.initData, psshPlayready);
+    }
+    else
+    {
+      FAIL() << "Error unexpected Key System";
+    }
+  }
 }
 
 TEST_F(DASHTreeAdaptiveStreamTest, subtitles)

--- a/src/test/TestHLSTree.cpp
+++ b/src/test/TestHLSTree.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TestHelper.h"
+#include "../decrypters/Helpers.h"
 #include "../CompKodiProps.h"
 #include "../SrvBroker.h"
 
@@ -40,13 +41,12 @@ protected:
 
   bool OpenTestFileMaster(std::string filePath, std::string url)
   {
-    return OpenTestFileMaster(filePath, url, {}, std::vector<std::string_view>{});
+    return OpenTestFileMaster(filePath, url, {});
   }
 
   bool OpenTestFileMaster(std::string filePath,
                           std::string url,
-                          std::map<std::string, std::string> manifestHeaders,
-                          std::vector<std::string_view> supportedKeySystems)
+                          std::map<std::string, std::string> manifestHeaders)
   {
     testHelper::testFile = filePath;
 
@@ -65,7 +65,7 @@ protected:
     // We set the download speed to calculate the initial network bandwidth
     m_reprChooser->SetDownloadSpeed(500000);
 
-    tree->Configure(m_reprChooser, supportedKeySystems, "");
+    tree->Configure(m_reprChooser, "");
 
     // Parse the manifest
     if (!tree->Open(resp.effectiveUrl, resp.headers, resp.data))
@@ -213,8 +213,11 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlash)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
-  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+
+  auto& timeline = tree->m_currentRepr->Timeline();
+  EXPECT_EQ(timeline.GetSize(), 6);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo().has_value(), true);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo()->keyUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
@@ -229,8 +232,11 @@ TEST_F(HLSTreeTest, ParseKeyUriStartingWithSlashFromRedirect)
       tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
-  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+
+  auto& timeline = tree->m_currentRepr->Timeline();
+  EXPECT_EQ(timeline.GetSize(), 6);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo().has_value(), true);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo()->keyUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
@@ -242,8 +248,11 @@ TEST_F(HLSTreeTest, ParseKeyUriAbsolute)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  EXPECT_EQ(tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl,
-            "https://foo.bar/hls/key/key.php?stream=stream_name");
+
+  auto& timeline = tree->m_currentRepr->Timeline();
+  EXPECT_EQ(timeline.GetSize(), 6);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo().has_value(), true);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo()->keyUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelative)
@@ -255,8 +264,11 @@ TEST_F(HLSTreeTest, ParseKeyUriRelative)
       "https://foo.bar/hls/video/stream_name/chunklist.m3u8", tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
-  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+
+  auto& timeline = tree->m_currentRepr->Timeline();
+  EXPECT_EQ(timeline.GetSize(), 6);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo().has_value(), true);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo()->keyUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
@@ -273,8 +285,11 @@ TEST_F(HLSTreeTest, ParseKeyUriRelativeFromRedirect)
       tree->m_currentAdpSet, tree->m_currentRepr);
 
   EXPECT_EQ(ret, true);
-  std::string licUrl = tree->m_currentPeriod->GetPSSHSets()[1].m_licenseUrl;
-  EXPECT_EQ(licUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
+
+  auto& timeline = tree->m_currentRepr->Timeline();
+  EXPECT_EQ(timeline.GetSize(), 6);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo().has_value(), true);
+  EXPECT_EQ(timeline.GetFront()->AESKeyInfo()->keyUrl, "https://foo.bar/hls/key/key.php?stream=stream_name");
 }
 
 TEST_F(HLSTreeTest, PtsSetInMultiPeriod)
@@ -330,59 +345,52 @@ TEST_F(HLSTreeTest, MultipleEncryptionSequence)
   auto& periods = tree->m_periods;
   EXPECT_EQ(periods.size(), 3);
 
-  // Check if each period has the period encryption state
-  EXPECT_EQ(periods[0]->GetEncryptionState(), PLAYLIST::EncryptionState::UNENCRYPTED);
-  EXPECT_EQ(periods[1]->GetEncryptionState(), PLAYLIST::EncryptionState::ENCRYPTED_CK);
-  EXPECT_EQ(periods[2]->GetEncryptionState(), PLAYLIST::EncryptionState::UNENCRYPTED);
+  // the first period have unencrypted segments
+  auto& p1repr = periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0];
+  EXPECT_EQ(p1repr->Timeline().GetSize(), 4);
+  for (auto& seg : p1repr->Timeline())
+  {
+    EXPECT_EQ(seg.AESKeyInfo().has_value(), false);
+  }
+
+  // the second period have segments AES-128 encrypted
+  auto& p2repr = periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0];
+  EXPECT_EQ(p2repr->Timeline().GetSize(), 2);
+  for (auto& seg : p2repr->Timeline())
+  {
+    EXPECT_EQ(seg.AESKeyInfo().has_value(), true);
+    EXPECT_EQ(seg.AESKeyInfo()->keyUrl.empty(), false);
+    EXPECT_EQ(seg.AESKeyInfo()->iv.empty(), false);
+  }
+
+  // the third period have unencrypted segments
+  auto& p3repr = periods[2]->GetAdaptationSets()[0]->GetRepresentations()[0];
+  EXPECT_EQ(p3repr->Timeline().GetSize(), 4);
+  for (auto& seg : p3repr->Timeline())
+  {
+    EXPECT_EQ(seg.AESKeyInfo().has_value(), false);
+  }
 }
 
 TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrmNoKSMaster)
 {
-  // Open the master manifest without any supported key system
-  // OpenTestFileMaster must return false to prevent ISA to process child manifests
-  // since master manifest contains EXT-X-SESSION-KEY used to check supported ks's
+  // master manifest contains EXT-X-SESSION-KEY that can be used to check supported DRM's
+  // but currently this check is not performed, so the open operation return true
   testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
   bool ret = OpenTestFileMaster("hls/encrypt_master_drm.m3u8",
-                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, std::vector<std::string_view>{});
-  EXPECT_EQ(ret, false);
-}
-
-TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrmNoKS)
-{
-  // Open the master manifest without any supported key system
-  // OpenTestFileMaster must return true and process child manifests
-  // since master manifest DO NOT contains EXT-X-SESSION-KEY
-  testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
-
-  bool ret = OpenTestFileMaster("hls/encrypt_master.m3u8",
-                                "https://baz.qux/hls/video/stream_name/master.m3u8", {}, std::vector<std::string_view>{});
-
+                                "https://baz.qux/hls/video/stream_name/master.m3u8", {});
   EXPECT_EQ(ret, true);
-
-  std::string var_download_url =
-      tree->m_currentPeriod->GetAdaptationSets()[0]->GetRepresentations()[0]->GetSourceUrl();
-
-  ret = OpenTestFileVariant("hls/encrypt_seq_stream_drm.m3u8", var_download_url,
-                            tree->m_currentPeriod, tree->m_currentAdpSet, tree->m_currentRepr);
-
-  EXPECT_EQ(ret, true);
-  auto& periods = tree->m_periods;
-  EXPECT_EQ(periods.size(), 2);
-
-  // Check if each period has the period encryption state
-  EXPECT_EQ(periods[0]->GetEncryptionState(), PLAYLIST::EncryptionState::NOT_SUPPORTED);
-  EXPECT_EQ(periods[1]->GetEncryptionState(), PLAYLIST::EncryptionState::NOT_SUPPORTED);
 }
 
 TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrm)
 {
-  // Open the master manifest with the supported Widevine key system
-  // OpenTestFileMaster must return true and process child manifests
+  // The child manifest support multiple DRM's, but have an unsupported KEYFORMAT that should be ignored
+  // the representation's of each period must contains the DRM info
   testHelper::effectiveUrl = "https://foo.bar/hls/video/stream_name/master.m3u8";
 
-  bool ret = OpenTestFileMaster("hls/encrypt_master_drm.m3u8",
-    "https://baz.qux/hls/video/stream_name/master.m3u8", {}, std::vector<std::string_view>{URN_WIDEVINE});
+  bool ret = OpenTestFileMaster("hls/encrypt_master.m3u8",
+                                "https://baz.qux/hls/video/stream_name/master.m3u8", {});
 
   EXPECT_EQ(ret, true);
 
@@ -396,7 +404,21 @@ TEST_F(HLSTreeTest, MultipleEncryptionSequenceDrm)
   auto& periods = tree->m_periods;
   EXPECT_EQ(periods.size(), 2);
 
-  // Check if each period has the period encryption state
-  EXPECT_EQ(periods[0]->GetEncryptionState(), PLAYLIST::EncryptionState::ENCRYPTED_DRM);
-  EXPECT_EQ(periods[1]->GetEncryptionState(), PLAYLIST::EncryptionState::ENCRYPTED_DRM);
+  auto& p1rep = periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0];
+  EXPECT_EQ(p1rep->DrmInfos().size(), 2);
+  std::set<std::string_view> ks1{DRM::KS_WIDEVINE, DRM::KS_PLAYREADY};
+  for (auto& drmInfo : p1rep->DrmInfos()) // Do not rely on the order of DrmInfos items
+  {
+    ks1.erase(drmInfo.keySystem);
+  }
+  EXPECT_TRUE(ks1.empty());
+
+  auto& p2rep = periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0];
+  EXPECT_EQ(p2rep->DrmInfos().size(), 2);
+  std::set<std::string_view> ks2{DRM::KS_WIDEVINE, DRM::KS_PLAYREADY};
+  for (auto& drmInfo : p1rep->DrmInfos()) // Do not rely on the order of DrmInfos items
+  {
+    ks2.erase(drmInfo.keySystem);
+  }
+  EXPECT_TRUE(ks2.empty());
 }

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -115,7 +115,7 @@ bool TestAdaptiveStream::DownloadSegment(const DownloadInfo& downloadInfo)
         break;
 
       m_tree->OnDataArrived(downloadInfo.m_segmentBuffer->segment_number,
-                            downloadInfo.m_segmentBuffer->segment.pssh_set_, m_decrypterIv,
+                            downloadInfo.m_segmentBuffer->segment.AESKeyInfo(), m_decrypterIv,
                             bufferData, bytesRead, segmentBuffer, segmentBuffer.size(), false);
 
       totalByteRead += bytesRead;
@@ -151,9 +151,9 @@ void AESDecrypterTest::decrypt(const AP4_UI08* aes_key,
 {
 }
 
-std::string AESDecrypterTest::convertIV(const std::string& input)
+std::vector<uint8_t> AESDecrypterTest::convertIV(const std::string& input)
 {
-  std::string result;
+  std::vector<uint8_t> result;
   return result;
 }
 

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -86,7 +86,7 @@ public:
                size_t dstOffset,
                size_t& dataSize,
                bool lastChunk);
-  std::string convertIV(const std::string& input);
+  std::vector<uint8_t> convertIV(const std::string& input);
   void ivFromSequence(uint8_t* buffer, uint64_t sid);
   const std::string& getLicenseKey() const { return m_licenseKey; };
   // bool RenewLicense(const std::string& pluginUrl);

--- a/src/test/TestSmoothTree.cpp
+++ b/src/test/TestSmoothTree.cpp
@@ -60,7 +60,7 @@ protected:
     // We set the download speed to calculate the initial network bandwidth
     m_reprChooser->SetDownloadSpeed(500000);
 
-    tree->Configure(m_reprChooser, std::vector<std::string_view>{DRM::URN_WIDEVINE}, "");
+    tree->Configure(m_reprChooser, "");
 
     // Parse the manifest
     if (!tree->Open(resp.effectiveUrl, resp.headers, resp.data))

--- a/src/utils/Base64Utils.cpp
+++ b/src/utils/Base64Utils.cpp
@@ -8,10 +8,12 @@
 
 #include "Base64Utils.h"
 
+#include "StringUtils.h"
 #include "log.h"
 
 #include <regex>
 
+using namespace UTILS;
 using namespace UTILS::BASE64;
 
 namespace
@@ -257,4 +259,18 @@ bool UTILS::BASE64::AddPadding(std::string& base64str)
     return true;
   }
   return false;
+}
+
+std::string UTILS::BASE64::UrlSafeEncode(std::string base64)
+{
+  STRING::ReplaceAll(base64, "+", "-");
+  STRING::ReplaceAll(base64, "/", "_");
+  return base64;
+}
+
+std::string UTILS::BASE64::UrlSafeDecode(std::string base64)
+{
+  STRING::ReplaceAll(base64, "-", "+");
+  STRING::ReplaceAll(base64, "_", "/");
+  return base64;
 }

--- a/src/utils/Base64Utils.h
+++ b/src/utils/Base64Utils.h
@@ -32,5 +32,17 @@ bool IsValidBase64(const std::string& input);
 
 bool AddPadding(std::string& base64str);
 
+/*!
+ * \brief Encode a base64 into URL-safe format.
+ * \return The base64 URL-safe format.
+ */
+std::string UrlSafeEncode(std::string base64);
+
+/*!
+ * \brief Decode a URL-safe base64 format into standard base64.
+ * \return The base64.
+ */
+std::string UrlSafeDecode(std::string base64);
+
 } // namespace BASE64
 } // namespace UTILS

--- a/src/utils/CryptoUtils.h
+++ b/src/utils/CryptoUtils.h
@@ -6,7 +6,10 @@
  *  See LICENSES/README.md for more information.
  */
 #pragma once
+
 #include <cstdint>
+#include <string>
+#include <vector>
 
  // These values must match their respective constant values
  // defined in the Android MediaCodec class
@@ -22,4 +25,12 @@ struct CryptoInfo
   uint8_t m_cryptBlocks{0};
   uint8_t m_skipBlocks{0};
   CryptoMode m_mode{ CryptoMode::NONE };
+};
+
+// \brief AES-128 Key info
+struct CAesKeyInfo
+{
+  std::vector<uint8_t> key;
+  std::vector<uint8_t> iv;
+  std::string keyUrl;
 };

--- a/src/utils/JsonUtils.cpp
+++ b/src/utils/JsonUtils.cpp
@@ -18,7 +18,23 @@ const rapidjson::Value* TraversePaths(const rapidjson::Value& node, const std::s
     {
       if (itr->name.GetString() == keyName)
       {
-        return &itr->value;
+        if (itr->value.IsString() || itr->value.IsNumber())
+          return &itr->value;
+        else if (itr->value.IsObject() || itr->value.IsArray())
+        {
+          const rapidjson::Value* ret = TraversePaths(itr->value, keyName);
+          if (ret)
+            return ret;
+        }
+      }
+      else if (itr->value.IsArray())
+      {
+        for (auto& item : itr->value.GetArray())
+        {
+          const rapidjson::Value* ret = TraversePaths(item, keyName);
+          if (ret)
+            return ret;
+        }
       }
       else if (itr->value.IsObject())
       {
@@ -26,6 +42,15 @@ const rapidjson::Value* TraversePaths(const rapidjson::Value& node, const std::s
         if (ret)
           return ret;
       }
+    }
+  }
+  else if (node.IsArray())
+  {
+    for (auto& item : node.GetArray())
+    {
+      const rapidjson::Value* ret = TraversePaths(item, keyName);
+      if (ret)
+        return ret;
     }
   }
 

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -354,3 +354,16 @@ std::vector<uint8_t> UTILS::STRING::HexToBytes(const std::string& hex)
 
   return bytes;
 }
+
+int UTILS::STRING::GetNumbers(std::string_view str)
+{
+  std::string extractedNbr;
+
+  for (auto c : str)
+  {
+    if (std::isdigit(c))
+      extractedNbr += c;
+  }
+
+  return ToInt32(extractedNbr);
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -290,5 +290,12 @@ std::string Trim(std::string value);
  */
 std::vector<uint8_t> HexToBytes(const std::string& hex);
 
+/*!
+ * \brief Finds and concatenates all the numbers contained in the string
+ * \param str The string to be parsed
+ * \return The concatenated numbers
+ */
+int GetNumbers(std::string_view str);
+
 } // namespace STRING
 } // namespace UTILS

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -8,11 +8,13 @@
 
 #include "UrlUtils.h"
 
+#include "Base64Utils.h"
 #include "StringUtils.h"
+#include "log.h"
 
 #include "kodi/tools/StringUtils.h"
 
-using namespace UTILS::URL;
+using namespace UTILS;
 using namespace kodi::tools;
 
 namespace
@@ -102,9 +104,9 @@ std::string RemoveDotSegments(std::string url)
   UTILS::STRING::ReplaceAll(url, PREFIX_SINGLE_DOT, "");
 
   size_t addrsStartPos{0};
-  if (IsUrlAbsolute(url))
+  if (URL::IsUrlAbsolute(url))
     addrsStartPos = url.find("://") + 3;
-  else if (IsUrlRelativeLevel(url))
+  else if (URL::IsUrlRelativeLevel(url))
     addrsStartPos = 3;
 
   // Remove segments from the end (if any)
@@ -335,4 +337,36 @@ void UTILS::URL::RemovePipePart(std::string& url)
   const size_t urlPipePos = url.find("|");
   if (urlPipePos != std::string::npos)
     url.erase(urlPipePos);
+}
+
+bool UTILS::URL::IsValidUri(const std::string& uri, std::string_view scheme /* = "data" */)
+{
+  return uri.find("data:", 0) == 0;
+}
+
+bool UTILS::URL::GetUriByteData(std::string_view uri, std::vector<uint8_t>& data)
+{
+  // Uri data format: "data:[media type][;attribute=value][;base64],<data>"
+  std::vector<std::string> colonSplit = STRING::SplitToVec(uri, ':');
+  if (colonSplit.size() == 2 && colonSplit[0] == "data")
+  {
+    std::vector<std::string> semiColonSplit = STRING::SplitToVec(colonSplit[1], ';');
+    if (semiColonSplit.size() > 0)
+    {
+      std::vector<std::string> comSplit = STRING::SplitToVec(semiColonSplit.back(), ',');
+      if (comSplit.size() == 2)
+      {
+        const bool isBase64 = comSplit[0] == "base64";
+        const std::string dataStr = comSplit[1];
+        if (isBase64)
+          data = BASE64::Decode(dataStr);
+        else
+          data = STRING::ToVecUint8(dataStr);
+        return true;
+      }
+    }
+    LOG::Log(LOGERROR, "Cannot parse URI: %s", uri.data());
+    return true;
+  }
+  return false;
 }

--- a/src/utils/UrlUtils.h
+++ b/src/utils/UrlUtils.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace UTILS
 {
@@ -98,6 +100,20 @@ void EnsureEndingBackslash(std::string& url);
  * \param url[IN][OUT] An URL.
  */
 void RemovePipePart(std::string& url);
+
+/*!
+ * \brief Check if a string contains a valid URI scheme.
+ * \param uri An URI.
+ * \param scheme[OPT] A scheme, by default "data".
+ */
+bool IsValidUri(const std::string& uri, std::string_view scheme = "data");
+
+/*!
+ * \brief Get the byte data from an URI.
+ * \param uri[IN] An URL.
+ * \param data[OUT] The byte read.
+ */
+bool GetUriByteData(std::string_view uri, std::vector<uint8_t>& data);
 
 } // namespace URL
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is the last big step of my drm rework

This PR completely rewrites the code of how DRM info provided by manifests are handled, and how DRM/CDM are initialized and managed.

The main goal is to introduce a common place where manage DRM info and CDM so in the DRMEngine,
this avoids the need for each manifest parser to have the task of choosing and managing DRM info (which parsers should not do, as is self-explained by the name) and along this introduce the automatic selection of DRM.

To reach this point, i started working on this 2 years ago, initially with the RFC test PR #1415, then with PR #1672 and in between other minor PRs not mentioned here, thousands of changes were needed to achieve something of acceptable quality with this PR, although there are some poor code parts that require more attention and much more time.

The amount of work to achieve this is very high, and despite my efforts to do dozens of tests, i will never have the opportunity to verify every single use case, so it is possible that this imlementation introduces some bugs that do not allow correct playback. It would be oppurtune to have some feedback from some users who use ISA with some video add-ons, if you read this please give your feedback.

Main changes:

### DRM auto-selection (new)
This requires a manifest that supports multiple DRMs, 
in this case you will have to provide each DRM configuration by using the new property:
`inputstream.adaptive.drm`
as explained on Wiki https://github.com/xbmc/inputstream.adaptive/wiki/Integration-DRM (that i will update later time)
therefore ISA will automatically determine which DRM to use, but you will also be able to give some sort of priority to the type of DRM to be used by making use of the `priority` parameter.

### HDCP (breaking changes)
In my research it seems to me (but i could be wrong since i haven't found comprehensive docs) that a media player should not have a way to handle HDCP, take task is inherent possibly in the DRM (CDM), which should block non-usable Keys and nothing more.
The possibility of managing the rejection of keys seem not so good handled on ISA, and cannot be done on this PR, also because there is a problem in stream ID selection in Kodi core, that prevent a fallback an appropriate stream ID when one fails, which should be fixed before that.

Breaking changes 1:
The ISA setting "Ignore HDCP status" is now removed,
the current behavior is that the HDCP "status" is never verified, but can be re-enabled by using the new `check_hdcp`, read below.

Breaking changes 2:
In the `unwrapper_params`, child parameter of the `license` parameter,
the `path_hdcp` and `path_hdcp_traverse` has been renamed into `path_hdcp_res` and `path_hdcp_res_traverse` (that handle resolution limit),
and there is a new `path_hdcp_ver` and `path_hdcp_ver_traverse`, that handle an HDCP Version comparison with the manifest value.
Details on wiki page https://github.com/xbmc/inputstream.adaptive/wiki/HDCP-resolution-limit

### New property parameters
The `inputstream.adaptive.config` have two new parameters:
- `resolution_limit` - Allow to limit the playable resolutions provided by manifests. This is a kind of workaround since currently we cant handle appropriately HDCP use cases. Just set the max resolution that can be used e.g. "1024x768"
- `check_hdcp` - Allows to enable the check of the HDCP values provided in the license response. Details on wiki page https://github.com/xbmc/inputstream.adaptive/wiki/HDCP-resolution-limit

The `inputstream.adaptive.drm` have a new parameter:
- `force_single_session` - Allow to enforce a single DRM session, when possible. (while with new "drm" prop this is disabled by default, in the old properties and "drm_legacy" still use the enforced single session. more details below)

### DRM configuration changes
1) When a manifest include DRM protections that dont require additional configurations, it will be played directly, so there is no need to set `inputstream.adaptive.drm` or `inputstream.adaptive.drm_legacy` property.
This is the case for example for PlayReady, or ClearKey case that embed its license url in the manifest.

2) In the ClearKey configuration with  `inputstream.adaptive.drm` or `inputstream.adaptive.drm_legacy`, its not only supported to set the license URL, but now its also supported to set a URI with "data" scheme. The data follow the W3C standard, so: `data:application/json;base64,REPLACE_WITH_CK_LICENSE_RESPONSE_AS_BASE64`

### DRM Sessions (breaking change)
With older ISA versons (older kodi versions) sessions created most of time was a single one (when license provide all KIDs) and on android was always enforced into a single session, that was leading to possible decryption problems by displaying corrupted/pixellated videos.

Now by using the new properties to configure the DRM so `inputstream.adaptive.drm` and `inputstream.adaptive.drm_legacy`
the DRM sessions sessions are distinguished by media type and will be reused when:
- They have same init data (default KID)
or when:
- The obtained license support multiple KIDs, but this only applies to DRMs that allow it to be known, for example on Widevine for android this is not possible and so this option will be excluded (means no session reused if there are different initdata/KIDs). 

So if there are multiple DRM sessions opened means also multiple license requests,
if this is a problem for your provider and you are sure that the license response provide all KIDs in a single request,
**you can enforce the use of a single session, by using `force_single_session` parameter of `inputstream.adaptive.drm`,**
this way you can also save the time it takes to request multiple licenses and start playback faster.

_Brief summary session breaking-changes:_
- Nothing is changed if you are using old DRM properties (e.g. inputstream.adaptive.license_key)
- `inputstream.adaptive.drm_legacy` unlike Kodi 21, it no longer forces single session
- `inputstream.adaptive.drm` never force a single session, if not specified by using `force_single_session` parameter

### Stream selector type: Ask quality (improvement)
In multi-codec manifests, all codec variants will now be shown. I had to include this change here out of test necessity.

### Deprecated old DRM properties
All following old DRM properties:
```
inputstream.adaptive.license_type
inputstream.adaptive.license_key
inputstream.adaptive.license_data
inputstream.adaptive.server_certificate
inputstream.adaptive.license_flags
inputstream.adaptive.pre_init_data
```
Are now --officially-- deprecated, in favor of the more advanced methods:
`inputstream.adaptive.drm_legacy` and `inputstream.adaptive.drm`
Its recommended to use the new properties from Kodi v22, see Wiki for more details.
Old properties still work, for now, but will be removed on future Kodi versions.

### Other changes under the hood
- ~Now the initialization of DRM/CDM Sessions are done on streams to be played only. where previously sessions were created for all streams even if unused, this improve also the playback start speed (with the exception of HDCP license based is enabled).~ Changes restored to old behavior due to lack of Widevine CDM Secure decoder for audio media preventing code optimization
- Add support to SmoothStreaming to allow override PlayReady DRM with ClearKey DRM
- Removed HLS parser hack that used DRM objects to store AES data, now the AES data is stored on each segment, with an appropriate cache for downloads
- Fix JSON traverse feature used on JSON license response to find data by path, now correctly traverse also json array type cases

### To do / tests
[x] Rework drm info on Dash parser
[x] Rework drm info on HLS parser
[x] Rework drm info on Smoothstreaming parser
[x] Reimplement CheckHDCP
[x] Adapt test project, if needed
[x] Enable multi-drm support to "drm" property
[x] Deprecate old properties
[x] Test stream with single drm widevine
[x] Test stream with single drm playready
[x] Test stream with clearkey
[x] Test stream with widevine "to" clearkey
[x] Test multi drm's stream widevine+playready, between windows and android
[x] Test HLS AES-128
[x] Test HLS AES-128 - key on each segment
[x] Test HLS multi-period, encryption transitions: unencrypted->AES-128->unencrypted
[x] Some tests on android (tested SS+PR, some widevine)
[x] Some tests on linux (under Ubuntu widevine)

fix #1585 about to separate audio/video sessions

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR will finish the multi-drm configuration support for `inputstream.adaptive.drm` property

### What is auto selection of DRM?
in this case we are talking about manifests (usually HLS/DASH) that support multiple DRMs at same time.
Until now, every python video add-on was forced to manually set the appropriate DRM for the type of operating system in use
by setting appropriate `inputstream.adaptive.license_type` and `inputstream.adaptive.license_key` (and all other properties).
for example a manifest that support playready and widevine,
on Windows OS is needed that the python addon set the drm configuration for widevine, and on android could be for playready.

This implementation allows a video add-ons to provide all the DRM configurations supported by the provider in a distinct way, so that ISA can automatically select a DRM by finding a match between DRM supported in the operating system in use and the manifest, so a video add-on will no longer have to check if a DRM is compatible with the operating system in use, to configure ISA.

This will be even more useful in the future when a support to new DRMs can be implemented.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [x] I have updated the documentation accordingly
