### PR TITLE
[Backport] [FragmentedSampleReader] Fix transitions from unencrypted fragments to encrypted

### DIFF
--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -466,6 +466,9 @@ void CFragmentedSampleReader::UpdateSampleDescription()
       return;
     }
   }
+  else {
+    m_protectedDesc = nullptr;
+  }
 
   LOG::LogF(LOGDEBUG, "Codec fourcc: %s (%u)", CODEC::FourCCToString(desc->GetFormat()).c_str(),
             desc->GetFormat());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
UpdateSampleDescription() will update the m_protectedDesc member variable, but never clear it when the sample description box says there is no protection. Since ProcessMoof() makes a decision to process the fragment as decrypted or not based on this variable being assigned or not, we can end up decrypting unencrypted content. On windows, trying to 'play' unencrypted audio content can cause a crash.

This change will clear the m_protectedDesc member when the fragment is not protected, allowing other logic to function as intended

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes playback of the CBCS Google 'Tears of Steel' sample stream. This stream starts with the first fragment unencrypted. We however populate m_protectedDesc because the Initialize() method uses a magic number (0) get the first sample description, regardless of what sample description is specified for in the first fragment. This should be looked at in the future.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
