### PR TITLE
Implemented TRC Color transfer characteristic

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -291,10 +291,11 @@ msgid "Select video stream"
 msgstr ""
 
 #. Description of each list item in #30231 dialog window
-#. Do not translate placeholders: {codec} {quality}
+#. Do not translate placeholders: {codec} {quality} {hdr-type}
+#. Use of double graphes e.g. {whatyouwant{hdr-type}whatyouwant} allows you to add additional text printed only when a value is present
 #: src/common/RepresentationChooserAskQuality.cpp
 msgctxt "#30232"
-msgid "Video stream {codec} {quality}"
+msgid "Video stream {codec}{ [{hdr-type}]} {quality}"
 msgstr ""
 
 #. Enum setting to set the test mode

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -455,7 +455,14 @@ void SESSION::CSession::UpdateStream(CStream& stream)
     stream.m_info.SetColorSpace(INPUTSTREAM_COLORSPACE_UNSPECIFIED);
     stream.m_info.SetColorRange(INPUTSTREAM_COLORRANGE_UNKNOWN);
     stream.m_info.SetColorPrimaries(INPUTSTREAM_COLORPRIMARY_UNSPECIFIED);
-    stream.m_info.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_UNSPECIFIED);
+
+    ColorTRC colorTRC = rep->GetColorTRC();
+    if (colorTRC == ColorTRC::SMPTE2084)
+      stream.m_info.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_SMPTE2084);
+    else if (colorTRC == ColorTRC::ARIB_STD_B67)
+      stream.m_info.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_ARIB_STD_B67);
+    else
+      stream.m_info.SetColorTransferCharacteristic(INPUTSTREAM_COLORTRC_UNSPECIFIED);
 
     if (CODEC::Contains(codecs, CODEC::FOURCC_AVC_, codecStr) ||
         CODEC::Contains(codecs, CODEC::FOURCC_H264, codecStr))

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -202,6 +202,18 @@ PLAYLIST::CAdaptationSet* PLAYLIST::CAdaptationSet::FindByCodec(
   return nullptr;
 }
 
