### PR TITLE
Fix regressions and improvements to stream selection

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -164,7 +164,14 @@ msgctxt "#30171"
 msgid "Defines the initial bandwidth when it cannot be automatically determined. This value can be overridden by the minimum bandwidth setting."
 msgstr ""
 
-#empty strings from id 30171 to 30173
+msgctxt "#30172"
+msgid "Resolution limit"
+msgstr ""
+
+#. Description of setting with label #30172
+msgctxt "#30173"
+msgid "If set, based on the capabilities of the video stream an attempt will be made to limit the range of resolutions to the one chosen."
+msgstr ""
 
 #. To set the stream selection type (refer to RepresentationChooser's)
 msgctxt "#30174"
@@ -228,44 +235,49 @@ msgctxt "#30204"
 msgid "Decrypter path"
 msgstr ""
 
-#empty strings from id 30205 to 30209
+#empty strings from id 30205 to 30208
+
+#. Item list value of setting with label #30172
+msgctxt "#30209"
+msgid "Disabled"
+msgstr ""
 
 #. Item list value of setting with label #30110, #30113
 msgctxt "#30210"
 msgid "Auto"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30211"
 msgid "480p"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30212"
 msgid "640p"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30213"
 msgid "720p"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30214"
 msgid "1080p"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30215"
 msgid "2K"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30216"
 msgid "1440p"
 msgstr ""
 
-#. Item list value of setting with label #30110, #30113
+#. Item list value of setting with label #30110, #30113, #30172
 msgctxt "#30217"
 msgid "4K"
 msgstr ""

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -69,6 +69,30 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
+        <setting parent="adaptivestream.type" id="adaptivestream.res.rangelimit" type="string" label="30172" help="30173">
+          <level>0</level>
+          <default>disabled</default>
+          <constraints>
+            <options>
+              <option label="30209">disabled</option>
+              <option label="30211">480p</option>
+              <option label="30212">640p</option>
+              <option label="30213">720p</option>
+              <option label="30214">1080p</option>
+              <option label="30215">2K</option>
+              <option label="30216">1440p</option>
+              <option label="30217">4K</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <or>
+                <condition setting="adaptivestream.type">ask-quality</condition>
+              </or>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
         <setting parent="adaptivestream.type" id="adaptivestream.bandwidth.init.auto" type="boolean" label="30168" help="30169">
           <level>0</level>
           <default>true</default>

--- a/src/CompSettings.cpp
+++ b/src/CompSettings.cpp
@@ -55,6 +55,16 @@ std::pair<int, int> ADP::SETTINGS::CCompSettings::GetResSecureMax() const
   return val;
 }
 
