### PR TITLE
[cdm] Fix MacOS SDK deprecations

### DIFF
--- a/lib/cdm/cdm/base/native_library.h
+++ b/lib/cdm/cdm/base/native_library.h
@@ -47,7 +47,6 @@ enum NativeLibraryObjCStatus {
 };
 struct NativeLibraryStruct {
   NativeLibraryType type;
-  CFBundleRefNum bundle_resource_ref;
   NativeLibraryObjCStatus objc_status;
   union {
     CFBundleRef bundle;

--- a/lib/cdm/cdm/base/native_library_mac.mm
+++ b/lib/cdm/cdm/base/native_library_mac.mm
@@ -74,7 +74,6 @@ NativeLibrary LoadNativeLibrary(const std::string& library_path,
   NativeLibrary native_lib = new NativeLibraryStruct();
   native_lib->type = BUNDLE;
   native_lib->bundle = bundle;
-  native_lib->bundle_resource_ref = CFBundleOpenBundleResourceMap(bundle);
   native_lib->objc_status = OBJC_UNKNOWN;
   return native_lib;
 }
@@ -85,8 +84,6 @@ void UnloadNativeLibrary(NativeLibrary library) {
     return;
   if (library->objc_status == OBJC_NOT_PRESENT) {
     if (library->type == BUNDLE) {
-      CFBundleCloseBundleResourceMap(library->bundle,
-                                     library->bundle_resource_ref);
       CFRelease(library->bundle);
     } else {
       dlclose(library->dylib);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Remove warnings, i dont have way to test, so i will see only CI results

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
MacOS compiler warnings

```
/Users/Shared/jenkins/workspace/binary-addons/kodi-osx-arm64-Piers/tools/depends/target/binary-addons/inputstream.adaptive/lib/cdm/cdm/base/native_library_mac.mm:77:37: warning: 'CFBundleOpenBundleResourceMap' is deprecated: first deprecated in macOS 10.15 - The Carbon Resource Manager is deprecated. This should only be used to access Resource Manager-style resources in old bundles. [-Wdeprecated-declarations]
  native_lib->bundle_resource_ref = CFBundleOpenBundleResourceMap(bundle);
                                    ^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBundle.h:330:16: note: 'CFBundleOpenBundleResourceMap' has been explicitly marked deprecated here
CFBundleRefNum CFBundleOpenBundleResourceMap(CFBundleRef bundle) API_DEPRECATED("The Carbon Resource Manager is deprecated. This should only be used to access Resource Manager-style resources in old bundles.", macosx(10.0, 10.15)) API_UNAVAILABLE(ios, watchos, tvos);
               ^
/Users/Shared/jenkins/workspace/binary-addons/kodi-osx-arm64-Piers/tools/depends/target/binary-addons/inputstream.adaptive/lib/cdm/cdm/base/native_library_mac.mm:88:7: warning: 'CFBundleCloseBundleResourceMap' is deprecated: first deprecated in macOS 10.15 - The Carbon Resource Manager is deprecated. This should only be used to access Resource Manager-style resources in old bundles. [-Wdeprecated-declarations]
      CFBundleCloseBundleResourceMap(library->bundle,
      ^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBundle.h:343:6: note: 'CFBundleCloseBundleResourceMap' has been explicitly marked deprecated here
void CFBundleCloseBundleResourceMap(CFBundleRef bundle, CFBundleRefNum refNum) API_DEPRECATED("The Carbon Resource Manager is deprecated. This should only be used to access Resource Manager-style resources in old bundles.", macosx(10.0, 10.15)) API_UNAVAILABLE(ios, watchos, tvos);
     ^
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
