### PR TITLE
[Session] Set Atmos profile instead of JOC codec string

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -819,12 +819,11 @@ void SESSION::CSession::UpdateStream(CStream& stream)
       stream.m_info.SetCodecName(CODEC::NAME_DTS);
     else if (CODEC::Contains(codecs, CODEC::FOURCC_AC_3, codecStr))
       stream.m_info.SetCodecName(CODEC::NAME_AC3);
-    else if (CODEC::Contains(codecs, CODEC::NAME_EAC3_JOC, codecStr) ||
-             CODEC::Contains(codecs, CODEC::FOURCC_EC_3, codecStr))
+    else if (CODEC::Contains(codecs, CODEC::FOURCC_EC_3, codecStr))
     {
-      // In the above condition above is checked NAME_EAC3_JOC as first,
-      // in order to get the codec string to signal DD+ Atmos in to the SetCodecInternalName
       stream.m_info.SetCodecName(CODEC::NAME_EAC3);
+      if (CODEC::Contains(codecs, CODEC::NAME_EAC3_JOC))
+        stream.m_info.SetCodecProfile(STREAMCODEC_PROFILE::DDPlusCodecProfileAtmos);
     }
     else if (CODEC::Contains(codecs, CODEC::FOURCC_OPUS, codecStr))
       stream.m_info.SetCodecName(CODEC::NAME_OPUS);

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -59,7 +59,7 @@ namespace CODEC
 {
 constexpr const char* NAME_UNKNOWN = "unk"; // Kodi codec name for unknown codec
 
-// Kodi internal codec name to signal DD+ Atmos ("joc"), not a ffmpeg definition
+// ISA internal codec name to signal DD+ Atmos profile ("joc")
 constexpr const char* NAME_EAC3_JOC = "eac3-joc";
 
 // IMPORTANT: Codec names must match the ffmpeg library definition


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Since has been merged ffmpeg 7.1 in to kodi core
https://github.com/xbmc/xbmc/pull/24972
the string "eac3-joc" is no longer recognized as a workaround to display the atmos profile in the GUI
but in its place the atmos codec profile is now working so lets use it

no changes are required to codec handlers/readers since i had already prepared them for this change

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
