### PR TITLE
Implemented GUI feedback for playback errors

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -352,3 +352,17 @@ msgstr ""
 msgctxt "#30243"
 msgid "Verbose debugging can be useful for debugging components, but in some cases it may expose sensitive information in the log."
 msgstr ""
+
+#empty strings reserved for settings from id 30244 to 30299
+
+#. A GUI window title, "InputStream Adaptive" its the add-on name, not to be translated
+msgctxt "#30300"
+msgid "InputStream Adaptive error"
+msgstr ""
+
+#. A GUI message that is displayed when there is a problem playing a stream
+#. Do not translate placeholders: {error-details}
+#. Use of double graphes e.g. {whatyouwant{error-details}whatyouwant} allows you to add additional text printed only when a value is present
+msgctxt "#30301"
+msgid "Unable to play the stream.{[CR]Error: {error-details}}"
+msgstr ""

--- a/lib/cdm/cdm/debug.h
+++ b/lib/cdm/cdm/debug.h
@@ -20,7 +20,6 @@ enum class LogLevel
 };
 
 void Log(const LogLevel level, const char* format, ...);
-#define LogF(level, format, ...) Log((level), ("%s: " format), __FUNCTION__, ##__VA_ARGS__)
 
 void SetDBGMsgCallback(void (*msgcb)(const LogLevel level, const char* msg));
 

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.cc
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.cc
@@ -193,88 +193,60 @@ CdmAdapter::CdmAdapter(
   const std::string& base_path,
   const CdmConfig& cdm_config,
   CdmAdapterClient *client)
-: library_(0)
-, cdm_path_(cdm_path)
+: cdm_path_(cdm_path)
 , cdm_base_path_(base_path)
 , client_(client)
 , key_system_(key_system)
 , cdm_config_(cdm_config)
-, active_buffer_(0)
-, cdm9_(0), cdm10_(0), cdm11_(0)
 {
   //DCHECK(!key_system_.empty());
-  Initialize();
 }
 
 CdmAdapter::~CdmAdapter()
 {
-  if (cdm9_)
-    cdm9_->Destroy(), cdm9_ = nullptr;
-  else if (cdm10_)
-    cdm10_->Destroy(), cdm10_ = nullptr;
-  else if (cdm11_)
-    cdm11_->Destroy(), cdm11_ = nullptr;
-  else
-    return;
-
-  deinit_cdm_func();
-
-  base::UnloadNativeLibrary(library_);
+  UnloadCDM();
 }
 
-void CdmAdapter::Initialize()
+bool CdmAdapter::LoadCDM()
 {
-  m_isClosingSession = false;
-  if (cdm9_ || cdm10_ || cdm11_)
-  {
-    if (cdm9_)
-      cdm9_->Destroy(), cdm9_ = nullptr;
-    else if (cdm10_)
-      cdm10_->Destroy(), cdm10_ = nullptr;
-    else if (cdm11_)
-      cdm11_->Destroy(), cdm11_ = nullptr;
-    base::UnloadNativeLibrary(library_);
-    library_ = 0;
-  }
+  UnloadCDM();
 
   base::NativeLibraryLoadError error;
   library_ = base::LoadNativeLibrary(cdm_path_, &error);
 
   if (!library_)
   {
-    LogF(LogLevel::ERROR, "Failed to load library: %s", error.ToString().c_str());
-    return;
+    Log(LogLevel::ERROR, "Failed to load library: %s", error.ToString().c_str());
+    return false;
   }
 
-  init_cdm_func = reinterpret_cast<InitializeCdmModuleFunc>(base::GetFunctionPointerFromNativeLibrary(library_, MAKE_STRING(INITIALIZE_CDM_MODULE)));
-  deinit_cdm_func = reinterpret_cast<DeinitializeCdmModuleFunc>(base::GetFunctionPointerFromNativeLibrary(library_, "DeinitializeCdmModule"));
-  create_cdm_func = reinterpret_cast<CreateCdmFunc>(base::GetFunctionPointerFromNativeLibrary(library_, "CreateCdmInstance"));
-  get_cdm_verion_func = reinterpret_cast<GetCdmVersionFunc>(base::GetFunctionPointerFromNativeLibrary(library_, "GetCdmVersion"));
+  init_cdm_func = reinterpret_cast<InitializeCdmModuleFunc>(
+      base::GetFunctionPointerFromNativeLibrary(library_, MAKE_STRING(INITIALIZE_CDM_MODULE)));
+  deinit_cdm_func = reinterpret_cast<DeinitializeCdmModuleFunc>(
+      base::GetFunctionPointerFromNativeLibrary(library_, "DeinitializeCdmModule"));
+  create_cdm_func = reinterpret_cast<CreateCdmFunc>(
+      base::GetFunctionPointerFromNativeLibrary(library_, "CreateCdmInstance"));
+  get_cdm_verion_func = reinterpret_cast<GetCdmVersionFunc>(
+      base::GetFunctionPointerFromNativeLibrary(library_, "GetCdmVersion"));
 
   if (!init_cdm_func || !create_cdm_func || !get_cdm_verion_func || !deinit_cdm_func)
   {
-    base::UnloadNativeLibrary(library_);
-    library_ = 0;
-    return;
+    Log(LogLevel::ERROR, "Failed to binding CDM library functions");
+    return false;
   }
+  return true;
+}
 
-  std::string version{get_cdm_verion_func()};
+bool CdmAdapter::Initialize()
+{
+  m_isClosingSession = false;
 
-  if (version == "4.10.2891.0")
-  {
-    // This version have unclear problems
-    // such as crashes on OnStorageId() method calls and others video decoding crashes
-    Log(LogLevel::ERROR,
-        "THE CDM VERSION \"4.10.2891.0\" IS NOT SUPPORTED DUE TO UNCLEAR LIBRARY ISSUES.\n"
-        "------------------------------> PLEASE INSTALL AN OLDER VERSION OF WIDEVINE CDM!");
-    return;
-  }
-
-  Log(LogLevel::DEBUG, "CDM version: %s", version.c_str());
+  Log(LogLevel::DEBUG, "CDM version: %s", GetVersion().c_str());
 
 #if defined(OS_WIN)
   // Load DXVA before sandbox lockdown to give CDM access to Output Protection
   // Manager (OPM).
+  base::NativeLibraryLoadError error;
   base::LoadNativeLibrary("dxva2.dll", &error);
 #endif  // defined(OS_WIN)
 
@@ -301,11 +273,45 @@ void CdmAdapter::Initialize()
     else if (cdm11_)
       cdm11_->Initialize(cdm_config_.allow_distinctive_identifier,
         cdm_config_.allow_persistent_state, false);
+
+    return true;
   }
