### PR TITLE
Add dvcc parsing and store in inputstream

### DIFF
--- a/src/codechandler/AV1CodecHandler.cpp
+++ b/src/codechandler/AV1CodecHandler.cpp
@@ -12,8 +12,8 @@
 
 using namespace UTILS;
 
-AV1CodecHandler::AV1CodecHandler(AP4_SampleDescription* sd)
-  : CodecHandler(sd), m_codecProfile{STREAMCODEC_PROFILE::CodecProfileUnknown}
+AV1CodecHandler::AV1CodecHandler(AP4_SampleDescription* sd, AP4_Track* track)
+  : CodecHandler(sd, track), m_codecProfile{STREAMCODEC_PROFILE::CodecProfileUnknown}
 {
   if (AP4_Atom* atom = m_sampleDescription->GetDetails().GetChild(AP4_ATOM_TYPE_AV1C, 0))
   {
@@ -51,6 +51,12 @@ bool AV1CodecHandler::GetInformation(kodi::addon::InputstreamInfo& info)
   {
     info.SetCodecProfile(m_codecProfile);
     isChanged = true;
+  }
+
+  // store dvcc metadata
+  if (auto dvcc = ParseDvcc())
+  {
+    PopulateDvccMetadata(info, dvcc, isChanged);
   }
 
   return isChanged;

--- a/src/codechandler/AV1CodecHandler.h
+++ b/src/codechandler/AV1CodecHandler.h
@@ -13,7 +13,7 @@
 class ATTR_DLL_LOCAL AV1CodecHandler : public CodecHandler
 {
 public:
-  AV1CodecHandler(AP4_SampleDescription* sd);
+  AV1CodecHandler(AP4_SampleDescription* sd, AP4_Track* track = nullptr);
 
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
   STREAMCODEC_PROFILE GetProfile() override { return m_codecProfile; }

--- a/src/codechandler/CodecHandler.cpp
+++ b/src/codechandler/CodecHandler.cpp
@@ -60,3 +60,69 @@ bool CodecHandler::UpdateInfoCodecName(kodi::addon::InputstreamInfo& info, const
 
   return isChanged;
 };
+
+AP4_DvccAtom* CodecHandler::ParseDvcc()
+{
+  if (!m_track)
+    return nullptr;
+
+  if (AP4_TrakAtom* trak = m_track->UseTrakAtom())
+  {
+    if (auto mdia = AP4_DYNAMIC_CAST(AP4_ContainerAtom, trak->GetChild(AP4_ATOM_TYPE_MDIA, 0)))
+    {
+      if (auto minf = AP4_DYNAMIC_CAST(AP4_ContainerAtom, mdia->GetChild(AP4_ATOM_TYPE_MINF, 0)))
+      {
+        if (auto stbl = AP4_DYNAMIC_CAST(AP4_ContainerAtom, minf->GetChild(AP4_ATOM_TYPE_STBL, 0)))
+        {
+          if (auto stsd =
+                  AP4_DYNAMIC_CAST(AP4_ContainerAtom, stbl->GetChild(AP4_ATOM_TYPE_STSD, 0)))
+          {
+            for (auto* eitem = stsd->GetChildren().FirstItem(); eitem; eitem = eitem->GetNext())
+            {
+              auto entry_ctn = AP4_DYNAMIC_CAST(AP4_ContainerAtom, eitem->GetData());
+
+              if (!entry_ctn)
+                continue;
+              AP4_Atom* dv_atom = entry_ctn->GetChild(AP4_ATOM_TYPE_DVCC, 0);
+              if (!dv_atom)
+                dv_atom = entry_ctn->GetChild(AP4_ATOM_TYPE_DVVC, 0);
+              if (!dv_atom)
+                continue;
+
+              if (auto dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, dv_atom))
+              {
+                return dvcc;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+void CodecHandler::PopulateDvccMetadata(kodi::addon::InputstreamInfo& info,
+                                        AP4_DvccAtom* dvcc,
+                                        bool& isChanged)
+{
+  if (!dvcc)
+    return;
+
+  kodi::addon::InputstreamDvccMetadata meta;
+  meta.SetDvVersionMajor(dvcc->GetDvVersionMajor());
+  meta.SetDvVersionMinor(dvcc->GetDvVersionMinor());
+  meta.SetDvProfile(dvcc->GetDvProfile());
+  meta.SetDvLevel(dvcc->GetDvLevel());
+  meta.SetRpuPresentFlag(dvcc->GetRpuPresentFlag());
+  meta.SetElPresentFlag(dvcc->GetElPresentFlag());
+  meta.SetBlPresentFlag(dvcc->GetBlPresentFlag());
+  meta.SetBlSignalCompatibilityId(dvcc->GetDvBlSignalCompatibilityID());
+
+  if (!(meta == info.GetDvccMetadata()))
+  {
+    info.SetDvccMetadata(meta);
+    isChanged = true;
+  }
+}

--- a/src/codechandler/CodecHandler.h
+++ b/src/codechandler/CodecHandler.h
@@ -23,8 +23,9 @@
 class ATTR_DLL_LOCAL CodecHandler
 {
 public:
-  CodecHandler(AP4_SampleDescription* sd)
-    : m_sampleDescription(sd), m_naluLengthSize(0), m_pictureId(0), m_pictureIdPrev(0xFF){};
+  CodecHandler(AP4_SampleDescription* sd, AP4_Track* track = nullptr)
+    : m_sampleDescription(sd), m_naluLengthSize(0), m_pictureId(0), m_pictureIdPrev(0xFF),
+      m_track(track){};
   virtual ~CodecHandler(){};
 
   virtual void UpdatePPSId(const AP4_DataBuffer& buffer) {}
@@ -57,11 +58,17 @@ public:
   virtual bool TimeSeek(AP4_UI64 seekPos) { return true; };
   virtual void Reset(){};
 
+  AP4_DvccAtom* ParseDvcc();
+  void PopulateDvccMetadata(kodi::addon::InputstreamInfo& info,
+                            AP4_DvccAtom* dvcc,
+                            bool& isChanged);
+
   AP4_SampleDescription* m_sampleDescription;
   std::vector<uint8_t> m_extraData;
   AP4_UI08 m_naluLengthSize;
   AP4_UI08 m_pictureId;
   AP4_UI08 m_pictureIdPrev;
+  AP4_Track* m_track;
 
   protected:
   bool UpdateInfoCodecName(kodi::addon::InputstreamInfo& info, const char* codecName);

--- a/src/codechandler/HEVCCodecHandler.cpp
+++ b/src/codechandler/HEVCCodecHandler.cpp
@@ -13,7 +13,8 @@
 
 using namespace UTILS;
 
-HEVCCodecHandler::HEVCCodecHandler(AP4_SampleDescription* sd) : CodecHandler(sd)
+HEVCCodecHandler::HEVCCodecHandler(AP4_SampleDescription* sd, AP4_Track* track)
+  : CodecHandler(sd, track)
 {
   if (AP4_HevcSampleDescription* hevcSampleDescription =
           AP4_DYNAMIC_CAST(AP4_HevcSampleDescription, m_sampleDescription))
@@ -92,5 +93,12 @@ bool HEVCCodecHandler::GetInformation(kodi::addon::InputstreamInfo& info)
       }
     }
   }
+
+  // store dvcc metadata
+  if (auto dvcc = ParseDvcc())
+  {
+    PopulateDvccMetadata(info, dvcc, isChanged);
+  }
+
   return isChanged;
 }

--- a/src/codechandler/HEVCCodecHandler.h
+++ b/src/codechandler/HEVCCodecHandler.h
@@ -13,7 +13,7 @@
 class ATTR_DLL_LOCAL HEVCCodecHandler : public CodecHandler
 {
 public:
-  HEVCCodecHandler(AP4_SampleDescription* sd);
+  HEVCCodecHandler(AP4_SampleDescription* sd, AP4_Track* track = nullptr);
 
   bool CheckExtraData(std::vector<uint8_t>& extraData, bool isRequiredAnnexB) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -520,7 +520,7 @@ void CFragmentedSampleReader::UpdateSampleDescription()
 
   LOG::LogF(LOGDEBUG, "Codec fourcc: %s (%u)", CODEC::FourCCToString(desc->GetFormat()).c_str(),
             desc->GetFormat());
-  
+
   if (AP4_DYNAMIC_CAST(AP4_AudioSampleDescription, desc))
   {
     // Audio sample of any format
@@ -540,7 +540,7 @@ void CFragmentedSampleReader::UpdateSampleDescription()
       case AP4_SAMPLE_FORMAT_HVC1:
       case AP4_SAMPLE_FORMAT_DVHE:
       case AP4_SAMPLE_FORMAT_DVH1:
-        m_codecHandler = new HEVCCodecHandler(desc);
+        m_codecHandler = new HEVCCodecHandler(desc, m_track);
         break;
       case AP4_SAMPLE_FORMAT_STPP:
         m_codecHandler = new TTMLCodecHandler(desc, false);
@@ -552,7 +552,7 @@ void CFragmentedSampleReader::UpdateSampleDescription()
         m_codecHandler = new VP9CodecHandler(desc);
         break;
       case AP4_SAMPLE_FORMAT_AV01:
-        m_codecHandler = new AV1CodecHandler(desc);
+        m_codecHandler = new AV1CodecHandler(desc, m_track);
         break;
       default:
         m_codecHandler = new CodecHandler(desc);


### PR DESCRIPTION
## Description
Moved into a separate PR as it involves a change to the InputStream interface

Requires https://github.com/xbmc/xbmc/pull/27136 to be merged first.

## Motivation and context
Pass dolby vision profile information needed by webOS playerAPI

## How has this been tested?
Playback on Disney+ (4K UHD DV, 4K UHD HDR, 1080p streams) on webOS TV

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
