### PR TITLE
webOS: Implement L1 secure path decoding

### DIFF
--- a/lib/cdm/cdm/media/base/cdm_config.h
+++ b/lib/cdm/cdm/media/base/cdm_config.h
@@ -15,10 +15,12 @@ namespace media {
 // |requestMediaKeySystemAccess|. This is in some sense the Chromium-side
 // counterpart of Blink's WebMediaKeySystemConfiguration.
 struct CdmConfig {
-  CdmConfig(bool distinctive_identifier=false, bool persistent_state=false)
-    :allow_distinctive_identifier(distinctive_identifier)
-    , allow_persistent_state(persistent_state)
-    , use_hw_secure_codecs(false){};
+  CdmConfig(bool distinctive_identifier = false,
+            bool persistent_state = false,
+            bool hw_secure_codecs = false)
+    : allow_distinctive_identifier(distinctive_identifier),
+      allow_persistent_state(persistent_state),
+      use_hw_secure_codecs(hw_secure_codecs) {};
 
   // Allow access to a distinctive identifier.
   bool allow_distinctive_identifier;

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.cc
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.cc
@@ -61,6 +61,8 @@ const char PATH_SEPARATOR = '\\';
 const char PATH_SEPARATOR = '/';
 #endif
 
+constexpr std::chrono::seconds INIT_FUTURE_TIMEOUT_SEC{3};
+
 void* GetCdmHost(int host_interface_version, void* user_data)
 {
   if (!user_data)
@@ -216,6 +218,9 @@ bool CdmAdapter::LoadCDM()
 
 bool CdmAdapter::Initialize()
 {
+  m_initPromise = std::promise<void>{};
+  m_initFuture = m_initPromise.get_future();
+  m_provisioningCompleteOrStarted = false;
   m_isClosingSession = false;
 
   Log(LogLevel::DEBUG, "CDM version: %s", GetVersion().c_str());
@@ -263,6 +268,22 @@ bool CdmAdapter::Initialize()
       cdm10_->Initialize(cdm_config_.allow_distinctive_identifier,
                          cdm_config_.allow_persistent_state, false);
     }
+
+    // Wait for the CDM to be initialized
+    // Add a maximum timeout in case we never hear back!
+    if (m_initFuture.valid() &&
+        m_initFuture.wait_for(INIT_FUTURE_TIMEOUT_SEC) != std::future_status::ready)
+    {
+      Log(LogLevel::ERROR, "CDM initialization timed out");
+      return false;
+    }
+
+    if (!m_provisioningCompleteOrStarted)
+    {
+      Log(LogLevel::ERROR, "CDM initialization failed or not started");
+      return false;
+    }
+
     return true;
   }
 
@@ -786,6 +807,15 @@ void CdmAdapter::ReportMetrics(cdm::MetricName metric_name, uint64_t value)
 
 void CdmAdapter::OnInitialized(bool success)
 {
+  // Notify the client that the CDM is initialized
+  if (success)
+  {
+    m_provisioningCompleteOrStarted = true;
+  }
+
+  // Set the promise value so that execution can continue
+  m_initPromise.set_value();
+
   Log(LogLevel::DEBUG, "CDM is initialized: %s", success ? "true" : "false");
 }
 

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.cc
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.cc
@@ -613,10 +613,32 @@ void CdmAdapter::OnResolvePromise(uint32_t promise_id)
 {
 }
 
-void CdmAdapter::OnResolveNewSessionPromise(uint32_t promise_id,
-                      const char* session_id,
-                      uint32_t session_id_size)
+std::future<std::string> CdmAdapter::PrepareSessionFuture(uint32_t promiseId)
 {
+  std::lock_guard<std::mutex> lock(m_sessionMx);
+  std::promise<std::string> promise;
+  auto future = promise.get_future();
+  m_sessionPromises[promiseId] = std::move(promise);
+  return future;
+}
+
+void CdmAdapter::OnResolveNewSessionPromise(uint32_t promise_id,
+                                            const char* session_id,
+                                            uint32_t session_id_size)
+{
+  std::string sessionStr(session_id, session_id_size);
+
+  std::lock_guard<std::mutex> lock(m_sessionMx);
+  auto it = m_sessionPromises.find(promise_id);
+  if (it != m_sessionPromises.end())
+  {
+    it->second.set_value(sessionStr);
+    m_sessionPromises.erase(it);
+  }
+  else
+  {
+    Log(LogLevel::ERROR, "Promise ID %u not found", promise_id);
+  }
 }
 
 void CdmAdapter::OnSessionKeysChange(const char* session_id,
@@ -709,9 +731,37 @@ void CdmAdapter::OnResolveKeyStatusPromise(uint32_t promise_id, cdm::KeyStatus_2
 {
 }
 
-void CdmAdapter::OnRejectPromise(uint32_t promise_id, cdm::Exception exception,
-  uint32_t system_code, const char* error_message, uint32_t error_message_size)
+void CdmAdapter::OnRejectPromise(uint32_t promise_id,
+                                 cdm::Exception exception,
+                                 uint32_t system_code,
+                                 const char* error_message,
+                                 uint32_t error_message_size)
 {
+  std::lock_guard<std::mutex> lk(m_sessionMx);
+  auto it = m_sessionPromises.find(promise_id);
+  if (it == m_sessionPromises.end())
+    return;
+
+  try
+  {
+    std::string msg;
+    if (error_message && error_message_size)
+    {
+      msg.assign(error_message, error_message_size);
+    }
+    else
+    {
+      msg = "CDM reject: " + std::to_string(static_cast<int>(exception)) +
+            " sys=" + std::to_string(system_code);
+    }
+
+    it->second.set_exception(std::make_exception_ptr(std::runtime_error(msg)));
+  }
+  catch (...)
+  {
+  }
+
+  m_sessionPromises.erase(it);
 }
 
 void CdmAdapter::OnSessionMessage(const char* session_id, uint32_t session_id_size,

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.cc
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.cc
@@ -429,7 +429,8 @@ void CdmAdapter::TimerExpired(void* context)
 }
 
 cdm::Status CdmAdapter::Decrypt(const cdm::InputBuffer_2& encrypted_buffer,
-  cdm::DecryptedBlock* decrypted_buffer)
+                                cdm::DecryptedBlock* decrypted_buffer,
+                                cdm::StreamType streamType)
 {
   //We need this wait here for fast systems, during buffering
   //widewine stopps if some seconds (5??) are fetched too fast
@@ -444,17 +445,13 @@ cdm::Status CdmAdapter::Decrypt(const cdm::InputBuffer_2& encrypted_buffer,
     ret = cdm12_->Decrypt(encrypted_buffer, decrypted_buffer);
   else if (cdm11_)
 #ifdef TARGET_WEBOS
-    // we set this to kStreamTypeAudio, as this bypasses automatic SVP header/meta data injection
-    // this is lost in RepackSubsampleData
-    ret = cdm11_->Decrypt(encrypted_buffer, decrypted_buffer, cdm::StreamType::kStreamTypeAudio);
+    ret = cdm11_->Decrypt(encrypted_buffer, decrypted_buffer, streamType);
 #else
     ret = cdm11_->Decrypt(encrypted_buffer, decrypted_buffer);
 #endif
   else if (cdm10_)
 #ifdef TARGET_WEBOS
-    // we set this to kStreamTypeAudio, as this bypasses automatic SVP header/meta data injection
-    // this is lost in RepackSubsampleData
-    ret = cdm10_->Decrypt(encrypted_buffer, decrypted_buffer, cdm::StreamType::kStreamTypeAudio);
+    ret = cdm10_->Decrypt(encrypted_buffer, decrypted_buffer, streamType);
 #else
     ret = cdm10_->Decrypt(encrypted_buffer, decrypted_buffer);
 #endif

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.cc
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.cc
@@ -256,17 +256,17 @@ bool CdmAdapter::Initialize()
     if (cdm12_)
     {
       cdm12_->Initialize(cdm_config_.allow_distinctive_identifier,
-                         cdm_config_.allow_persistent_state, false);      
+                         cdm_config_.allow_persistent_state, cdm_config_.use_hw_secure_codecs);
     }
     else if (cdm11_)
     {
       cdm11_->Initialize(cdm_config_.allow_distinctive_identifier,
-                         cdm_config_.allow_persistent_state, false);
+                         cdm_config_.allow_persistent_state, cdm_config_.use_hw_secure_codecs);
     }
     else if (cdm10_)
     {
       cdm10_->Initialize(cdm_config_.allow_distinctive_identifier,
-                         cdm_config_.allow_persistent_state, false);
+                         cdm_config_.allow_persistent_state, cdm_config_.use_hw_secure_codecs);
     }
 
     // Wait for the CDM to be initialized

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.h
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.h
@@ -221,7 +221,6 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>,
 
   void OnInitialized(bool success) override;
 
-
   std::future<std::string> PrepareSessionFuture(uint32_t promiseId);
 
   //Misc
@@ -269,6 +268,10 @@ private:
   CdmConfig cdm_config_;
 
   cdm::Buffer* active_buffer_{nullptr};
+
+  std::promise<void> m_initPromise;
+  std::future<void> m_initFuture;
+  std::atomic<bool> m_provisioningCompleteOrStarted;
 
   cdm::ContentDecryptionModule_10* cdm10_{nullptr};
   cdm::ContentDecryptionModule_11* cdm11_{nullptr};

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.h
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.h
@@ -9,19 +9,20 @@
 #ifndef MEDIA_CDM_CDM_ADAPTER_H_
 #define MEDIA_CDM_CDM_ADAPTER_H_
 
-#include <string>
-#include <vector>
+#include "../../base/compiler_specific.h"
+#include "../../base/macros.h"
+#include "../../base/native_library.h"
+#include "../base/cdm_config.h"
+#include "api/content_decryption_module.h"
+
+#include <atomic>
+#include <future>
 #include <inttypes.h>
 #include <memory>
 #include <mutex>
-#include <atomic>
-#include <future>
-
-#include "../../base/native_library.h"
-#include "../../base/compiler_specific.h"
-#include "../../base/macros.h"
-#include "api/content_decryption_module.h"
-#include "../base/cdm_config.h"
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace media {
 
@@ -221,11 +222,17 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>,
   void OnInitialized(bool success) override;
 
 
+  std::future<std::string> PrepareSessionFuture(uint32_t promiseId);
+
   //Misc
   ~CdmAdapter();
   bool LoadCDM();
   bool Initialize();
   std::string GetVersion() const;
+
+protected:
+  std::mutex m_sessionMx;
+  std::unordered_map<uint32_t, std::promise<std::string>> m_sessionPromises;
 
 private:
   void UnloadCDM();

--- a/lib/cdm/cdm/media/cdm/cdm_adapter.h
+++ b/lib/cdm/cdm/media/cdm/cdm_adapter.h
@@ -122,7 +122,8 @@ class CdmAdapter : public std::enable_shared_from_this<CdmAdapter>,
 	void TimerExpired(void* context);
 
 	cdm::Status Decrypt(const cdm::InputBuffer_2& encrypted_buffer,
-		cdm::DecryptedBlock* decrypted_buffer);
+                      cdm::DecryptedBlock* decrypted_buffer,
+                      cdm::StreamType streamType = cdm::StreamType::kStreamTypeVideo);
 
   cdm::Status InitializeAudioDecoder(
 		const cdm::AudioDecoderConfig_2& audio_decoder_config);

--- a/src/common/AdaptiveCencSampleDecrypter.cpp
+++ b/src/common/AdaptiveCencSampleDecrypter.cpp
@@ -17,9 +17,10 @@ CAdaptiveCencSampleDecrypter::CAdaptiveCencSampleDecrypter(
 }
 
 AP4_Result CAdaptiveCencSampleDecrypter::DecryptSampleData(AP4_UI32 poolid,
-                                       AP4_DataBuffer& data_in,
-                                       AP4_DataBuffer& data_out,
-                                       const AP4_UI08* iv)
+                                                           AP4_DataBuffer& data_in,
+                                                           AP4_DataBuffer& data_out,
+                                                           const AP4_UI08* iv,
+                                                           DRM::DRMMediaType streamType)
   {
     // increment the sample cursor
     unsigned int sample_cursor = m_SampleCursor++;
@@ -51,5 +52,6 @@ AP4_Result CAdaptiveCencSampleDecrypter::DecryptSampleData(AP4_UI32 poolid,
 
     // decrypt the sample
     return m_decrypter->DecryptSampleData(poolid, data_in, data_out, iv_block, subsample_count,
-                                          bytes_of_cleartext_data, bytes_of_encrypted_data);
+                                          bytes_of_cleartext_data, bytes_of_encrypted_data,
+                                          streamType);
   }

--- a/src/common/AdaptiveCencSampleDecrypter.h
+++ b/src/common/AdaptiveCencSampleDecrypter.h
@@ -7,6 +7,7 @@
  */
 
 #include "AdaptiveDecrypter.h"
+#include "decrypters/DrmEngineDefines.h"
 
 #include <memory>
 
@@ -22,7 +23,8 @@ public:
   virtual AP4_Result DecryptSampleData(AP4_UI32 poolid,
                                        AP4_DataBuffer& data_in,
                                        AP4_DataBuffer& data_out,
-                                       const AP4_UI08* iv);
+                                       const AP4_UI08* iv,
+                                       DRM::DRMMediaType streamType);
 
 protected:
   std::shared_ptr<Adaptive_CencSingleSampleDecrypter> m_decrypter;