-  else
+
+  Log(LogLevel::ERROR, "Cannot get the ContentDecryptionModule interface");
+  return false;
+}
+
+std::string CdmAdapter::GetVersion() const
+{
+  if (get_cdm_verion_func)
+    return get_cdm_verion_func();
+
+  return "";
+}
+
+void CdmAdapter::UnloadCDM()
+{
+  if (cdm9_)
+    cdm9_->Destroy(), cdm9_ = nullptr;
+  else if (cdm10_)
+    cdm10_->Destroy(), cdm10_ = nullptr;
+  else if (cdm11_)
+    cdm11_->Destroy(), cdm11_ = nullptr;
+
+  init_cdm_func = nullptr;
+  create_cdm_func = nullptr;
+  get_cdm_verion_func = nullptr;
+
+  if (deinit_cdm_func)
+  {
+    deinit_cdm_func();
+    deinit_cdm_func = nullptr;
+  }
+
+  if (library_)
   {
     base::UnloadNativeLibrary(library_);
-    library_ = 0;
+    library_ = nullptr;
   }
 }
 
@@ -770,7 +776,7 @@ void CdmFileIoImpl::Write(const uint8_t* data, uint32_t data_size)
 {
   if (!ExistsDir(base_path_.c_str()) && !CreateDirs(base_path_.c_str()))
   {
-    LogF(LogLevel::ERROR, "Cannot create directory: %s", base_path_.c_str());
+    Log(LogLevel::ERROR, "Cannot create directory: %s", base_path_.c_str());
     client_->OnWriteComplete(cdm::FileIOClient::Status::kError);
     return;
   }

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.h
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.h
@@ -210,10 +210,14 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>
   void OnInitialized(bool success) override;
 
 
-public: //Misc
-	~CdmAdapter();
-	bool valid(){ return library_ != 0; };
+  //Misc
+  ~CdmAdapter();
+  bool LoadCDM();
+  bool Initialize();
+  std::string GetVersion() const;
+
 private:
+  void UnloadCDM();
   using InitializeCdmModuleFunc = void(*)();
   using DeinitializeCdmModuleFunc = void(*)();
   using GetCdmVersionFunc = char* (*)();
@@ -223,20 +227,19 @@ private:
     GetCdmHostFunc get_cdm_host_func,
     void* user_data);
 
-  InitializeCdmModuleFunc init_cdm_func;
-  CreateCdmFunc create_cdm_func;
-  GetCdmVersionFunc get_cdm_verion_func;
-  DeinitializeCdmModuleFunc deinit_cdm_func;
+  InitializeCdmModuleFunc init_cdm_func{nullptr};
+  CreateCdmFunc create_cdm_func{nullptr};
+  GetCdmVersionFunc get_cdm_verion_func{nullptr};
+  DeinitializeCdmModuleFunc deinit_cdm_func{nullptr};
 
-  void Initialize();
   void SendClientMessage(const char* session, uint32_t session_size, CdmAdapterClient::CDMADPMSG msg, const uint8_t *data, size_t data_size, uint32_t status);
 
   // Keep a reference to the CDM.
-  base::NativeLibrary library_;
+  base::NativeLibrary library_{nullptr};
 
   std::string cdm_path_;
   std::string cdm_base_path_;
-  CdmAdapterClient *client_;
+  CdmAdapterClient* client_{nullptr};
   std::mutex client_mutex_;
   std::mutex decrypt_mutex_;
   std::mutex m_closeSessionMutex;
@@ -247,12 +250,11 @@ private:
   std::string key_system_;
   CdmConfig cdm_config_;
 
-  cdm::MessageType message_type_;
-  cdm::Buffer *active_buffer_;
+  cdm::Buffer* active_buffer_{nullptr};
 
-  cdm::ContentDecryptionModule_9 *cdm9_;
-  cdm::ContentDecryptionModule_10 *cdm10_;
-  cdm::ContentDecryptionModule_11 *cdm11_;
+  cdm::ContentDecryptionModule_9* cdm9_{nullptr};
+  cdm::ContentDecryptionModule_10* cdm10_{nullptr};
+  cdm::ContentDecryptionModule_11* cdm11_{nullptr};
 
   DISALLOW_COPY_AND_ASSIGN(CdmAdapter);
 };

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -21,6 +21,7 @@
 #include "samplereader/SampleReaderFactory.h"
 #include "utils/Base64Utils.h"
 #include "utils/CurlUtils.h"
+#include "utils/GUIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/UrlUtils.h"
 #include "utils/Utils.h"
@@ -59,7 +60,7 @@ void SESSION::CSession::DeleteStreams()
 |   initialize
 +---------------------------------------------------------------------*/
 
-bool SESSION::CSession::Initialize(std::string manifestUrl)
+SResult SESSION::CSession::Initialize(std::string manifestUrl)
 {
   m_reprChooser = CHOOSER::CreateRepresentationChooser();
 
@@ -100,7 +101,7 @@ bool SESSION::CSession::Initialize(std::string manifestUrl)
 
   CURL::HTTPResponse manifestResp;
   if (!CURL::DownloadFile(manifestUrl, manifestHeaders, {"etag", "last-modified"}, manifestResp))
-    return false;
+    return SResult::Error("Cannot download the manifest file.");
 
   // The download speed with small file sizes is not accurate, we should download at least 512Kb
   // to have a sufficient acceptable value to calculate the bandwidth,
@@ -115,15 +116,12 @@ bool SESSION::CSession::Initialize(std::string manifestUrl)
 
   m_adaptiveTree = PLAYLIST_FACTORY::CreateAdaptiveTree(manifestResp);
   if (!m_adaptiveTree)
-    return false;
+    return SResult::Error("Unable to determine type of manifest file.");
 
   m_adaptiveTree->Configure(m_reprChooser, kodiProps.GetManifestUpdParams());
 
   if (!m_adaptiveTree->Open(manifestResp.effectiveUrl, manifestResp.headers, manifestResp.data))
-  {
-    LOG::Log(LOGERROR, "Cannot parse the manifest (%s)", manifestUrl.c_str());
-    return false;
-  }
+    return SResult::Error("Cannot parse the manifest file.");
 
   m_adaptiveTree->PostOpen();
   m_reprChooser->PostInit();
@@ -132,7 +130,7 @@ bool SESSION::CSession::Initialize(std::string manifestUrl)
 
   InitializePeriod();
 
-  return true;
+  return SResultCode::OK;
 }
 
 bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
