### PR TITLE
[HLSTree] Fix playing live segments in a loop

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1343,6 +1343,10 @@ void adaptive::AdaptiveStream::Stop()
 void adaptive::AdaptiveStream::clear()
 {
   current_adp_ = 0;
+
+  if (current_rep_)
+    current_rep_->current_segment_.reset();
+
   current_rep_ = 0;
 }
 

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1197,13 +1197,6 @@ bool adaptive::AdaptiveStream::seek_time(double seek_seconds, bool preceeding, b
   if (choosen_seg && current_rep_->Timeline().Get(choosen_seg)->startPTS_ > sec_in_ts)
     --choosen_seg;
 
-  if (!preceeding && sec_in_ts > current_rep_->Timeline().Get(choosen_seg)->startPTS_ &&
-      current_adp_->GetStreamType() == StreamType::VIDEO)
-  {
-    //Assume that we have I-Frames only at segment start
-    ++choosen_seg;
-  }
-
   const std::optional<CSegment> oldSeg = current_rep_->current_segment_;
   const CSegment* newSeg = current_rep_->Timeline().Get(choosen_seg);
 

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -102,11 +102,6 @@ namespace adaptive
              m_isLive ? "live" : "VOD");
   }
 
-  void AdaptiveTree::FreeSegments(CRepresentation* repr)
-  {
-    repr->Timeline().Clear();
-  }
-
   void AdaptiveTree::OnDataArrived(uint64_t segNum,
                                    std::optional<CAesKeyInfo>& aesKey,
                                    uint8_t iv[16],

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -105,7 +105,6 @@ namespace adaptive
   void AdaptiveTree::FreeSegments(CRepresentation* repr)
   {
     repr->Timeline().Clear();
-    repr->current_segment_.reset();
   }
 
   void AdaptiveTree::OnDataArrived(uint64_t segNum,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -192,8 +192,6 @@ public:
    */
   virtual void OnPeriodChange() {}
 
-  void FreeSegments(PLAYLIST::CRepresentation* repr);
-
   /*!
    * \brief Some types of live manifests do not include segments, so the client must create them,
    *        this method could be used in conjunction with manifest updates.

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -773,7 +773,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
           period->SetTlDuration(periodDuration);
         }
 
-        FreeSegments(rep);
+        rep->Timeline().Clear();
 
         rep->SetStartNumber(mediaSequenceNbr);
 
@@ -868,7 +868,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
     rep->AddDrmInfo(info.second);
   }
 
-  FreeSegments(rep);
+  rep->Timeline().Clear();
   rep->Timeline().Swap(newSegments);
   rep->SetStartNumber(mediaSequenceNbr);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The main problem is due to AdaptiveTree::FreeSegments
this method is called while in playback during manifest updates and reset the "current segment"
resetting current segment while we have "wait for segment" set
https://github.com/xbmc/inputstream.adaptive/blob/cd3fef6b0138af7803943224ab5d69d60510a44d/src/common/AdaptiveStream.cpp#L920-L922
This will cause side effects because there is no longer a reference point from which to resume playback once new segments have been obtained, i.e., to choose the next segment. Therefore, playback continued by always taking the oldest (initial) segment, causing a loop in the video

while investigating on this, i found another bug,
following code about i-frames (where we dont have any documentation about the use cases)
https://github.com/xbmc/inputstream.adaptive/blob/cd3fef6b0138af7803943224ab5d69d60510a44d/src/common/AdaptiveStream.cpp#L1200-L1205
was potentially forcing the segment forward to a position that may not exist in the timeline
causing in some cases a forced stop of playback (due to missing segment position),
therefore, even if the problem could be fixed by adding a check on the number of segments available in the timeline,
this code will never behave consistently, so i choose to full remove it, and see if someone report some kind of weirdness

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1954 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Play stream with "stream selection type":
- fixed resolution
- Manual OSD (by changing quality)
- Test (auto changing quality)

and video seek

on both: Live and VOD streams

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
