### PR TITLE
[FragmentedSampleReader] Included audio streams

### DIFF
--- a/src/AdaptiveByteStream.cpp
+++ b/src/AdaptiveByteStream.cpp
@@ -32,7 +32,9 @@ bool CAdaptiveByteStream::ReadFull(std::vector<uint8_t>& buffer)
 
 AP4_Result CAdaptiveByteStream::Seek(AP4_Position position)
 {
-  return m_adStream->seek(position) ? AP4_SUCCESS : AP4_ERROR_NOT_SUPPORTED;
+  bool isEos{false};
+  const bool ret = m_adStream->seek(position, isEos);
+  return ret ? AP4_SUCCESS : isEos ? AP4_ERROR_EOS : AP4_ERROR_NOT_SUPPORTED;
 }
 
 AP4_Result CAdaptiveByteStream::Tell(AP4_Position& position)

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -368,7 +368,7 @@ void SESSION::CSession::InitializePeriod()
     GUI::ErrorDialog(GUI::GetLocalizedString(30309));
   }
 
-  // Ensure that video streams are always placed before all others
+  // Ensure that video streams are always placed before all other types
   std::stable_sort(m_streams.begin(), m_streams.end(),
                    [](const std::shared_ptr<CStream>& a, const std::shared_ptr<CStream>& b)
                    {
@@ -990,7 +990,7 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
     streamReader->WaitReadSampleAsyncComplete();
     if (stream->IsEnabled() && (streamId == 0 || stream->m_info.GetPhysicalIndex() == streamId))
     {
-      bool reset{true};
+      bool reset{false};
       // all streams must be started before seeking to ensure cross chapter seeks
       // will seek to the correct location/segment
       if (!streamReader->IsStarted())
@@ -1000,7 +1000,14 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
       
       double seekSecs{static_cast<double>(seekTimeCorrected - ptsDiff) /
                       STREAM_TIME_BASE};
-      if (stream->m_adStream.seek_time(seekSecs, preceeding, reset))
+
+      // With FMP4 audio stream included to video stream you must not seek with AdaptiveStream
+      // segments are managed by AdaptiveStream of the video stream
+      // so CFragmentedSampleReader read data from the reader of the video stream
+      const bool noAdStream = streamReader->GetType() == ISampleReader::Type::FMP4 &&
+                              stream->m_adStream.getRepresentation()->IsIncludedStream();
+
+      if (noAdStream || stream->m_adStream.seek_time(seekSecs, preceeding, reset))
       {
         if (reset)
           streamReader->Reset(false);

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -26,6 +26,8 @@
 #include "utils/Utils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace adaptive;
 using namespace PLAYLIST;
 using namespace SESSION;
@@ -365,6 +367,15 @@ void SESSION::CSession::InitializePeriod()
               "No stream can be played, common causes: resolution limits or HDCP problem");
     GUI::ErrorDialog(GUI::GetLocalizedString(30309));
   }
+
+  // Ensure that video streams are always placed before all others
+  std::stable_sort(m_streams.begin(), m_streams.end(),
+                   [](const std::shared_ptr<CStream>& a, const std::shared_ptr<CStream>& b)
+                   {
+                     const bool aIsVideo = a && a->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO;
+                     const bool bIsVideo = b && b->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO;
+                     return aIsVideo && !bIsVideo;
+                   });
 }
 
 void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
@@ -373,7 +384,7 @@ void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
                                   uint32_t uniqueId,
                                   std::string_view audioLanguageOrig)
 {
-  m_streams.push_back(std::make_unique<CStream>(m_adaptiveTree, adp, initialRepr));
+  m_streams.push_back(std::make_shared<CStream>(m_adaptiveTree, adp, initialRepr));
 
   CStream& stream{*m_streams.back()};
 
@@ -626,12 +637,12 @@ void SESSION::CSession::UpdateStream(CStream& stream)
   stream.m_info.SetCodecInternalName(codecStr);
 }
 
-bool SESSION::CSession::PrepareStream(CStream* stream, uint64_t startPts)
+bool SESSION::CSession::PrepareStream(CStream& stream, uint64_t startPts)
 {
-  const EVENT_TYPE startEvent = stream->m_adStream.GetStartEvent();
-  CPeriod* period = stream->m_adStream.getPeriod();
-  CAdaptationSet* adp = stream->m_adStream.getAdaptationSet();
-  CRepresentation* repr = stream->m_adStream.getRepresentation();
+  const EVENT_TYPE startEvent = stream.m_adStream.GetStartEvent();
+  CPeriod* period = stream.m_adStream.getPeriod();
+  CAdaptationSet* adp = stream.m_adStream.getAdaptationSet();
+  CRepresentation* repr = stream.m_adStream.getRepresentation();
 
   // Prepare the representation when the period change usually its not needed,
   // because the timeline is always already updated
@@ -663,24 +674,24 @@ bool SESSION::CSession::PrepareStream(CStream* stream, uint64_t startPts)
     }
 
     if (!m_drmEngine.InitializeSession(repr->DrmInfos(), drmMediaType,
-                                       period->IsSecureDecodeNeeded(), stream->m_info, repr, adp,
+                                       period->IsSecureDecodeNeeded(), stream.m_info, repr, adp,
                                        m_adaptiveTree->IsChangingPeriod(), initDrmInfo))
     {
       return false;
     }
   }
 
-  stream->m_adStream.start_stream(startPts);
-  stream->SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream->m_adStream));
+  stream.m_adStream.start_stream(startPts);
+  stream.SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream.m_adStream));
 
   ContainerType reprContainerType = repr->GetContainerType();
-  uint32_t mask = (1U << stream->m_info.GetStreamType()) | GetIncludedStreamMask();
-  auto reader = ADP::CreateStreamReader(reprContainerType, stream, mask);
+  uint32_t mask = (1U << stream.m_info.GetStreamType()) | GetIncludedStreamMask();
+  auto reader = ADP::CreateStreamReader(reprContainerType, &stream, mask);
 
   if (!reader)
     return false;
 
-  const auto session = m_drmEngine.GetSession(stream->m_info.GetCryptoSession().GetSessionId(),
+  const auto session = m_drmEngine.GetSession(stream.m_info.GetCryptoSession().GetSessionId(),
                                               initDrmInfo.defaultKid);
 
   if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::VIDEO_AUDIO)
@@ -692,7 +703,7 @@ bool SESSION::CSession::PrepareStream(CStream* stream, uint64_t startPts)
   if (session)
     reader->SetDecrypter(session->decrypter, session->capabilities);
 