--- a/src/common/AdaptiveDecrypter.h
+++ b/src/common/AdaptiveDecrypter.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "decrypters/DrmEngineDefines.h"
 #include "utils/CryptoUtils.h"
 
 #include <cstdint>
@@ -52,7 +53,8 @@ public:
                                        const AP4_UI08* iv,
                                        unsigned int subsampleCount,
                                        const AP4_UI16* bytesOfCleartextData,
-                                       const AP4_UI32* bytesOfEncryptedData) = 0;
+                                       const AP4_UI32* bytesOfEncryptedData,
+                                       DRM::DRMMediaType streamType) = 0;
 
   virtual AP4_UI32 AddPool() { return 0; }
   virtual void RemovePool(AP4_UI32 poolId) {}

--- a/src/decrypters/DrmEngine.cpp
+++ b/src/decrypters/DrmEngine.cpp
@@ -101,7 +101,7 @@ bool GetCapabilities(const std::optional<bool> isForceSecureDecoder,
                      DRMSession& session)
 {
   auto& caps = session.capabilities;
-  session.drm->GetCapabilities(session.decrypter, defaultKid, caps);
+  session.drm->GetCapabilities(session.decrypter, defaultKid, caps, session.mediaType);
 
   if (caps.flags & DRM::DecrypterCapabilites::SSD_INVALID)
   {

--- a/src/decrypters/IDecrypter.h
+++ b/src/decrypters/IDecrypter.h
@@ -112,7 +112,8 @@ public:
    */
   virtual void GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
                                const std::vector<uint8_t>& keyId,
-                               DecrypterCapabilites& caps) = 0;
+                               DecrypterCapabilites& caps,
+                               DRMMediaType mediaType) = 0;
 
   /*
    * \brief Check if the supplied KID has a license in the decrypter,

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -150,7 +150,8 @@ AP4_Result CClearKeyCencSingleSampleDecrypter::DecryptSampleData(
     const AP4_UI08* iv,
     unsigned int subsampleCount,
     const AP4_UI16* bytesOfCleartextData,
-    const AP4_UI32* bytesOfEncryptedData)
+    const AP4_UI32* bytesOfEncryptedData,
+    DRM::DRMMediaType streamType)
 {
   if (m_pool.empty())
   {

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.h
@@ -43,7 +43,8 @@ public:
                                        const AP4_UI08* iv,
                                        unsigned int subsampleCount,
                                        const AP4_UI16* bytesOfCleartextData,
-                                       const AP4_UI32* bytesOfEncryptedData) override;
+                                       const AP4_UI32* bytesOfEncryptedData,
+                                       DRM::DRMMediaType streamType) override;
   void SetDefaultKeyId(const std::vector<uint8_t>& keyId) override{};
   void AddKeyId(const std::vector<uint8_t>& keyId) override{};
   bool HasKeys() { return !m_kidPairs.empty(); }

--- a/src/decrypters/clearkey/ClearKeyDecrypter.h
+++ b/src/decrypters/clearkey/ClearKeyDecrypter.h
@@ -26,7 +26,8 @@ public:
 
   virtual void GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
                                const std::vector<uint8_t>& keyid,
-                               DRM::DecrypterCapabilites& caps) override
+                               DRM::DecrypterCapabilites& caps,
+                               DRMMediaType mediaType) override
   {
   }
   virtual std::optional<bool> HasLicenseKey(

--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -88,7 +88,9 @@ SResult CWVCdmAdapter::Initialize(const DRM::Config& config, CWVDecrypter* host)
     return SResultCode::ERROR;
   }
   std::string cdmPath;
+  bool useHwSecureCodecs = false;
 #ifdef TARGET_WEBOS
+  useHwSecureCodecs = true;
   auto it = std::ranges::find_if(candidatePaths, [](std::string_view sv)
                                  { return std::filesystem::exists(std::filesystem::path{sv}); });
 
@@ -118,10 +120,10 @@ SResult CWVCdmAdapter::Initialize(const DRM::Config& config, CWVDecrypter* host)
   basePath = FILESYS::PathCombine(basePath, DRM::GenerateUrlDomainHash(licUrl));
   basePath += FILESYS::SEPARATOR;
 
-  auto cdmAdapter =
-      std::make_shared<media::CdmAdapter>("com.widevine.alpha", cdmPath, basePath,
-                                          media::CdmConfig(false, m_config.isPersistentStorage),
-                                          dynamic_cast<media::CdmAdapterClient*>(this));
+  auto cdmAdapter = std::make_shared<media::CdmAdapter>(
+      "com.widevine.alpha", cdmPath, basePath,
+      media::CdmConfig(false, m_config.isPersistentStorage, useHwSecureCodecs),
+      dynamic_cast<media::CdmAdapterClient*>(this));
 
   if (!cdmAdapter->LoadCDM())
   {

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -31,6 +31,10 @@ using namespace UTILS;
 
 namespace
 {
+#ifdef TARGET_WEBOS
+constexpr size_t DECRYPTION_SVP_MARGIN = 64;
+#endif
+
 cdm::StreamType ToCdmStreamType(DRM::DRMMediaType stream_type)
 {
   switch (stream_type)
@@ -555,44 +559,97 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
       return AP4_ERROR_NOT_SUPPORTED;
     }
 
-    AP4_UI16 dummyClear(0);
-    AP4_UI32 dummyCipher(dataIn.GetDataSize());
+    AP4_DataBuffer payload;
+    std::vector<cdm::SubsampleEntry> rebuiltSubs;
+    bool convertAnnexB =
+        (fragInfo.m_decrypterFlags & DecrypterCapabilites::SSD_ANNEXB_REQUIRED) != 0;
+
+    // Convert only when safe to look at clear_bytes[0]
+    if (fragInfo.m_nalLengthSize && (!iv || (subsampleCount > 0 && bytesOfCleartextData[0] > 0)))
+    {
+      AP4_Result res = ConvertToAnnexBandInject(dataIn, payload, subsampleCount, fragInfo, iv,
+                                                bytesOfCleartextData, bytesOfEncryptedData,
+                                                convertAnnexB, rebuiltSubs);
+      if (res != AP4_SUCCESS)
+      {
+        LOG::LogF(LOGERROR, "ConvertToAnnexBandInject failed: %d", res);
+        return res;
+      }
+    }
+    else
+    {
+      payload.AppendData(dataIn.GetData(), dataIn.GetDataSize());
+      if (subsampleCount)
+      {
+        rebuiltSubs.reserve(subsampleCount);
+        for (unsigned i = 0; i < subsampleCount; ++i)
+        {
+          rebuiltSubs.push_back({bytesOfCleartextData[i], bytesOfEncryptedData[i]});
+        }
+      }
+    }
+
+    // If IV present but no subs were provided, treat as fully encrypted payload
+    if (iv && rebuiltSubs.empty())
+    {
+      rebuiltSubs.push_back({0u, static_cast<uint32_t>(payload.GetDataSize())});
+    }
+
+    dataOut.SetDataSize(0);
 
     if (iv)
     {
-      if (!subsampleCount)
-      {
-        subsampleCount = 1;
-        bytesOfCleartextData = &dummyClear;
-        bytesOfEncryptedData = &dummyCipher;
+      const AP4_UI32 subsOut = static_cast<AP4_UI32>(rebuiltSubs.size());
+
+      std::vector<AP4_UI16> rebuiltBytesOfCleartextData(subsOut);
+      std::vector<AP4_UI32> rebuiltBytesOfEncryptedData(subsOut);
+      for (AP4_UI32 i = 0; i < subsOut; ++i) {
+        rebuiltBytesOfCleartextData[i] = rebuiltSubs[i].clear_bytes;
+        rebuiltBytesOfEncryptedData[i] = rebuiltSubs[i].cipher_bytes;
       }
 
-      dataOut.SetData(reinterpret_cast<const AP4_Byte*>(&subsampleCount), sizeof(subsampleCount));
-      dataOut.AppendData(reinterpret_cast<const AP4_Byte*>(bytesOfCleartextData),
-                         subsampleCount * sizeof(AP4_UI16));
-      dataOut.AppendData(reinterpret_cast<const AP4_Byte*>(bytesOfEncryptedData),
-                         subsampleCount * sizeof(AP4_UI32));
+      // CENC-like prefix: [count:32][clear[]:16*N][cipher[]:32*N][IV:16][key]
+      dataOut.SetData(reinterpret_cast<const AP4_Byte*>(&subsOut), sizeof(AP4_UI32));
+      dataOut.AppendData(reinterpret_cast<const AP4_Byte*>(rebuiltBytesOfCleartextData.data()),
+                         subsOut * sizeof(AP4_UI16));
+      dataOut.AppendData(reinterpret_cast<const AP4_Byte*>(rebuiltBytesOfEncryptedData.data()),
+                         subsOut * sizeof(AP4_UI32));
       dataOut.AppendData(reinterpret_cast<const AP4_Byte*>(iv), 16);
       dataOut.AppendData(fragInfo.m_key.data(), static_cast<AP4_Size>(fragInfo.m_key.size()));
     }
     else
     {
       dataOut.SetDataSize(0);
-      bytesOfCleartextData = &dummyClear;
-      bytesOfEncryptedData = &dummyCipher;
     }
 
-    if (fragInfo.m_nalLengthSize && (!iv || bytesOfCleartextData[0] > 0))
+#ifdef TARGET_WEBOS
+    // Prepare CDM input using rebuiltSubs
+    cdm::InputBuffer_2 cdmIn;
+    SetInput(cdmIn, payload, static_cast<uint32_t>(rebuiltSubs.size()), iv, fragInfo, rebuiltSubs);
+
+    m_decryptOut.Reserve(payload.GetDataSize() + dataOut.GetDataSize() + DECRYPTION_SVP_MARGIN);
+    m_decryptOut.SetDataSize(0);
+
+    CdmBuffer buf = &m_decryptOut;
+    CdmDecryptedBlock cdmOut;
+    cdmOut.SetDecryptedBuffer(&buf);
+
+    CheckLicenseRenewal();
+
+    cdm::Status ret = m_cdmAdapter->GetCDM()->Decrypt(cdmIn, &cdmOut, ToCdmStreamType(streamType));
+    if (ret != cdm::kSuccess)
     {
-      if (!ConvertToAnnexBandInject(dataIn, dataOut, subsampleCount, fragInfo, iv,
-                                    bytesOfCleartextData, bytesOfEncryptedData))
-      {
-        LOG::LogF(LOGERROR, "ConvertToAnnexB failed");
-        return AP4_ERROR_NOT_SUPPORTED;
-      }
+      LOG::LogF(LOGERROR, "[DecryptSampleData] CDM->Decrypt failed, status=%d",
+                static_cast<int>(ret));
+      return AP4_ERROR_INVALID_FORMAT;
     }
-    else
-      dataOut.AppendData(dataIn.GetData(), dataIn.GetDataSize());
+
+    // Prefix (if any) + SVP-wrapped payload
+    dataOut.AppendData(m_decryptOut.GetData(), m_decryptOut.GetDataSize());
+#else
+    // Prefix (if IV) + raw payload
+    dataOut.AppendData(payload.GetData(), payload.GetDataSize());
+#endif
 
     return AP4_SUCCESS;
   }
@@ -725,7 +782,9 @@ AP4_Result CWVCencSingleSampleDecrypter::ConvertToAnnexBandInject(
     CWVCencSingleSampleDecrypter::FINFO& fragInfo,
     const AP4_UI08* iv,
     const AP4_UI16* bytesOfCleartextData,
-    const AP4_UI32* bytesOfEncryptedData)
+    const AP4_UI32* bytesOfEncryptedData,
+    bool convertAnnexB,
+    std::vector<cdm::SubsampleEntry>& rebuiltSubs)
 {
   //check NAL / subsample
   const AP4_Byte *packetIn(dataIn.GetData()), *packetInEnd(dataIn.GetData() + dataIn.GetDataSize());
@@ -734,86 +793,115 @@ AP4_Result CWVCencSingleSampleDecrypter::ConvertToAnnexBandInject(
   size_t clrDataBytePos = sizeof(subsampleCount);
   // size_t nalUnitCount = 0; // is there a use for this?
   size_t nalUnitSum = 0;
-  // size_t configSize = 0; // is there a use for this?
+
+  // Prepare subs from originals
+  rebuiltSubs.clear();
+  if (iv && subsampleCount)
+  {
+    rebuiltSubs.reserve(subsampleCount);
+    for (unsigned i = 0; i < subsampleCount; ++i)
+    {
+      cdm::SubsampleEntry e;
+      e.clear_bytes = bytesOfCleartextData[i];
+      e.cipher_bytes = bytesOfEncryptedData[i];
+      rebuiltSubs.push_back(e);
+    }
+  }
+
+  size_t curSub = 0;
+  bool injectedStartupNALs = false;
 
   while (packetIn < packetInEnd)
   {
-    uint32_t nalSize(0);
+    // Read length-prefixed NAL size
+    uint32_t nalSize = 0;
     for (size_t i = 0; i < fragInfo.m_nalLengthSize; ++i)
     {
       nalSize = (nalSize << 8) + *packetIn++;
-    };
+    }
 
-    //look if we have to inject sps / pps
-    if (!fragInfo.m_annexbSpsPps.empty() && (*packetIn & 0x1F) != 9 /*AVC_NAL_AUD*/)
+    // Inject SPS/PPS once before first non-AUD
+    if (!injectedStartupNALs && !fragInfo.m_annexbSpsPps.empty() &&
+        ((*packetIn & 0x1F) != 9 /*AVC_NAL_AUD*/))
     {
       dataOut.AppendData(fragInfo.m_annexbSpsPps.data(),
                          static_cast<AP4_Size>(fragInfo.m_annexbSpsPps.size()));
-      if (iv)
-      {
-        // Update the byte containing the data size of current subsample referred to clear bytes array
-        AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrDataBytePos);
-        *clrb_out += fragInfo.m_annexbSpsPps.size();
+
+      if (iv && curSub < rebuiltSubs.size()) {
+        // attribute injected bytes to clear region of current subsample
+        rebuiltSubs[curSub].clear_bytes += static_cast<uint32_t>(fragInfo.m_annexbSpsPps.size());
       }
 
-      // configSize = fragInfo.m_annexbSpsPps.GetDataSize();
       fragInfo.m_annexbSpsPps.clear();
+      injectedStartupNALs = true;
     }
