### PR TITLE
[AdaptiveStream] Workaround to 0 segment position on live delay

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -677,6 +677,12 @@ bool AdaptiveStream::start_stream(const uint64_t startPts)
       size_t segPosDelay =
           static_cast<size_t>((m_tree->m_liveDelay * current_rep_->GetTimescale()) / segDur);
 
+      //! @todo: hackish workaround, when segment duration is same of live delay, force at least 1 position delay
+      //! otherwise the current segment will be last available on the timeline,
+      //! therefore when GetNextSegment is executed will return nullptr and the below (todo) BUG condition stop the playback
+      if (segPosDelay == 0)
+        segPosDelay = 1;
+
       if (segPos > segPosDelay)
         segPos -= segPosDelay;
       else


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
the HLS provided on the issue has segments of 16secs and we have a default live delay of 16 secs
this means that number of segments required for live delay are 0
despite can be sufficient time for the manifest update, the problem is related to an old standing bug few lines below

https://github.com/xbmc/inputstream.adaptive/blob/3342336a5ba6bec9422e7435d9a0eda8868fca89/src/common/AdaptiveStream.cpp#L712-L714

this small workaround have zero impact to possible side effects so can be backported safely
this problem is know and an appropriate fix require much more time and code changes

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1809
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested HLS provided on the issue
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
