### PR TITLE
[DashTree] Changes to parsing values from "Role" tag

### DIFF
--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -466,13 +466,14 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
 
     if (schemeIdUri == "urn:mpeg:dash:role:2011")
     {
-      if (value == "subtitle")
-        contentType = "text";
-      else if (value == "forced") // ISA custom attribute
+      //! @todo: If no complains, remove commented lines on Kodi 23
+      // if ((value == "subtitle" || value == "caption") && contentType.empty())
+      //   contentType = "text";
+      if (value == "forced") // ISA custom attribute
         adpSet->SetIsForced(true);
       else if (value == "main")
         adpSet->SetIsDefault(true);
-      else if (value == "caption" || value == "alternate" || value == "commentary")
+      else if (value == "alternate" || value == "commentary")
         adpSet->SetIsImpaired(true);
     }
   }

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -469,7 +469,16 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
       //! @todo: If no complains, remove commented lines on Kodi 23
       // if ((value == "subtitle" || value == "caption") && contentType.empty())
       //   contentType = "text";
+
+      //! @todo: Remove custom "forced" value support on Kodi 23
       if (value == "forced") // ISA custom attribute
+      {
+        LOG::LogF(LOGWARNING, "The support for the custom \"forced\" value on \"Role\" tag is now "
+                              "deprecated, it will be removed on Kodi v23.\n"
+                              "Please use the \"forced-subtitle\" standard value.");
+        adpSet->SetIsForced(true);
+      }
+      else if (value == "forced-subtitle")
         adpSet->SetIsForced(true);
       else if (value == "main")
         adpSet->SetIsDefault(true);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Changes on "Role" tag value parsing:

### Disabled "subtitle", "caption" uses

"subtitle" looks like a kind of old workaround to set content type,
but "should" be used only to signal burned-in subtitles to video stream (not CC 608 etc..)

"caption" instead has been used to set impaired flag, imo its not correct thing
its not a rule that "caption" stand for impaired, as you can read also
on wikipedia this should not be a rule, but only some countries may use it as rule

IOP/ISO EIC specs say that "subtitle" and "caption" have same meaning of burned-in subtitles
so lets try to remove both and we will see if someone complains

(compared to the past the current source code have more robust code to identify the “content type” so it should be low risk of breaking some service by removing "subtitle" case value)

### Deprecated custom "forced" support

i have implemented "forced" value years ago, i was not aware of "forced-subtitle" official specs value,
so lets deprecate it, for future removal

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1768 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
cant be test by my part

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