@@ -346,6 +344,13 @@ void SESSION::CSession::InitializePeriod()
 
       AddStream(adp.get(), defaultRepr, isDefaultAdpSet, uniqueId, audioLanguageOrig);
     }
+  }
+
+  if (m_streams.empty())
+  {
+    LOG::LogF(LOGERROR,
+              "No stream can be played, common causes: resolution limits or HDCP problem");
+    GUI::ErrorDialog("No stream can be played");
   }
 }
 

--- a/src/Session.h
+++ b/src/Session.h
@@ -13,6 +13,7 @@
 #include "common/AdaptiveTree.h"
 #include "decrypters/DrmEngine.h"
 #include "decrypters/IDecrypter.h"
+#include "utils/ResultType.h"
 
 #if defined(ANDROID)
 #include <kodi/platform/android/System.h>
@@ -36,7 +37,7 @@ public:
    *  \param manifestUrl The manifest URL
    *  \return True if has success, false otherwise
    */
-  bool Initialize(std::string manifestUrl);
+  SResult Initialize(std::string manifestUrl);
 
   bool CheckPlayableStreams(PLAYLIST::CPeriod* period);
 

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -15,7 +15,6 @@
 #include "Representation.h"
 #include "SrvBroker.h"
 #include "Period.h"
-#include "kodi/tools/StringUtils.h"
 #include "utils/GUIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/Utils.h"
@@ -23,7 +22,6 @@
 
 #include <vector>
 
-using namespace kodi::tools;
 using namespace CHOOSER;
 using namespace PLAYLIST;
 using namespace UTILS;
@@ -32,7 +30,7 @@ namespace
 {
 std::string CovertFpsToString(float value)
 {
-  std::string str{StringUtils::Format("%.3f", value)};
+  std::string str{STRING::Format("%.3f", value)};
   std::size_t found = str.find_last_not_of("0");
   if (found != std::string::npos)
     str.erase(found + 1);
@@ -102,11 +100,11 @@ std::string CreateStreamName(const CRepresentation* repr)
 
       std::string quality = "(";
       if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
-        quality += StringUtils::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
+        quality += STRING::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
       if (fps > 0)
-        quality += StringUtils::Format("%s fps, ", CovertFpsToString(fps).c_str());
+        quality += STRING::Format("%s fps, ", CovertFpsToString(fps).c_str());
 
-      quality += StringUtils::Format("%u Kbps)", repr->GetBandwidth() / 1000);
+      quality += STRING::Format("%u Kbps)", repr->GetBandwidth() / 1000);
 
       ReplacePhValue(streamName, ph, "{quality}", quality);
     }

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -16,13 +16,10 @@
 #include "SrvBroker.h"
 #include "Period.h"
 #include "kodi/tools/StringUtils.h"
+#include "utils/GUIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/Utils.h"
 #include "utils/log.h"
-
-#ifndef INPUTSTREAM_TEST_BUILD
-#include <kodi/gui/dialogs/Select.h>
-#endif
 
 #include <vector>
 
@@ -165,7 +162,7 @@ PLAYLIST::CAdaptationSet* CHOOSER::CRepresentationChooserAskQuality::GetPreferre
     CRepresentationSelector selector{m_screenCurrentWidth, m_screenCurrentHeight};
     std::vector<std::string> entries;
     std::vector<std::pair<CAdaptationSet*, CRepresentation*>> entriesOjb;
-    int preselIndex{-1}; // Preselected list item
+    int preselIndex{GUI::DIALOG_NO_VALUE}; // Preselected list item
     int selIndex{0};
 
     for (auto& adpSet : period->GetAdaptationSets())
@@ -213,14 +210,13 @@ PLAYLIST::CAdaptationSet* CHOOSER::CRepresentationChooserAskQuality::GetPreferre
 
     if (entries.size() > 1)
     {
-      selIndex = kodi::gui::dialogs::Select::Show(kodi::addon::GetLocalizedString(30231), entries,
-                                                  preselIndex, 10000);
+      selIndex = GUI::SelectDialog(GUI::GetLocalizedString(30231), entries, preselIndex, 10000);
     }
 
     if (!entries.empty())
     {
-      if (selIndex == -1) // has been cancelled by the user
-        selIndex = preselIndex == -1 ? 0 : preselIndex;
+      if (selIndex == GUI::DIALOG_NO_VALUE) // has been cancelled by the user
+        selIndex = preselIndex == GUI::DIALOG_NO_VALUE ? 0 : preselIndex;
 
       CAdaptationSet* selAdpSet{entriesOjb[selIndex].first};
       CRepresentation* selRep{entriesOjb[selIndex].second};

--- a/src/common/ChooserAskQuality.cpp
+++ b/src/common/ChooserAskQuality.cpp
@@ -62,54 +62,42 @@ void ReplacePhValue(std::string& text,
 
 std::string CreateStreamName(const CRepresentation* repr)
 {
-  std::string streamName{kodi::addon::GetLocalizedString(30232)};
-  const std::vector<std::string> phs = STRING::ExtractPlaceholders(streamName, '{', '}');
-
-  for (const std::string& ph : phs)
+  std::string hdrType;
+  const ColorTRC colorTrc = repr->GetColorTRC();
+  if (colorTrc == ColorTRC::SMPTE2084)
   {
-    if (STRING::Contains(ph, "{codec}", true))
+    if (CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_DVH1) ||
+        CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_DVHE))
     {
-      ReplacePhValue(streamName, ph, "{codec}", CODEC::GetVideoDesc(repr->GetCodecs()));
+      hdrType = "DV";
     }
-    else if (STRING::Contains(ph, "{hdr-type}", true))
+    else
     {
-      std::string hdrType;
-      const ColorTRC colorTrc = repr->GetColorTRC();
-      if (colorTrc == ColorTRC::SMPTE2084)
-      {
-        if (CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_DVH1) ||
-            CODEC::Contains(repr->GetCodecs(), CODEC::FOURCC_DVHE))
-        {
-          hdrType = "DV";
-        }
-        else
-        {
-          hdrType = "HDR10";
-        }
-      }
-      if (colorTrc == ColorTRC::ARIB_STD_B67)
-        hdrType = "HLG";
-
-      ReplacePhValue(streamName, ph, "{hdr-type}", hdrType);
-    }
-    else if (STRING::Contains(ph, "{quality}", true))
-    {
-      float fps{static_cast<float>(repr->GetFrameRate())};
-      if (fps > 0 && repr->GetFrameRateScale() > 0)
-        fps /= repr->GetFrameRateScale();
-
-      std::string quality = "(";
-      if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
-        quality += STRING::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
-      if (fps > 0)
-        quality += STRING::Format("%s fps, ", CovertFpsToString(fps).c_str());
-
-      quality += STRING::Format("%u Kbps)", repr->GetBandwidth() / 1000);
-
-      ReplacePhValue(streamName, ph, "{quality}", quality);
+      hdrType = "HDR10";
     }
   }
-  return streamName;
+  if (colorTrc == ColorTRC::ARIB_STD_B67)
+    hdrType = "HLG";
+
+
+  float fps{static_cast<float>(repr->GetFrameRate())};
+  if (fps > 0 && repr->GetFrameRateScale() > 0)
+    fps /= repr->GetFrameRateScale();
+
+  std::string quality = "(";
+  if (repr->GetWidth() > 0 && repr->GetHeight() > 0)
+    quality += STRING::Format("%ix%i, ", repr->GetWidth(), repr->GetHeight());
+  if (fps > 0)
+    quality += STRING::Format("%s fps, ", CovertFpsToString(fps).c_str());
+
+  quality += STRING::Format("%u Kbps)", repr->GetBandwidth() / 1000);
+
+  const std::unordered_map<std::string, std::string> phValues = {
+      {"codec", CODEC::GetVideoDesc(repr->GetCodecs())},
+      {"hdr-type", hdrType},
+      {"quality", quality}};
+
+  return STRING::ReplacePlaceholders(GUI::GetLocalizedString(30232), phValues, '{', '}');
 }
 } // unnamed namespace
 

