### PR TITLE
[FragmentedSampleReader] Fix check for EOS on seek method

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1048,6 +1048,19 @@ bool adaptive::AdaptiveStream::seek(uint64_t const pos, bool& isEos)
 {
   if (m_segBuffers.IsEmpty())
   {
+    // NOTE: FragmentedSampleReader (FMP4) hacky sequential read:
+    // When FragmentedSampleReader run ReadNextSample, its possible that AP4_LinearReader
+    // try to go to the start of the next fragment even though it has already reached the end of the file
+    // (of the last segment fed) so AP4_LinearReader::AdvanceFragment do a callback to this method.
+    // This method assume to read always from the current segment,
+    // but if there are no segments, on live streams it could mean that we are waiting for the next
+    // manifest update or the insertion of new live segments.
+    // At this point, since the value of "IsWaitForSegment" could have been changed to False
+    // just before this "seek" callback, we must call "ensureSegment" to guarantee the next segment
+    // and obtain an updated value for "IsWaitForSegment" to determine a EOS
+    if (ensureSegment())
+      return true;
+
     if (!current_rep_->IsWaitForSegment())
       isEos = true;
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -149,6 +149,8 @@ AP4_Result CFragmentedSampleReader::ReadSample()
   {
     if (AP4_FAILED(result = m_lReader->ExecReadNextSample(this, m_track->GetId(), m_sample, sampleData)))
     {
+      m_sampleData.SetDataSize(0);
+
       if (result == AP4_ERROR_EOS)
       {
         auto adByteStream = dynamic_cast<CAdaptiveByteStream*>(m_lReader->GetByteStream());
@@ -159,14 +161,8 @@ AP4_Result CFragmentedSampleReader::ReadSample()
         }
         else
         {
-          if (adByteStream->waitingForSegment())
-          {
-            m_sampleData.SetDataSize(0);
-          }
-          else
-          {
+          if (!adByteStream->waitingForSegment())
             m_eos = true;
-          }
         }
       }
       return result;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix check for EOS on seek method

problem seem introduced from PR #1915 by commit 84ceab70648269e0cd4f06c65b4684f843e0b70f
cause of premature playback stop on live streams
due to the unreliable value of `IsWaitForSegment` that trigger EOS when the buffer runs out

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1969 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
user provided sample stream, but can be reproduced with all live streams having FMP4 a/v container
just force the buffer to empty to activate IsWaitForSegment, so force seek video to live edge more times

tested again FMP4 streams with included audio, to avoid a new regression fixed by initial intention of 84ceab70648269e0cd4f06c65b4684f843e0b70f

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