+std::pair<int, int> ADP::SETTINGS::CCompSettings::GetResRangeLimit() const
+{
+  std::pair<int, int> val;
+  if (!STRING::GetMapValue(RES_CONV_LIST,
+                           kodi::addon::GetSettingString("adaptivestream.res.rangelimit"), val))
+    LOG::Log(LOGERROR, "Unknown value for \"adaptivestream.res.rangelimit\" setting");
+
+  return val;
+}
+
 bool ADP::SETTINGS::CCompSettings::IsBandwidthInitAuto() const
 {
   return kodi::addon::GetSettingBoolean("adaptivestream.bandwidth.init.auto");

--- a/src/CompSettings.h
+++ b/src/CompSettings.h
@@ -26,8 +26,9 @@ namespace SETTINGS
 // Generic conversion map from family of resolutions to a common pixel format.
 // If modified, the changes should reflect XML settings and Kodi properties related to resolutions.
 const std::map<std::string, std::pair<int, int>> RES_CONV_LIST{
-    {"auto", {0, 0}},        {"480p", {640, 480}}, {"640p", {960, 640}},    {"720p", {1280, 720}},
-    {"1080p", {1920, 1080}}, {"2K", {2048, 1080}}, {"1440p", {2560, 1440}}, {"4K", {3840, 2160}}};
+    {"disabled", {0, 0}}, {"auto", {0, 0}},        {"480p", {640, 480}},
+    {"640p", {960, 640}}, {"720p", {1280, 720}},   {"1080p", {1920, 1080}},
+    {"2K", {2048, 1080}}, {"1440p", {2560, 1440}}, {"4K", {3840, 2160}}};
 
 enum class StreamSelMode
 {
@@ -50,6 +51,7 @@ public:
 
   std::pair<int, int> GetResMax() const;
   std::pair<int, int> GetResSecureMax() const;
+  std::pair<int, int> GetResRangeLimit() const;
 
   bool IsBandwidthInitAuto() const;
   uint32_t GetBandwidthInit() const;

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -304,8 +304,12 @@ void SESSION::CSession::InitializePeriod()
     else
       isManualStreamSelection = streamSelectionMode == CHOOSER::StreamSelection::MANUAL;
 
+    const bool isDefaultAdpSet{adp == defVideoAdpSet};
+
     // Get the default initial stream repr. based on "adaptive repr. chooser"
     CRepresentation* defaultRepr{m_reprChooser->GetRepresentation(adp)};
+    if (isDefaultAdpSet)
+      m_reprChooser->LogDetails(defaultRepr);
 
     if (isManualStreamSelection)
     {
@@ -320,9 +324,9 @@ void SESSION::CSession::InitializePeriod()
         if (!currentRepr->isPlayable)
           continue;
 
-        const bool isDefaultRepr{adp == defVideoAdpSet && currentRepr == defaultRepr}; // meant for video only
+        const bool isDefaultVideoRepr{isDefaultAdpSet && currentRepr == defaultRepr};
 
-        AddStream(adp, currentRepr, isDefaultRepr, uniqueId, audioLanguageOrig);
+        AddStream(adp, currentRepr, isDefaultVideoRepr, uniqueId, audioLanguageOrig);
       }
     }
     else
@@ -335,16 +339,14 @@ void SESSION::CSession::InitializePeriod()
       uint32_t uniqueId{adpIndex};
       uniqueId |= reprIndex << 16;
 
-      const bool isDefaultRepr{adp == defVideoAdpSet}; // meant for video only
-
-      AddStream(adp, defaultRepr, isDefaultRepr, uniqueId, audioLanguageOrig);
+      AddStream(adp, defaultRepr, isDefaultAdpSet, uniqueId, audioLanguageOrig);
     }
   }
 }
 
 void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
                                   PLAYLIST::CRepresentation* initialRepr,
-                                  bool isDefaultRepr,
+                                  bool isDefaultVideoRepr,
                                   uint32_t uniqueId,
                                   std::string_view audioLanguageOrig)
 {
@@ -360,7 +362,7 @@ void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
     case StreamType::VIDEO:
     {
       stream.m_info.SetStreamType(INPUTSTREAM_TYPE_VIDEO);
-      if (isDefaultRepr)
+      if (isDefaultVideoRepr)
         flags |= INPUTSTREAM_FLAG_DEFAULT;
       break;
     }

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1180,6 +1180,8 @@ PLAYLIST::CAdaptationSet* SESSION::CSession::DetermineDefaultAdpSet()
       CODEC::FOURCC_HEVC, CODEC::FOURCC_AV01, CODEC::NAME_AV1,    CODEC::FOURCC_VP09,
       CODEC::NAME_VP9,    CODEC::FOURCC_AVC_, CODEC::FOURCC_H264};
 
+  CAdaptationSet* defaultAdp{nullptr}; // Default determined by codec order
+
   for (auto& codecCC : videoCodecOrder)
   {
     CAdaptationSet* currAdp{nullptr};
@@ -1189,10 +1191,16 @@ PLAYLIST::CAdaptationSet* SESSION::CSession::DetermineDefaultAdpSet()
       if (currAdp->GetRepresentations().empty() || currAdp->GetStreamType() != StreamType::VIDEO)
         continue;
 
-      if (CODEC::Contains(currAdp->GetCodecs(), codecCC))
+      if (currAdp->IsDefault()) // Override by manifest custom parameter
+      {
         return currAdp;
+      }
+      else if (CODEC::Contains(currAdp->GetCodecs(), codecCC) && !defaultAdp)
+      {
+        defaultAdp = currAdp;
+      }
     }
   }
 