-    // Annex-B Start pos
-    static AP4_Byte annexbStartCode[4] = {0x00, 0x00, 0x00, 0x01};
-    dataOut.AppendData(annexbStartCode, 4);
+
+    // Write Annex-B start code and payload
+    static const AP4_Byte annexbStartCode[4] = {0x00, 0x00, 0x00, 0x01};
+    if (convertAnnexB && !(nalSize >= 4 && packetIn[0] == 0x00 && packetIn[1] == 0x00 &&
+                           packetIn[2] == 0x00 && packetIn[3] == 0x01))
+    {
+      dataOut.AppendData(annexbStartCode, 4);
+    }
+
     dataOut.AppendData(packetIn, nalSize);
     packetIn += nalSize;
 
     if (iv)
     {
-      // Update the byte containing the data size of current subsample referred to clear bytes array
-      AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrDataBytePos);
-      *clrb_out += (4 - fragInfo.m_nalLengthSize);
+      // Start-code delta: 4 - nalLengthSize (0,2,3) goes to clear_bytes of current subsample
+      if (curSub < rebuiltSubs.size())
+      {
+        rebuiltSubs[curSub].clear_bytes += static_cast<uint32_t>(4 - fragInfo.m_nalLengthSize);
+      }
     }
 
-    // ++nalUnitCount;
-
-    if (!iv)
-    {
+    if (!iv) {
       nalUnitSum = 0;
     }
     else if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum >=
              *bytesOfCleartextData + *bytesOfEncryptedData)
     {
-      AP4_UI32 summedBytes(0);
+      // We may cross one or more subsample boundaries; advance pointers and curSub in lockstep
+      AP4_UI32 summedBytes = 0;
+      size_t advanced = 0;
+
       do
       {
         summedBytes += *bytesOfCleartextData + *bytesOfEncryptedData;
         ++bytesOfCleartextData;
         ++bytesOfEncryptedData;
-        clrDataBytePos += sizeof(AP4_UI16); // Move to the next clear data subsample byte position
+        ++advanced;
         --subsampleCount;
       } while (subsampleCount && nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes);
 
-      if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes)
-      {
+      if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes) {
         LOG::LogF(LOGERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
-                  static_cast<unsigned int>(fragInfo.m_nalLengthSize),
-                  static_cast<unsigned int>(nalSize + fragInfo.m_nalLengthSize + nalUnitSum),
+                  static_cast<unsigned>(fragInfo.m_nalLengthSize),
+                  static_cast<unsigned>(nalSize + fragInfo.m_nalLengthSize + nalUnitSum),
                   summedBytes);
         return AP4_ERROR_NOT_SUPPORTED;
       }
