### PR TITLE
[Session] Fix inconsistent streams packets PTS comparison

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -689,7 +689,7 @@ bool SESSION::CSession::PrepareStream(CStream* stream, uint64_t startPts)
 
   stream->SetReader(std::move(reader));
 
-  if (reprContainerType == ContainerType::TS)
+  if (reprContainerType == ContainerType::TS || reprContainerType == ContainerType::ADTS)
   {
     // With TS streams the elapsed time would be calculated incorrectly as during the tree refresh,
     // nextSegment would be deleted by the FreeSegments/newsegments swap. Do this now before the tree refresh.

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -826,9 +826,9 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
         waiting = stream.get();
         break;
       }
-      else if (streamReader->IsReady() && !streamReader->EOS())
+      else if (!streamReader->EOS())
       {
-        if (AP4_SUCCEEDED(streamReader->Start(isStarted)))
+        if (AP4_SUCCEEDED(streamReader->Start(isStarted)) && streamReader->IsReady())
         {
           if (!res || streamReader->DTSorPTSManifest() < res->GetReader()->DTSorPTSManifest())
           {

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -830,13 +830,7 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
       {
         if (AP4_SUCCEEDED(streamReader->Start(isStarted)))
         {
-          //!@ todo: DTSorPTS comparison is wrong
-          //! currently we are compare audio/video/subtitles
-          //! for audio/video the pts/dts come from demuxer, but subtitles use pts from manifest
-          //! these values not always are comparable because pts/dts that come from demuxer packet data
-          //! can be different and makes this package selection ineffective
-          //! see also workaround on CSubtitleSampleReader::ReadSample
-          if (!res || streamReader->DTSorPTS() < res->GetReader()->DTSorPTS())
+          if (!res || streamReader->DTSorPTSManifest() < res->GetReader()->DTSorPTSManifest())
           {
             if (stream->m_adStream.waitingForSegment())
             {

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -366,14 +366,8 @@ void AdaptiveStream::worker()
 
       //! @todo: for live content we should calculate max attempts and sleep timing
       //! based on segment duration / playlist updates timing
-      size_t maxAttempts = m_tree->IsLive() ? 10 : 6;
+      size_t maxAttempts = m_tree->IsLive() ? 6 : 3;
       std::chrono::milliseconds msSleep = m_tree->IsLive() ? 1000ms : 500ms;
-
-      //! @todo: Some streaming software offers subtitle tracks with missing fragments, usually live tv
-      //! When a programme is broadcasted that has subtitles, subtitles fragments are offered,
-      //! Ensure we continue with the next segment after one retry on errors
-      if (current_adp_->GetStreamType() == StreamType::SUBTITLE && m_tree->IsLive())
-        maxAttempts = 2;
 
       size_t downloadAttempts = 1;
       bool isSegmentDownloaded = false;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -389,7 +389,9 @@ void AdaptiveStream::worker()
 
       lckdl.lock();
 
-      if (!isSegmentDownloaded)
+      // Stop the playback if the data cant be downloaded
+      // is not the case for subtitles where in the case of missing files they can be ignored
+      if (!isSegmentDownloaded && current_adp_->GetStreamType() != StreamType::SUBTITLE)
       {
         std::lock_guard<std::mutex> lckrw(thread_data_->mutex_rw_);
         // Download cancelled or cannot download the file

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -120,8 +120,8 @@ enum class EVENT_TYPE
     PLAYLIST::CAdaptationSet* getAdaptationSet() { return current_adp_; };
     PLAYLIST::CRepresentation* getRepresentation() { return current_rep_; };
 
-    uint64_t GetCurrentPTSOffset() { return currentPTSOffset_; };
-    uint64_t GetAbsolutePTSOffset() { return absolutePTSOffset_; };
+    uint64_t GetCurrentPTSOffset() const { return currentPTSOffset_; }
+    uint64_t GetAbsolutePTSOffset() const { return absolutePTSOffset_; }
     bool waitingForSegment() const;
     void FixateInitialization(bool on);
     void SetSegmentFileOffset(uint64_t offset) { m_segmentFileOffset = offset; };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -355,7 +355,7 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
 
       if (srHaveData)
       {
-        m_lastPts = sr->PTS();
+        m_lastPts = sr->DTSorPTSManifest();
         p->dts = static_cast<double>(sr->DTS());
         p->pts = static_cast<double>(sr->PTS());
         p->duration = static_cast<double>(sr->GetDuration());

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -71,6 +71,16 @@ public:
   virtual void SetPTSDiff(uint64_t pts) {}
 
   /*!
+   * \brief Get the DTS or PTS of current packet, in manifest timing format
+   *        (since packet DTS/PTS can be different from manifest PTS, and sliced).
+   * \return The DTS/PTS in manifest timing format, scaled in STREAM_TIME_BASE.
+   */
+  virtual uint64_t DTSorPTSManifest() const {
+    int64_t value = static_cast<int64_t>(DTSorPTS()) - GetPTSDiff();
+    return value < 0 ? 0 : static_cast<uint64_t>(value);
+  };
+
+  /*!
    * \brief Read info about fragment on current segment (fMP4)
    * \param duration[OUT] Set the duration of current media sample
    * \return True if the fragment info was successfully retrieved, otherwise false

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -135,6 +135,8 @@ bool CSubtitleSampleReader::IsReady()
 
 AP4_Result CSubtitleSampleReader::ReadSample()
 {
+  m_sampleData.SetDataSize(0);
+
   if (m_codecHandler->ReadNextSample(m_sample,
                                      m_sampleData)) // Read the sample data from a file url
   {
@@ -147,6 +149,12 @@ AP4_Result CSubtitleSampleReader::ReadSample()
     std::vector<uint8_t> buffer;
     if (m_adByteStream->ReadFull(buffer))
     {
+      if (buffer.empty()) // No data, more likely due to download error
+      {
+        LOG::LogF(LOGWARNING, "No buffer segment data from subtitle stream");
+        return AP4_ERROR_READ_FAILED;
+      }
+
       auto rep = m_adStream->getRepresentation();
       if (rep)
       {

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -159,18 +159,7 @@ AP4_Result CSubtitleSampleReader::ReadSample()
           AP4_UI32 duration =
               static_cast<AP4_UI32>((segDur * STREAM_TIME_BASE) / rep->GetTimescale());
 
-          uint64_t startPts = currentSegment->startPTS_;
-
-          //! @todo: startPTS workaround! pts has been taken by substracting the period start
-          //! this just to have a lower pts value, but the real problem is in CSession::GetNextSample
-          //! that that makes an incorrect comparison of DTSorPTS
-          if (CSrvBroker::GetResources().GetTree().GetTreeType() == adaptive::TreeType::HLS)
-          {
-            const uint64_t pStart = m_adStream->getPeriod()->GetStart() * rep->GetTimescale() / 1000;
-            startPts -= pStart;
-          }
-
-          AP4_UI64 pts = (startPts * STREAM_TIME_BASE) / rep->GetTimescale();
+          const AP4_UI64 pts = (currentSegment->startPTS_ * STREAM_TIME_BASE) / rep->GetTimescale();
 
           m_codecHandler->Transform(pts, duration, segData, 1000);
           if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -120,7 +120,7 @@ AP4_Result CSubtitleSampleReader::Start(bool& bStarted)
     return AP4_SUCCESS;
 
   m_started = true;
-  return AP4_SUCCESS;
+  return ReadSample();
 }
 
 bool CSubtitleSampleReader::IsReady()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
this problem happens easily with HLS manifest,
the CSession::GetNextSample method does a PTS comparison to decide which data packet to provide to the kodi demuxer (between audio/video/subtitles) then takes the data with oldest PTS (lowest value)

however, the value provided by the DTSorPTS method for audio and video the value is extracted from the packet data, while for subtitles it can (but depends) comes from the manifest and this is where the problem arises
the PTS of the A/V packet is not comparable with the PTS from the manifest and causes malfunctions in packet selection,
with side effects for subtitle display and possible video freeze when enabling/disabling subtitles

as solution since the samplereader store the difference from initial pts vs the manifest initial pts
i made a new method DTSorPTSManifest to get a "manifest based" pts value
that can be compared in right way from CSession::GetNextSample

to take in account that you cant get and compare a manifest segment PTS directly, because for example for **TS container** segments are sliced into small chunks with partial pts parts, then its mandatory check the PTS provided by samplereader and calculate the difference

mainly i used ISA Samples "google shaka demo [multi-audio-codecs, subtitles]" as test

### Related (segmented) subtitles fix
i added other fixes found by testing better the above sample stream,
the "google shaka demo [multi-audio-codecs, subtitles]" has a missing subtitle file segment (at today), the `fileSequence11.webvtt` that cannot be downloaded
this caused an inconsistent state that prevented the downloading of subsequent (available) segments files
now if a segment file is missing it will be ignored and subtitles will continue as soon as available

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1611
fix #1831

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ATM tested only ARD live stream, and after enabled disabled subtitles more times seem to works

ISA Samples "google shaka demo [multi-audio-codecs, subtitles]"

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