--- a/src/decrypters/DrmEngine.cpp
+++ b/src/decrypters/DrmEngine.cpp
@@ -19,6 +19,7 @@
 #include "common/AdaptiveDecrypter.h"
 #include "common/Representation.h"
 #include "utils/Base64Utils.h"
+#include "utils/GUIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/UrlUtils.h"
 #include "utils/log.h"
@@ -46,35 +47,30 @@ STREAM_CRYPTO_KEY_SYSTEM KSToCryptoKeySystem(std::string_view keySystem)
     return STREAM_CRYPTO_KEY_SYSTEM_NONE;
 }
 
-std::shared_ptr<DRM::IDecrypter> CreateDRM(std::string_view keySystem)
+SResult CreateDRM(std::string_view keySystem, std::shared_ptr<DRM::IDecrypter>& drm)
 {
   std::string decrypterPath = CSrvBroker::GetSettings().GetDecrypterPath();
   if (decrypterPath.empty())
   {
-    LOG::Log(LOGWARNING,
-             "Cannot create the decrypter, the decrypter path is not set in the add-on settings");
-    return nullptr;
+    return SResult::Error("Decrypter path not set in the add-on settings.");
   }
-
-  std::shared_ptr<DRM::IDecrypter> drm;
 
   drm = DRM::FACTORY::GetDecrypter(KSToCryptoKeySystem(keySystem));
 
   if (!drm)
   {
-    LOG::LogF(LOGERROR, "Unable to create the DRM decrypter");
-    return nullptr;
+    return SResult::Error("Unable to create the DRM decrypter.");
   }
 
   drm->SetLibraryPath(decrypterPath);
 
   if (!drm->Initialize())
   {
-    LOG::Log(LOGERROR, "The DRM decrypter cannot be initialized");
-    return nullptr;
+    drm = nullptr;
+    return SResult::Error("Unable to initialize the DRM decrypter.");
   }
 
-  return drm;
+  return SResultCode::OK;
 }
 
 /*!
@@ -203,19 +199,24 @@ bool DRM::CDRMEngine::PreInitializeDRM(DRMSession& session)
 
   m_keySystem = KS_WIDEVINE;
 
-  auto drm = CreateDRM(m_keySystem);
-  if (!drm)
+  std::shared_ptr<DRM::IDecrypter> drm;
+  SResult ret = CreateDRM(m_keySystem, drm);
+  if (ret.IsFailed())
   {
     m_status = EngineStatus::DRM_ERROR;
+    LOG::LogF(LOGERROR, "%s", ret.Message().c_str());
+    GUI::ErrorDialog(ret.Message());
     return false;
   }
 
   DRM::Config drmCfg = CreateDRMConfig(m_keySystem, kodiProps.GetDrmConfig(m_keySystem));
 
-  if (!drm->OpenDRMSystem(drmCfg))
+  ret = drm->OpenDRMSystem(drmCfg);
+  if (ret.IsFailed())
   {
     LOG::LogF(LOGERROR, "Failed to open the DRM");
     m_status = EngineStatus::DRM_ERROR;
+    GUI::ErrorDialog(ret.Message());
     return false;
   }
 
@@ -280,7 +281,8 @@ bool DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
 
   if (!SelectDRM(drmInfos))
   {
-    LOG::LogF(LOGERROR, "The stream is encrypted with a DRM not supported by this system");
+    LOG::LogF(LOGERROR, "The stream requires an unsupported DRM.");
+    GUI::ErrorDialog("The stream requires an unsupported DRM.");
     m_status = EngineStatus::DRM_ERROR;
     return false;
   }
@@ -347,10 +349,13 @@ bool DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
     //! @todo: to test a way to preinitialize DRM when manifest is downloaded/parsed
     //! in the hoping to have a more smoother playback transition
     //! this can be tested with multiperiods video where first period is unencrypted and second one DRM crypted
-    auto drm = CreateDRM(m_keySystem);
-    if (!drm)
+    std::shared_ptr<DRM::IDecrypter> drm;
+    SResult ret = CreateDRM(m_keySystem, drm);
+    if (ret.IsFailed())
     {
       m_status = EngineStatus::DRM_ERROR;
+      LOG::LogF(LOGERROR, "%s", ret.Message().c_str());
+      GUI::ErrorDialog(ret.Message());
       return false;
     }
     m_drms.emplace(m_keySystem, drm);
@@ -412,10 +417,12 @@ bool DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
     if (!newSes.drm->IsInitialised())
     {
       DRM::Config drmCfg = DRM::CreateDRMConfig(m_keySystem, drmPropCfg);
-      if (!newSes.drm->OpenDRMSystem(drmCfg))
+      const SResult ret = newSes.drm->OpenDRMSystem(drmCfg);
+      if (ret.IsFailed())
       {
         LOG::LogF(LOGERROR, "Failed to open the DRM");
         m_status = EngineStatus::DRM_ERROR;
+        GUI::ErrorDialog(ret.Message());
         return false;
       }
     }

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -10,6 +10,8 @@
 
 #include "DrmEngineDefines.h"
 
+#include "utils/ResultType.h"
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -84,7 +86,7 @@ public:
    * \param config The DRM configuration
    * \return true on success 
    */