+
+      curSub += advanced;
       nalUnitSum = 0;
     }
     else
+    {
       nalUnitSum += nalSize + fragInfo.m_nalLengthSize;
+    }
   }
-  if (packetIn != packetInEnd || subsampleCount)
-  {
-    LOG::Log(LOGERROR, "NAL Unit definition incomplete (nls: %u) %u -> %u ",
-             static_cast<unsigned int>(fragInfo.m_nalLengthSize),
-             static_cast<unsigned int>(packetInEnd - packetIn), subsampleCount);
 
+  if (packetIn != packetInEnd || subsampleCount) {
+    LOG::Log(LOGERROR, "NAL Unit definition incomplete (nls: %u) %u -> %u ",
+             static_cast<unsigned>(fragInfo.m_nalLengthSize),
+             static_cast<unsigned>(packetInEnd - packetIn), subsampleCount);
     return AP4_ERROR_NOT_SUPPORTED;
   }
+
   return AP4_SUCCESS;
 }
+
 
 bool CWVCencSingleSampleDecrypter::OpenVideoDecoder(const VIDEOCODEC_INITDATA* initData)
 {

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -87,14 +87,25 @@ CWVCencSingleSampleDecrypter::CWVCencSingleSampleDecrypter(
     UTILS::FILESYS::SaveFile(debugFilePath, {m_pssh.cbegin(), m_pssh.cend()}, true);
   }
 
-  m_cdmAdapter->GetCDM()->CreateSessionAndGenerateRequest(
-      m_promiseId++, cdm::SessionType::kTemporary, cdm::InitDataType::kCenc, m_pssh.data(),
-      static_cast<uint32_t>(m_pssh.size()));
+  const uint32_t pid = m_promiseId++;
 
-  //! @todo: loop with thread sleep should be removed, use callbacks
-  int retrycount = 0;
-  while (m_strSession.empty() && ++retrycount < 100)
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  // prepare the promise before calling into CDM
+  std::future<std::string> sessionFut = m_cdmAdapter->GetCDM()->PrepareSessionFuture(pid);
+
+  m_cdmAdapter->GetCDM()->CreateSessionAndGenerateRequest(pid, cdm::SessionType::kTemporary,
+                                                          cdm::InitDataType::kCenc, m_pssh.data(),
+                                                          static_cast<uint32_t>(m_pssh.size()));
+
+  // block until CDM resolves or rejects the promise
+  try
+  {
+    m_strSession = sessionFut.get(); // throws if CDM rejected
+  }
+  catch (const std::exception& e)
+  {
+    LOG::LogF(LOGERROR, "Session creation failed: %s", e.what());
+    return;
+  }
 
   if (m_strSession.empty())
   {

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -563,94 +563,16 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
 
     if (fragInfo.m_nalLengthSize && (!iv || bytesOfCleartextData[0] > 0))
     {
-      //check NAL / subsample
-      const AP4_Byte *packetIn(dataIn.GetData()),
-          *packetInEnd(dataIn.GetData() + dataIn.GetDataSize());
-      // Byte position of "bytesOfCleartextData" where to set the size of the data,
-      // by default starts after the subsample count data (so the size of subsampleCount data type)
-      size_t clrDataBytePos = sizeof(subsampleCount);
-      // size_t nalUnitCount = 0; // is there a use for this?
-      size_t nalUnitSum = 0;
-      // size_t configSize = 0; // is there a use for this?
-
-      while (packetIn < packetInEnd)
+      if (!ConvertToAnnexBandInject(dataIn, dataOut, subsampleCount, fragInfo, iv,
+                                    bytesOfCleartextData, bytesOfEncryptedData))
       {
-        uint32_t nalSize(0);
-        for (size_t i = 0; i < fragInfo.m_nalLengthSize; ++i)
-        {
-          nalSize = (nalSize << 8) + *packetIn++;
-        };
-
-        //look if we have to inject sps / pps
-        if (!fragInfo.m_annexbSpsPps.empty() && (*packetIn & 0x1F) != 9 /*AVC_NAL_AUD*/)
-        {
-          dataOut.AppendData(fragInfo.m_annexbSpsPps.data(),
-                             static_cast<AP4_Size>(fragInfo.m_annexbSpsPps.size()));
-          if (iv)
-          {
-            // Update the byte containing the data size of current subsample referred to clear bytes array
-            AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrDataBytePos);
-            *clrb_out += fragInfo.m_annexbSpsPps.size();
-          }
-
-          // configSize = fragInfo.m_annexbSpsPps.GetDataSize();
-          fragInfo.m_annexbSpsPps.clear();
-        }
-        // Annex-B Start pos
-        static AP4_Byte annexbStartCode[4] = {0x00, 0x00, 0x00, 0x01};
-        dataOut.AppendData(annexbStartCode, 4);
-        dataOut.AppendData(packetIn, nalSize);
-        packetIn += nalSize;
-        
-        if (iv)
-        {
-          // Update the byte containing the data size of current subsample referred to clear bytes array
-          AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrDataBytePos);
-          *clrb_out += (4 - fragInfo.m_nalLengthSize);
-        }
-        
-        // ++nalUnitCount;
-
-        if (!iv)
-        {
-          nalUnitSum = 0;
-        }
-        else if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum >=
-                 *bytesOfCleartextData + *bytesOfEncryptedData)
-        {
-          AP4_UI32 summedBytes(0);
-          do
-          {
-            summedBytes += *bytesOfCleartextData + *bytesOfEncryptedData;
-            ++bytesOfCleartextData;
-            ++bytesOfEncryptedData;
-            clrDataBytePos += sizeof(AP4_UI16); // Move to the next clear data subsample byte position
-            --subsampleCount;
-          } while (subsampleCount && nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes);
-
-          if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes)
-          {
-            LOG::LogF(LOGERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
-                      static_cast<unsigned int>(fragInfo.m_nalLengthSize),
-                      static_cast<unsigned int>(nalSize + fragInfo.m_nalLengthSize + nalUnitSum),
-                      summedBytes);
-            return AP4_ERROR_NOT_SUPPORTED;
-          }
-          nalUnitSum = 0;
-        }
-        else
-          nalUnitSum += nalSize + fragInfo.m_nalLengthSize;
-      }
-      if (packetIn != packetInEnd || subsampleCount)
-      {
-        LOG::Log(LOGERROR, "NAL Unit definition incomplete (nls: %u) %u -> %u ",
-                 static_cast<unsigned int>(fragInfo.m_nalLengthSize),
-                 static_cast<unsigned int>(packetInEnd - packetIn), subsampleCount);
+        LOG::LogF(LOGERROR, "ConvertToAnnexB failed");
         return AP4_ERROR_NOT_SUPPORTED;
       }
     }
     else
       dataOut.AppendData(dataIn.GetData(), dataIn.GetDataSize());
