### PR TITLE
[Deps][Bento4] Video seek crash on FMP4 with inlcuded audio

### DIFF
--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -676,13 +676,39 @@ AP4_LinearReader::Tracker* CLinearReader::FindTracker(AP4_UI32 track_id)
 
 AP4_Result CLinearReader::GetSample(AP4_UI32 track_id, AP4_Sample& sample, AP4_Ordinal sample_index)
 {
-  return AP4_LinearReader::GetSample(track_id, sample, sample_index);
+  // look for a sample from a specific track
+  Tracker* tracker = FindTracker(track_id);
+  if (tracker == NULL)
+    return AP4_ERROR_INVALID_PARAMETERS;
+
+  // don't continue if we've reached the end of that tracker
+  if (tracker->m_Eos)
+    return AP4_ERROR_EOS;
+
+  return tracker->m_SampleTable->GetSample(sample_index, sample);
 }
 
 void CLinearReader::Reset()
 {
   std::lock_guard<std::mutex> lock(m_readerMtx);
-  AP4_LinearReader::Reset();
+
+  // flush any queued samples
+  FlushQueues();
+
+  // reset tracker states
+  for (unsigned int i = 0; i < m_Trackers.ItemCount(); i++)
+  {
+    if (m_Trackers[i]->m_SampleTableIsOwned)
+    {
+      delete m_Trackers[i]->m_SampleTable;
+    }
+    delete m_Trackers[i]->m_NextSample;
+    m_Trackers[i]->m_SampleTable = NULL;
+    m_Trackers[i]->m_NextSample = NULL;
+    m_Trackers[i]->m_NextSampleIndex = 0;
+    m_Trackers[i]->m_Eos = false;
+  }
+  m_NextFragmentPosition = 0;
 }
 
 AP4_ByteStream* CLinearReader::GetByteStream()
@@ -693,6 +719,59 @@ AP4_ByteStream* CLinearReader::GetByteStream()
 AP4_Movie& CLinearReader::GetMovie()
 {
   return AP4_LinearReader::m_Movie;
+}
+
+AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id,
+                                     AP4_UI64 ts,
+                                     AP4_Ordinal& sample_index,
+                                     bool preceedingSync)
+{
+  // we only support fragmented sources for now
+  if (!m_HasFragments)
+    return AP4_ERROR_NOT_SUPPORTED;
+
+  if (m_Trackers.ItemCount() == 0)
+  {
+    return AP4_ERROR_NO_SUCH_ITEM;
+  }
+
+  // look for a sample from a specific track
+  Tracker* tracker = FindTracker(track_id);
+  if (tracker == NULL)
+    return AP4_ERROR_INVALID_PARAMETERS;
+
+  // don't continue if we've reached the end of that tracker
+  if (tracker->m_Eos)
+    return AP4_ERROR_EOS;
+
+  AP4_Result result;
+
+  if (!tracker->m_SampleTable && AP4_FAILED(result = Advance()))
+    return result;
+
+  while (AP4_FAILED(result = tracker->m_SampleTable->GetSampleIndexForTimeStamp(ts, sample_index)))
+  {
+    if (result == AP4_ERROR_NOT_ENOUGH_DATA)
+    {
+      tracker->m_NextSampleIndex = tracker->m_SampleTable->GetSampleCount();
+      if (AP4_FAILED(result = Advance()))
+        return result;
+      continue;
+    }
+    return result;
+  }
+
+  sample_index = tracker->m_SampleTable->GetNearestSyncSampleIndex(sample_index, preceedingSync);
+  //we have reached the end -> go for the first sample of the next segment
+  if (sample_index == tracker->m_SampleTable->GetSampleCount())
+  {
+    tracker->m_NextSampleIndex = tracker->m_SampleTable->GetSampleCount();
+    if (AP4_FAILED(result = Advance()))
+      return result;
+
+    sample_index = 0;
+  }
+  return SetSampleIndex(tracker->m_Track->GetId(), sample_index);
 }
 
 AP4_Result CLinearReader::ProcessMoof(AP4_ContainerAtom* moof,

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -766,11 +766,25 @@ AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id,
   if (sample_index == tracker->m_SampleTable->GetSampleCount())
   {
     tracker->m_NextSampleIndex = tracker->m_SampleTable->GetSampleCount();
-    if (AP4_FAILED(result = Advance()))
-      return result;
 
+    const bool isOwned = tracker->m_SampleTableIsOwned;
+    // Temporarily set m_SampleTableIsOwned to false to prevent "Advance" method
+    // from deleting the tracker sample table
+    tracker->m_SampleTableIsOwned = false;
+
+    if (AP4_FAILED(result = Advance()))
+    {
+      tracker->m_SampleTableIsOwned = isOwned;
+      return result;
+    }
+
+    tracker->m_SampleTableIsOwned = isOwned;
     sample_index = 0;
   }
+
+  if (!tracker->m_SampleTable) // Required for SetSampleIndex
+    return AP4_ERROR_INVALID_STATE;
+
   return SetSampleIndex(tracker->m_Track->GetId(), sample_index);
 }
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -290,18 +290,22 @@ bool CFragmentedSampleReader::TimeSeek(uint64_t pts, bool preceeding)
 {
   AP4_Ordinal sampleIndex;
   AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));
