### PR TITLE
[Widevine] Add webOS support (L3)

### DIFF
--- a/.github/workflows/build-webos.yml
+++ b/.github/workflows/build-webos.yml
@@ -1,0 +1,73 @@
+name: Build for webOS
+on: [push, pull_request]
+env:
+  app_id: inputstream.adaptive
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ZIP_NAME_SUFFIX: [webos]
+    steps:
+    - name: Install system cmake
+      run: |
+        sudo apt-get update
+        sudo apt-get install cmake
+        echo "System CMake installed at: $(which cmake)"
+        cmake --version
+    - name: Download webOS NDK
+      uses: robinraju/release-downloader@v1.11
+      with:
+        repository: "openlgtv/buildroot-nc4"
+        latest: true
+        fileName: "linux-intel-webos-sdk.tar.gz"
+        out-file-path: "/tmp"
+    - name: Extract webOS NDK
+      working-directory: /tmp
+      run: |
+        tar xzf linux-intel-webos-sdk.tar.gz
+        ./arm-webos-linux-gnueabi_sdk-buildroot/relocate-sdk.sh
+    - name: Checkout Kodi repo
+      uses: actions/checkout@v4
+      with:
+        repository: xbmc/xbmc
+        ref: master
+        path: xbmc
+    - name: Bootstrap depends
+      run: |
+        cd xbmc/tools/depends
+        ./bootstrap
+        ./configure --prefix=${{ github.workspace }}/xbmc-deps \
+                    --with-toolchain=/tmp/arm-webos-linux-gnueabi_sdk-buildroot --host=arm-webos-linux-gnueabi \
+                    --with-platform=webos --enable-debug=no
+    - name: Checkout add-on repo
+      uses: actions/checkout@v4
+      with:
+        path: ${{ env.app_id }}
+    - name: Configure
+      run: |
+        cd ${app_id}
+        mkdir -p build && cd build
+        /usr/bin/cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=../.. \
+              -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons \
+              -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons
+    - name: Build
+      run: |
+        cd ${app_id}/build
+        make
+    - name: Run tests
+      run: |
+        cd ${app_id}/build/${app_id}-prefix/src/${app_id}-build
+        make CTEST_OUTPUT_ON_FAILURE=1 GTEST_COLOR=1 test
+    - name: Make ZIP artifact
+      run: |
+        cd ${{ github.workspace }}/xbmc/addons
+        zip -r inputstream.adaptive.zip inputstream.adaptive
+    - name: Upload zipped artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.app_id }}_${{ matrix.ZIP_NAME_SUFFIX }}.zip
+        path: ${{ github.workspace }}/xbmc/addons/inputstream.adaptive.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ find_package(pugixml REQUIRED)
 find_package(Bento4 REQUIRED)
 find_package(NlohmannJSON REQUIRED)
 
+if(CMAKE_CXX_COMPILER MATCHES "arm-webos")
+  add_compile_definitions(TARGET_WEBOS=1)
+endif()
+
 if(WIN32)
   if(MSVC)
     # Allow build for WindowsStore with Visual Studio

--- a/lib/cdm/cdm/media/cdm/api/content_decryption_module.h
+++ b/lib/cdm/cdm/media/cdm/api/content_decryption_module.h
@@ -25,7 +25,11 @@ typedef __int64 int64_t;
 // The version number must be rolled when the exported functions are updated!
 // If the CDM and the adapter use different versions of these functions, the
 // adapter will fail to load or crash!
-#define CDM_MODULE_VERSION 4
+#ifdef TARGET_WEBOS
+  #define CDM_MODULE_VERSION 10
+#else
+  #define CDM_MODULE_VERSION 4
+#endif
 
 // Build the versioned entrypoint name.
 // The extra macros are necessary to expand version to an actual value.