-  virtual bool OpenDRMSystem(const DRM::Config& config) = 0;
+  virtual SResult OpenDRMSystem(const DRM::Config& config) = 0;
   
   /*
    * \brief Creates a Single Sample Decrypter for decrypting content 

--- a/src/decrypters/clearkey/ClearKeyDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.cpp
@@ -12,11 +12,11 @@
 #include "decrypters/Helpers.h"
 #include "utils/log.h"
 
-bool CClearKeyDecrypter::OpenDRMSystem(const DRM::Config& config)
+SResult CClearKeyDecrypter::OpenDRMSystem(const DRM::Config& config)
 {
   m_config = config;
   m_isInitialized = true;
-  return true;
+  return SResultCode::OK;
 }
 
 std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CClearKeyDecrypter::CreateSingleSampleDecrypter(

--- a/src/decrypters/clearkey/ClearKeyDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.h
@@ -16,7 +16,7 @@ class CClearKeyDecrypter : public IDecrypter
 public:
   CClearKeyDecrypter(){};
   virtual ~CClearKeyDecrypter() override{};
-  virtual bool OpenDRMSystem(const DRM::Config& config) override;
+  virtual SResult OpenDRMSystem(const DRM::Config& config) override;
   virtual std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CreateSingleSampleDecrypter(
       const std::vector<uint8_t>& initData,
       const std::vector<uint8_t>& defaultkeyid,

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -55,15 +55,30 @@ void DebugLog(const CDM_DBG::LogLevel level, const char* msg)
 }
 } // unnamed namespace
 
-CWVCdmAdapter::CWVCdmAdapter(const DRM::Config& config, CWVDecrypter* host)
-  : m_config(config), m_host(host)
+CWVCdmAdapter::CWVCdmAdapter()
 {
   CDM_DBG::SetDBGMsgCallback(DebugLog);
+}
+
+CWVCdmAdapter::~CWVCdmAdapter()
+{
+  if (m_cdmAdapter)
+  {
+    m_cdmAdapter->RemoveClient();
+    // LOG::LogF(LOGDEBUG, "CDM Adapter instances: %u", m_cdmAdapter.use_count());
+    m_cdmAdapter = nullptr;
+  }
+}
+
+SResult CWVCdmAdapter::Initialize(const DRM::Config& config, CWVDecrypter* host)
+{
+  m_config = config;
+  m_host = host;
 
   if (m_host->GetLibraryPath().empty())
   {
     LOG::LogF(LOGERROR, "Widevine CDM library path not specified");
-    return;
+    return SResultCode::ERROR;
   }
   std::string cdmPath = FILESYS::PathCombine(m_host->GetLibraryPath(), LIBRARY_FILENAME);
 
@@ -80,36 +95,45 @@ CWVCdmAdapter::CWVCdmAdapter(const DRM::Config& config, CWVDecrypter* host)
   basePath = FILESYS::PathCombine(basePath, DRM::GenerateUrlDomainHash(licUrl));
   basePath += FILESYS::SEPARATOR;
 
-  m_cdmAdapter =
+  auto cdmAdapter =
       std::make_shared<media::CdmAdapter>("com.widevine.alpha", cdmPath, basePath,
                                           media::CdmConfig(false, m_config.isPersistentStorage),
                                           dynamic_cast<media::CdmAdapterClient*>(this));
 
-  if (!m_cdmAdapter->valid())
+  if (!cdmAdapter->LoadCDM())
   {
     LOG::Log(LOGERROR, "Unable to load widevine shared library (%s)", cdmPath.c_str());
-    m_cdmAdapter = nullptr;
-    return;
+    return SResult::Error("Cannot load Widevine CDM.");
   }
+
+  const std::string version{cdmAdapter->GetVersion()};
+
+  if (version == "4.10.2891.0")
+  {
+    // This version have unclear problems
+    // such as crashes on OnStorageId() method calls and others video decoding crashes
+    LOG::Log(LOGERROR,
+             "THE CDM VERSION \"4.10.2891.0\" IS NOT SUPPORTED DUE TO UNCLEAR LIBRARY ISSUES.\n"
+             "------------------------------> PLEASE INSTALL AN ALTERNATIVE VERSION OF WIDEVINE CDM!");
+
+    return SResult::Error("Widevine CDM version " + version +
+                          " cannot be used. Install an alternative version.");
+  }
+
+  if (!cdmAdapter->Initialize())
+    return SResult::Error("Cannot initialize Widevine CDM.");
 
   const std::vector<uint8_t>& cert = m_config.license.serverCert;
   if (!cert.empty())
   {
-    m_cdmAdapter->SetServerCertificate(0, cert.data(), cert.size());
+    cdmAdapter->SetServerCertificate(0, cert.data(), cert.size());
   }
 
-  // m_cdmAdapter->GetStatusForPolicy();
-  // m_cdmAdapter->QueryOutputProtectionStatus();
-}
+  // cdmAdapter->GetStatusForPolicy();
+  // cdmAdapter->QueryOutputProtectionStatus();
 
-CWVCdmAdapter::~CWVCdmAdapter()
-{
-  if (m_cdmAdapter)
-  {
-    m_cdmAdapter->RemoveClient();
-    // LOG::LogF(LOGDEBUG, "CDM Adapter instances: %u", m_cdmAdapter.use_count());
-    m_cdmAdapter = nullptr;
-  }
+  m_cdmAdapter = cdmAdapter;
+  return SResultCode::OK;
 }
 
 void CWVCdmAdapter::OnCDMMessage(const char* session,

--- a/src/decrypters/widevine/WVCdmAdapter.h
+++ b/src/decrypters/widevine/WVCdmAdapter.h
@@ -26,8 +26,10 @@ class ATTR_DLL_LOCAL CWVCdmAdapter : public media::CdmAdapterClient,
                                      public IWVCdmAdapter<media::CdmAdapter>
 {
 public:
-  CWVCdmAdapter(const DRM::Config& config, CWVDecrypter* host);
+  CWVCdmAdapter();
   virtual ~CWVCdmAdapter();
+
+  SResult Initialize(const DRM::Config& config, CWVDecrypter* host);
 
   // media::CdmAdapterClient interface methods
 
@@ -58,7 +60,7 @@ private:
   DRM::Config m_config;
   std::shared_ptr<media::CdmAdapter> m_cdmAdapter;
   kodi::addon::CInstanceVideoCodec* m_codecInstance{nullptr};
-  CWVDecrypter* m_host;
+  CWVDecrypter* m_host{nullptr};
   std::list<IWVObserver*> m_observers;
   std::mutex m_observer_mutex;
 };

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -59,16 +59,23 @@ bool CWVDecrypter::Initialize()
   return true;
 }
 
-bool CWVDecrypter::OpenDRMSystem(const DRM::Config& config)
+SResult CWVDecrypter::OpenDRMSystem(const DRM::Config& config)
 {
   if (config.license.serverUri.empty())
   {
     LOG::LogF(LOGERROR, "The DRM license server url has not been specified");
-    return false;
+    return SResult::Error("Missing DRM license server URL.");
   }
-  m_WVCdmAdapter = std::make_shared<CWVCdmAdapter>(config, this);
 
-  return m_WVCdmAdapter->GetCDM() != nullptr;
+  auto cdmAdapter = std::make_shared<CWVCdmAdapter>();
+  const SResult ret = cdmAdapter->Initialize(config, this);
+
+  if (ret.IsFailed())
+    m_WVCdmAdapter = nullptr;
+  else
+    m_WVCdmAdapter = cdmAdapter;
+
+  return ret;
 }
 
 std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CWVDecrypter::CreateSingleSampleDecrypter(
@@ -78,6 +85,12 @@ std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CWVDecrypter::CreateSingleSa
     bool skipSessionMessage,
     CryptoMode cryptoMode)
 {
+  if (!m_WVCdmAdapter)
+  {
+    LOG::LogF(LOGERROR, "Cannot create decrypter, adapter not initialized");
+    return nullptr;
+  }
+
   auto decrypter = std::make_shared<CWVCencSingleSampleDecrypter>(
       m_WVCdmAdapter.get(), initData, defaultKeyId, skipSessionMessage, cryptoMode);
   if (decrypter->GetSessionId().empty())

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -19,7 +19,7 @@ public:
 
   virtual bool Initialize() override;
 
-  virtual bool OpenDRMSystem(const DRM::Config& config) override;
+  virtual SResult OpenDRMSystem(const DRM::Config& config) override;
   virtual std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CreateSingleSampleDecrypter(
       const std::vector<uint8_t>& initData,
       const std::vector<uint8_t>& defaultKeyId,

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -52,17 +52,20 @@ void JNIThread(JavaVM* vm)
 }
 #endif
 
-bool CWVDecrypterA::OpenDRMSystem(const DRM::Config& config)
+SResult CWVDecrypterA::OpenDRMSystem(const DRM::Config& config)
 {
   if (config.license.serverUri.empty())
   {
     LOG::LogF(LOGERROR, "The DRM license server url has not been specified");
-    return false;
+    return SResult::Error("Missing DRM license server URL.");
   }
 
   m_WVCdmAdapter = std::make_shared<CWVCdmAdapterA>(config.keySystem, config, m_classLoader, this);
 
-  return m_WVCdmAdapter->GetCDM() != nullptr;
+  if (!m_WVCdmAdapter->GetCDM())
+    return SResultCode::ERROR;
+
+  return SResultCode::OK;
 }
 
 std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CWVDecrypterA::CreateSingleSampleDecrypter(

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -44,7 +44,7 @@ public:
   }
 #endif
 
-  virtual bool OpenDRMSystem(const DRM::Config& config) override;
+  virtual SResult OpenDRMSystem(const DRM::Config& config) override;
 
   virtual std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CreateSingleSampleDecrypter(
       const std::vector<uint8_t>& initData,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
 #include "Stream.h"
+#include "utils/GUIUtils.h"
 #include "utils/ThreadPool.h"
 #include "utils/log.h"
 
@@ -43,8 +44,11 @@ bool CInputStreamAdaptive::Open(const kodi::addon::InputstreamProperty& props)
 
   m_session = std::make_shared<CSession>();
 
-  if (!m_session->Initialize(props.GetURL()))
+  SResult ret = m_session->Initialize(props.GetURL());
+  if (ret.IsFailed())
   {
+    LOG::Log(LOGERROR, ret.Message().c_str());
+    UTILS::GUI::ErrorDialog(ret.Message());
     m_session = nullptr;
     return false;
   }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(${BINARY}
     ../utils/CurlUtils.cpp
     ../utils/DigestMD5Utils.cpp
     ../utils/FileUtils.cpp
+    ../utils/GUIUtils.cpp
     ../utils/JsonUtils.cpp
     ../utils/StringUtils.cpp
     ../utils/UrlUtils.cpp

--- a/src/test/KodiStubs.h
+++ b/src/test/KodiStubs.h
@@ -308,6 +308,15 @@ inline int Show(const std::string& heading,
 
 } // namespace Select
 
+namespace OK
+{
+
+inline void ShowAndGetInput(const std::string& heading, const std::string& text)
+{
+}
+
+} // namespace OK
+
 } // namespace dialogs
 
 } // namespace gui

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -23,6 +23,7 @@ set(HEADERS
   GUIUtils.h
   JsonUtils.h
   log.h
+  ResultType.h
   StringUtils.h
   ThreadPool.h
   UrlUtils.h

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
   CurlUtils.cpp
   DigestMD5Utils.cpp
   FileUtils.cpp
+  GUIUtils.cpp
   JsonUtils.cpp
   StringUtils.cpp
   ThreadPool.cpp
@@ -19,6 +20,7 @@ set(HEADERS
   CurlUtils.h
   DigestMD5Utils.h
   FileUtils.h
+  GUIUtils.h
   JsonUtils.h
   log.h
   StringUtils.h

--- a/src/utils/GUIUtils.cpp
+++ b/src/utils/GUIUtils.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIUtils.h"
+
+#ifdef INPUTSTREAM_TEST_BUILD
+#include "test/KodiStubs.h"
+#else
+#include <kodi/gui/dialogs/OK.h>
+#include <kodi/gui/dialogs/Select.h>
+#endif
+
+int UTILS::GUI::SelectDialog(const std::string& windowTitle,
+                             const std::vector<std::string>& entries,
+                             int selectedIndex /* = DIALOG_NO_VALUE */,
+                             unsigned int autocloseMs /* = 0 */)
+{
+  if (selectedIndex == DIALOG_NO_VALUE)
+    selectedIndex = -1;
+
+  const int ret = kodi::gui::dialogs::Select::Show(windowTitle, entries, selectedIndex, autocloseMs);
+  if (ret == -1)
+    return DIALOG_NO_VALUE;
+
+  return ret;
+}
+
+std::string UTILS::GUI::GetLocalizedString(uint32_t labelId)
+{
+  return kodi::addon::GetLocalizedString(labelId);
+}

