### PR TITLE
[AdaptiveStream] Fix/simplify obtaining segment from PTS

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1168,44 +1168,17 @@ bool adaptive::AdaptiveStream::seek_time(double seek_seconds, bool preceeding, b
 
   std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(m_tree->GetTreeUpdMutex());
 
-  uint64_t sec_in_ts = static_cast<uint64_t>(seek_seconds * current_rep_->GetTimescale());
+  const uint64_t pts = static_cast<uint64_t>(seek_seconds * current_rep_->GetTimescale());
 
-  //Skip initialization
-  size_t choosen_seg{0};
-
-  while (choosen_seg < current_rep_->Timeline().GetSize() &&
-         sec_in_ts > current_rep_->Timeline().Get(choosen_seg)->startPTS_)
-  {
-    ++choosen_seg;
-  }
-
-  if (choosen_seg == current_rep_->Timeline().GetSize())
-  {
-    if (!current_rep_->Timeline().Get(0))
-    {
-      LOG::LogF(LOGERROR, "[AS-%u] Segment at position 0 not found from representation id: %s",
-                clsId, current_rep_->GetId().c_str());
-      return false;
-    }
-
-    if (sec_in_ts < current_rep_->Timeline().Get(0)->startPTS_ + current_rep_->Timeline().GetDuration())
-      --choosen_seg;
-    else
-      return false;
-  }
-
-  if (choosen_seg && current_rep_->Timeline().Get(choosen_seg)->startPTS_ > sec_in_ts)
-    --choosen_seg;
-
+  const CSegment* seekSeg = current_rep_->Timeline().FindByPTSOrNext(pts);
   const std::optional<CSegment> oldSeg = current_rep_->current_segment_;
-  const CSegment* newSeg = current_rep_->Timeline().Get(choosen_seg);
 
-  if (newSeg)
+  if (seekSeg)
   {
     needReset = true;
-    if (oldSeg.has_value() && !newSeg->IsSame(*oldSeg))
+    if (oldSeg.has_value() && !seekSeg->IsSame(*oldSeg))
     {
-      ResetCurrentSegment(*newSeg);
+      ResetCurrentSegment(*seekSeg);
     }
     else if (!preceeding)
     {
@@ -1224,7 +1197,7 @@ bool adaptive::AdaptiveStream::seek_time(double seek_seconds, bool preceeding, b
       //! and these downloads will be deleted just later without to be read, because CSession::SeekTime call these
       //! method two times so by starting two times downloads.
       //! This code has been introduced as part of subtitles fixes from https://github.com/xbmc/inputstream.adaptive/pull/1082
-      ResetCurrentSegment(*newSeg);
+      ResetCurrentSegment(*seekSeg);
 
       absolute_position_ -= segment_read_pos_;
       segment_read_pos_ = 0;

--- a/src/common/Segment.cpp
+++ b/src/common/Segment.cpp
@@ -136,6 +136,19 @@ const CSegment* PLAYLIST::CSegContainer::Find(const CSegment& seg) const
   return nullptr;
 }
 
+const CSegment* PLAYLIST::CSegContainer::FindByPTSOrNext(uint64_t pts) const
+{
+  for (const CSegment& seg : m_segments)
+  {
+    if (seg.startPTS_ <= pts && pts <= seg.m_endPts)
+      return &seg;
+
+    if (seg.startPTS_ > pts)
+      return &seg;
+  }
+  return nullptr;
+}
+
 const size_t PLAYLIST::CSegContainer::GetPos(const CSegment& seg) const
 {
   for (size_t i = 0; i < m_segments.size(); ++i)

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -116,6 +116,13 @@ public:
   const CSegment* Find(const CSegment& seg) const;
 
   /*!
+   * \brief Find segment containing the PTS, or the next segment if PTS falls in a gap.
+   * \param pts The PTS, in timescale
+   * \return Segment containing PTS, or next segment after PTS, or nullptr if PTS is after all segments
+   */
+  const CSegment* FindByPTSOrNext(uint64_t pts) const;
+
+  /*!
    * \brief Get index position of a segment in the timeline.
    * \param elem The segment to get the position
    * \return The index position, or SEGMENT_NO_POS if not found


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
From recent PR #1955 i removed code commented as "Assume that we have I-Frames only at segment start"
commit https://github.com/xbmc/inputstream.adaptive/commit/94f6e40c8cb720f9d918084c9ab3771b77df0d5f

but i notices a crash on video seek from some streams
for example following HLS AVC https://www.dailymotion.com/video/x9u25zs 

seem that since i removed the above linked code on AdaptiveStream::seek_time
now select a segment where the PTS is not in the range (start/end PTS) of the segment
this PTS discrepancy seems to cause Bento4 to crash

the crash come from a call of `SeekSample` from `CFragmentedSampleReader::TimeSeek`
(seeksample method is a our custom implementation so i wonder if there is something wrong on it)
https://github.com/xbmc/Bento4/blob/f5eed3d7a4ec39bab8ed43332e58a0e6337fa189/Source/C%2B%2B/Core/Ap4LinearReader.cpp#L688-L692
seem that when the PTS is not in the range, 
last call to `Advance` method in `AP4_LinearReader::SeekSample` cause to delete the SampleTable of the tracker
then when call `SetSampleIndex` crash due to missing SampleTable

my idea is rework all related code to find more precisely the segment
by taking in account start/end PTS of each segment in the timeline

Unfortunately i haven't yet been able to fully understand how that bento4 method works, and atm i can't spend many hours on it
i'm afraid that it might contain old standing bugs

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
while working on WIP PR i found this problem

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://www.dailymotion.com/video/x9u25zs 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
