### PR TITLE
[Session] Set appropriate media type to drm engine init

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -189,7 +189,7 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
           else
           {
             LOG::LogF(LOGWARNING, "Stream media type \"%i\" is not supported by the DRM engine",
-                      sType);
+                      static_cast<int>(sType));
             continue;
           }
 
@@ -683,7 +683,8 @@ bool SESSION::CSession::PrepareStream(CStream& stream, uint64_t startPts)
       drmMediaType = DRM::DRMMediaType::AUDIO;
     else
     {
-      LOG::LogF(LOGWARNING, "Stream media type \"%i\" is not supported by the DRM engine", sType);
+      LOG::LogF(LOGWARNING, "Stream media type \"%i\" is not supported by the DRM engine",
+                static_cast<int>(sType));
       return false;
     }
 

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -179,7 +179,21 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
           kodi::addon::InputstreamInfo isInfo;
           DRM::DRMInfo initDrmInfo;
 
-          if (m_drmEngine.InitializeSession(repr->DrmInfos(), DRM::DRMMediaType::VIDEO,
+          DRM::DRMMediaType drmMediaType{DRM::DRMMediaType::UNKNOWN};
+          const StreamType sType = adp->GetStreamType();
+
+          if (sType == StreamType::VIDEO || sType == StreamType::VIDEO_AUDIO)
+            drmMediaType = DRM::DRMMediaType::VIDEO;
+          else if (sType == StreamType::AUDIO)
+            drmMediaType = DRM::DRMMediaType::AUDIO;
+          else
+          {
+            LOG::LogF(LOGWARNING, "Stream media type \"%i\" is not supported by the DRM engine",
+                      sType);
+            continue;
+          }
+
+          if (m_drmEngine.InitializeSession(repr->DrmInfos(), drmMediaType,
                                             period->IsSecureDecodeNeeded(), isInfo, repr.get(),
                                             adp.get(), false, initDrmInfo))
           {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Set appropriate media type to drm engine init
i think its a oversight of the big drm code change from PR #1724

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
found by investigating for other things
by testing following ISASamples  stream
<img width="560" height="32" alt="immagine" src="https://github.com/user-attachments/assets/7f5287aa-9b12-4c54-969d-82dee6b66e61" />
i noticed that drm sessions created was only one instead of two

`CSession::CheckPlayableStreams` has a different way to initialize drm also due to a workaround for a missing widevine feature, initilize in advance all streams

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
