### PR TITLE
Fix to avoid Kodi core to reopen same stream twice times

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -713,7 +713,7 @@ void CSession::EnableStream(CStream* stream, bool enable)
     if (!m_timingStream || stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
       m_timingStream = stream;
 
-    stream->m_isEnabled = true;
+    stream->SetIsEnabled(true);
   }
   else
   {
@@ -821,7 +821,7 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
     if (!streamReader)
       continue;
 
-    if (stream->m_isEnabled)
+    if (stream->IsEnabled())
     {
       // Advice is that VP does not want to wait longer than 10ms for a return from
       // DemuxRead() - here we ask to not wait at all and if ReadSample has not yet
@@ -914,7 +914,7 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
     uint64_t maxTime{0};
     for (auto& stream : m_streams)
     {
-      if (stream->m_isEnabled && (curTime = stream->m_adStream.getMaxTimeMs()) && curTime > maxTime)
+      if (stream->IsEnabled() && (curTime = stream->m_adStream.getMaxTimeMs()) && curTime > maxTime)
       {
         maxTime = curTime;
       }
@@ -961,7 +961,7 @@ bool SESSION::CSession::SeekTime(double seekTime, unsigned int streamId, bool pr
       continue;
 
     streamReader->WaitReadSampleAsyncComplete();
-    if (stream->m_isEnabled && (streamId == 0 || stream->m_info.GetPhysicalIndex() == streamId))
+    if (stream->IsEnabled() && (streamId == 0 || stream->m_info.GetPhysicalIndex() == streamId))
     {
       bool reset{true};
       // all streams must be started before seeking to ensure cross chapter seeks
@@ -1043,7 +1043,7 @@ void SESSION::CSession::OnStreamChange(adaptive::AdaptiveStream* adStream)
 {
   for (auto& stream : m_streams)
   {
-    if (stream->m_isEnabled && &stream->m_adStream == adStream)
+    if (stream->IsEnabled() && &stream->m_adStream == adStream)
     {
       UpdateStream(*stream);
       m_changed = true;

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -25,11 +25,23 @@ public:
   CStream(adaptive::AdaptiveTree* tree,
           PLAYLIST::CAdaptationSet* adp,
           PLAYLIST::CRepresentation* initialRepr)
-    : m_isEnabled{false}, m_adStream{tree, adp, initialRepr}, m_isValid{true}
+    : m_adStream{tree, adp, initialRepr}, m_isValid{true}
   {
   }
 
   ~CStream() { Disable(); }
+
+  /*!
+   * \brief Determines whether the stream is enabled for playback
+   * \return True if the stream is enabled, otherwise false
+   */
+  bool IsEnabled() const { return m_isEnabled; }
+
+  /*!
+   * \brief Set if the stream is enabled for playback
+   * \param isEnabled Set to true to enable the stream
+   */
+  void SetIsEnabled(bool isEnabled) { m_isEnabled = isEnabled; };
 
   /*!
    * \brief Stop/disable the AdaptiveStream and reset
@@ -80,13 +92,13 @@ public:
     m_adByteStream = std::move(adByteStream);
   }
 
-  bool m_isEnabled;
   std::optional<unsigned int> m_mainStreamIndex; // Used when this stream is "included" to video (main stream)
   adaptive::AdaptiveStream m_adStream;
   kodi::addon::InputstreamInfo m_info;
   bool m_isValid;
 
 private:
+  bool m_isEnabled{false};
   std::unique_ptr<ISampleReader> m_streamReader;
   std::unique_ptr<CAdaptiveByteStream> m_adByteStream;
   std::unique_ptr<AP4_File> m_streamFile;

--- a/src/decrypters/DrmEngine.cpp
+++ b/src/decrypters/DrmEngine.cpp
@@ -662,7 +662,7 @@ void DRM::CDRMEngine::ExtractStreamProtectionData(PLAYLIST::CRepresentation* rep
   SESSION::CStream stream{
       const_cast<adaptive::AdaptiveTree*>(&CSrvBroker::GetResources().GetTree()), adp, repr};
 
-  stream.m_isEnabled = true;
+  stream.SetIsEnabled(true);
   stream.m_adStream.start_stream();
   stream.SetAdByteStream(std::make_unique<CAdaptiveByteStream>(&stream.m_adStream));
   stream.SetStreamFile(std::make_unique<AP4_File>(*stream.GetAdByteStream(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,11 @@ bool CInputStreamAdaptive::GetStreamIds(std::vector<unsigned int>& ids)
   if (!m_session)
     return false;
 
+  // You need to reset "stream open" count at each GetStreamIds callback
+  // because after this event all streams will be opened
+  m_streamOpenCount.clear();
+  m_checkCoreReopen = false;
+
   const unsigned int streamCount = m_session->GetStreamCount();
   if (streamCount > INPUTSTREAM_MAX_STREAM_COUNT)
   {
@@ -99,7 +104,9 @@ bool CInputStreamAdaptive::GetStreamIds(std::vector<unsigned int>& ids)
           continue;
       }
 
-      ids.emplace_back(m_session->GetStreamIdFromIndex(i));
+      const int id = m_session->GetStreamIdFromIndex(i);
+      ids.emplace_back(id);
+      m_streamOpenCount[id] = 0;
     }
   }
 
@@ -172,19 +179,26 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
   }
 }
 
-// If we change some Kodi stream property we must to return true
-// to allow Kodi demuxer to reset with our changes the stream properties.
+// OpenStream method notes:
+// - This method is called:
+//    - At playback start
+//    - At chapter/period change (DEMUX_SPECIALID_STREAMCHANGE)
+//    - At stream quality change (DEMUX_SPECIALID_STREAMCHANGE) by "adaptive" streaming or from Kodi OSD
+// - The "streamid" requested can be influenced from preferences set in Kodi settings (e.g. language).
+// - If the requested "streamid" fails to open on the Kodi core side (after OpenStream callback, e.g. for missing extradata)
+//   Kodi core will try to (fallback) open another video "streamid", this will happen recursively until success.
+// - The OpenStream method not only opens the stream, but also implicitly enables it
+//     so don't exists a EnableStream callback to explicitly enable the stream after the opening,
+//     EnableStream method is used by VP only to disable the stream
+//     which can happen immediately after opening (e.g. subtitles disabled on playback startup).
+// - If a stream info property has been changed, you need to return "true" on OpenStream
+//   to allow Kodi core to update its internal properties with our changes.
+// - If you return "true" (it doesn't matter for which stream)
+//   in any case will cause Kodi core to REOPEN ALL STREAMS TWICE TIMES,
+//   so OpenStream method will be called again for all streams.
 bool CInputStreamAdaptive::OpenStream(int streamid)
 {
   LOG::Log(LOGDEBUG, "OpenStream(%d)", streamid);
-  // This method can be called when:
-  // - Stream first start
-  // - Chapter/period change
-  // - Automatic stream (representation) quality change (such as adaptive)
-  // - Manual stream (representation) quality change (from OSD)
-  // streamid behaviour:
-  // - The streamid can be influenced by Kodi core based on preferences set in Kodi settings (e.g. language)
-  // - Fallback calls, e.g. if the opened video streamid fails, Kodi core will try to open another video streamid
 
   if (!m_session)
     return false;
@@ -194,15 +208,18 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (!stream)
     return false;
 
-  if (stream->m_isEnabled)
+  m_streamOpenCount[streamid]++;
+
+  if (stream->m_adStream.StreamChanged())
   {
-    if (stream->m_adStream.StreamChanged())
-    {
-      UnlinkIncludedStreams(stream);
-      stream->Reset();
-      stream->m_adStream.Reset();
-    }
-    else
+    UnlinkIncludedStreams(stream);
+    stream->Reset();
+    stream->m_adStream.Reset();
+  }
+  else
+  {
+    // Check to prevent Kodi core from attempting to open stream twice times (read OpenStream method note)
+    if (m_checkCoreReopen && m_streamOpenCount[streamid] == 2)
     {
       LOG::Log(LOGDEBUG, "OpenStream(%d): The stream has already been opened", streamid);
       return false;
@@ -210,12 +227,6 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   }
 
   stream->m_isEnabled = true;
-
-  //! @todo: for live with multiple periods (like HLS DISCONTINUITIES) for subtitle case
-  //! when the subtitle has been disabled from video start, and happens a period change,
-  //! kodi call OpenStream to the subtitle stream as if it were enabled, and disable it with EnableStream
-  //! just after it, this lead to log error "GenerateSidxSegments: [AS-x] Cannot generate segments from SIDX on repr..."
-  //! need to find a solution to avoid open the stream when previously disabled from previous period
 
   CRepresentation* rep = stream->m_adStream.getRepresentation();
 
@@ -288,6 +299,10 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   // If stream use DRM always update stream info
   const bool isInfoChanged = stream->GetReader()->GetInformation(stream->m_info) ||
                              !stream->m_info.GetCryptoSession().GetSessionId().empty();
+
+  if (isInfoChanged)
+    m_checkCoreReopen = true;
+
   return isInfoChanged;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,7 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
 
   CStream* stream{m_session->GetStream(m_session->GetStreamIndexFromId(streamid))};
 
-  if (!enable && stream && stream->m_isEnabled)
+  if (!enable && stream && stream->IsEnabled())
   {
     UnlinkIncludedStreams(stream);
     m_session->EnableStream(stream, false);
@@ -226,7 +226,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     }
   }
 
-  stream->m_isEnabled = true;
+  stream->SetIsEnabled(true);
 
   CRepresentation* rep = stream->m_adStream.getRepresentation();
 
@@ -239,7 +239,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
 
     while ((mainStream = m_session->GetStream(mainStreamIndex++)))
     {
-      if (mainStream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO && mainStream->m_isEnabled)
+      if (mainStream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO && mainStream->IsEnabled())
         break;
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -65,6 +65,9 @@ private:
   std::atomic<uint64_t> m_lastPts{PLAYLIST::NO_PTS_VALUE};
 
   void UnlinkIncludedStreams(SESSION::CStream* stream);
+
+  bool m_checkCoreReopen{false}; // Check if Kodi core will reopen all streams
+  std::map<int, size_t> m_streamOpenCount; // Count how many times a stream has been opened (Stream ID - count)
 };
 
 /*******************************************************/


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When OpenStream is called by VP and you return "true" to OpenStream callback
https://github.com/xbmc/inputstream.adaptive/blob/f88d2520a76f1a1f2f5118083ce15e70394d83c3/src/main.cpp#L291
it doesn't matter which stream, one or all,
in any case **this will cause to VP to reopen again ALL streams a second time**
(even though there would be no real need for it...and in case if only one stream requires it (not ISA addon case), you should not reopen all the others as well...)

the old code was assuming that if the stream was already enabled was meaning that was already opened from previous OpenStream callback
https://github.com/xbmc/inputstream.adaptive/blob/f88d2520a76f1a1f2f5118083ce15e70394d83c3/src/main.cpp#L197
(that print `OpenStream(xxxx): The stream has already been opened` on log)

but this is not a valid behavior for subtitles case when the playback start with subtitles disabled,
where you have the following situation of callbacks:

GetStreamIds -> OpenStream (return true) -> EnableStream(false) -> OpenStream -> EnableStream(false) -> playback start

on the second OpenStream `m_isEnabled` will be false, and the old check for "reopened" stream will not work, therefore the stream will be opened again, with possible side effects, for example on `CSession::PrepareStream` where call `m_adStream.start_stream` performing not needed operations

since you cant rely to stream `m_isEnabled` value there is no other solution that count how many times the stream has been opened and acts when a single OpenStream has returned "true"

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Long standing todo
where subtitles stream was reopened twice times,
users dont see nothing but this can cause side effects and unnecessary operations that can cause delays

It is somewhere between a workaround and a fix, as it is currently unclear why Kodi core force to opens all the streams twice times, i have no time to analyze all VP code,
imo to me sound a wrong behavior or derived by ancient kodi core implementations,
at least this should be optional, or in alternative the `EnableStream` callback should be used to also enable stream in a explicit way and not implicitly with `OpenStream` (until today `EnableStream` callback is used only to disable a stream)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Case 1:
1) start the stream with subtitles disabled
2) look at log, the log print  `OpenStream(xxxx): The stream has already been opened` dont appears for subtitles (PR fix it)

Case 2: this can be tested with streams having multiple chapters/periods
1) start the stream
2) disable subtitles
3) while playing, wait for the chapter/period change
4) look at log, the log print  `OpenStream(xxxx): The stream has already been opened` dont appears for subtitles (PR fix it)

Case 3: stream quality change
1) Set "stream selection type" on ISA settings to "Test"
2) Wait stream video quality change (`DEMUX_SPECIALID_STREAMCHANGE` event from log)
3) The stream quality change, will force VP to request again all streams, the OpenStream on subtitles must be kept consistent

Case 4: user enable/disable subtitles
1) from kodi OSD enable/disable subtitles
2) the OpenStream on subtitles must be kept consistent

since this happens only when you return true from `OpenStream` callback, its more easy catch this use case by playing: HLS TS stream, or a stream DRM protected

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