+CAdaptationSet* PLAYLIST::CAdaptationSet::FindByCodec(
+    std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, std::string codec, const ColorTRC trc)
+{
+  auto itAdpSet = std::find_if(
+      adpSets.cbegin(), adpSets.cend(), [&codec, &trc](const std::unique_ptr<CAdaptationSet>& item)
+      { return CODEC::Contains(item->GetCodecs(), codec) && item->GetColorTRC() == trc; });
+  if (itAdpSet != adpSets.cend())
+    return (*itAdpSet).get();
+
+  return nullptr;
+}
+
 CAdaptationSet* PLAYLIST::CAdaptationSet::FindMergeable(
     std::vector<std::unique_ptr<CAdaptationSet>>& adpSets, CAdaptationSet* adpSet)
 {

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -135,6 +135,16 @@ public:
                                      std::string codec);
 
   /*!
+   * \brief Find an adaptation set by codec string and TRC.
+   * \param adpSets The adaptation set list where to search
+   * \param codec The codec string
+   * \return The adaptation set if found, otherwise nullptr
+   */
+  static CAdaptationSet* FindByCodec(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                                     std::string codec,
+                                     const ColorTRC trc);
+
+  /*!
    * \brief Find a mergeable adaptation set by comparing properties.
    * \param adpSets The adaptation set list where to search
    * \param adpSet The adaptation set to be compared

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -46,24 +46,74 @@ std::string CovertFpsToString(float value)
   return str;
 }
 
+void ReplacePhValue(std::string& text,
+                    const std::string& phTextPart,
+                    const std::string& phName,
+                    const std::string& value)
+{
+  std::string result;
+  if (!value.empty())
+  {
+    result = phTextPart;
+    STRING::ReplaceFirst(result, phName, value);
+    // Placeholder contained within other parentheses e.g.: {some text {ph} some text}
+    if (result.front() == '{')
+      result.erase(0, 1);
+    if (result.back() == '}')
+      result.pop_back();
+  }
+  STRING::ReplaceFirst(text, phTextPart, result);
+}
+
 std::string CreateStreamName(const CRepresentation* repr)
 {
   std::string streamName{kodi::addon::GetLocalizedString(30232)};
-  STRING::ReplaceFirst(streamName, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
+  const std::vector<std::string> phs = STRING::ExtractPlaceholders(streamName, '{', '}');
 
-  float fps{static_cast<float>(repr->GetFrameRate())};
-  if (fps > 0 && repr->GetFrameRateScale() > 0)
-    fps /= repr->GetFrameRateScale();
+  for (const std::string& ph : phs)
+  {
+    if (STRING::Contains(ph, "{codec}", true))
+    {
+      ReplacePhValue(streamName, ph, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
+    }
+    else if (STRING::Contains(ph, "{hdr-type}", true))
+    {
+      std::string hdrType;
+      const ColorTRC colorTrc = repr->GetColorTRC();
+      if (colorTrc == ColorTRC::SMPTE2084)
+      {
+        if (CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_DVH1) ||
+            CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_DVHE))
+        {
+          hdrType = "DV";
+        }
+        else
+        {
+          hdrType = "HDR10";
+        }
+      }
+      if (colorTrc == ColorTRC::ARIB_STD_B67)
+        hdrType = "HLG";
 
-  std::string quality = "(";
-  if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
-    quality += StringUtils::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
-  if (fps > 0)
-    quality += StringUtils::Format("%s fps, ", CovertFpsToString(fps).c_str());
+      ReplacePhValue(streamName, ph, "{hdr-type}", hdrType);
+    }
+    else if (STRING::Contains(ph, "{quality}", true))
+    {
+      float fps{static_cast<float>(repr->GetFrameRate())};
+      if (fps > 0 && repr->GetFrameRateScale() > 0)
+        fps /= repr->GetFrameRateScale();
 
-  quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
-  STRING::ReplaceFirst(streamName, "{quality}", quality);
+      std::string quality = "(";
+      if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
+        quality += StringUtils::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
+      if (fps > 0)
+        quality += StringUtils::Format("%s fps, ", CovertFpsToString(fps).c_str());
 
+      quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
+
+      ReplacePhValue(streamName, ph, "{quality}", quality);
+    }
+  }
   return streamName;
 }
 } // unnamed namespace

--- a/src/common/CommonAttribs.cpp
+++ b/src/common/CommonAttribs.cpp
@@ -82,3 +82,10 @@ uint32_t PLAYLIST::CCommonAttribs::GetAudioChannels() const
     return m_audioChannels;
   return m_parentCommonAttributes->GetAudioChannels();
 }
+
+const ColorTRC PLAYLIST::CCommonAttribs::GetColorTRC() const
+{
+  if (m_colorTRC != ColorTRC::NONE || !m_parentCommonAttributes)
+    return m_colorTRC;
+  return m_parentCommonAttributes->GetColorTRC();
+}

--- a/src/common/CommonAttribs.h
+++ b/src/common/CommonAttribs.h
@@ -34,6 +34,18 @@ struct ProtectionScheme
   std::string licenseUrl;
 };
 
+/*!
+ * \brief Color Transfer Characteristics (TRC)
+ *        references from InputStream API interface and
+ *        https://en.wikipedia.org/wiki/Coding-independent_code_points
+ */
+enum class ColorTRC
+{
+  NONE,
+  SMPTE2084 = 16,
+  ARIB_STD_B67 = 18,
+};
+
 // CCommonAttribs class provide attribute data
 // of class itself or when not set of the parent class (if any).
 class ATTR_DLL_LOCAL CCommonAttribs
@@ -72,6 +84,9 @@ public:
   bool HasProtectionSchemes() const { return !m_protSchemes.empty(); }
   std::vector<ProtectionScheme>& ProtectionSchemes() { return m_protSchemes; }
 
+  void SetColorTRC(ColorTRC trc) { m_colorTRC = trc; }
+  const ColorTRC GetColorTRC() const;
+
 protected:
   CCommonAttribs* m_parentCommonAttributes{nullptr};
   std::string m_mimeType;
@@ -84,6 +99,7 @@ protected:
   uint32_t m_sampleRate{0};
   uint32_t m_audioChannels{0};
   std::vector<ProtectionScheme> m_protSchemes;
+  ColorTRC m_colorTRC{ColorTRC::NONE};
 };
 
 } // namespace PLAYLIST

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -569,6 +569,13 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
       adpSet->AddSwitchingIds(value);
     else if (schemeIdUri == "http://dashif.org/guidelines/last-segment-number")
       adpSet->SetSegmentEndNr(STRING::ToUint64(value));
+    else if (schemeIdUri == "urn:mpeg:mpegB:cicp:TransferCharacteristics")
+    {
+      if (value == "16")
+        adpSet->SetColorTRC(ColorTRC::SMPTE2084);
+      else if (value == "18")
+        adpSet->SetColorTRC(ColorTRC::ARIB_STD_B67);
+    }
   }
 
   // Parse <BaseURL> tag (just first, multi BaseURL not supported yet)

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1446,6 +1446,7 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
       }
       var.m_groupIdAudio = attribs["AUDIO"];
       var.m_groupIdSubtitles = attribs["SUBTITLES"];
