### PR TITLE
[AdaptiveStream] Ensure that worker thread is running

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -286,6 +286,10 @@ void adaptive::AdaptiveStream::ResetActiveBuffer()
 
 void adaptive::AdaptiveStream::worker()
 {
+  // Change the status to STOP and signal main thread that this one is running
+  thread_data_->StopDownloads();
+  thread_data_->cvState.notify_all();
+
   do
   {
     // Check the thread state to wait in case of PAUSE or STOP
@@ -1370,6 +1374,14 @@ void adaptive::AdaptiveStream::Dispose()
     delete thread_data_;
     thread_data_ = nullptr;
   }
+}
+
+void adaptive::AdaptiveStream::THREADDATA::Initialize(AdaptiveStream* parent)
+{
+  m_downloadThread = std::thread(&AdaptiveStream::worker, parent);
+  // Wait until the thread is actually running
+  std::unique_lock<std::mutex> lckWorker(mutexWorker);
+  cvState.wait(lckWorker, [&] { return State() != THREADDATA::ThState::NONE || IsThreadExit(); });
 }
 
 void adaptive::AdaptiveStream::THREADDATA::StopDownloads()

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -206,10 +206,7 @@ enum class EVENT_TYPE
     {
       THREADDATA() = default;
 
-      void Initialize(AdaptiveStream *parent)
-      {
-        m_downloadThread = std::thread(&AdaptiveStream::worker, parent);
-      }
+      void Initialize(AdaptiveStream* parent);
 
       ~THREADDATA()
       {
@@ -229,6 +226,7 @@ enum class EVENT_TYPE
       // \brief Thread state
       enum class ThState
       {
+        NONE, // No state
         RUNNING, // Process downloads in queue
         PAUSED, // Complete the current download, then pause the next downloads in the queue
         STOPPED, // Cancel the current download, then pause the next downloads in the queue
@@ -246,7 +244,7 @@ enum class EVENT_TYPE
     private:
       std::thread m_downloadThread;
       bool m_isThreadExit{false};
-      std::atomic<ThState> m_state = ThState::STOPPED;
+      std::atomic<ThState> m_state = ThState::NONE;
     };
     THREADDATA* thread_data_{nullptr};
 


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Previously, a race condition could occur on the start_stream method, between the initialization of the worker thread and the execution of StartDownloads. StartDownloads could change state at the wrong time, causing cvState.wait in the "worker" method to miss the notification and read the "State" value before it changed, making it impossible to unlock the wait condition

regression of refator PR #1902
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run "tests" multiple times on linux, all tests must end without freezing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