+
     return AP4_SUCCESS;
   }
 
@@ -773,6 +695,103 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
     }
   }
   return (ret == cdm::Status::kSuccess) ? AP4_SUCCESS : AP4_ERROR_INVALID_PARAMETERS;
+}
+
+AP4_Result CWVCencSingleSampleDecrypter::ConvertToAnnexBandInject(
+    AP4_DataBuffer& dataIn,
+    AP4_DataBuffer& dataOut,
+    unsigned int subsampleCount,
+    CWVCencSingleSampleDecrypter::FINFO& fragInfo,
+    const AP4_UI08* iv,
+    const AP4_UI16* bytesOfCleartextData,
+    const AP4_UI32* bytesOfEncryptedData)
+{
+  //check NAL / subsample
+  const AP4_Byte *packetIn(dataIn.GetData()), *packetInEnd(dataIn.GetData() + dataIn.GetDataSize());
+  // Byte position of "bytesOfCleartextData" where to set the size of the data,
+  // by default starts after the subsample count data (so the size of subsampleCount data type)
+  size_t clrDataBytePos = sizeof(subsampleCount);
+  // size_t nalUnitCount = 0; // is there a use for this?
+  size_t nalUnitSum = 0;
+  // size_t configSize = 0; // is there a use for this?
+
+  while (packetIn < packetInEnd)
+  {
+    uint32_t nalSize(0);
+    for (size_t i = 0; i < fragInfo.m_nalLengthSize; ++i)
+    {
+      nalSize = (nalSize << 8) + *packetIn++;
+    };
+
+    //look if we have to inject sps / pps
+    if (!fragInfo.m_annexbSpsPps.empty() && (*packetIn & 0x1F) != 9 /*AVC_NAL_AUD*/)
+    {
+      dataOut.AppendData(fragInfo.m_annexbSpsPps.data(),
+                         static_cast<AP4_Size>(fragInfo.m_annexbSpsPps.size()));
+      if (iv)
+      {
+        // Update the byte containing the data size of current subsample referred to clear bytes array
+        AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrDataBytePos);
+        *clrb_out += fragInfo.m_annexbSpsPps.size();
+      }
+
+      // configSize = fragInfo.m_annexbSpsPps.GetDataSize();
+      fragInfo.m_annexbSpsPps.clear();
+    }
+    // Annex-B Start pos
+    static AP4_Byte annexbStartCode[4] = {0x00, 0x00, 0x00, 0x01};
+    dataOut.AppendData(annexbStartCode, 4);
+    dataOut.AppendData(packetIn, nalSize);
+    packetIn += nalSize;
+
+    if (iv)
+    {
+      // Update the byte containing the data size of current subsample referred to clear bytes array
+      AP4_UI16* clrb_out = reinterpret_cast<AP4_UI16*>(dataOut.UseData() + clrDataBytePos);
+      *clrb_out += (4 - fragInfo.m_nalLengthSize);
+    }
+
+    // ++nalUnitCount;
+
+    if (!iv)
+    {
+      nalUnitSum = 0;
+    }
+    else if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum >=
+             *bytesOfCleartextData + *bytesOfEncryptedData)
+    {
+      AP4_UI32 summedBytes(0);
+      do
+      {
+        summedBytes += *bytesOfCleartextData + *bytesOfEncryptedData;
+        ++bytesOfCleartextData;
+        ++bytesOfEncryptedData;
+        clrDataBytePos += sizeof(AP4_UI16); // Move to the next clear data subsample byte position
+        --subsampleCount;
+      } while (subsampleCount && nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes);
+
+      if (nalSize + fragInfo.m_nalLengthSize + nalUnitSum > summedBytes)
+      {
+        LOG::LogF(LOGERROR, "NAL Unit exceeds subsample definition (nls: %u) %u -> %u ",
+                  static_cast<unsigned int>(fragInfo.m_nalLengthSize),
+                  static_cast<unsigned int>(nalSize + fragInfo.m_nalLengthSize + nalUnitSum),
+                  summedBytes);
+        return AP4_ERROR_NOT_SUPPORTED;
+      }
+      nalUnitSum = 0;
+    }
+    else
+      nalUnitSum += nalSize + fragInfo.m_nalLengthSize;
+  }
+  if (packetIn != packetInEnd || subsampleCount)
+  {
+    LOG::Log(LOGERROR, "NAL Unit definition incomplete (nls: %u) %u -> %u ",
+             static_cast<unsigned int>(fragInfo.m_nalLengthSize),
+             static_cast<unsigned int>(packetInEnd - packetIn), subsampleCount);
+
+    return AP4_ERROR_NOT_SUPPORTED;
+  }
+  return AP4_SUCCESS;
 }
 
 bool CWVCencSingleSampleDecrypter::OpenVideoDecoder(const VIDEOCODEC_INITDATA* initData)

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -155,7 +155,17 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
 
   if (!caps.hdcpLimit)
     caps.hdcpLimit = m_resolutionLimit;
