### PR TITLE
[UrlUtils] Fix Join to keep dots in a path

### DIFF
--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -134,6 +134,17 @@ TEST_F(UtilsTest, JoinUrls)
   otherUrl = "./";
   EXPECT_EQ(URL::Join(baseUrl, otherUrl), "https://foo.bar/sub1/sub2/");
 
+
+  baseUrl = "https://foo.bar/sub1../sub2./";
+  otherUrl = ".ending";
+  EXPECT_EQ(URL::Join(baseUrl, otherUrl), "https://foo.bar/sub1../sub2./.ending");
+
+  otherUrl = "./.ending/.";
+  EXPECT_EQ(URL::Join(baseUrl, otherUrl), "https://foo.bar/sub1../sub2./.ending/");
+
+  otherUrl = "./.ending/./";
+  EXPECT_EQ(URL::Join(baseUrl, otherUrl), "https://foo.bar/sub1../sub2./.ending/");
+
   // Less common and malformed test cases
 
   baseUrl = "https://foo.bar/sub1/sub2/";

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -12,10 +12,7 @@
 #include "StringUtils.h"
 #include "log.h"
 
-#include "kodi/tools/StringUtils.h"
-
 using namespace UTILS;
-using namespace kodi::tools;
 
 namespace
 {
@@ -298,7 +295,7 @@ std::string UTILS::URL::Join(std::string baseUrl, std::string relativeUrl)
     relativeUrl.clear();
 
   // Sanitize for missing backslash
-  if (relativeUrl == ".." || StringUtils::EndsWith(relativeUrl, "/.."))
+  if (relativeUrl == ".." || relativeUrl.ends_with("/.."))
     relativeUrl += "/";
 
   // The part of the base url after last / is not a directory so will not be taken into account

--- a/src/utils/UrlUtils.cpp
+++ b/src/utils/UrlUtils.cpp
@@ -80,6 +80,29 @@ bool isUrl(std::string url,
   return true;
 }
 
+void RemovePrefixSingleDot(std::string& url)
+{
+  size_t pos{0};
+  // Remove occurrences of "/./" preserving the separator
+  while ((pos = url.find("/./")) != std::string::npos)
+  {
+    url.erase(pos, 2);
+  }
+
+  if (url.ends_with("/."))
+    url.pop_back(); // Delete the dot and preserve the separator
+}
+
+void RemovePrefixDoubleDot(std::string& url)
+{
+  size_t pos{0};
+  // Remove occurrences of "/../" preserving the separator
+  while ((pos = url.find("/../")) != std::string::npos)
+  {
+    url.erase(pos, 3);
+  }
+}
+
 /*
  * \brief Remove and resolve special dot's from the end of the url.
  *        e.g. "http://foo.bar/sub1/sub2/.././" will result "http://foo.bar/sub1/"
@@ -90,18 +113,18 @@ std::string RemoveDotSegments(std::string url)
   size_t numSegsRemove{0};
   size_t currPos{0};
   size_t startPos{url.size() - 2};
-  while ((currPos = url.rfind("/", startPos)) != std::string::npos)
+  while ((currPos = url.rfind('/', startPos)) != std::string::npos)
   {
     // Stop to ignore "/../" from the start of string, e.g. ignored --> "../../something/../" <-- handled
-    if (url.substr(currPos + 1, startPos - currPos + 1) != PREFIX_DOUBLE_DOT)
+    if (currPos == 0 || url.substr(currPos + 1, startPos - currPos + 1) != PREFIX_DOUBLE_DOT)
       break;
     startPos = currPos - 1;
     numSegsRemove++;
   }
 
   // Remove special prefixes
-  UTILS::STRING::ReplaceAll(url, PREFIX_DOUBLE_DOT, "");
-  UTILS::STRING::ReplaceAll(url, PREFIX_SINGLE_DOT, "");
+  RemovePrefixSingleDot(url);
+  RemovePrefixDoubleDot(url);
 
   size_t addrsStartPos{0};
   if (URL::IsUrlAbsolute(url))
@@ -273,8 +296,6 @@ std::string UTILS::URL::Join(std::string baseUrl, std::string relativeUrl)
 
   if (relativeUrl == ".") // Ignore single dot
     relativeUrl.clear();
-  else if (relativeUrl.compare(0, 2, PREFIX_SINGLE_DOT) == 0) // Ignore prefix ./
-    relativeUrl.erase(0, 2);
 
   // Sanitize for missing backslash
   if (relativeUrl == ".." || StringUtils::EndsWith(relativeUrl, "/.."))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
for example
`https://foo.bar/example./`
when a path ends with  `./` or there are dots in the middle they was incorrectly removed from the segment paths

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1842
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit test
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