--- a/src/utils/GUIUtils.cpp
+++ b/src/utils/GUIUtils.cpp
@@ -8,12 +8,16 @@
 
 #include "GUIUtils.h"
 
+#include "StringUtils.h"
+
 #ifdef INPUTSTREAM_TEST_BUILD
 #include "test/KodiStubs.h"
 #else
 #include <kodi/gui/dialogs/OK.h>
 #include <kodi/gui/dialogs/Select.h>
 #endif
+
+using namespace UTILS;
 
 int UTILS::GUI::SelectDialog(const std::string& windowTitle,
                              const std::vector<std::string>& entries,
@@ -38,4 +42,12 @@ std::string UTILS::GUI::GetLocalizedString(uint32_t labelId)
 void UTILS::GUI::MessageDialog(const std::string& windowTitle, const std::string& msg)
 {
   kodi::gui::dialogs::OK::ShowAndGetInput(windowTitle, msg);
+}
+
+void UTILS::GUI::ErrorDialog(const std::string& errorMsg /* = "" */)
+{
+  const std::string msg = STRING::ReplacePlaceholders(GetLocalizedString(30301),
+                                                      {{"error-details", errorMsg}}, '{', '}');
+
+  kodi::gui::dialogs::OK::ShowAndGetInput(GetLocalizedString(30300), msg);
 }

--- a/src/utils/GUIUtils.cpp
+++ b/src/utils/GUIUtils.cpp
@@ -34,3 +34,8 @@ std::string UTILS::GUI::GetLocalizedString(uint32_t labelId)
 {
   return kodi::addon::GetLocalizedString(labelId);
 }
+
+void UTILS::GUI::MessageDialog(const std::string& windowTitle, const std::string& msg)
+{
+  kodi::gui::dialogs::OK::ShowAndGetInput(windowTitle, msg);
+}

--- a/src/utils/GUIUtils.h
+++ b/src/utils/GUIUtils.h
@@ -47,5 +47,12 @@ std::string GetLocalizedString(uint32_t labelId);
  */
 void MessageDialog(const std::string& windowTitle, const std::string& msg);
 
+/*!
+ * \brief Show an error message dialog window that show a message with
+ *        "Unable to play the stream" followed by the specified error message details.
+ * \param errorMsg[OPT] The error details, can be empty.
+ */
+void ErrorDialog(const std::string& errorMsg = "");
+
 } // namespace GUI
 } // namespace UTILS

