### PR TITLE
[UrlUtils] Fix GetBaseDomain for SMIL URLs

### DIFF
--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -48,6 +48,9 @@ TEST_F(UtilsTest, DetermineBaseDomain)
 
   url = "https://www.foo.bar:1234/mpd/test.mpd?ping=pong";
   EXPECT_EQ(URL::GetBaseDomain(url), "https://www.foo.bar");
+
+  url = "https://www.foo.bar/example/smil:rtmp.smil/playlist.m3u8?ping=pong";
+  EXPECT_EQ(URL::GetBaseDomain(url), "https://www.foo.bar");
 }
 
 TEST_F(UtilsTest, JoinUrls)

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -242,18 +242,20 @@ std::string UTILS::URL::GetBaseDomain(std::string url)
     if (paramsPos != std::string::npos)
       url.erase(paramsPos);
 
-    const size_t domainStartPos = url.find("://") + 3;
-    // Try remove url port number and path
-    const size_t port = url.find_first_of(':', domainStartPos);
-    if (port != std::string::npos)
-      url.erase(port);
-    else
-    {
-      // Try remove the path
-      const size_t slashPos = url.find_first_of('/', domainStartPos);
-      if (slashPos != std::string::npos)
-        url.erase(slashPos);
-    }
+    const size_t schemeEndPos = url.find("://");
+    if (schemeEndPos == std::string::npos)
+      return ""; // Not valid
+
+    const size_t domainStartPos = schemeEndPos + 3;
+    const size_t portPos = url.find_first_of(':', domainStartPos);
+    const size_t pathPos = url.find_first_of('/', domainStartPos);
+
+    size_t endPos = url.size();
+    if (portPos != std::string::npos && portPos < pathPos)
+      url.erase(portPos); // remove port number
+    else if (pathPos != std::string::npos)
+      url.erase(pathPos); // remove from slash
+
     return url;
   }
   return "";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
GetBaseDomain was not able to get correctly the base domain

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed some HLS streaming wasnt playing due to SMIL URLs

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
