### PR TITLE
[AdaptiveStream] A couple of fixes after the refactor PR #1902

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -791,6 +791,7 @@ bool adaptive::AdaptiveStream::ensureSegment()
                   "[AS-%u] Not valid buffer segment (status %i, rep. id \"%s\", period id \"%s\")",
                   clsId, currSegBuff.State(), current_rep_->GetId().c_str(),
                   current_period_->GetId().c_str());
+        segment_read_pos_ = 0;
         return false;
       }
       // Note: In live streaming, the segments stored in the buffers may have expired

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1002,12 +1002,17 @@ bool adaptive::AdaptiveStream::ReadFullBuffer(std::vector<uint8_t>& buffer)
     // Signal we have read until the last byte
     segment_read_pos_ = buffer.size();
 
+    // The state is updated after read/write operations
     if (currSegBuffer.State() == BufferState::DOWNLOADING)
     {
-      // Wait for the mutex release, to ensure that the segment status is updated
+      // So wait for the mutex release, to ensure that the segment state is updated
       std::lock_guard<std::mutex> lckWorker(thread_data_->mutexWorker);
     }
-    return currSegBuffer.State() == BufferState::DOWNLOADED;
+
+    if (currSegBuffer.State() == BufferState::INVALID)
+      buffer.clear();
+
+    return true;
   }
 
   return false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
A couple of fixes after the refactor PR #1902

this should be also a final fix to issue #1645,
in my tests now if the audio stream segments cant be downloaded
the audio stream will be set as EOS and stop to feed kodi demuxer
this will cause that on playback the video can still be played but without audio (and without loud audio stuttering due to broken segments)

fix #1645

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