--- a/src/utils/GUIUtils.h
+++ b/src/utils/GUIUtils.h
@@ -40,5 +40,12 @@ int SelectDialog(const std::string& windowTitle,
  */
 std::string GetLocalizedString(uint32_t labelId);
 
+/*!
+ * \brief Show a message dialog window
+ * \param windowTitle The title of the window.
+ * \param msg The text message.
+ */
+void MessageDialog(const std::string& windowTitle, const std::string& msg);
+
 } // namespace GUI
 } // namespace UTILS

--- a/src/utils/GUIUtils.h
+++ b/src/utils/GUIUtils.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace UTILS
+{
+namespace GUI
+{
+constexpr int DIALOG_NO_VALUE = -1;
+
+/*!
+ * \brief Show a select dialog window
+ * \param windowTitle The title of the window.
+ * \param entries List about entries.
+ * \param selectedIndex Preselected entry based on index (default DIALOG_NO_VALUE select the first entry).
+ * \param autocloseSecs To close dialog automatic after the given MS time (default 0 it stays open).
+ * \return The selected entry index, otherwise DIALOG_NO_VALUE when nothing selected or canceled.
+ */
+int SelectDialog(const std::string& windowTitle,
+                 const std::vector<std::string>& entries,
+                 int selectedIndex = DIALOG_NO_VALUE,
+                 unsigned int autocloseMs = 0);
+
+/*!
+ * \brief Get add-on localized unicode string from strings included on
+ *        "./resources/language/resource.language.??_??/strings.po" or Kodi core.
+ * \param labelId The label ID of the string to be retrieved.
+ * \param entries List about entries.
+ * \return The localized string.
+ */
+std::string GetLocalizedString(uint32_t labelId);
+
+} // namespace GUI
+} // namespace UTILS

--- a/src/utils/ResultType.h
+++ b/src/utils/ResultType.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+// SResult status codes
+enum class SResultCode
+{
+  OK,
+  ERROR, // Generic error
+};
+
+/*!
+ * \brief Handles return status of operations. It can be tested also as a bool type.
+ */
+struct SResult
+{
+  SResult(SResultCode setCode, const std::string& setMessage = "")
+    : code(setCode), message(setMessage)
+  {
+  }
+
+  operator bool() const { return code == SResultCode::OK; }
+
+  // \brief Get the result code
+  SResultCode Code() const { return code; }
+  // \brief Get the (optional) message
+  const std::string& Message() const { return message; }
+
+  // \brief Return true when the operation is failed
+  bool IsFailed() const { return code != SResultCode::OK; }
+
+  static SResult Ok(const std::string& setMessage = "") { return {SResultCode::OK, setMessage}; }
+  static SResult Error(const std::string& setMessage = "")
+  {
+    return {SResultCode::ERROR, setMessage};
+  }
+  static SResult Fail(SResultCode setCode, const std::string& setMessage = "")
+  {
+    return {setCode, setMessage};
+  }
+
+protected:
+  SResultCode code;
+  std::string message;
+};

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -409,3 +409,13 @@ std::vector<std::string> UTILS::STRING::ExtractPlaceholders(const std::string& t
 
   return placeholders;
 }
