### PR TITLE
[TestHelper] Fix ODR violation that causes crash

### DIFF
--- a/src/aes_decrypter.cpp
+++ b/src/aes_decrypter.cpp
@@ -9,7 +9,9 @@
 #include "aes_decrypter.h"
 #include "utils/log.h"
 #include <bento4/Ap4StreamCipher.h>
-#include <kodi/Filesystem.h>
+// #ifndef INPUTSTREAM_TEST_BUILD
+// #include <kodi/Filesystem.h>
+// #endif
 #include <vector>
 
 void AESDecrypter::decrypt(const AP4_UI08* aes_key,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${BINARY}
     TestSmoothTree.cpp
     TestHelper.cpp
     TestUtils.cpp
+    ../aes_decrypter.cpp
     ../decrypters/Helpers.cpp
     ../decrypters/HelperPr.cpp
     ../decrypters/HelperWv.cpp

--- a/src/test/TestHelper.cpp
+++ b/src/test/TestHelper.cpp
@@ -141,23 +141,25 @@ bool TestAdaptiveStream::Download(const DownloadInfo& downloadInfo, std::vector<
   return true;
 }
 
-void AESDecrypter::decrypt(const AP4_UI08* aes_key,
-                           const AP4_UI08* aes_iv,
-                           const AP4_UI08* src,
-                           std::vector<uint8_t>& dst,
-                           size_t dstOffset,
-                           size_t& dataSize,
-                           bool lastChunk)
+void AESDecrypterTest::decrypt(const AP4_UI08* aes_key,
+                               const AP4_UI08* aes_iv,
+                               const AP4_UI08* src,
+                               std::vector<uint8_t>& dst,
+                               size_t dstOffset,
+                               size_t& dataSize,
+                               bool lastChunk)
 {
 }
 
-std::string AESDecrypter::convertIV(const std::string& input)
+std::string AESDecrypterTest::convertIV(const std::string& input)
 {
   std::string result;
   return result;
 }
 
-void AESDecrypter::ivFromSequence(uint8_t* buffer, uint64_t sid){}
+void AESDecrypterTest::ivFromSequence(uint8_t* buffer, uint64_t sid)
+{
+}
 
 std::string DASHTestTree::RunManifestUpdate(std::string manifestUpdFile)
 {
@@ -183,7 +185,7 @@ bool DASHTestTree::DownloadManifestUpd(std::string_view url,
 
 HLSTestTree::HLSTestTree() : CHLSTree() 
 {
-  m_decrypter = std::make_unique<AESDecrypter>(AESDecrypter(std::string()));
+  m_decrypter = std::make_unique<AESDecrypterTest>(std::string());
 }
 
 bool HLSTestTree::DownloadKey(std::string_view url,

--- a/src/test/TestHelper.h
+++ b/src/test/TestHelper.h
@@ -77,11 +77,11 @@ protected:
   virtual bool Download(const DownloadInfo& downloadInfo, std::vector<uint8_t>& data) override;
 };
 
-class AESDecrypter : public IAESDecrypter
+class AESDecrypterTest : public IAESDecrypter
 {
 public:
-  AESDecrypter(const std::string& licenseKey) : m_licenseKey(licenseKey){};
-  virtual ~AESDecrypter() = default;
+  AESDecrypterTest(const std::string& licenseKey) : m_licenseKey(licenseKey) {};
+  virtual ~AESDecrypterTest() = default;
 
   void decrypt(const AP4_UI08* aes_key,
                const AP4_UI08* aes_iv,
@@ -93,7 +93,7 @@ public:
   std::string convertIV(const std::string& input);
   void ivFromSequence(uint8_t* buffer, uint64_t sid);
   const std::string& getLicenseKey() const { return m_licenseKey; };
-  bool RenewLicense(const std::string& pluginUrl);
+  // bool RenewLicense(const std::string& pluginUrl);
 
 private:
   std::string m_licenseKey;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixes a problem with the _One Definition Rule_. This prevents the following crash when executing the tests:

<details>
<summary>stack trace</summary>

```
==208457==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000212b8 at pc 0x5ccdf721f19e bp 0x7ffc1c32ecd0 sp 0x7ffc1c32ecc8
READ of size 8 at 0x5020000212b8 thread T0
    #0 0x5ccdf721f19d in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_data() const /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/basic_string.h:228:28
    #1 0x5ccdf721fb78 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_is_local() const /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/basic_string.h:269:6
    #2 0x5ccdf721fab8 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_dispose() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/basic_string.h:287:7
    #3 0x5ccdf721ff48 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::~basic_string() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/basic_string.h:809:9
    #4 0x5ccdf730f648 in AESDecrypter::~AESDecrypter() src/test/TestHelper.h:84:35
    #5 0x5ccdf730f968 in AESDecrypter::~AESDecrypter() src/test/TestHelper.h:84:35
    #6 0x5ccdf7319744 in std::default_delete<IAESDecrypter>::operator()(IAESDecrypter*) const /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/unique_ptr.h:93:2
    #7 0x5ccdf73193fe in std::unique_ptr<IAESDecrypter, std::default_delete<IAESDecrypter>>::~unique_ptr() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/unique_ptr.h:398:4
    #8 0x5ccdf730f71b in adaptive::CHLSTree::~CHLSTree() src/test/../parser/HLSTree.h:30:24
    #9 0x5ccdf730fd28 in HLSTestTree::~HLSTestTree() src/test/TestHelper.h:131:7
    #10 0x5ccdf730fd78 in HLSTestTree::~HLSTestTree() src/test/TestHelper.h:131:7
    #11 0x5ccdf72df9ea in HLSTreeTest::TearDown() src/test/TestHLSTree.cpp:29:5
    #12 0x7a29555638e9 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2638:27
    #13 0x7a29555638e9 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (.constprop.0) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2674:52
    #14 0x7a295554f36e in testing::TestInfo::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2859:14
    #15 0x7a295554f553 in testing::TestSuite::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:3037:33
    #16 0x7a295554f553 in testing::TestSuite::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2991:6
    #17 0x7a295555b708 in testing::internal::UnitTestImpl::RunAllTests() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:5967:47
    #18 0x7a295555bd78 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2638:27
    #19 0x7a295555bd78 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2674:52
    #20 0x7a295555bd78 in testing::UnitTest::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:5546:55
    #21 0x5ccdf721c5d0 in RUN_ALL_TESTS() /usr/include/gtest/gtest.h:2334:73
    #22 0x5ccdf721be50 in main src/test/TestMain.cpp:20:10
    #23 0x7a2954f45e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #24 0x7a2954f45ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #25 0x5ccdf70e4464 in _start (/home/mark/Coding/Repos/inputstream.adaptive/build_clang_debug_sanitizer/src/test/inputstream.adaptive_test+0xf30464) (BuildId: 53a3fced4234a38f5911a78d952158d8708ef61b)

0x5020000212b8 is located 0 bytes after 8-byte region [0x5020000212b0,0x5020000212b8)
allocated by thread T0 here:
    #0 0x5ccdf7218f82 in operator new(unsigned long) (/home/mark/Coding/Repos/inputstream.adaptive/build_clang_debug_sanitizer/src/test/inputstream.adaptive_test+0x1064f82) (BuildId: 53a3fced4234a38f5911a78d952158d8708ef61b)
    #1 0x5ccdf74647e8 in std::__detail::_MakeUniq<AESDecrypter>::__single_object std::make_unique<AESDecrypter>() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/unique_ptr.h:1076:30
    #2 0x5ccdf7426d2d in adaptive::CHLSTree::Configure(CHOOSER::IRepresentationChooser*, std::vector<std::basic_string_view<char, std::char_traits<char>>, std::allocator<std::basic_string_view<char, std::char_traits<char>>>>, std::basic_string_view<char, std::char_traits<char>>) src/parser/HLSTree.cpp:169:17
    #3 0x5ccdf72ddc3b in HLSTreeTest::OpenTestFileMaster(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>, std::vector<std::basic_string_view<char, std::char_traits<char>>, std::allocator<std::basic_string_view<char, std::char_traits<char>>>>) src/test/TestHLSTree.cpp:67:11
    #4 0x5ccdf72db255 in HLSTreeTest::OpenTestFileMaster(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) src/test/TestHLSTree.cpp:42:12
    #5 0x5ccdf72b7144 in HLSTreeTest_CalculateSourceUrl_Test::TestBody() src/test/TestHLSTree.cpp:102:3
    #6 0x7a29555638e9 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2638:27
    #7 0x7a29555638e9 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (.constprop.0) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2674:52
    #8 0x7a295554f16f in testing::Test::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2713:50
    #9 0x7a295554f16f in testing::Test::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2703:6
    #10 0x7a295554f36e in testing::TestInfo::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2859:14
    #11 0x7a295554f553 in testing::TestSuite::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:3037:33
    #12 0x7a295554f553 in testing::TestSuite::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2991:6
    #13 0x7a295555b708 in testing::internal::UnitTestImpl::RunAllTests() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:5967:47
    #14 0x7a295555bd78 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2638:27
    #15 0x7a295555bd78 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:2674:52
    #16 0x7a295555bd78 in testing::UnitTest::Run() /usr/src/debug/gtest/googletest-1.15.2/googletest/src/gtest.cc:5546:55
    #17 0x5ccdf721c5d0 in RUN_ALL_TESTS() /usr/include/gtest/gtest.h:2334:73
    #18 0x5ccdf721be50 in main src/test/TestMain.cpp:20:10
    #19 0x7a2954f45e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #20 0x7a2954f45ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #21 0x5ccdf70e4464 in _start (/home/mark/Coding/Repos/inputstream.adaptive/build_clang_debug_sanitizer/src/test/inputstream.adaptive_test+0xf30464) (BuildId: 53a3fced4234a38f5911a78d952158d8708ef61b)

SUMMARY: AddressSanitizer: heap-buffer-overflow src/test/TestHelper.h:84:35 in AESDecrypter::~AESDecrypter()
Shadow bytes around the buggy address:
  0x502000021000: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fd
  0x502000021080: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
  0x502000021100: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fa
  0x502000021180: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x502000021200: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
=>0x502000021280: fa fa fd fa fa fa 00[fa]fa fa 00 fa fa fa fd fa
  0x502000021300: fa fa 00 00 fa fa fd fa fa fa 00 00 fa fa 00 fa
  0x502000021380: fa fa fd fd fa fa fd fa fa fa fa fa fa fa fa fa
  0x502000021400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000021480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000021500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==208457==ABORTING
```
</details>

This could be resolved more elegant with maybe a factory function but I'm too lazy right now.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The tests shouldn't crash. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests run without crash.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