-  if (AP4_SUCCEEDED(m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex, preceeding)))
+
+  AP4_Result result = m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex, preceeding);
+  if (AP4_FAILED(result))
   {
-    if (m_decrypter)
-      m_decrypter->SetSampleIndex(sampleIndex);
-
-    if (m_codecHandler)
-      m_codecHandler->TimeSeek(seekPos);
-
-    m_started = true;
-    return AP4_SUCCEEDED(ReadSample());
+    LOG::LogF(LOGERROR, "Cannot seek track id %u, error %i", m_track->GetId(), result);
+    return false;
   }
-  return false;
+
+  if (m_decrypter)
+    m_decrypter->SetSampleIndex(sampleIndex);
+
+  if (m_codecHandler)
+    m_codecHandler->TimeSeek(seekPos);
+
+  m_started = true;
+  return AP4_SUCCEEDED(ReadSample());
 }
 
 void CFragmentedSampleReader::SetPTSOffset(uint64_t offset)

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -70,6 +70,11 @@ public:
   // \brief Get AP4_LinearReader::m_Movie
   AP4_Movie& GetMovie();
 
+  AP4_Result SeekSample(AP4_UI32 track_id,
+                        AP4_UI64 ts,
+                        AP4_Ordinal& sample_index,
+                        bool preceedingSync);
+
 protected:
   // AP4_LinearReader implementations
   AP4_Result ProcessMoof(AP4_ContainerAtom* moof,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Attempt to fix bento4 crash on video seek

the crash is raised by `SetSampleIndex` call of our custom `AP4_LinearReader::SeekSample` implementation method
https://github.com/xbmc/Bento4/blob/f5eed3d7a4ec39bab8ed43332e58a0e6337fa189/Source/C%2B%2B/Core/Ap4LinearReader.cpp#L692

that method assume that the sample table of specified track id/tracker (`m_SampleTable`) exists, since will be deleted cause the crash

Code flow and possible solution:

`GetSampleIndexForTimeStamp` find the sample index by PTS,
so we have an index, example 4, but if the sample "sync" was (for example) on index 3
this mean that `GetNearestSyncSampleIndex` called later, can't see the 3 because only looks for another one at later position, if it exists

in this case, it cannot be found
so `sample_index` become equal to `GetSampleCount` and triggers the following condition
https://github.com/xbmc/Bento4/blob/f5eed3d7a4ec39bab8ed43332e58a0e6337fa189/Source/C%2B%2B/Core/Ap4LinearReader.cpp#L685-L688
then `Advance` method will be called, but this one delete the sample table since `m_NextSampleIndex` is equal to `GetSampleCount` and its a "owned" sample table.

i tried add an additional call to `GetNearestSyncSampleIndex` by setting "before" method argument to True, to allow a backward search (and find the index 3, example above) but seem to cause more  `CVideoPlayer::CheckPlayerInit - dropping packet` log prints than before with other DASH streams

so i kept the code as is, and i temporary set `m_SampleTableIsOwned` of current used tracker to false, to prevent that "Advance" method delete the sample table. This way seem to not affect other DASH streams with `CVideoPlayer::CheckPlayerInit - dropping packet` and fix in the dailymotion video seek that at least dont crash anymore

since i don't have in-depth knowledge of FMP4, i hope this change is a sufficient solution for this purpose


EDIT:
since now we have a local `AP4_LinearReader` imlementation `CLinearReader`
i took the opportunity to lighten the bento4 patches from our fork and move (code untouched) the custom implementations here, the fix is still done on a separate commit.
i will do a bento4 fork cleanup, and new release on separate PR

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1909
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
