### PR TITLE
[AdaptiveStream] Fix wrong live delay calculation

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -669,30 +669,29 @@ bool AdaptiveStream::start_stream(const uint64_t startPts)
         !m_tree->IsChangingPeriod() && !CSrvBroker::GetKodiProps().IsPlayTimeshift() &&
         !current_rep_->Timeline().IsEmpty())
     {
-      size_t segPos = current_rep_->Timeline().GetSize() - 1;
-      //! @todo: segment duration is not fixed for each segment, this can calculate a wrong delay
-      const CSegment* lastSeg = current_rep_->Timeline().GetBack();
-      uint64_t segDur = lastSeg->m_endPts - lastSeg->startPTS_;
+      uint64_t totalDurSecs{0};
+      const uint64_t liveDelaySecs = m_tree->m_liveDelay;
+      const uint32_t timescale = current_rep_->GetTimescale();
 
-      size_t segPosDelay =
-          static_cast<size_t>((m_tree->m_liveDelay * current_rep_->GetTimescale()) / segDur);
-
-      //! @todo: hackish workaround, when segment duration is same of live delay, force at least 1 position delay
-      //! otherwise the current segment will be last available on the timeline,
-      //! therefore when GetNextSegment is executed will return nullptr and the below (todo) BUG condition stop the playback
-      if (segPosDelay == 0)
-        segPosDelay = 1;
-
-      if (segPos > segPosDelay)
-        segPos -= segPosDelay;
-      else
+      //! @todo: This code does not consider that the live delay could cause the startup segment to be selected
+      //! in the previous period when the current period has too few segments
+      //! more likely live delay management should be moved just after manifest parsing and before period init
+      for (auto itSeg = current_rep_->Timeline().rbegin(); itSeg != current_rep_->Timeline().rend();
+           ++itSeg)
       {
-        //! @todo: Unhandled! should fall on previous period (when exists)
-        //! since is needed change period all this code should be moved just after manifest parsing and before period init
-        segPos = 0;
-      }
+        // Implicit rounding down because managing PTS milliseconds negatively affects segment selection
+        totalDurSecs += (itSeg->m_endPts - itSeg->startPTS_) / timescale;
+        // Dont use >= since if live delay is equal to the segment duration
+        // we may fall too close to the live edge to get new segments from manifest update
+        if (totalDurSecs > liveDelaySecs)
+        {
+          // current_segment_ expects the previous segment as a reference to find the next segment (this one)
+          if (itSeg != current_rep_->Timeline().rend())
+            current_rep_->current_segment_ = &*(++itSeg);
 
-      current_rep_->current_segment_ = current_rep_->Timeline().Get(segPos);
+          break;
+        }
+      }
     }
     else if (m_startEvent == EVENT_TYPE::REP_CHANGE) // switching streams, align new stream segment no.
     {

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -160,6 +160,8 @@ public:
 
   std::deque<CSegment>::const_iterator begin() const { return m_segments.begin(); }
   std::deque<CSegment>::const_iterator end() const { return m_segments.end(); }
+  std::deque<CSegment>::const_reverse_iterator rbegin() const { return m_segments.rbegin(); }
+  std::deque<CSegment>::const_reverse_iterator rend() const { return m_segments.rend(); }
 
 private:
   // Has been used std::deque because there are uses of pointer references


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
An old issue to do,
segments do not have fixed durations, it is not a rule
the old code dont take in account of variable duration of segments

this should solve a bad live delay with some videos that was causing constant buffering each time go to the live edge
where the only workaround was increasing the livedelay value by using the ISA property

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
solve one code "todo"

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
a couple of live HLS with variable segment durations

check the start media segment from log, compare it with the manifest by taking in account of 16secs of default ISA live delay

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