@@ -796,8 +800,14 @@ class CDM_CLASS_API ContentDecryptionModule_10 {
   // Returns kDecryptError if any other error happened.
   // If the return value is not kSuccess, |decrypted_buffer| should be ignored
   // by the caller.
+#ifdef TARGET_WEBOS
+  virtual Status Decrypt(const InputBuffer_2& encrypted_buffer,
+                         DecryptedBlock* decrypted_buffer,
+                         StreamType stream_type) = 0;
+#else
   virtual Status Decrypt(const InputBuffer_2& encrypted_buffer,
                          DecryptedBlock* decrypted_buffer) = 0;
+#endif
 
   // Initializes the CDM audio decoder with |audio_decoder_config|. This
   // function must be called before DecryptAndDecodeSamples() is called.
@@ -1016,8 +1026,14 @@ class CDM_CLASS_API ContentDecryptionModule_11 {
   // Returns kDecryptError if any other error happened.
   // If the return value is not kSuccess, |decrypted_buffer| should be ignored
   // by the caller.
+#ifdef TARGET_WEBOS
+  virtual Status Decrypt(const InputBuffer_2& encrypted_buffer,
+                         DecryptedBlock* decrypted_buffer,
+                         StreamType stream_type) = 0;
+#else
   virtual Status Decrypt(const InputBuffer_2& encrypted_buffer,
                          DecryptedBlock* decrypted_buffer) = 0;
+#endif
 
   // Initializes the CDM audio decoder with |audio_decoder_config|. This
   // function must be called before DecryptAndDecodeSamples() is called.

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.cc
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.cc
@@ -228,9 +228,11 @@ bool CdmAdapter::Initialize()
 #endif  // defined(OS_WIN)
 
   init_cdm_func();
-
+  
+#ifndef TARGET_WEBOS
   cdm12_ = static_cast<cdm::ContentDecryptionModule_12*>(create_cdm_func(
       12, key_system_.data(), static_cast<uint32_t>(key_system_.size()), GetCdmHost, this));
+#endif
 
   if (!cdm12_)
   {
@@ -441,9 +443,21 @@ cdm::Status CdmAdapter::Decrypt(const cdm::InputBuffer_2& encrypted_buffer,
   if (cdm12_)
     ret = cdm12_->Decrypt(encrypted_buffer, decrypted_buffer);
   else if (cdm11_)
+#ifdef TARGET_WEBOS
+    // we set this to kStreamTypeAudio, as this bypasses automatic SVP header/meta data injection
+    // this is lost in RepackSubsampleData
+    ret = cdm11_->Decrypt(encrypted_buffer, decrypted_buffer, cdm::StreamType::kStreamTypeAudio);
+#else
     ret = cdm11_->Decrypt(encrypted_buffer, decrypted_buffer);
+#endif
   else if (cdm10_)
+#ifdef TARGET_WEBOS
+    // we set this to kStreamTypeAudio, as this bypasses automatic SVP header/meta data injection
+    // this is lost in RepackSubsampleData
+    ret = cdm10_->Decrypt(encrypted_buffer, decrypted_buffer, cdm::StreamType::kStreamTypeAudio);
+#else
     ret = cdm10_->Decrypt(encrypted_buffer, decrypted_buffer);
+#endif
 
   active_buffer_ = 0;
   return ret;

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -17,6 +17,11 @@
 #include "utils/GUIUtils.h"
 #include "utils/log.h"
 
+#include <array>
+#include <filesystem>
+#include <ranges>
+#include <string_view>
+
 using namespace UTILS;
 
 namespace
@@ -25,6 +30,9 @@ namespace
 constexpr const char* LIBRARY_FILENAME = "widevinecdm.dll";
 #elif TARGET_DARWIN
 constexpr const char* LIBRARY_FILENAME = "libwidevinecdm.dylib";
+#elif TARGET_WEBOS
+constexpr std::array<std::string_view, 2> candidatePaths = {"/usr/lib/libwidevine-wrapper.so",
+                                                            "/usr/lib/libwvcdm_shared.so"};
 #else
 constexpr const char* LIBRARY_FILENAME = "libwidevinecdm.so";
 #endif
@@ -79,7 +87,23 @@ SResult CWVCdmAdapter::Initialize(const DRM::Config& config, CWVDecrypter* host)
     LOG::LogF(LOGERROR, "Widevine CDM library path not specified");
     return SResultCode::ERROR;
   }
-  std::string cdmPath = FILESYS::PathCombine(m_host->GetLibraryPath(), LIBRARY_FILENAME);
+  std::string cdmPath;
+#ifdef TARGET_WEBOS
+  auto it = std::ranges::find_if(candidatePaths, [](std::string_view sv)
+                                 { return std::filesystem::exists(std::filesystem::path{sv}); });
+
+  if (it != candidatePaths.end())
+  {
+    cdmPath = std::string(*it);
+  }
+  else
+  {
+    LOG::LogF(LOGERROR, "Widevine CDM library not found");
+    return SResultCode::ERROR;
+  }
+#else
+  cdmPath = FILESYS::PathCombine(m_host->GetLibraryPath(), LIBRARY_FILENAME);
+#endif
 
   // The license url come from license_key kodi property
   // we have to kept only the url without the parameters specified after pipe "|" char


### PR DESCRIPTION
## Description
This adds L3 Widevine support to the webOS port of Kodi.

## Motivation and context
webOS cannot use chromium supplied widevine libs as it still uses a 32-bit softfp tool chain. However, LG have their own widevine libraries installed anyway.

I am investigating the usage of secure video path which **might** give us L1 but in the mean time L3 is here, and webOS does not have anything at the moment so this is a major improvement.

partially solve #1874 (secure decoder still wip)

## How has this been tested?
Tested with Google Tears [CBCS] and real usage testing by [Uukrull](https://github.com/Uukrull) with Amazon Prime, Movistar+ and DAZN.

## How did I go about this?
https://opensource.lge.com/
Search for your TV (e.g. OLED65C5)
Download firmware source and extract chromium120 source.

In webOS they use an additional parameter to determine the type of stream:

src/media/cdm/cdm_adapter.cc
```
void CdmAdapter::Decrypt(StreamType stream_type,
                         scoped_refptr<DecoderBuffer> encrypted,
                         DecryptCB decrypt_cb) {
<snip>
#if defined(USE_NEVA_MEDIA)
  cdm::Status status = cdm_->Decrypt(input_buffer, decrypted_block.get(),
                                     ToCdmStreamType(stream_type));
#else
  cdm::Status status = cdm_->Decrypt(input_buffer, decrypted_block.get());
#endif
```

src/media/cdm/cdm_wrapper.h
```
  virtual cdm::Status Decrypt(const cdm::InputBuffer_2& encrypted_buffer,
#if defined(USE_NEVA_MEDIA)
                              cdm::DecryptedBlock* decrypted_buffer,
                              const cdm::StreamType decoder_type) = 0;
#else
                              cdm::DecryptedBlock* decrypted_buffer) = 0;
#endif
```

The presence of SVP headers was detected through HEX dumps of the decrypted packet.

As for libwidevine-wrapper and libwvcdm_shared, these are only found by SSH to the TV and change based on how old your webOS is.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
