### PR TITLE
[Workflows][CI] Update new naming scheme for webOS buildroot

### DIFF
--- a/.github/workflows/build-webos.yml
+++ b/.github/workflows/build-webos.yml
@@ -12,23 +12,17 @@ jobs:
         os: [ubuntu-latest]
         ZIP_NAME_SUFFIX: [webos]
     steps:
-    - name: Install system cmake
-      run: |
-        sudo apt-get update
-        sudo apt-get install cmake
-        echo "System CMake installed at: $(which cmake)"
-        cmake --version
     - name: Download webOS NDK
       uses: robinraju/release-downloader@v1.11
       with:
         repository: "openlgtv/buildroot-nc4"
         latest: true
-        fileName: "linux-intel-webos-sdk.tar.gz"
+        fileName: "arm-webos-linux-gnueabi_sdk-buildroot-x86_64.tar.gz"
         out-file-path: "/tmp"
     - name: Extract webOS NDK
       working-directory: /tmp
       run: |
-        tar xzf linux-intel-webos-sdk.tar.gz
+        tar xzf arm-webos-linux-gnueabi_sdk-buildroot-x86_64.tar.gz
         ./arm-webos-linux-gnueabi_sdk-buildroot/relocate-sdk.sh
     - name: Checkout Kodi repo
       uses: actions/checkout@v4
@@ -51,7 +45,7 @@ jobs:
       run: |
         cd ${app_id}
         mkdir -p build && cd build
-        /usr/bin/cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=../.. \
+        cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=../.. \
               -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons \
               -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons
     - name: Build


### PR DESCRIPTION
## Description
The naming scheme for buildroot-nc4 was changed just 13 hours ago causing the filename to be longer valid.

https://github.com/openlgtv/buildroot-nc4/releases/tag/webos-a38c582

Also the new release of buildroot-nc4 has cmake with fixed https support, so you no longer need system cmake installed.

## Motivation and context
Fixes previous PR

## How has this been tested?
Built on new CI, completes:

https://github.com/cscd98/inputstream.adaptive/actions/runs/16566456025

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