-  
+
+#ifdef TARGET_WEBOS
+  LOG::LogF(LOGDEBUG,
+            "Overriding settings to: SSD_SECURE PATH | SSD_ANNEXB_REQUIRED | SSD_SECURE_DECODER");
+  caps = {DRM::DecrypterCapabilites::SSD_SECURE_PATH |
+              DRM::DecrypterCapabilites::SSD_ANNEXB_REQUIRED,
+          DRM::DecrypterCapabilites::SSD_SECURE_DECODER};
+  caps.hdcpVersion = DRM::HDCP_V_MAX;
+  return;
+#endif
+
   if ((caps.flags & DecrypterCapabilites::SSD_SUPPORTS_DECODING) != 0)
   {
     AP4_UI32 poolId(AddPool());

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -29,6 +29,22 @@
 
 using namespace UTILS;
 
+namespace
+{
+cdm::StreamType ToCdmStreamType(DRM::DRMMediaType stream_type)
+{
+  switch (stream_type)
+  {
+    case DRM::DRMMediaType::AUDIO:
+      return cdm::StreamType::kStreamTypeAudio;
+    case DRM::DRMMediaType::VIDEO:
+      return cdm::StreamType::kStreamTypeVideo;
+  }
+
+  return cdm::StreamType::kStreamTypeVideo;
+}
+} // unnamed namespace
+
 void CWVCencSingleSampleDecrypter::SetSession(const std::string sessionId,
                                               const uint8_t* data,
                                               const size_t dataSize)
@@ -105,7 +121,8 @@ CWVCencSingleSampleDecrypter::~CWVCencSingleSampleDecrypter()
 }
 
 void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& keyId,