+
+std::string UTILS::STRING::Format(const char* fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  std::string str = StringUtils::FormatV(fmt, args);
+  va_end(args);
+
+  return str;
+}

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -368,46 +368,65 @@ int UTILS::STRING::GetNumbers(std::string_view str)
   return ToInt32(extractedNbr);
 }
 
-std::vector<std::string> UTILS::STRING::ExtractPlaceholders(const std::string& text,
-                                                            const char openChar,
-                                                            const char closeChar)
+std::string UTILS::STRING::ReplacePlaceholders(
+    const std::string& text,
+    const std::unordered_map<std::string, std::string>& phValues,
+    const char openChar,
+    const char closeChar,
+    const bool noValueReturnEmpty /* = false */)
 {
-  std::vector<std::string> placeholders;
-  std::string currentPlaceholder;
   int braceCount{0};
+  std::string::const_iterator itPosStart;
+  std::string::const_iterator itPosEnd;
+  std::string result;
+  result.reserve(text.size());
 
-  for (char ch : text)
+  for (auto it = text.cbegin(); it != text.cend(); ++it)
   {
-    if (ch == openChar)
+    if (*it == openChar)
     {
-      // Start a new placeholder
       if (braceCount == 0)
-      {
-        currentPlaceholder.clear();
-      }
+        itPosStart = it + 1;
+
       braceCount++;
-      currentPlaceholder += ch;
     }
-    else if (ch == closeChar)
+    else if (*it == closeChar)
     {
-      // Close a placeholder
-      if (braceCount > 0)
+      braceCount--;
+      if (braceCount < 0)
       {
-        currentPlaceholder += ch;
-        braceCount--;
-        if (braceCount == 0)
+        break; // Missing opening braces
+      }
+      else if (braceCount == 0)
+      {
+        itPosEnd = it;
+        std::string phPart(itPosStart, itPosEnd);
+
+        if (STRING::KeyExists(phValues, phPart))
         {
-          placeholders.push_back(currentPlaceholder);
+          const std::string& value = phValues.at(phPart);
+
+          if (noValueReturnEmpty && value.empty())
+            return "";
+
+          result += value;
+        }
+        else // Expected nested braces
+        {
+          // Placeholder nested in outer braces can have optional text to be shown only
+          // when there is a value assigned to the related placeholder
+          result += ReplacePlaceholders(phPart, phValues, openChar, closeChar, true);
         }
       }
     }
-    else if (braceCount > 0)
-    {
-      currentPlaceholder += ch;
-    }
+    else if (braceCount == 0)
+      result += *it;
   }
 
-  return placeholders;
+  if (braceCount != 0)
+    LOG::LogF(LOGERROR, "Missing braces on placeholders of the string: \"%s\"", text.c_str());
+
+  return result;
 }
 
 std::string UTILS::STRING::Format(const char* fmt, ...)
@@ -419,3 +438,4 @@ std::string UTILS::STRING::Format(const char* fmt, ...)
 
   return str;
 }
+

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -13,6 +13,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace UTILS
@@ -298,15 +299,23 @@ std::vector<uint8_t> HexToBytes(const std::string& hex);
 int GetNumbers(std::string_view str);
 
 /*!
- * \brief Extract placeholders from a string
+ * \brief Replace placeholders in a string, e.g. "{ph-name}", nested braces are allowed
+ *        to shown conditionally a text only when a value is not empty.
+ *        For example: "The sun{ is {ph-color}}."
+ *        result with placeholder value "yellow": "The sun is yellow."
+ *        result with placeholder value empty: "The sun."
  * \param text The string to be parsed
+ * \param phValues The placeholders and relative values
  * \param openChar The opening char used to enclose the placeholder
  * \param closeChar The closing char used to enclose the placeholder
- * \return The placeholders
+ * \param noValueReturnEmpty When a placeholder dont have a value will return empty string
+ * \return The string with placeholders replaced.
  */
-std::vector<std::string> ExtractPlaceholders(const std::string& text,
-                                             const char openChar,
-                                             const char closeChar);
+std::string ReplacePlaceholders(const std::string& text,
+                                const std::unordered_map<std::string, std::string>& phValues,
+                                const char openChar,
+                                const char closeChar,
+                                const bool noValueReturnEmpty = false);
 
 /*!
  * \brief Formatting functions used to output the given values in newly formatted text using functions.

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -308,5 +308,13 @@ std::vector<std::string> ExtractPlaceholders(const std::string& text,
                                              const char openChar,
                                              const char closeChar);
 
+/*!
+ * \brief Formatting functions used to output the given values in newly formatted text using functions.
+ * \param fmt The string to be formatted
+ * \param ... Additional arguments
+ * \return Formatted string
+ */
+std::string Format(const char* fmt, ...);
+
 } // namespace STRING
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Finally users will be happy to know what goes wrong with the playback
without necessarily having to read the debug log

this implementation will not make use of the localizations (language translations) of error details
because it would be too extensive a task and subject to frequent change depending on code change,
the only localization is done in the "generic" error message (Unable to play the stream)

GUI messages cover the most common problems that can occur during playback initialization, such as this example

![immagine](https://github.com/user-attachments/assets/03e47ddb-3b7d-4303-a5b1-f3f0496b31b0)
![immagine](https://github.com/user-attachments/assets/8b323fdf-db47-4a5d-abdf-5d90516ad865)

Sidenote:
i have removed `LogF` from cdm library, i noticed only now that was conflicting with `LogF` defines in the utils/log.h

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a playback fails for X reasons Kodi most of the time returns to the video list without letting the user know what happened... (sometimes there is a generic message "one or more items failed to play" but is not shown always)
so users are forced to read the debug log to know reasons for playback problems, or randomly try to blame something

a media player usually lets the user know what happened in a minimal way
but this currently is not supported by using InputStream API interface

hint from comment https://github.com/xbmc/inputstream.adaptive/pull/1803#issuecomment-2772783579

and partially fix https://github.com/xbmc/inputstream.adaptive/issues/497
about this last one, they also talk about revoked CDM widevine versions therefore no longer working, in this case we do not have the possibility to verify the situation in advance, the only possible way is to intercept a possible HTTP 400 error from the license request, which however not always this error code can have this specific meaning. theoretically, i think there should be a way to make a call to the ISHelper add-on to initiate a check/download of a different version of the CDM, but this is out of scope of this PR

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
