### PR TITLE
[CMakelists] symbol visibility hidden to all OS's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ else()
   list(APPEND DEPLIBS ${CMAKE_DL_LIBS})
   # Required on some old linux platforms to use macro like PRIu64
   add_definitions(-D__STDC_FORMAT_MACROS)
-  # Force symbol visibility hidden by default for operative systems different than Windows,
-  # by default on Windows is hidden, on linux is the opposite, and lead to have singleton static objects
-  # stored in memory in a persistent way between all ISAdaptive instances (kodi core dlopen/dlclose)
-  add_compile_options(-fvisibility=hidden)
 endif()
+
+# Force symbol visibility hidden by default otherwise you will have singleton static objects
+# stored in memory in a persistent way between all ISAdaptive instances (kodi core dlopen/dlclose)
+add_compile_options(-fvisibility=hidden)
 
 # Sources to build
 # (use add_dir_sources function to add source/header files from the CMakeLists files of subdirectories)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
it seemed to me that on Windows a few months ago it worked even without forcing the hidden flag
maybe i was wrong or something else is changed in the build flow
(original change #1706)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1770

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