-  return nullptr;
+  return defaultAdp;
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -57,12 +57,12 @@ public:
   /*! \brief Create and push back a new Stream object
    *  \param adp The AdaptationSet of the stream
    *  \param repr The Representation of the stream
-   *  \param isDefaultRepr Whether this Representation is the default
+   *  \param isDefaultVideoRepr Whether this video Representation is the default
    *  \param uniqueId A unique identifier for the Representation
    */
   void AddStream(PLAYLIST::CAdaptationSet* adp,
                  PLAYLIST::CRepresentation* repr,
-                 bool isDefaultRepr,
+                 bool isDefaultVideoRepr,
                  uint32_t uniqueId,
                  std::string_view audioLanguageOrig);
 

--- a/src/common/Chooser.cpp
+++ b/src/common/Chooser.cpp
@@ -114,8 +114,13 @@ void CHOOSER::IRepresentationChooser::OnUpdateScreenRes()
   }
 }
 
-void CHOOSER::IRepresentationChooser::LogDetails(PLAYLIST::CRepresentation* currentRep,
-                                                 PLAYLIST::CRepresentation* nextRep)
+void CHOOSER::IRepresentationChooser::LogDetails(const PLAYLIST::CRepresentation* rep)
+{
+  LogDetails(nullptr, rep);
+}
+
+void CHOOSER::IRepresentationChooser::LogDetails(const PLAYLIST::CRepresentation* currentRep,
+                                                 const PLAYLIST::CRepresentation* nextRep)
 {
   if (!nextRep)
     return;

--- a/src/common/Chooser.h
+++ b/src/common/Chooser.h
@@ -121,12 +121,17 @@ public:
       PLAYLIST::CAdaptationSet* adp,
       PLAYLIST::CRepresentation* currentRep) = 0;
 
+  /*!
+   * \brief Prints details of the specified representation in the log
+   */
+  void LogDetails(const PLAYLIST::CRepresentation* rep);
+
 protected:
   /*!
    * \brief Prints details of the selected or changed representation in the log
    */
-  void LogDetails(PLAYLIST::CRepresentation* currentRep,
-                  PLAYLIST::CRepresentation* nextRep);
+  void LogDetails(const PLAYLIST::CRepresentation* currentRep,
+                  const PLAYLIST::CRepresentation* nextRep);
 
   bool m_isSecureSession{false};
 

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -9,6 +9,7 @@
 #include "ChooserAskQuality.h"
 
 #include "AdaptationSet.h"
+#include "CompSettings.h"
 #include "CompKodiProps.h"
 #include "ReprSelector.h"
 #include "Representation.h"
@@ -44,6 +45,27 @@ std::string CovertFpsToString(float value)
 
   return str;
 }
+
+std::string CreateStreamName(const CRepresentation* repr)
+{
+  std::string streamName{kodi::addon::GetLocalizedString(30232)};
+  STRING::ReplaceFirst(streamName, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
+
+  float fps{static_cast<float>(repr->GetFrameRate())};
+  if (fps > 0 && repr->GetFrameRateScale() > 0)
+    fps /= repr->GetFrameRateScale();
+
+  std::string quality = "(";
+  if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
+    quality += StringUtils::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
+  if (fps > 0)
+    quality += StringUtils::Format("%s fps, ", CovertFpsToString(fps).c_str());
+
+  quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
+  STRING::ReplaceFirst(streamName, "{quality}", quality);
+
+  return streamName;
+}
 } // unnamed namespace
 
 CRepresentationChooserAskQuality::CRepresentationChooserAskQuality()
@@ -53,6 +75,13 @@ CRepresentationChooserAskQuality::CRepresentationChooserAskQuality()
 
 void CRepresentationChooserAskQuality::Initialize(const ADP::KODI_PROPS::ChooserProps& props)
 {
+  auto& settings = CSrvBroker::GetSettings();
+  m_resRangeLimit = settings.GetResRangeLimit();
+
+  LOG::Log(LOGDEBUG,
+           "[Repr. chooser] Configuration\n"
+           "Resolution range limit: %ix%i",
+           m_resRangeLimit.first, m_resRangeLimit.second);
 }
 
 void CRepresentationChooserAskQuality::PostInit()
