### PR TITLE
Fix widevine on aarch64

### DIFF
--- a/lib/cdm_aarch64/cdm_loader.cpp
+++ b/lib/cdm_aarch64/cdm_loader.cpp
@@ -16,13 +16,13 @@ extern "C"
 // See https://github.com/xbmc/inputstream.adaptive/issues/1128
 #if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
 
-  __attribute__((target("no-outline-atomics"))) int32_t __aarch64_ldadd4_acq_rel(int32_t value,
+  __attribute__((target("no-outline-atomics"))) __attribute__((visibility("default"))) int32_t __aarch64_ldadd4_acq_rel(int32_t value,
                                                                                  int32_t* ptr)
   {
     return __atomic_fetch_add(ptr, value, __ATOMIC_ACQ_REL);
   }
 
-  __attribute__((target("no-outline-atomics"))) int32_t __aarch64_swp4_acq_rel(int32_t value,
+  __attribute__((target("no-outline-atomics"))) __attribute__((visibility("default"))) int32_t __aarch64_swp4_acq_rel(int32_t value,
                                                                                int32_t* ptr)
   {
     return __atomic_exchange_n(ptr, value, __ATOMIC_ACQ_REL);


### PR DESCRIPTION
## Description
The switch to hidden symbol visibility broke widevine on aarch64 as the functions in the aarch64 cdm_loader.cpp were no longer exported:
```
error <general>: AddOnLog: inputstream.adaptive: Initialize: Initialize: Failed to load library: /storage/.kodi/cdm/libwidevinecdm.so: undefined symbol: __aarch64_ldadd4_acq_rel
```

Add attributes to specify default visibility to those functions to make it work again.

## Motivation and context
Make widevine work on aarch64 again

## How has this been tested?
Playing ORF livestream with the ORF ON addon on RPi5 running LibreELEC 13

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
