### PR TITLE
[HLSTree] Fix media sequence number on discontinuity

### DIFF
--- a/plugin.video.isasamples/menu_data.py
+++ b/plugin.video.isasamples/menu_data.py
@@ -79,14 +79,6 @@ menu_data = {
                     'manifest_url': 'https://media.axprod.net/TestVectors/v7-Clear/Manifest_1080p.mpd',
                 }
             },
-            'TravelXP [video]': {
-                SI_FEATURE: 'ADP,CMP4,CWEBM',
-                SI_CODECS: 'vp9,hvc1,mp4a',
-                SI_INFO: 'Two adaptive videos VP9 and HEVC',
-                SI_CONFIG: {
-                    'manifest_url': 'https://travelxp.s.llnwi.net/watch1/61025c11781ce3c543f5abcd/manifest_v4.mpd'
-                }
-            },
             'Dashif testpic_2s [subtitles]': {
                 SI_FEATURE: 'SUBMP4',
                 SI_CODECS: 'avc1,mp4a,stpp',
@@ -497,6 +489,14 @@ menu_data = {
                 SI_INFO: 'Subtitle TTML MP4 container',
                 SI_CONFIG: {
                     'manifest_url': 'https://test-streams.mux.dev/tos_ismc/main.m3u8',
+                }
+            },
+            'TravelXP [multi-period][CC subtitles]': {
+                SI_FEATURE: 'ADPV,AUDI',
+                SI_CODECS: 'h264,aac',
+                SI_INFO: 'TS container',
+                SI_CONFIG: {
+                    'manifest_url': 'https://travelxp-travelxp-1-eu.xiaomi.wurl.tv/playlist.m3u8'
                 }
             },
         },

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -816,15 +816,18 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
         }
 
         FreeSegments(period, rep);
-        rep->Timeline().Swap(newSegments);
 
         rep->SetStartNumber(mediaSequenceNbr);
+
+        // Update MEDIA-SEQUENCE for next period
+        mediaSequenceNbr += newSegments.GetSize();
+
+        rep->Timeline().Swap(newSegments);
       }
 
       isSkipUntilDiscont = false;
       ++discontCount;
 
-      mediaSequenceNbr += rep->Timeline().GetSize();
       currentSegNumber = mediaSequenceNbr;
 
       CPeriod* newPeriod = FindDiscontinuityPeriod(m_discontSeq + discontCount);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
For HLS live case with discontinuities (dont affect VOD)

its possible that at some time you are updating same representation
so the `mediaSequenceNbr += rep->Timeline().GetSize();`
was looking to already existing segments to update the media seq. number
where instead on the "current" manifest update can be that have no new segments for the same discontinuity,
this lead to a wrong mediaSequenceNbr and a bad downloaded segments (show on screen as repeated frames)

fix it by updating the media seq. number with the current total segments `newSegments.GetSize()`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i was testing travelxp sample and noticed repeated video frames because was downloading again same segments

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
HLS travelxp sample
and Pluto TV darts with its malformed HLS
i have not noticed regressions

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