@@ -94,40 +123,41 @@ PLAYLIST::CAdaptationSet* CHOOSER::CRepresentationChooserAskQuality::GetPreferre
       if (adpSet->GetStreamType() != StreamType::VIDEO || adpSet->GetRepresentations().size() == 0)
         continue;
 
-      CRepresentation* bestRep{nullptr};
-
-      // preferred adaptation set, in order to have a preferred codec for multi-codec manifests
-      if (adpSetPreferred == adpSet.get())
+      if (m_resRangeLimit.first != 0) // Show only the nearest resolution to the preference
       {
-        bestRep = selector.Highest(adpSetPreferred);
+        CRepresentationSelector selector{m_resRangeLimit.first, m_resRangeLimit.second};
+        CRepresentation* nearestRep = selector.Nearest(adpSet.get());
+
+        if (nearestRep)
+        {
+          entries.emplace_back(CreateStreamName(nearestRep));
+          entriesOjb.emplace_back(adpSet.get(), nearestRep);
+
+          if (adpSet.get() == adpSetPreferred)
+            preselIndex = static_cast<int>(entries.size()) - 1;
+        }
       }
-
-      for (auto& repr : adpSet->GetRepresentations())
+      else // Show all resolutions
       {
-        if (!repr->isPlayable)
-          continue;
+        CRepresentation* bestRep{nullptr};
 
-        std::string entryName{kodi::addon::GetLocalizedString(30232)};
-        STRING::ReplaceFirst(entryName, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
+        // preferred adaptation set, in order to have a preferred codec for multi-codec manifests
+        if (adpSetPreferred == adpSet.get())
+        {
+          bestRep = selector.Highest(adpSetPreferred);
+        }
 
-        float fps{static_cast<float>(repr->GetFrameRate())};
-        if (fps > 0 && repr->GetFrameRateScale() > 0)
-          fps /= repr->GetFrameRateScale();
+        for (auto& repr : adpSet->GetRepresentations())
+        {
+          if (!repr->isPlayable)
+            continue;
 
-        std::string quality = "(";
-        if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
-          quality += StringUtils::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
-        if (fps > 0)
-          quality += StringUtils::Format("%s fps, ", CovertFpsToString(fps).c_str());
-
-        quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
-        STRING::ReplaceFirst(entryName, "{quality}", quality);
-
-        entries.emplace_back(entryName);
+        entries.emplace_back(CreateStreamName(repr.get()));
         entriesOjb.emplace_back(adpSet.get(), repr.get());
 
         if (repr.get() == bestRep)
           preselIndex = static_cast<int>(entries.size()) - 1;
+        }
       }
     }
 

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -147,6 +147,7 @@ PLAYLIST::CAdaptationSet* CHOOSER::CRepresentationChooserAskQuality::GetPreferre
 
       m_selectedResWidth = selRep->GetWidth();
       m_selectedResHeight = selRep->GetHeight();
+      m_selectedBandwidth = selRep->GetBandwidth();
       // Convert codec to description, as the codec string may be slightly different
       // when using ISO BMFF format, and the comparison may fail
       m_selectedVideoCodecDesc = CODEC::GetVideoDesc(selAdpSet->GetCodecs());
@@ -166,11 +167,12 @@ PLAYLIST::CRepresentation* CRepresentationChooserAskQuality::GetNextRepresentati
   if (currentRep)
     return currentRep;
 
+  CRepresentationSelector selector{m_selectedResWidth, m_selectedResHeight};
+
   if (adp->GetStreamType() != StreamType::VIDEO)
   {
-    CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
     return selector.HighestBw(adp);
   }
 
-  return currentRep;
+  return selector.NearestBw(adp, m_selectedBandwidth);
 }

--- a/src/common/ChooserAskQuality.h
+++ b/src/common/ChooserAskQuality.h
@@ -35,6 +35,7 @@ private:
   bool m_isDialogShown{false};
   int m_selectedResWidth{0};
   int m_selectedResHeight{0};
+  uint32_t m_selectedBandwidth{0};
   std::string m_selectedVideoCodecDesc;
 };
 

