### PR TITLE
[FragmentedSampleReader] Fix switching between unencrypted/crypted content

### DIFF
--- a/src/decrypters/widevine/CdmTypeConversion.cpp
+++ b/src/decrypters/widevine/CdmTypeConversion.cpp
@@ -203,37 +203,44 @@ void media::ToCdmInputBuffer(const DEMUX_PACKET* encryptedBuffer,
   inputBuffer->data = encryptedBuffer->pData;
   inputBuffer->data_size = encryptedBuffer->iSize;
   inputBuffer->timestamp = static_cast<int64_t>(encryptedBuffer->pts * 1000000 / STREAM_TIME_BASE);
-  inputBuffer->key_id = encryptedBuffer->cryptoInfo->kid;
-  inputBuffer->key_id_size = 16;
-  inputBuffer->iv = encryptedBuffer->cryptoInfo->iv;
-  inputBuffer->iv_size = 16;
-
-  const uint16_t numSubsamples =
-      encryptedBuffer->cryptoInfo ? encryptedBuffer->cryptoInfo->numSubSamples : 0;
-  if (numSubsamples > 0)
-  {
-    subsamples->reserve(numSubsamples);
-    for (uint16_t i = 0; i < numSubsamples; i++)
-    {
-      subsamples->push_back({encryptedBuffer->cryptoInfo->clearBytes[i],
-                             encryptedBuffer->cryptoInfo->cipherBytes[i]});
-    }
-  }
-
-  inputBuffer->subsamples = subsamples->data();
-  inputBuffer->num_subsamples = numSubsamples;
 
   if (encryptedBuffer->cryptoInfo)
   {
+    DEMUX_CRYPTO_INFO* cryptoInfo = encryptedBuffer->cryptoInfo;
+
+    inputBuffer->key_id = cryptoInfo->kid;
+    inputBuffer->key_id_size = 16;
+    inputBuffer->iv = cryptoInfo->iv;
+    inputBuffer->iv_size = 16;
+
+    const uint16_t numSubsamples = cryptoInfo->numSubSamples;
+    if (numSubsamples > 0)
+    {
+      subsamples->reserve(numSubsamples);
+      for (uint16_t i = 0; i < numSubsamples; i++)
+      {
+        subsamples->push_back({cryptoInfo->clearBytes[i], cryptoInfo->cipherBytes[i]});
+      }
+
+      inputBuffer->num_subsamples = numSubsamples;
+      inputBuffer->subsamples = subsamples->data();
+    }
+    else
+    {
+      inputBuffer->num_subsamples = 0;
+      inputBuffer->subsamples = nullptr;
+    }
+
     inputBuffer->encryption_scheme =
-        ToCdmEncryptionScheme(static_cast<CryptoMode>(encryptedBuffer->cryptoInfo->mode)); // ??
+        ToCdmEncryptionScheme(static_cast<CryptoMode>(cryptoInfo->mode));
+
+    if (inputBuffer->encryption_scheme != cdm::EncryptionScheme::kUnencrypted)
+    {
+      inputBuffer->pattern = {cryptoInfo->cryptBlocks, cryptoInfo->skipBlocks};
+    }
   }
   else
-    inputBuffer->encryption_scheme = cdm::EncryptionScheme::kUnencrypted;
-
-  if (inputBuffer->encryption_scheme != cdm::EncryptionScheme::kUnencrypted)
   {
-    inputBuffer->pattern = {encryptedBuffer->cryptoInfo->cryptBlocks,
-                            encryptedBuffer->cryptoInfo->skipBlocks};
+    inputBuffer->encryption_scheme = cdm::EncryptionScheme::kUnencrypted;
   }
 }

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -938,6 +938,7 @@ VIDEOCODEC_RETVAL CWVCencSingleSampleDecrypter::DecryptAndDecodeVideo(
   if (sample->cryptoInfo && sample->cryptoInfo->numSubSamples > 0 &&
       (!sample->cryptoInfo->clearBytes || !sample->cryptoInfo->cipherBytes))
   {
+    LOG::LogF(LOGERROR, "Missing crypting clear/cipher bytes info");
     return VC_ERROR;
   }
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -406,7 +406,7 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
       AP4_ContainerAtom* traf =
           AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
 
-      if (!m_protectedDesc || !traf)
+      if (!traf)
         return AP4_ERROR_INVALID_FORMAT;
 
       bool isDefaultProtected{true};

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -196,8 +196,13 @@ AP4_Result CFragmentedSampleReader::ReadSample()
       // to help convert packets to annex-b
       // it depends on decrypter implementation
       m_sampleData.Reserve(sampleData.GetDataSize());
-      m_singleSampleDecryptor->DecryptSampleData(m_poolId, sampleData, m_sampleData, nullptr, 0,
-                                                 nullptr, nullptr, streamType);
+      if (AP4_FAILED(
+              result = m_singleSampleDecryptor->DecryptSampleData(
+                  m_poolId, sampleData, m_sampleData, nullptr, 0, nullptr, nullptr, streamType)))
+      {
+        Reset(true);
+        return result;
+      }
     }
     else
     {

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -44,7 +44,7 @@ CFragmentedSampleReader::~CFragmentedSampleReader()
 {
   if (m_singleSampleDecryptor)
     m_singleSampleDecryptor->RemovePool(m_poolId);
-  delete m_decrypter;
+
   delete m_codecHandler;
 }
 
@@ -55,11 +55,10 @@ bool CFragmentedSampleReader::Initialize(SESSION::CStream* stream)
   AP4_SampleDescription* desc{m_track->GetSampleDescription(0)};
   if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
   {
-    m_protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
+    auto protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
 
     AP4_ContainerAtom* schi;
-    if (m_protectedDesc->GetSchemeInfo() &&
-        (schi = m_protectedDesc->GetSchemeInfo()->GetSchiAtom()))
+    if (protectedDesc->GetSchemeInfo() && (schi = protectedDesc->GetSchemeInfo()->GetSchiAtom()))
     {
       AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
       if (tenc && tenc->GetDefaultKid())
@@ -133,15 +132,10 @@ AP4_Result CFragmentedSampleReader::ReadSample()
     streamType = DRM::DRMMediaType::AUDIO;
 
   AP4_Result result;
+  AP4_DataBuffer sampleData;
   if (!m_codecHandler->ReadNextSample(m_sample, m_sampleData))
   {
-    bool useDecryptingDecoder =
-        m_protectedDesc &&
-        (m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0;
-    bool decrypterPresent{m_decrypter != nullptr};
-    if (AP4_FAILED(result = ReadNextSample(m_track->GetId(), m_sample,
-                                           (m_decrypter || useDecryptingDecoder) ? m_encrypted
-                                                                                 : m_sampleData)))
+    if (AP4_FAILED(result = ReadNextSample(m_track->GetId(), m_sample, sampleData)))
     {
       if (result == AP4_ERROR_EOS)
       {
@@ -170,16 +164,14 @@ AP4_Result CFragmentedSampleReader::ReadSample()
     //AP4_AvcFrameParser::ParseFrameForSPS(m_sampleData.GetData(), m_sampleData.GetDataSize(), 4, sps);
 
     //Protection could have changed in ProcessMoof
-    if (!decrypterPresent && m_decrypter != nullptr && !useDecryptingDecoder)
-      m_encrypted.SetData(m_sampleData.GetData(), m_sampleData.GetDataSize());
-    else if (decrypterPresent && m_decrypter == nullptr && !useDecryptingDecoder)
-      m_sampleData.SetData(m_encrypted.GetData(), m_encrypted.GetDataSize());
+    bool useDecryptingDecoder =
+        m_singleSampleDecryptor &&
+        (m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0;
 
     if (m_decrypter)
     {
-      m_sampleData.Reserve(m_encrypted.GetDataSize());
-      if (AP4_FAILED(result =
-                         m_decrypter->DecryptSampleData(m_poolId, m_encrypted, m_sampleData,
+      m_sampleData.Reserve(sampleData.GetDataSize());
+      if (AP4_FAILED(result = m_decrypter->DecryptSampleData(m_poolId, sampleData, m_sampleData,
                                                         NULL, streamType)))
       {
         LOG::Log(LOGERROR, "Decrypt Sample returns failure!");
@@ -200,9 +192,16 @@ AP4_Result CFragmentedSampleReader::ReadSample()
     }
     else if (useDecryptingDecoder)
     {
-      m_sampleData.Reserve(m_encrypted.GetDataSize());
-      m_singleSampleDecryptor->DecryptSampleData(m_poolId, m_encrypted, m_sampleData, nullptr, 0,
+      // Should fall here for the specific case of unencrypted content,
+      // to help convert packets to annex-b
+      // it depends on decrypter implementation
+      m_sampleData.Reserve(sampleData.GetDataSize());
+      m_singleSampleDecryptor->DecryptSampleData(m_poolId, sampleData, m_sampleData, nullptr, 0,
                                                  nullptr, nullptr, streamType);
+    }
+    else
+    {
+      m_sampleData.SetData(sampleData.GetData(), sampleData.GetDataSize());
     }
 
     if (m_codecHandler->Transform(m_sample.GetDts(), m_sample.GetDuration(), m_sampleData,
@@ -235,8 +234,7 @@ uint64_t CFragmentedSampleReader::GetDuration() const
 
 bool CFragmentedSampleReader::IsEncrypted() const
 {
-  return (m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0 &&
-         m_decrypter != nullptr;
+  return (m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0 && m_decrypter;
 }
 
 bool CFragmentedSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
@@ -405,9 +403,6 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
       AP4_CencSampleInfoTable* sample_table{nullptr};
       AP4_UI32 algorithm_id = 0;
 
-      delete m_decrypter;
-      m_decrypter = 0;
-
       AP4_ContainerAtom* traf =
           AP4_DYNAMIC_CAST(AP4_ContainerAtom, moof->GetChild(AP4_ATOM_TYPE_TRAF, 0));
 
@@ -446,7 +441,7 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
       if (!m_singleSampleDecryptor)
         return AP4_ERROR_INVALID_PARAMETERS;
 
-      m_decrypter = new CAdaptiveCencSampleDecrypter(m_singleSampleDecryptor, sample_table);
+      m_decrypter = std::make_unique<CAdaptiveCencSampleDecrypter>(m_singleSampleDecryptor, sample_table);
 
       // Inform decrypter of pattern decryption (CBCS)
       AP4_UI32 schemeType = m_protectedDesc->GetSchemeType();
@@ -472,6 +467,7 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
     else
     {
       // Reset for unencrypted content
+      m_decrypter.reset();
       m_readerCryptoInfo = CryptoInfo();
     }
   }

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -195,6 +195,8 @@ AP4_Result CFragmentedSampleReader::ReadSample()
       // Should fall here for the specific case of unencrypted content,
       // to help convert packets to annex-b
       // it depends on decrypter implementation
+      //! @todo: it appears to have been implemented in the past for Widevine
+      //!        and may not be suitable for other decryptors
       m_sampleData.Reserve(sampleData.GetDataSize());
       if (AP4_FAILED(
               result = m_singleSampleDecryptor->DecryptSampleData(

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -70,12 +70,11 @@ private:
   uint64_t m_timeBaseExt{0};
   uint64_t m_timeBaseInt{0};
   AP4_Sample m_sample;
-  AP4_DataBuffer m_encrypted;
   AP4_DataBuffer m_sampleData;
   CodecHandler* m_codecHandler{nullptr};
   std::vector<uint8_t> m_defaultKey;
   AP4_ProtectedSampleDescription* m_protectedDesc{nullptr};
   std::shared_ptr<Adaptive_CencSingleSampleDecrypter> m_singleSampleDecryptor{nullptr};
-  CAdaptiveCencSampleDecrypter* m_decrypter{nullptr};
+  std::unique_ptr<CAdaptiveCencSampleDecrypter> m_decrypter;
   CryptoInfo m_readerCryptoInfo{};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
followup of PR #1916

Here is a partial reworking of how `CFragmentedSampleReader::ReadSample` chooses which decryptor to use
still not so clear to me the reason why there was so messy variables in that method before,
perhaps some manifests use cases that i am unaware of and that should be documented,
or past attempts to fix other issues that are now unnecessary...who knowns

at least for n€tflix use case, the stream start with unencrypted packets, and then switch to encrypted content
so this lead to initially use `useDecryptingDecoder` condition for unencrypted content and then use `m_decrypter` condition for encrypted content,
so in any case also the unencrypted packets need to be passed to the WV decrypter

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
final fix #1865
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
user of issue confirm to works

i also tested another similar (but not equal) stream use case from ISA Samples:
`Dash -> Google Tears [CBCS]`

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