-  stream->SetReader(std::move(reader));
+  stream.SetReader(std::move(reader));
 
   if (reprContainerType == ContainerType::TS || reprContainerType == ContainerType::ADTS)
   {
@@ -700,18 +711,29 @@ bool SESSION::CSession::PrepareStream(CStream* stream, uint64_t startPts)
     // nextSegment would be deleted by the FreeSegments/newsegments swap. Do this now before the tree refresh.
     // Also, when reopening a stream (switching reps) the elapsed time would be incorrectly set until the
     // second segment plays, now force a correct calculation at the start of the stream.
-    OnSegmentChanged(&stream->m_adStream);
+    OnSegmentChanged(&stream.m_adStream);
   }
 
   return true;
 }
 
-CStream* SESSION::CSession::GetStream(unsigned int index) const
+std::shared_ptr<CStream> SESSION::CSession::GetStream(unsigned int index) const
 {
-  return index < m_streams.size() ? m_streams[index].get() : nullptr;
+  return index < m_streams.size() ? m_streams[index] : nullptr;
 }
 
-void CSession::EnableStream(CStream* stream, bool enable)
+std::shared_ptr<CStream> SESSION::CSession::GetCurrentVideoStream() const
+{
+  for (auto& stream : m_streams)
+  {
+    if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO && stream->IsEnabled())
+      return stream;
+  }
+
+  return nullptr;
+}
+
+void CSession::EnableStream(std::shared_ptr<CStream> stream, bool enable)
 {
   if (enable)
   {
@@ -949,7 +971,7 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
     }
     timingReader->WaitReadSampleAsyncComplete();
     if (!timingReader->IsStarted())
-      StartReader(m_timingStream, seekTimeCorrected, ptsDiff, preceeding, true);
+      StartReader(m_timingStream.get(), seekTimeCorrected, ptsDiff, preceeding, true);
 
     seekTimeCorrected += m_timingStream->m_adStream.GetAbsolutePTSOffset();
     ptsDiff = timingReader->GetPTSDiff();
@@ -1071,7 +1093,7 @@ bool SESSION::CSession::OnGetStream(int streamid, kodi::addon::InputstreamInfo& 
   }
   else
   {
-    CStream* stream = GetStream(GetStreamIndexFromId(streamid));
+    auto stream = GetStream(GetStreamIndexFromId(streamid));
     if (!stream)
       return false;
 

--- a/src/Session.h
+++ b/src/Session.h
@@ -76,20 +76,28 @@ public:
    * \brief Update stream's InputstreamInfo
    * \param stream The stream to prepare
    */
-  bool PrepareStream(CStream* stream, uint64_t startPts);
+  bool PrepareStream(CStream& stream, uint64_t startPts);
 
   /*!
    * \brief Get a stream by index
    * \param index The stream index
    * \return The stream object if the index exists
    */
-  CStream* GetStream(unsigned int index) const;
+  std::shared_ptr<CStream> GetStream(unsigned int index) const;
+
+  const std::vector<std::shared_ptr<CStream>>& GetStreams() const { return m_streams; }
+
+  /*!
+   * \brief Get the current (enabled) video stream
+   * \return The video stream if found, otherwise nullptr
+   */
+  std::shared_ptr<CStream> GetCurrentVideoStream() const;
 
   /*! \brief Enable or disable a stream
    *  \param stream The stream object to act on
    *  \param enable Whether to enable or disable the stream
    */
-  void EnableStream(CStream* stream, bool enable);
+  void EnableStream(std::shared_ptr<CStream> stream, bool enable);
 
   /*! \brief Get the number of streams in the session
    *  \return The number of streams in the session
@@ -273,8 +281,8 @@ private:
   adaptive::AdaptiveTree* m_adaptiveTree{nullptr};
   CHOOSER::IRepresentationChooser* m_reprChooser{nullptr};
 
-  std::vector<std::unique_ptr<CStream>> m_streams;
-  CStream* m_timingStream{nullptr};
+  std::vector<std::shared_ptr<CStream>> m_streams;
+  std::shared_ptr<CStream> m_timingStream;
 
   bool m_changed{false};
   uint64_t m_elapsedTime{0};

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -8,6 +8,9 @@
 
 #include "Stream.h"
 
+#include "samplereader/TSSampleReader.h"
+#include "utils/log.h"
+
 using namespace SESSION;
 
 void CStream::Disable()
@@ -35,12 +38,13 @@ void CStream::Reset()
 {
   if (m_isEnabled)
   {
+    m_isEnabled = false;
+
     if (m_streamReader)
       m_streamReader->WaitReadSampleAsyncComplete();
     m_streamReader.reset();
     m_streamFile.reset();
     m_adByteStream.reset();
-    m_mainStreamIndex.reset();
   }
 }
 
@@ -48,4 +52,61 @@ void SESSION::CStream::SetReader(std::unique_ptr<ISampleReader> reader)
 {
   m_streamReader = std::move(reader);
   m_streamReader->SetObserver(&m_adStream);
+}
+
+void SESSION::CStream::LinkStream(std::shared_ptr<CStream> mainStream, int streamId)
+{
+  ISampleReader* mainStreamReader = mainStream->GetReader();
+  if (!mainStreamReader)
+  {
+    LOG::LogF(LOGERROR, "Cannot link stream ID %i, due to missing sample reader on main stream",
+              streamId);
+    return;
+  }
+
+  if (mainStreamReader->GetType() == ISampleReader::Type::TS)
+  {
+    auto tsReader = static_cast<CTSSampleReader*>(mainStreamReader);
+    tsReader->AddStreamType(m_info.GetStreamType(), streamId);
+    tsReader->GetInformation(m_info);
+  }
+  else
+  {
+    LOG::LogF(LOGERROR, "Cannot link stream ID %i, due to unsupported sample reader type: %i",
+              streamId, mainStreamReader->GetType());
+  }
+}
+
+void SESSION::CStream::UnlinkStream()
+{
+  if (auto linkStream = m_linkedStream.lock()) // check pointer validity
+  {
+    ISampleReader* linkStreamReader = linkStream->GetReader();
+    if (!linkStreamReader)
+    {
+      LOG::LogF(LOGERROR, "Cannot unlink stream, due to missing sample reader on main stream");
+      return;
+    }
+
+    if (linkStreamReader->GetType() == ISampleReader::Type::TS)
+    {
+      auto tsReader = static_cast<CTSSampleReader*>(linkStreamReader);
+      tsReader->RemoveStreamType(m_info.GetStreamType());
+    }
+    else
+    {
+      LOG::LogF(LOGERROR, "Cannot unlink stream, due to unsupported sample reader type: %i",
+                linkStreamReader->GetType());
+    }
+  }
+
+  m_linkedStream.reset();
+}
+bool SESSION::CStream::IsLinkedToStreamType(INPUTSTREAM_TYPE type)
+{
+  if (auto linkStream = m_linkedStream.lock()) // check pointer validity
+  {
+    return linkStream->m_info.GetStreamType() == type;
+  }
+  return false;
 }

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -8,6 +8,7 @@
 
 #include "Stream.h"
 
+#include "samplereader/FragmentedSampleReader.h"
 #include "samplereader/TSSampleReader.h"
 #include "utils/log.h"
 
@@ -70,11 +71,26 @@ void SESSION::CStream::LinkStream(std::shared_ptr<CStream> mainStream, int strea
     tsReader->AddStreamType(m_info.GetStreamType(), streamId);
     tsReader->GetInformation(m_info);
   }
+  else if (mainStreamReader->GetType() == ISampleReader::Type::FMP4)
+  {
+    auto fMainReader = static_cast<CFragmentedSampleReader*>(mainStreamReader);
+
+    m_streamReader = fMainReader->CreateReaderByTrack();
+    if (!m_streamReader)
+      return;
+
+    m_streamReader->Initialize(this);
+    m_streamReader->SetStreamId(m_info.GetStreamType(), streamId);
+    m_streamReader->GetInformation(m_info);
+  }
   else
   {
     LOG::LogF(LOGERROR, "Cannot link stream ID %i, due to unsupported sample reader type: %i",
               streamId, mainStreamReader->GetType());
+    return;
   }
+
+  m_linkedStream = mainStream;
 }
 
 void SESSION::CStream::UnlinkStream()
@@ -93,6 +109,10 @@ void SESSION::CStream::UnlinkStream()
       auto tsReader = static_cast<CTSSampleReader*>(linkStreamReader);
       tsReader->RemoveStreamType(m_info.GetStreamType());
     }
+    else if (linkStreamReader->GetType() == ISampleReader::Type::FMP4)
+    {
+      m_streamReader.reset();
+    }
     else
     {
       LOG::LogF(LOGERROR, "Cannot unlink stream, due to unsupported sample reader type: %i",
@@ -102,7 +122,7 @@ void SESSION::CStream::UnlinkStream()
 
   m_linkedStream.reset();
 }
-bool SESSION::CStream::IsLinkedToStreamType(INPUTSTREAM_TYPE type)
+bool SESSION::CStream::IsLinkedToStreamType(INPUTSTREAM_TYPE type) const
 {
   if (auto linkStream = m_linkedStream.lock()) // check pointer validity
   {

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -107,7 +107,12 @@ public:
    */
   void UnlinkStream();
 
-  bool IsLinkedToStreamType(INPUTSTREAM_TYPE type);
+  /*!
+   * \brief Determines if this stream is linked to a parent stream of specified type
+   * \param type The stream type
+   * \return True if it is linked to specified type, otherwise false
+   */
+  bool IsLinkedToStreamType(INPUTSTREAM_TYPE type) const;
 
   adaptive::AdaptiveStream m_adStream;
   kodi::addon::InputstreamInfo m_info;

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -16,6 +16,7 @@
 #include <kodi/addon-instance/Inputstream.h>
 
 #include <optional>
+#include <memory>
 
 namespace SESSION
 {
@@ -92,7 +93,22 @@ public:
     m_adByteStream = std::move(adByteStream);
   }
 
-  std::optional<unsigned int> m_mainStreamIndex; // Used when this stream is "included" to video (main stream)
+  /*!
+   * \brief Link a multiplexed stream to this one
+   *        (usually audio embedded to the video stream).
+   * \param mainStream The stream to be linked to this stream
+   * \param streamId The InputStream stream ID relative to the linked stream
+   */
+  void LinkStream(std::shared_ptr<CStream> mainStream, int streamId);
+
+  /*!
+   * \brief Unlink a multiplexed stream from this one
+   *        (usually audio embedded to the video stream).
+   */
+  void UnlinkStream();
+
+  bool IsLinkedToStreamType(INPUTSTREAM_TYPE type);
+
   adaptive::AdaptiveStream m_adStream;
   kodi::addon::InputstreamInfo m_info;
   bool m_isValid;
@@ -102,5 +118,7 @@ private:
   std::unique_ptr<ISampleReader> m_streamReader;
   std::unique_ptr<CAdaptiveByteStream> m_adByteStream;
   std::unique_ptr<AP4_File> m_streamFile;
+
+  std::weak_ptr<CStream> m_linkedStream; // This CStream is part of a multiplexed audio/video stream
 };
 } // namespace SESSION

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1165,6 +1165,8 @@ PLAYLIST::StreamType adaptive::AdaptiveStream::GetStreamType() const
 
 bool adaptive::AdaptiveStream::seek_time(double seek_seconds, bool preceeding, bool& needReset)
 {
+  needReset = true;
+
   if (!current_rep_)
     return false;
 
@@ -1180,7 +1182,6 @@ bool adaptive::AdaptiveStream::seek_time(double seek_seconds, bool preceeding, b
 
   if (seekSeg)
   {
-    needReset = true;
     if (oldSeg.has_value() && !seekSeg->IsSame(*oldSeg))
     {
       ResetCurrentSegment(*seekSeg);

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1044,10 +1044,15 @@ uint64_t adaptive::AdaptiveStream::tell()
   return absolute_position_;
 }
 
-bool adaptive::AdaptiveStream::seek(uint64_t const pos)
+bool adaptive::AdaptiveStream::seek(uint64_t const pos, bool& isEos)
 {
   if (m_segBuffers.IsEmpty())
+  {
+    if (!current_rep_->IsWaitForSegment())
+      isEos = true;
+
     return false;
+  }
 
   SegmentBuffer& currSegBuffer = m_segBuffers.Front();
 

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -114,9 +114,10 @@ enum class EVENT_TYPE
     /*!
      * \brief Seek the stream to the specified data position on the current segment.
      * \param pos The data position to seek, is the sum of the absolute position and any additional bytes to be seek for
+     * \param isEos[OUT] The value will be changed to true, only when the stream is end
      * \return True if has success, otherwise false (it should cause EOS in the sample reader demuxer)
      */
-    bool seek(uint64_t const pos);
+    bool seek(uint64_t const pos, bool& isEos);
 
     bool seek_time(double seek_seconds, bool preceeding, bool &needReset);
     PLAYLIST::CPeriod* getPeriod() { return current_period_; };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,6 @@
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
 #include "Stream.h"
-#include "samplereader/TSSampleReader.h"
 #include "utils/GUIUtils.h"
 #include "utils/ThreadPool.h"
 #include "utils/log.h"
@@ -82,7 +81,7 @@ bool CInputStreamAdaptive::GetStreamIds(std::vector<unsigned int>& ids)
 
   for (unsigned int i(0); i < INPUTSTREAM_MAX_STREAM_COUNT && i < streamCount; ++i)
   {
-    CStream* stream = m_session->GetStream(i);
+    auto stream = m_session->GetStream(i);
     if (!stream)
     {
       LOG::LogF(LOGERROR, "Cannot get the stream from sid %u", i);
@@ -142,34 +141,6 @@ bool CInputStreamAdaptive::GetStream(int streamid, kodi::addon::InputstreamInfo&
   //! this needs to be fixed in the Kodi core VP
 }
 
-void CInputStreamAdaptive::UnlinkIncludedStreams(CStream* stream)
-{
-  if (stream->m_mainStreamIndex.has_value())
-  {
-    CStream* mainStream = m_session->GetStream(*stream->m_mainStreamIndex);
-    if (!mainStream)
-    {
-      LOG::LogF(LOGERROR, "Cannot get main stream from index %u", *stream->m_mainStreamIndex);
-      return;
-    }
-
-    ISampleReader* sReader = mainStream->GetReader();
-    if (sReader)
-    {
-      if (sReader->GetType() == ISampleReader::Type::TS)
-      {
-        auto tsReader = static_cast<CTSSampleReader*>(sReader);
-        tsReader->RemoveStreamType(stream->m_info.GetStreamType());
-      }
-    }
-  }
-
-  const CRepresentation* rep = stream->m_adStream.getRepresentation();
-
-  if (rep->IsIncludedStream())
-    m_IncludedStreams.erase(stream->m_info.GetStreamType());
-}
-
 void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
 {
   LOG::Log(LOGDEBUG, "EnableStream(%d: %s)", streamid, enable ? "true" : "false");
@@ -177,11 +148,11 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
   if (!m_session)
     return;
 
-  CStream* stream{m_session->GetStream(m_session->GetStreamIndexFromId(streamid))};
+  auto stream = m_session->GetStream(m_session->GetStreamIndexFromId(streamid));
 
   if (!enable && stream && stream->IsEnabled())
   {
-    UnlinkIncludedStreams(stream);
+    stream->UnlinkStream();
     m_session->EnableStream(stream, false);
   }
 }
@@ -208,17 +179,16 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (!m_session)
     return false;
 
-  CStream* stream(m_session->GetStream(m_session->GetStreamIndexFromId(streamid)));
+  auto stream = m_session->GetStream(m_session->GetStreamIndexFromId(streamid));
 
   if (!stream)
     return false;
 
   if (stream->IsEnabled())
   {
-    // Stream quality changed
+    // Stream quality changed (by "adaptive" streaming, not OSD)
     if (stream->m_adStream.StreamChanged())
     {
-      UnlinkIncludedStreams(stream);
       stream->Reset();
       stream->m_adStream.Reset();
     }
@@ -261,52 +231,33 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
 
   CRepresentation* rep = stream->m_adStream.getRepresentation();
 
-  // If we select a dummy (=inside video) stream, open the video part
-  // Dummy streams will be never enabled, they will only enable / activate audio track.
+  // "included" streams are audio streams embedded into a video stream (multiplexed).
+  // How works:
+  // The manifest parser create a "dummy" (AdaptationSet + Representation) for the audio track,
+  // this dummy stream will be shared between all video representations
+  // so needs to be linked to the video stream currently in use,
+  // and if the video quality changes, must be re-linked with the current video.
+  // The behavior of how works the "dummy" stream changes depending on the type of demuxer used,
+  // in general way in this case the CStream dont use the AdaptiveStream class
+  // but could have a SampleReader that somewhat read the data from the video package.
+  //! @todo: HLS TS with multiple "included" audio streams, not implemented, more likely
+  //!   its needed implement a way to get PIDs of each stream from segment, and map them to the manifest variants
   if (rep->IsIncludedStream())
   {
-    CStream* mainStream;
-    unsigned int mainStreamIndex{0};
+    auto videoStream = m_session->GetCurrentVideoStream();
 
-    while ((mainStream = m_session->GetStream(mainStreamIndex++)))
+    if (!videoStream)
     {
-      if (mainStream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO && mainStream->IsEnabled())
-        break;
+      LOG::LogF(LOGERROR, "Cannot get video stream to link the included stream id: %i",
+                streamid);
+      return false;
     }
 
-    if (mainStream)
-    {
-      stream->m_mainStreamIndex = mainStreamIndex;
-      ISampleReader* mainReader = mainStream->GetReader();
-      if (!mainReader)
-      {
-        LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-      }
-      else
-      {
-        if (mainReader->GetType() == ISampleReader::Type::TS)
-        {
-          auto tsReader = static_cast<CTSSampleReader*>(mainReader);
-          tsReader->AddStreamType(stream->m_info.GetStreamType(), streamid);
-          tsReader->GetInformation(stream->m_info);
-        }
-        else
-        {
-          LOG::LogF(LOGERROR, "Unsupported included stream for sample reader type: %i",
-                    mainReader->GetType());
-        }
-      }
-    }
-    else
-    {
-      stream->m_mainStreamIndex.reset();
-    }
-
-    m_IncludedStreams[stream->m_info.GetStreamType()] = streamid;
-    return false;
+    stream->LinkStream(videoStream, streamid);
+    return true;
   }
 
-  if (!m_session->PrepareStream(stream, m_lastPts))
+  if (!m_session->PrepareStream(*stream, m_lastPts))
   {
     m_session->EnableStream(stream, false);
     return false;
@@ -314,36 +265,24 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
 
   stream->GetReader()->SetStreamId(stream->m_info.GetStreamType(), streamid);
 
+  // In case of video quality change (OSD)
+  // re-link "included" streams to current opened stream
+  // is assumed that "included" streams are still readable from the new selected stream
   if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
   {
-    for (auto& [streamType, id] : m_IncludedStreams)
+    for (unsigned int i{0}; i < m_session->GetStreamCount(); ++i)
     {
-      ISampleReader* sReader = stream->GetReader();
-      if (sReader)
-      {
-        if (sReader->GetType() == ISampleReader::Type::TS)
-        {
-          auto tsReader = static_cast<CTSSampleReader*>(sReader);
-          tsReader->AddStreamType(streamType, id);
+      auto sesStream = m_session->GetStream(i);
+      if (!sesStream || !sesStream->IsEnabled())
+        continue;
 
-          // Update info
-          const unsigned int streamIndex = m_session->GetStreamIndexFromId(id);
-          CStream* incStream = m_session->GetStream(streamIndex);
-          if (incStream)
-            stream->GetReader()->GetInformation(incStream->m_info);
-          else
-            LOG::LogF(LOGERROR, "Cannot get the stream from stream index %u", streamIndex);
-        }
-        else
-        {
-          LOG::LogF(LOGERROR, "Unsupported included stream for sample reader type: %i",
-                    sReader->GetType());
-        }
+      if (sesStream->IsLinkedToStreamType(INPUTSTREAM_TYPE_VIDEO))
+      {
+        sesStream->UnlinkStream();
+        sesStream->LinkStream(stream, m_session->GetStreamIdFromIndex(i));
       }
     }
   }
-
-  m_session->EnableStream(stream, true);
 
   // If stream use DRM always update stream info
   const bool isInfoChanged = stream->GetReader()->GetInformation(stream->m_info) ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "CompKodiProps.h"
 #include "SrvBroker.h"
 #include "Stream.h"
+#include "samplereader/TSSampleReader.h"
 #include "utils/GUIUtils.h"
 #include "utils/ThreadPool.h"
 #include "utils/log.h"
@@ -145,9 +146,22 @@ void CInputStreamAdaptive::UnlinkIncludedStreams(CStream* stream)
 {
   if (stream->m_mainStreamIndex.has_value())
   {
-    CStream* mainStream(m_session->GetStream(*stream->m_mainStreamIndex));
-    if (mainStream->GetReader())
-      mainStream->GetReader()->RemoveStreamType(stream->m_info.GetStreamType());
+    CStream* mainStream = m_session->GetStream(*stream->m_mainStreamIndex);
+    if (!mainStream)
+    {
+      LOG::LogF(LOGERROR, "Cannot get main stream from index %u", *stream->m_mainStreamIndex);
+      return;
+    }
+
+    ISampleReader* sReader = mainStream->GetReader();
+    if (sReader)
+    {
+      if (sReader->GetType() == ISampleReader::Type::TS)
+      {
+        auto tsReader = static_cast<CTSSampleReader*>(sReader);
+        tsReader->RemoveStreamType(stream->m_info.GetStreamType());
+      }
+    }
   }
 
   const CRepresentation* rep = stream->m_adStream.getRepresentation();
@@ -270,8 +284,17 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
       }
       else
       {
-        mainReader->AddStreamType(stream->m_info.GetStreamType(), streamid);
-        mainReader->GetInformation(stream->m_info);
+        if (mainReader->GetType() == ISampleReader::Type::TS)
+        {
+          auto tsReader = static_cast<CTSSampleReader*>(mainReader);
+          tsReader->AddStreamType(stream->m_info.GetStreamType(), streamid);
+          tsReader->GetInformation(stream->m_info);
+        }
+        else
+        {
+          LOG::LogF(LOGERROR, "Unsupported included stream for sample reader type: %i",
+                    mainReader->GetType());
+        }
       }
     }
     else
@@ -295,18 +318,27 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   {
     for (auto& [streamType, id] : m_IncludedStreams)
     {
-      stream->GetReader()->AddStreamType(streamType, id);
-
-      const unsigned int streamIndex = m_session->GetStreamIndexFromId(id);
-
-      CStream* incStream = m_session->GetStream(streamIndex);
-      if (!incStream)
+      ISampleReader* sReader = stream->GetReader();
+      if (sReader)
       {
-        LOG::LogF(LOGERROR, "Cannot get the stream from stream index %u", streamIndex);
-      }
-      else
-      {
-        stream->GetReader()->GetInformation(incStream->m_info);
+        if (sReader->GetType() == ISampleReader::Type::TS)
+        {
+          auto tsReader = static_cast<CTSSampleReader*>(sReader);
+          tsReader->AddStreamType(streamType, id);
+
+          // Update info
+          const unsigned int streamIndex = m_session->GetStreamIndexFromId(id);
+          CStream* incStream = m_session->GetStream(streamIndex);
+          if (incStream)
+            stream->GetReader()->GetInformation(incStream->m_info);
+          else
+            LOG::LogF(LOGERROR, "Cannot get the stream from stream index %u", streamIndex);
+        }
+        else
+        {
+          LOG::LogF(LOGERROR, "Unsupported included stream for sample reader type: %i",
+                    sReader->GetType());
+        }
       }
     }
   }

--- a/src/main.h
+++ b/src/main.h
@@ -57,14 +57,11 @@ public:
 
 private:
   std::shared_ptr<SESSION::CSession> m_session;
-  std::map<INPUTSTREAM_TYPE, int> m_IncludedStreams; // stream type - stream id
   int m_failedSeekTime = ~0;
 
   // The last PTS of the segment package fed to kodi.
   // NO_PTS_VALUE only when playback starts or a new period starts
   std::atomic<uint64_t> m_lastPts{PLAYLIST::NO_PTS_VALUE};
-
-  void UnlinkIncludedStreams(SESSION::CStream* stream);
 
   bool m_checkCoreReopen{false}; // Check if Kodi core will reopen all streams
 };

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -17,6 +17,8 @@ class ATTR_DLL_LOCAL CADTSSampleReader : public ISampleReader, public ADTSReader
 public:
   CADTSSampleReader(AP4_ByteStream* input);
 
+  Type GetType() const override { return Type::ADTS; }
+
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_pts; }

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -36,13 +36,22 @@ constexpr uint8_t MP4_TFRFBOX_UUID[] = {0xd4, 0x80, 0x7e, 0xf2, 0xca, 0x39, 0x46
 CFragmentedSampleReader::CFragmentedSampleReader(AP4_ByteStream* input,
                                                  AP4_Movie* movie,
                                                  AP4_Track* track)
-  : AP4_LinearReader{*movie, input}, m_track{track}
+  : m_track{track}
 {
+  m_lReader = std::make_shared<CLinearReader>(input, movie);
+}
+
+CFragmentedSampleReader::CFragmentedSampleReader(std::shared_ptr<CLinearReader> lReader,
+                                                 AP4_Track* track)
+  : m_track{track}
+{
+  m_lReader = lReader;
 }
 
 CFragmentedSampleReader::~CFragmentedSampleReader()
 {
-  if (m_singleSampleDecryptor)
+  // Remove the decryptor pool only with the last CLinearReader instance
+  if (m_lReader.use_count() == 1 && m_singleSampleDecryptor)
     m_singleSampleDecryptor->RemovePool(m_poolId);
 
   delete m_codecHandler;
@@ -50,7 +59,7 @@ CFragmentedSampleReader::~CFragmentedSampleReader()
 
 bool CFragmentedSampleReader::Initialize(SESSION::CStream* stream)
 {
-  EnableTrack(m_track->GetId());
+  m_lReader->EnableTrack(m_track->GetId());
 
   AP4_SampleDescription* desc{m_track->GetSampleDescription(0)};
   if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
@@ -135,11 +144,11 @@ AP4_Result CFragmentedSampleReader::ReadSample()
   AP4_DataBuffer sampleData;
   if (!m_codecHandler->ReadNextSample(m_sample, m_sampleData))
   {
-    if (AP4_FAILED(result = ReadNextSample(m_track->GetId(), m_sample, sampleData)))
+    if (AP4_FAILED(result = m_lReader->ExecReadNextSample(this, m_track->GetId(), m_sample, sampleData)))
     {
       if (result == AP4_ERROR_EOS)
       {
-        auto adByteStream = dynamic_cast<CAdaptiveByteStream*>(m_FragmentStream);
+        auto adByteStream = dynamic_cast<CAdaptiveByteStream*>(m_lReader->GetByteStream());
         if (!adByteStream)
         {
           LOG::LogF(LOGERROR, "Fragment stream cannot be casted to AdaptiveByteStream");
@@ -228,7 +237,8 @@ AP4_Result CFragmentedSampleReader::ReadSample()
 
 void CFragmentedSampleReader::Reset(bool bEOS)
 {
-  AP4_LinearReader::Reset();
+  m_lReader->Reset(); // Note: all shared readers call the same shared reader reset
+
   m_eos = bEOS;
   if (m_codecHandler)
     m_codecHandler->Reset();
@@ -280,7 +290,7 @@ bool CFragmentedSampleReader::TimeSeek(uint64_t pts, bool preceeding)
 {
   AP4_Ordinal sampleIndex;
   AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));
-  if (AP4_SUCCEEDED(SeekSample(m_track->GetId(), seekPos, sampleIndex, preceeding)))
+  if (AP4_SUCCEEDED(m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex, preceeding)))
   {
     if (m_decrypter)
       m_decrypter->SetSampleIndex(sampleIndex);
@@ -296,7 +306,7 @@ bool CFragmentedSampleReader::TimeSeek(uint64_t pts, bool preceeding)
 
 void CFragmentedSampleReader::SetPTSOffset(uint64_t offset)
 {
-  FindTracker(m_track->GetId())->m_NextDts = (offset * m_timeBaseInt) / m_timeBaseExt;
+  m_lReader->FindTracker(m_track->GetId())->m_NextDts = (offset * m_timeBaseInt) / m_timeBaseExt;
   m_ptsOffs = offset;
 
   if (m_codecHandler)
@@ -305,8 +315,8 @@ void CFragmentedSampleReader::SetPTSOffset(uint64_t offset)
 
 bool CFragmentedSampleReader::GetFragmentInfo(uint64_t& duration)
 {
-  auto fragSampleTable =
-      dynamic_cast<AP4_FragmentSampleTable*>(FindTracker(m_track->GetId())->m_SampleTable);
+  auto fragSampleTable = dynamic_cast<AP4_FragmentSampleTable*>(
+      m_lReader->FindTracker(m_track->GetId())->m_SampleTable);
   if (fragSampleTable)
     duration = fragSampleTable->GetDuration();
   else
@@ -315,6 +325,27 @@ bool CFragmentedSampleReader::GetFragmentInfo(uint64_t& duration)
     return false;
   }
   return true;
+}
+
+std::unique_ptr<ISampleReader> CFragmentedSampleReader::CreateReaderByTrack()
+{
+  auto& movie = m_lReader->GetMovie();
+
+  // Note that CLinearReader (AP4_LinearReader) will be shared among all readers created,
+  // which read from a different track ID
+  AP4_Track* selTrack = movie.GetTrack(AP4_Track::Type::TYPE_AUDIO, 0);
+  if (!selTrack)
+  {
+    LOG::LogF(LOGERROR, "Audio track not found");
+    return nullptr;
+  }
+
+  auto newFragReader = std::make_unique<CFragmentedSampleReader>(m_lReader, selTrack);
+  newFragReader->SetDecrypter(m_singleSampleDecryptor, m_decrypterCaps);
+
+  LOG::LogF(LOGDEBUG, "Created shared reader for audio track id %u", selTrack->GetId());
+
+  return std::move(newFragReader);
 }
 
 AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
@@ -344,8 +375,8 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
 
   AP4_Result result;
 
-  if (AP4_SUCCEEDED((result = AP4_LinearReader::ProcessMoof(moof, moof_offset, mdat_payload_offset,
-                                                            mdat_payload_size))))
+  if (AP4_SUCCEEDED((result = m_lReader->ExecProcessMoof(moof, moof_offset, mdat_payload_offset,
+                                                         mdat_payload_size))))
   {
     AP4_ContainerAtom* traf =
         AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
@@ -396,7 +427,7 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
     //! This code is present also on the others sample readers, that need to be verified
     if (~m_ptsOffs)
     {
-      if (AP4_SUCCEEDED(GetSample(m_track->GetId(), sample, 0)))
+      if (AP4_SUCCEEDED(m_lReader->GetSample(m_track->GetId(), sample, 0)))
       {
         m_pts = m_dts = (sample.GetCts() * m_timeBaseExt) / m_timeBaseInt;
         m_ptsDiff = m_pts - m_ptsOffs;
@@ -440,7 +471,7 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
 
       bool reset_iv(false);
       if (AP4_FAILED(result = AP4_CencSampleInfoTable::Create(m_protectedDesc, traf, algorithm_id,
-                                                              reset_iv, *m_FragmentStream,
+                                                              reset_iv, *m_lReader->GetByteStream(),
                                                               moof_offset, sample_table)))
         // we assume unencrypted fragment here
         goto SUCCESS;
@@ -601,4 +632,74 @@ void CFragmentedSampleReader::ParseTrafTfrf(AP4_UuidAtom* uuidAtom)
     }
     m_observer->OnTFRFatom(time, duration, m_track->GetMediaTimeScale());
   }
+}
+
+CLinearReader::CLinearReader(AP4_ByteStream* input, AP4_Movie* movie)
+  : AP4_LinearReader{*movie, input}
+{
+}
+
+void CLinearReader::SetCallback(CLinearReaderCB* lReaderCB)
+{
+  m_lReaderCB = lReaderCB;
+}
+
+AP4_Result CLinearReader::ExecReadNextSample(CLinearReaderCB* lReaderCB,
+                                             AP4_UI32 track_id,
+                                             AP4_Sample& sample,
+                                             AP4_DataBuffer& sample_data)
+{
+  // Protect call to ReadNextSample until method exit,
+  // to ensure appropriate callback to ProcessMoof
+  // with the specified reader (CLinearReaderCB) instance
+  std::lock_guard<std::mutex> lock(m_readerMtx);
+  SetCallback(lReaderCB);
+  return AP4_LinearReader::ReadNextSample(track_id, sample, sample_data);
+}
+
+AP4_Result CLinearReader::ExecProcessMoof(AP4_ContainerAtom* moof,
+                                          AP4_Position moof_offset,
+                                          AP4_Position mdat_payload_offset,
+                                          AP4_UI64 mdat_payload_size)
+{
+  return AP4_LinearReader::ProcessMoof(moof, moof_offset, mdat_payload_offset, mdat_payload_size);
+}
+
+AP4_LinearReader::Tracker* CLinearReader::FindTracker(AP4_UI32 track_id)
+{
+  return AP4_LinearReader::FindTracker(track_id);
+}
+
+AP4_Result CLinearReader::GetSample(AP4_UI32 track_id, AP4_Sample& sample, AP4_Ordinal sample_index)
+{
+  return AP4_LinearReader::GetSample(track_id, sample, sample_index);
+}
+
+void CLinearReader::Reset()
+{
+  std::lock_guard<std::mutex> lock(m_readerMtx);
+  AP4_LinearReader::Reset();
+}
+
+AP4_ByteStream* CLinearReader::GetByteStream()
+{
+  return AP4_LinearReader::m_FragmentStream;
+}
+
+AP4_Movie& CLinearReader::GetMovie()
+{
+  return AP4_LinearReader::m_Movie;
+}
+
+AP4_Result CLinearReader::ProcessMoof(AP4_ContainerAtom* moof,
+                                      AP4_Position moof_offset,
+                                      AP4_Position mdat_payload_offset,
+                                      AP4_UI64 mdat_payload_size)
+{
+  if (!m_lReaderCB)
+  {
+    LOG::LogF(LOGFATAL, "Unable to execute ProcessMoof, CLinearReaderCB is not set");
+    return AP4_ERROR_INVALID_STATE;
+  }
+  return m_lReaderCB->ProcessMoof(moof, moof_offset, mdat_payload_offset, mdat_payload_size);
 }

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -11,15 +11,81 @@
 #include "SampleReader.h"
 #include "decrypters/IDecrypter.h"
 
+#include <bento4/Ap4.h>
+#include <bento4/Ap4LinearReader.h>
+
+#include <memory>
+#include <mutex>
+
 // forwards
 class CAdaptiveCencSampleDecrypter;
 class CodecHandler;
 
-class ATTR_DLL_LOCAL CFragmentedSampleReader : public ISampleReader, public AP4_LinearReader
+// \brief Redirects AP4_LinearReader callbacks
+class ATTR_DLL_LOCAL CLinearReaderCB
+{
+public:
+  virtual AP4_Result ProcessMoof(AP4_ContainerAtom* moof,
+                                 AP4_Position moof_offset,
+                                 AP4_Position mdat_payload_offset,
+                                 AP4_UI64 mdat_payload_size) = 0;
+};
+
+// \brief Extends the AP4_LinearReader functionality.
+//        Shared use of this class between different CFragmentedSampleReaders is permitted
+//        for multiplexed streams (e.g. audio embedded in video), for this reason
+//        some methods are protected by mutex to avoid possible race conditions.
+class ATTR_DLL_LOCAL CLinearReader : public AP4_LinearReader
+{
+public:
+  CLinearReader(AP4_ByteStream* input, AP4_Movie* movie);
+
+  void SetCallback(CLinearReaderCB* lReaderCB);
+
+  // \brief Execute AP4_LinearReader::ReadNextSample
+  //        and provide the ProcessMoof callback to the specified reader
+  AP4_Result ExecReadNextSample(CLinearReaderCB* lReaderCB,
+                                AP4_UI32 track_id,
+                                AP4_Sample& sample,
+                                AP4_DataBuffer& sample_data);
+
+  // \brief Execute AP4_LinearReader::ProcessMoof
+  AP4_Result ExecProcessMoof(AP4_ContainerAtom* moof,
+                             AP4_Position moof_offset,
+                             AP4_Position mdat_payload_offset,
+                             AP4_UI64 mdat_payload_size);
+
+  // \brief Execute AP4_LinearReader::FindTracker
+  AP4_LinearReader::Tracker* FindTracker(AP4_UI32 track_id);
+
+  // \brief Execute AP4_LinearReader::GetSample
+  AP4_Result GetSample(AP4_UI32 track_id, AP4_Sample& sample, AP4_Ordinal sample_index);
+  
+  // \brief Execute AP4_LinearReader::Reset
+  void Reset();
+
+  // \brief Get AP4_LinearReader::m_FragmentStream
+  AP4_ByteStream* GetByteStream();
+
+  // \brief Get AP4_LinearReader::m_Movie
+  AP4_Movie& GetMovie();
+
+protected:
+  // AP4_LinearReader implementations
+  AP4_Result ProcessMoof(AP4_ContainerAtom* moof,
+                         AP4_Position moof_offset,
+                         AP4_Position mdat_payload_offset,
+                         AP4_UI64 mdat_payload_size) override;
+
+  CLinearReaderCB* m_lReaderCB{nullptr};
+  std::mutex m_readerMtx;
+};
+
+class ATTR_DLL_LOCAL CFragmentedSampleReader : public ISampleReader, public CLinearReaderCB
 {
 public:
   CFragmentedSampleReader(AP4_ByteStream* input, AP4_Movie* movie, AP4_Track* track);
-
+  CFragmentedSampleReader(std::shared_ptr<CLinearReader> lReader, AP4_Track* track);
   ~CFragmentedSampleReader();
 
   Type GetType() const override { return Type::FMP4; }
@@ -47,7 +113,14 @@ public:
   uint32_t GetTimeScale() const override { return m_track->GetMediaTimeScale(); }
   CryptoInfo GetReaderCryptoInfo() const override { return m_readerCryptoInfo; }
 
+  /*!
+   * \brief Create a new reader by sharing the same data reader and segment management (AdaptiveStream).
+   *        Use intended for multiplexed tracks (e.g. audio included on video stream).
+   */
+  std::unique_ptr<ISampleReader> CreateReaderByTrack();
+
 protected:
+  // CLinearReaderCB implementation
   AP4_Result ProcessMoof(AP4_ContainerAtom* moof,
                          AP4_Position moof_offset,
                          AP4_Position mdat_payload_offset,
@@ -79,4 +152,6 @@ private:
   std::shared_ptr<Adaptive_CencSingleSampleDecrypter> m_singleSampleDecryptor{nullptr};
   std::unique_ptr<CAdaptiveCencSampleDecrypter> m_decrypter;
   CryptoInfo m_readerCryptoInfo{};
+
+  std::shared_ptr<CLinearReader> m_lReader;
 };

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -22,6 +22,8 @@ public:
 
   ~CFragmentedSampleReader();
 
+  Type GetType() const override { return Type::FMP4; }
+
   virtual bool Initialize(SESSION::CStream* stream) override;
   virtual void SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
                             const DRM::DecrypterCapabilites& dcaps) override;

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -108,9 +108,6 @@ public:
   virtual const AP4_Byte* GetSampleData() const = 0;
   virtual uint64_t GetDuration() const = 0;
   virtual bool IsEncrypted() const = 0;
-  virtual void AddStreamType(INPUTSTREAM_TYPE type, int streamId) {}
-  virtual void SetStreamType(INPUTSTREAM_TYPE type, int streamId) {}
-  virtual bool RemoveStreamType(INPUTSTREAM_TYPE type) { return true; };
   virtual bool IsStarted() const = 0;
   virtual CryptoInfo GetReaderCryptoInfo() const { return CryptoInfo(); }
 

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -44,7 +44,19 @@ public:
 class ATTR_DLL_LOCAL ISampleReader
 {
 public:
+  enum class Type
+  {
+    FMP4,
+    TS,
+    ADTS,
+    WebM,
+    Subtitles,
+  };
+
   virtual ~ISampleReader() = default;
+
+  virtual Type GetType() const = 0;
+
   virtual bool Initialize(SESSION::CStream* stream) { return true; }
   virtual void SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
                             const DRM::DecrypterCapabilites& dcaps){};

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -29,6 +29,8 @@ class ATTR_DLL_LOCAL CSubtitleSampleReader : public ISampleReader
 public:
   CSubtitleSampleReader() = default;
 
+  Type GetType() const override { return Type::Subtitles; }
+
   virtual bool Initialize(SESSION::CStream* stream) override;
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -20,9 +20,11 @@ public:
   Type GetType() const override { return Type::TS; }
 
   bool Initialize(SESSION::CStream* stream) override;
-  void AddStreamType(INPUTSTREAM_TYPE type, int streamId) override;
-  void SetStreamType(INPUTSTREAM_TYPE type, int streamId) override;
-  bool RemoveStreamType(INPUTSTREAM_TYPE type) override;
+
+  void AddStreamType(INPUTSTREAM_TYPE type, int streamId);
+  void SetStreamType(INPUTSTREAM_TYPE type, int streamId);
+  bool RemoveStreamType(INPUTSTREAM_TYPE type);
+
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_dts; }

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -17,6 +17,8 @@ class ATTR_DLL_LOCAL CTSSampleReader : public ISampleReader, public TSReader
 public:
   CTSSampleReader(AP4_ByteStream* input, uint32_t requiredMask);
 
+  Type GetType() const override { return Type::TS; }
+
   bool Initialize(SESSION::CStream* stream) override;
   void AddStreamType(INPUTSTREAM_TYPE type, int streamId) override;
   void SetStreamType(INPUTSTREAM_TYPE type, int streamId) override;

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -17,6 +17,8 @@ class ATTR_DLL_LOCAL CWebmSampleReader : public ISampleReader, public WebmReader
 public:
   CWebmSampleReader(AP4_ByteStream* input);
 
+  Type GetType() const override { return Type::WebM; }
+
   bool IsStarted() const override { return m_started; }
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_dts; }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Currently ISA support to read the TS streams containing the audio stream into the same video stream

in other words, these HLS have a single video playlist stream in .ts, and the same video segments contains also the audio data (similar to local files)

in this case only a single `TSSampleReader` for video track is created, at each read the `TSSampleReader` is automatically able to distinguish between video and audio data and change automagically also the stream ID as needed
therefore, its internal state changes continuously, between video and audio and provide data in PTS order at each read

with MP4 this is different
the `FragmentedSampleReader` use `AP4_LinearReader` to read data, it that cannot switch automagically between audio/video data, it is strongly linked to `AP4_Track`'s usually one AP4_Track for video, one for audio

therefore we must use/share the same `AP4_LinearReader` for both a/v tracks,
(otherwise create multiple `AP4_LinearReader` that point to the same `AdaptiveStream` (AP4_ByteStream) will cause a bad behaviors on data to be read)

since most of code is coupled to `AP4_Track` it is difficult to reuse the same `FragmentedSampleReader` for both tracks, because we need read packet data from both tracks, also initialize the codechandler and extract extradata

I thought about creating a `FragmentedSampleReader` clone by changing the `AP4_Track` (imo maybe the "easy" way)
where share the same  `AP4_LinearReader` of video track,
then inject the sample reader to the CStream by setting the appropriate StreamId

~Currently, this is a POC that demonstrates that both audio and video work,~
~OFC it is not complete and has various problems~

~Currently in WIP state, missing DASH manifest support~

**UPDATE: I will not implement support to "included" streams on DASH with this PR,
after some studies, too many code changes are necessary, the current design of some ISA components are not so suitable, and i'm still not full sure how to deal with it, **

Current support/limitations:
- HLS only
- support to MP4 stream with single included/embedded audio track
- DASH suppport, in a future

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1909 #343

~also #1005 but require to include changes to DASH parser~

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with dailymotion videos such as
https://www.dailymotion.com/video/x9qgg9c
https://www.dailymotion.com/video/x9urjke
the m3u8 link expire, can be found also other videos
just take a look that playlist is with mp4 and not TS

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