--- a/src/common/ChooserAskQuality.h
+++ b/src/common/ChooserAskQuality.h
@@ -33,6 +33,7 @@ public:
 
 private:
   bool m_isDialogShown{false};
+  std::pair<int, int> m_resRangeLimit;
   int m_selectedResWidth{0};
   int m_selectedResHeight{0};
   uint32_t m_selectedBandwidth{0};

--- a/src/common/ChooserDefault.cpp
+++ b/src/common/ChooserDefault.cpp
@@ -225,7 +225,7 @@ PLAYLIST::CRepresentation* CRepresentationChooserDefault::GetNextRepresentation(
   if (!nextRep)
     nextRep = selector.Lowest(adp);
 
-  if (isVideoStreamType) // Only video, to avoid fill too much the log
+  if (isVideoStreamType && currentRep) // Only video, to avoid fill too much the log
   {
     LOG::Log(LOGDEBUG, "[Repr. chooser] Current average bandwidth: %u bit/s (filtered to %u bit/s)",
              m_bandwidthCurrent, bandwidth);

--- a/src/common/ChooserFixedRes.cpp
+++ b/src/common/ChooserFixedRes.cpp
@@ -76,9 +76,7 @@ PLAYLIST::CRepresentation* CRepresentationChooserFixedRes::GetNextRepresentation
 
   if (adp->GetStreamType() == StreamType::VIDEO)
   {
-    CRepresentation* selRep{selector.Highest(adp)};
-    LogDetails(nullptr, selRep);
-    return selRep;
+    return selector.Highest(adp);
   }
   else
   {

--- a/src/common/ChooserTest.cpp
+++ b/src/common/ChooserTest.cpp
@@ -99,7 +99,7 @@ PLAYLIST::CRepresentation* CRepresentationChooserTest::GetNextRepresentation(
     }
   }
 
-  if (adp->GetStreamType() == StreamType::VIDEO)
+  if (adp->GetStreamType() == StreamType::VIDEO && currentRep)
     LogDetails(currentRep, nextRep);
 
   return nextRep;

--- a/src/common/ReprSelector.cpp
+++ b/src/common/ReprSelector.cpp
@@ -81,7 +81,7 @@ PLAYLIST::CRepresentation* CRepresentationSelector::Higher(PLAYLIST::CAdaptation
   auto reps = adaptSet->GetRepresentationsPtr();
   auto repIt = std::find_if(
       reps.begin(), reps.end(), [currRep](const auto& rep)
-      { return rep->isPlayable && CRepresentation::CompareBandwidthPtr(rep, currRep); });
+      { return rep->isPlayable && CRepresentation::CompareBandwidthPtr(currRep, rep); });
 
   if (repIt == reps.end())
     return currRep;

--- a/src/common/ReprSelector.cpp
+++ b/src/common/ReprSelector.cpp
@@ -88,3 +88,71 @@ PLAYLIST::CRepresentation* CRepresentationSelector::Higher(PLAYLIST::CAdaptation
 
   return *repIt;
 }
+
+PLAYLIST::CRepresentation* CHOOSER::CRepresentationSelector::Nearest(
+    PLAYLIST::CAdaptationSet* adaptSet) const
+{
+  PLAYLIST::CRepresentation* nearestRep{nullptr};
+  uint32_t smallestDiff = std::numeric_limits<uint32_t>::max();
+
+  for (auto& rep : adaptSet->GetRepresentations())
+  {
+    if (!rep->isPlayable)
+      continue;
+
+    const uint32_t resolutionDiff =
+        (rep->GetWidth() > m_screenWidth ? rep->GetWidth() - m_screenWidth
+                                         : m_screenWidth - rep->GetWidth()) +
+        (rep->GetHeight() > m_screenHeight ? rep->GetHeight() - m_screenHeight
+                                           : m_screenHeight - rep->GetHeight());
+
+    if (resolutionDiff < smallestDiff ||
+        (resolutionDiff == smallestDiff &&
+         (!nearestRep || rep->GetBandwidth() > nearestRep->GetBandwidth())))
+    {
+      smallestDiff = resolutionDiff;
+      nearestRep = rep.get();
+    }
+  }
+
+  return nearestRep;
+}
+
+PLAYLIST::CRepresentation* CHOOSER::CRepresentationSelector::NearestBw(
+    PLAYLIST::CAdaptationSet* adaptSet, const PLAYLIST::CRepresentation* currRep) const
+{
+  return NearestBw(adaptSet, currRep->GetBandwidth());
+}
+
+PLAYLIST::CRepresentation* CHOOSER::CRepresentationSelector::NearestBw(
+    PLAYLIST::CAdaptationSet* adaptSet, const uint32_t bandwidth) const
+{
+  PLAYLIST::CRepresentation* nearestRep{nullptr};
+  uint32_t smallestDiff = std::numeric_limits<uint32_t>::max();
+
+  for (auto& rep : adaptSet->GetRepresentations())
+  {
+    if (!rep->isPlayable)
+      continue;
+
+    const uint32_t bandwidthDiff = (rep->GetBandwidth() > bandwidth)
+                                       ? (rep->GetBandwidth() - bandwidth)
+                                       : (bandwidth - rep->GetBandwidth());
+
+    const uint32_t resolutionDiff =
+        (rep->GetWidth() > m_screenWidth ? rep->GetWidth() - m_screenWidth
+                                         : m_screenWidth - rep->GetWidth()) +
+        (rep->GetHeight() > m_screenHeight ? rep->GetHeight() - m_screenHeight
+                                           : m_screenHeight - rep->GetHeight());
+
+    const uint32_t combinedDiff = bandwidthDiff + resolutionDiff;
+
+    if (combinedDiff < smallestDiff)
+    {
+      smallestDiff = combinedDiff;
+      nearestRep = rep.get();
+    }
+  }
+
+  return nearestRep;
+}

--- a/src/common/ReprSelector.h
+++ b/src/common/ReprSelector.h
@@ -55,6 +55,32 @@ public:
   PLAYLIST::CRepresentation* Higher(PLAYLIST::CAdaptationSet* adaptSet,
                                     PLAYLIST::CRepresentation* currRep) const;
 
+  /*!
+   * \brief Select the representation with the nearest resolution (and higher bandwidth).
+   * \param adaptSet The adaptation set where search for
+   * \param currRep The representation where get the bandwidth value
+   * \return The representation, otherwise nullptr if no available
+   */
+  PLAYLIST::CRepresentation* Nearest(PLAYLIST::CAdaptationSet* adaptSet) const;
+
+  /*!
+   * \brief Select the representation with the nearest bandwidth and resolution.
+   * \param adaptSet The adaptation set where search for
+   * \param currRep The representation where get the bandwidth value
+   * \return The representation, otherwise nullptr if no available
+   */
+  PLAYLIST::CRepresentation* NearestBw(PLAYLIST::CAdaptationSet* adaptSet,
+                                       const PLAYLIST::CRepresentation* currRep) const;
+
+  /*!
+   * \brief Select the representation with the nearest bandwidth and resolution.
+   * \param adaptSet The adaptation set where search for
+   * \param bandwidth The bandwidth value
+   * \return The representation, otherwise nullptr if no available
+   */
+  PLAYLIST::CRepresentation* NearestBw(PLAYLIST::CAdaptationSet* adaptSet,
+                                       const uint32_t bandwidth) const;
+
 private:
   int m_screenWidth{0};
   int m_screenHeight{0};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

- Fix regression double video quality change with «Ask quality», an attempt to fix has been done on PR #1810 but was not working good, that in some cases cause crashes
- Fix regression on Adaptive quality that dont change while in playback, due to wrong condition on Higher method
- Fix regression on DASH AdaptationSet «default» override parameter for video stream, that was not taken in account
- Add new setting «Limit resolution» to Stream selection «Ask Quality». I thought it might be useful for everyone, when you play multi-codec video a very long list of resolutions can be listed, which you struggle to scroll through, this option limits the list to only the set resolution, at least it tries to limit them based also on the capabilities (streams provided) of the manifest

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
new drm rework has changed some code introducing a codec selection with priority order that was incomplete
and other things was need to be fixed

fix #1821 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