+      var.m_videoRange = attribs["VIDEO-RANGE"];
       var.m_uri = uri;
 
       // Check if this uri has been already added
@@ -1639,15 +1640,24 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
         AddIncludedAudioStream(period, codecAudio);
       }
 
-      // We group all video representations by codec fourcc, similar to the DASH specs
+      // We group all video representations by codec fourcc (and TRC) similar to the DASH specs
       std::string codecFourcc = codecVideo.substr(0, codecVideo.find('.'));
+
+      // Determinate the TRC
+      ColorTRC colorTRC = ColorTRC::NONE;
+      if (var.m_videoRange == "PQ")
+        colorTRC = ColorTRC::SMPTE2084;
+      else if (var.m_videoRange == "HLG")
+        colorTRC = ColorTRC::ARIB_STD_B67;
+
       // Find existing adaptation set with same codec fourcc ...
-      CAdaptationSet* adpSet = CAdaptationSet::FindByCodec(period->GetAdaptationSets(), codecFourcc);
+      CAdaptationSet* adpSet = CAdaptationSet::FindByCodec(period->GetAdaptationSets(), codecFourcc, colorTRC);
       if (!adpSet) // ... or create a new one
       {
         auto newAdpSet = CAdaptationSet::MakeUniquePtr(period.get());
         newAdpSet->SetStreamType(streamType);
         newAdpSet->AddCodecs(codecFourcc);
+        newAdpSet->SetColorTRC(colorTRC);
         adpSet = newAdpSet.get();
         period->AddAdaptationSet(newAdpSet);
       }

--- a/src/parser/HLSTree.h
+++ b/src/parser/HLSTree.h
@@ -101,6 +101,7 @@ protected:
     float m_frameRate{0};
     std::string m_groupIdAudio;
     std::string m_groupIdSubtitles;
+    std::string m_videoRange;
     std::string m_uri;
     bool m_isUriDuplicate{false}; // Another variant have same uri
   };

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -367,3 +367,45 @@ int UTILS::STRING::GetNumbers(std::string_view str)
 
   return ToInt32(extractedNbr);
 }
+
+std::vector<std::string> UTILS::STRING::ExtractPlaceholders(const std::string& text,
+                                                            const char openChar,
+                                                            const char closeChar)
+{
+  std::vector<std::string> placeholders;
+  std::string currentPlaceholder;
+  int braceCount{0};
+
+  for (char ch : text)
+  {
+    if (ch == openChar)
+    {
+      // Start a new placeholder
+      if (braceCount == 0)
+      {
+        currentPlaceholder.clear();
+      }
+      braceCount++;
+      currentPlaceholder += ch;
+    }
+    else if (ch == closeChar)
+    {
+      // Close a placeholder
+      if (braceCount > 0)
+      {
+        currentPlaceholder += ch;
+        braceCount--;
+        if (braceCount == 0)
+        {
+          placeholders.push_back(currentPlaceholder);
+        }
+      }
+    }
+    else if (braceCount > 0)
+    {
+      currentPlaceholder += ch;
+    }
+  }
+
+  return placeholders;
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -297,5 +297,16 @@ std::vector<uint8_t> HexToBytes(const std::string& hex);
  */
 int GetNumbers(std::string_view str);
 
+/*!
+ * \brief Extract placeholders from a string
+ * \param text The string to be parsed
+ * \param openChar The opening char used to enclose the placeholder
+ * \param closeChar The closing char used to enclose the placeholder
+ * \return The placeholders
+ */
+std::vector<std::string> ExtractPlaceholders(const std::string& text,
+                                             const char openChar,
+                                             const char closeChar);
+
 } // namespace STRING
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Allow to determinate the HDR type in advance
this will allow users to recognize HDR/HLG/Dolby vision streams through kodi GUI info

This implement parsing TRC data from manifest only,
then not demuxers (by parsing SPS VUI on packages) ~it should not matter much~ it could be a good idea implement it in future (see relations with GUI/Subtitles https://github.com/xbmc/xbmc/pull/26631#pullrequestreview-2764487534) this because if a manifest provide malformed values can be fixed by VUI info

This PR depends from Kodi core changes https://github.com/xbmc/xbmc/pull/26631

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
impossible recognize HDR streams from kodi GUI video stream dialog
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