-                                                   DecrypterCapabilites& caps)
+                                                   DecrypterCapabilites& caps,
+                                                   DRMMediaType mediaType)
 {
   caps = {0, m_hdcpVersion, m_hdcpLimit};
 
@@ -127,7 +144,7 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
 
   if (!caps.hdcpLimit)
     caps.hdcpLimit = m_resolutionLimit;
-
+  
   if ((caps.flags & DecrypterCapabilites::SSD_SUPPORTS_DECODING) != 0)
   {
     AP4_UI32 poolId(AddPool());
@@ -142,11 +159,13 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
     const AP4_UI08 iv[] = {1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0};
     in.SetBuffer(testData, 12);
     in.SetDataSize(12);
+
     try
     {
       encryptedBytes[0] = 12;
       clearBytes[0] = 0;
-      if (DecryptSampleData(poolId, in, out, iv, 1, clearBytes, encryptedBytes) != AP4_SUCCESS)
+      if (DecryptSampleData(poolId, in, out, iv, 1, clearBytes, encryptedBytes, mediaType) !=
+          AP4_SUCCESS)
       {
         LOG::LogF(LOGDEBUG, "Single decrypt failed, secure path only");
         caps.flags |=
@@ -495,7 +514,8 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
                                                            const AP4_UI08* iv,
                                                            unsigned int subsampleCount,
                                                            const AP4_UI16* bytesOfCleartextData,
-                                                           const AP4_UI32* bytesOfEncryptedData)
+                                                           const AP4_UI32* bytesOfEncryptedData,
+                                                           DRM::DRMMediaType streamType)
 {
   if (!m_cdmAdapter->GetCDM())
   {
@@ -727,7 +747,7 @@ AP4_Result CWVCencSingleSampleDecrypter::DecryptSampleData(AP4_UI32 poolId,
     cdmOut.SetDecryptedBuffer(&buf);
 
     CheckLicenseRenewal();
-    ret = m_cdmAdapter->GetCDM()->Decrypt(cdmIn, &cdmOut);
+    ret = m_cdmAdapter->GetCDM()->Decrypt(cdmIn, &cdmOut, ToCdmStreamType(streamType));
 
     if (ret == cdm::Status::kSuccess)
     {

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -147,7 +147,9 @@ private:
                                       FINFO& fragInfo,
                                       const AP4_UI08* iv,
                                       const AP4_UI16* bytesOfCleartextData,
-                                      const AP4_UI32* bytesOfEncryptedData);
+                                      const AP4_UI32* bytesOfEncryptedData,
+                                      bool convertAnnexB,
+                                      std::vector<cdm::SubsampleEntry>& rebuiltSubs);
 
   uint32_t m_promiseId;
   bool m_isDrained;

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -36,7 +36,9 @@ public:
                                CryptoMode cryptoMode);
   virtual ~CWVCencSingleSampleDecrypter();
 
-  void GetCapabilities(const std::vector<uint8_t>& keyId, DecrypterCapabilites& caps);
+  void GetCapabilities(const std::vector<uint8_t>& keyId,
+                       DecrypterCapabilites& caps,
+                       DRMMediaType mediaType);
   virtual std::string GetSessionId() override;
   void CloseSessionId();
   AP4_DataBuffer GetChallengeData();
@@ -70,7 +72,9 @@ public:
       const AP4_UI16* bytesOfCleartextData,
 
       // array of <subsample_count> integers. NULL if subsample_count is 0
-      const AP4_UI32* bytesOfEncryptedData) override;
+      const AP4_UI32* bytesOfEncryptedData,
+
+      DRM::DRMMediaType streamType) override;
 
   bool OpenVideoDecoder(const VIDEOCODEC_INITDATA* initData);
   VIDEOCODEC_RETVAL DecryptAndDecodeVideo(kodi::addon::CInstanceVideoCodec* codecInstance,

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -141,6 +141,14 @@ private:
                 const uint8_t* iv,
                 const FINFO& fragInfo,
                 const std::vector<cdm::SubsampleEntry>& subsamples);
+  AP4_Result ConvertToAnnexBandInject(AP4_DataBuffer& dataIn,
+                                      AP4_DataBuffer& dataOut,
+                                      unsigned int subsampleCount,
+                                      FINFO& fragInfo,
+                                      const AP4_UI08* iv,
+                                      const AP4_UI16* bytesOfCleartextData,
+                                      const AP4_UI32* bytesOfEncryptedData);
+
   uint32_t m_promiseId;
   bool m_isDrained;
 

--- a/src/decrypters/widevine/WVDecrypter.cpp
+++ b/src/decrypters/widevine/WVDecrypter.cpp
@@ -103,7 +103,8 @@ std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CWVDecrypter::CreateSingleSa
 
 void CWVDecrypter::GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
                                    const std::vector<uint8_t>& keyId,
-                                   DRM::DecrypterCapabilites& caps)
+                                   DRM::DecrypterCapabilites& caps,
+                                   DRMMediaType mediaType)
 {
   if (!decrypter)
   {
@@ -114,7 +115,7 @@ void CWVDecrypter::GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecr
   auto wvDecrypter = std::dynamic_pointer_cast<CWVCencSingleSampleDecrypter>(decrypter);
   if (wvDecrypter)
   {
-    wvDecrypter->GetCapabilities(keyId, caps);
+    wvDecrypter->GetCapabilities(keyId, caps, mediaType);
   }
   else
     LOG::LogF(LOGFATAL, "Cannot cast the decrypter shared pointer.");

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -50,8 +50,12 @@ public:
   virtual void ReleaseBuffer(void* instance, void* buffer);
   virtual std::string_view GetLibraryPath() const override { return m_libraryPath; }
 
+#ifdef TARGET_WEBOS
+  virtual bool IsSecureDecoderAudioSupported() override { return true; }
+#else
   //! @todo: Secure path for audio is not implemented
   virtual bool IsSecureDecoderAudioSupported() override { return false; }
+#endif
 
 private:
   std::shared_ptr<CWVCdmAdapter> m_WVCdmAdapter;

--- a/src/decrypters/widevine/WVDecrypter.h
+++ b/src/decrypters/widevine/WVDecrypter.h
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "decrypters/DrmEngineDefines.h"
 #include "decrypters/IDecrypter.h"
 
 class CWVCdmAdapter;
@@ -29,7 +30,8 @@ public:
 
   virtual void GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
                                const std::vector<uint8_t>& keyId,
-                               DRM::DecrypterCapabilites& caps) override;
+                               DRM::DecrypterCapabilites& caps,
+                               DRM::DRMMediaType mediaType) override;
   virtual std::optional<bool> HasLicenseKey(
       std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
       const std::vector<uint8_t>& keyId) override;

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -511,7 +511,8 @@ AP4_Result CWVCencSingleSampleDecrypterA::DecryptSampleData(AP4_UI32 poolId,
                                                            const AP4_UI08* iv,
                                                            unsigned int subsampleCount,
                                                            const AP4_UI16* bytesOfCleartextData,
-                                                           const AP4_UI32* bytesOfEncryptedData)
+                                                           const AP4_UI32* bytesOfEncryptedData,
+                                                           DRM::DRMMediaType streamType)
 {
   if (!m_cdmAdapter->GetCDM())
     return AP4_ERROR_INVALID_STATE;

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.h
@@ -58,7 +58,8 @@ public:
       const AP4_UI16* bytesOfCleartextData,
 
       // array of <subsample_count> integers. NULL if subsample_count is 0
-      const AP4_UI32* bytesOfEncryptedData) override;
+      const AP4_UI32* bytesOfEncryptedData,
+      DRM::DRMMediaType streamType) override;
 
   void GetCapabilities(const std::vector<uint8_t>& keyId, DRM::DecrypterCapabilites& caps);
 

