### PR TITLE
[SubtitleSampleReader] Fix packet pts

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -966,7 +966,7 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
 
       streamReader->SetPTSDiff(ptsDiff);
       
-      double seekSecs{static_cast<double>(seekTimeCorrected - streamReader->GetPTSDiff()) /
+      double seekSecs{static_cast<double>(seekTimeCorrected - ptsDiff) /
                       STREAM_TIME_BASE};
       if (stream->m_adStream.seek_time(seekSecs, preceeding, reset))
       {

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -204,6 +204,7 @@ void CSubtitleSampleReader::Reset(bool bEOS)
     m_sampleData.SetDataSize(0);
     m_eos = bEOS;
     m_codecHandler->Reset();
+    m_pts = 0;
   }
 }
 
@@ -223,7 +224,6 @@ bool CSubtitleSampleReader::TimeSeek(uint64_t pts, bool preceeding)
 {
   if (dynamic_cast<WebVTTCodecHandler*>(m_codecHandler.get()))
   {
-    m_pts = pts;
     return true;
   }
   else
@@ -232,12 +232,4 @@ bool CSubtitleSampleReader::TimeSeek(uint64_t pts, bool preceeding)
       return AP4_SUCCEEDED(ReadSample());
     return false;
   }
-}
-
-void CSubtitleSampleReader::SetPTSDiff(uint64_t pts)
-{
-  // Its needed set the PTS diff from the timing stream
-  // to allow sync segmented subtitles for cases like
-  // HLS with multiple periods
-  m_ptsDiff = pts;
 }

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -187,10 +187,6 @@ AP4_Result CSubtitleSampleReader::ReadSample()
       // Wait for manifest live update to get next segment
       return AP4_SUCCESS;
     }
-    else
-    {
-      LOG::LogF(LOGERROR, "Failed to get segment data from subtitle stream");
-    }
   }
 
   m_eos = true;

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -41,8 +41,7 @@ public:
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
   bool TimeSeek(uint64_t pts, bool preceeding) override;
   void SetPTSOffset(uint64_t offset) override { }
-  int64_t GetPTSDiff() const override { return m_ptsDiff; }
-  void SetPTSDiff(uint64_t pts) override;
+  int64_t GetPTSDiff() const override { return 0; }
   uint32_t GetTimeScale() const override { return 1000; }
   AP4_Size GetSampleDataSize() const override { return m_sampleData.GetDataSize(); }
   const AP4_Byte* GetSampleData() const override { return m_sampleData.GetData(); }
@@ -53,7 +52,6 @@ private:
   bool InitializeFile(std::string url);
 
   uint64_t m_pts{0};
-  int64_t m_ptsDiff{0};
   bool m_eos{false};
   bool m_started{false};
   std::unique_ptr<CodecHandler> m_codecHandler;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
i suspect a regression of PR #1890 
that solved the problem of wrong pts comparisons on `CSession::GetNextSample`
looks like that the use of PTSDiff is not needed anymore since
`CSession::GetNextSample` now use "manifest based" pts

i hope this dont cause sideeffects on other subs use cases, touch this code cause always headaches due to difficult in testing all cases

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@cscd98 reported privately that D+ has again subtitle problems
NOTE: D+ have use case of segmented webvtt, on multiple periods

i realized that the problem can be reproduced this way:
play video->enable subs from GUI->seek video back of some time->after the seek the subs segments are initially downloaded but  not sent to kodi demuxer ofc subs are now broken

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The only stream i found affected with this similar problem is
HLS "daserste ARD" tv live stream

and to test HLS multiperiods subs, i used my local test stream "Akmai"

D+ confirmed by cscd98

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