--- a/src/decrypters/widevineandroid/WVDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVDecrypter.cpp
@@ -88,7 +88,8 @@ std::shared_ptr<Adaptive_CencSingleSampleDecrypter> CWVDecrypterA::CreateSingleS
 
 void CWVDecrypterA::GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
                                     const std::vector<uint8_t>& keyId,
-                                    DRM::DecrypterCapabilites& caps)
+                                    DRM::DecrypterCapabilites& caps,
+                                    DRM::DRMMediaType mediaType)
 {
   if (!decrypter)
   {

--- a/src/decrypters/widevineandroid/WVDecrypter.h
+++ b/src/decrypters/widevineandroid/WVDecrypter.h
@@ -55,7 +55,8 @@ public:
 
   virtual void GetCapabilities(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter,
                                const std::vector<uint8_t>& keyId,
-                               DRM::DecrypterCapabilites& caps) override;
+                               DRM::DecrypterCapabilites& caps,
+                               DRM::DRMMediaType mediaType) override;
 
   virtual std::string GetChallengeB64Data(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> decrypter) override;
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -128,6 +128,10 @@ AP4_Result CFragmentedSampleReader::ReadSample()
   if (!m_codecHandler)
     return AP4_FAILURE;
 
+  DRM::DRMMediaType streamType = DRM::DRMMediaType::VIDEO;
+  if (m_track->GetType() == AP4_Track::Type::TYPE_AUDIO)
+    streamType = DRM::DRMMediaType::AUDIO;
+
   AP4_Result result;
   if (!m_codecHandler->ReadNextSample(m_sample, m_sampleData))
   {
@@ -175,7 +179,8 @@ AP4_Result CFragmentedSampleReader::ReadSample()
     {
       m_sampleData.Reserve(m_encrypted.GetDataSize());
       if (AP4_FAILED(result =
-                         m_decrypter->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, NULL)))
+                         m_decrypter->DecryptSampleData(m_poolId, m_encrypted, m_sampleData,
+                                                        NULL, streamType)))
       {
         LOG::Log(LOGERROR, "Decrypt Sample returns failure!");
         if (++m_failCount > 50)
@@ -197,7 +202,7 @@ AP4_Result CFragmentedSampleReader::ReadSample()
     {
       m_sampleData.Reserve(m_encrypted.GetDataSize());
       m_singleSampleDecryptor->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, nullptr, 0,
-                                                 nullptr, nullptr);
+                                                 nullptr, nullptr, streamType);
     }
 
     if (m_codecHandler->Transform(m_sample.GetDts(), m_sample.GetDuration(), m_sampleData,


### PR DESCRIPTION
## Description
webOS supports L1 decoding - so we add this support for 4K

## Motivation and context
**Implements 4K UHD and DV support for Disney+, Prime.** 

The way this works is that the secure packet is routed through the CDM. This does not decrypt the packet, it is still encrypted, instead it is wrapped in SVP headers and then sent encrypted into the media pipeline.

It defaults to L1 for webOS from now on.

Other changes in this PR:

- Fixes Annex B conversion, before it was over writing bytes causing a blank screen
- Makes use of unimplemented call backs for cdm initialization and session creation in case of race condition
- Adds Dolby Vision meta data parsing and pass through to Kodi using Inputstream interface (moved to a separate PR: https://github.com/xbmc/inputstream.adaptive/pull/1920 due to breaking change in the interface)

## How has this been tested?
Tested on webOS 24 by myself using Disney+ and Prime addons.
Tested by @Uukrull also
Also tested on ITV X (which is 1080p max and no DV).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
