### PR TITLE
Implement "ignore_fmp4_defaultkid" parameter to "manifest_config" property

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -418,6 +418,10 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseManifestConfig(const std::string& dat
         break;
       }
     }
+    else if (configName == "ignore_fmp4_defaultkid" && jValue.is_boolean())
+    {
+      m_manifestConfig.ignoreFMP4defaultKid = jValue.get<bool>();
+    }
     else
     {
       LOG::LogF(LOGERROR, "Unsupported \"%s\" config or wrong data type on \"%s\" property",

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -72,6 +72,12 @@ struct ManifestConfig
   uint64_t liveDelay{0};
   // Allows to set a custom UTC Timing for DASH live streams (schemeIdUri, value)
   std::optional<std::pair<std::string, std::string>> dashUTCTiming;
+  // If true will ignore default KID provided from FMP4 init segment
+  // and so will be used from the manifest one
+  //! @todo: This is a temporary workaround for a much broader issue,
+  //! where DRM initialization should occur first with MP4 init segment protection data
+  //! and then if it fails, try init DRM with manifest protection data
+  bool ignoreFMP4defaultKid{false};
 };
 
 struct DrmCfg

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -716,7 +716,8 @@ bool SESSION::CSession::PrepareStream(CStream& stream, uint64_t startPts)
   }
 
   if (session)
-    reader->SetDecrypter(session->decrypter, session->capabilities);
+    reader->SetDecrypter(session->decrypter, session->capabilities,
+                         DRM::ConvertKidStrToBytes(session->kid));
 
   stream.SetReader(std::move(reader));
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -112,6 +112,8 @@ void CFragmentedSampleReader::SetDecrypter(std::shared_ptr<Adaptive_CencSingleSa
   if (!kodiProps.GetManifestConfig().ignoreFMP4defaultKid)
   {
     // Get default KID from initialization segment
+    //! @todo: init segment can provide also PSSH, see also DRM engine code
+    //! where there is a decoupled code, all this need to be reworked
     AP4_SampleDescription* desc{m_track->GetSampleDescription(0)};
     if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
     {
@@ -720,11 +722,11 @@ void CFragmentedSampleReader::ParseMoofPssh(AP4_ContainerAtom* moof)
 
   if (!psshEntries.empty())
   {
-    //! @todo: Key rotation feature not implemented
+    //! @todo: PSSH can also be used for Key rotation feature, that is not implemented
     //! Possible use case: MPD dont provide KID/PSSH and init segment has default KID 00000000000000000000000000000000
     //! a placeholder that means no default KID, so its needed initialize DRM later time when we can
     //! parse a media segment with a PSSH (or SEIG box)
-    LOG::LogF(LOGDEBUG, "Found %zu PSSH on media segment, key rotation feature not supported", psshEntries.size());
+    LOG::LogF(LOGDEBUG, "Found %zu PSSH on media segment", psshEntries.size());
   }
 }
 

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -9,6 +9,8 @@
 #include "FragmentedSampleReader.h"
 
 #include "AdaptiveByteStream.h"
+#include "CompKodiProps.h"
+#include "SrvBroker.h"
 #include "codechandler/AV1CodecHandler.h"
 #include "codechandler/AVCCodecHandler.h"
 #include "codechandler/AudioCodecHandler.h"
@@ -65,27 +67,6 @@ bool CFragmentedSampleReader::Initialize(SESSION::CStream* stream)
 {
   m_lReader->EnableTrack(m_track->GetId());
 
-  AP4_SampleDescription* desc{m_track->GetSampleDescription(0)};
-  if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
-  {
-    auto protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
-
-    AP4_ContainerAtom* schi;
-    if (protectedDesc->GetSchemeInfo() && (schi = protectedDesc->GetSchemeInfo()->GetSchiAtom()))
-    {
-      AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
-      if (tenc && tenc->GetDefaultKid())
-        m_defaultKey.assign(tenc->GetDefaultKid(), tenc->GetDefaultKid() + 16);
-      else
-      {
-        AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(
-            AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
-        if (piff && piff->GetDefaultKid())
-          m_defaultKey.assign(piff->GetDefaultKid(), piff->GetDefaultKid() + 16);
-      }
-    }
-  }
-
   m_timeBaseExt = STREAM_TIME_BASE;
   m_timeBaseInt = m_track->GetMediaTimeScale();
   if (m_timeBaseInt == 0)
@@ -113,7 +94,8 @@ bool CFragmentedSampleReader::Initialize(SESSION::CStream* stream)
 }
 
 void CFragmentedSampleReader::SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
-                                           const DRM::DecrypterCapabilites& dcaps)
+                                           const DRM::DecrypterCapabilites& dcaps,
+                                           const std::vector<uint8_t>& defaultKid)
 {
   if (ssd)
   {
@@ -122,6 +104,39 @@ void CFragmentedSampleReader::SetDecrypter(std::shared_ptr<Adaptive_CencSingleSa
   }
   
   m_decrypterCaps = dcaps;
+
+  auto& kodiProps = CSrvBroker::GetKodiProps();
+  //! @todo: This is a temporary workaround for a much broader issue,
+  //! where DRM initialization should occur first with MP4 init segment protection data
+  //! and then if it fails, try init DRM with manifest protection data
+  if (!kodiProps.GetManifestConfig().ignoreFMP4defaultKid)
+  {
+    // Get default KID from initialization segment
+    AP4_SampleDescription* desc{m_track->GetSampleDescription(0)};
+    if (desc->GetType() == AP4_SampleDescription::TYPE_PROTECTED)
+    {
+      auto protectedDesc = static_cast<AP4_ProtectedSampleDescription*>(desc);
+
+      AP4_ContainerAtom* schi;
+      if (protectedDesc->GetSchemeInfo() && (schi = protectedDesc->GetSchemeInfo()->GetSchiAtom()))
+      {
+        AP4_TencAtom* tenc(AP4_DYNAMIC_CAST(AP4_TencAtom, schi->GetChild(AP4_ATOM_TYPE_TENC, 0)));
+        if (tenc && tenc->GetDefaultKid())
+          m_defaultKey.assign(tenc->GetDefaultKid(), tenc->GetDefaultKid() + 16);
+        else
+        {
+          AP4_PiffTrackEncryptionAtom* piff(AP4_DYNAMIC_CAST(
+              AP4_PiffTrackEncryptionAtom, schi->GetChild(AP4_UUID_PIFF_TRACK_ENCRYPTION_ATOM, 0)));
+          if (piff && piff->GetDefaultKid())
+            m_defaultKey.assign(piff->GetDefaultKid(), piff->GetDefaultKid() + 16);
+        }
+      }
+    }
+  }
+  else // Use manifest default KID (or extracted by DRM engine from init segment)
+  {
+    m_defaultKey = defaultKid;
+  }
 }
 
 AP4_Result CFragmentedSampleReader::Start(bool& bStarted)
@@ -345,7 +360,7 @@ std::unique_ptr<ISampleReader> CFragmentedSampleReader::CreateReaderByTrack()
   }
 
   auto newFragReader = std::make_unique<CFragmentedSampleReader>(m_lReader, selTrack);
-  newFragReader->SetDecrypter(m_singleSampleDecryptor, m_decrypterCaps);
+  newFragReader->SetDecrypter(m_singleSampleDecryptor, m_decrypterCaps, m_defaultKey);
 
   LOG::LogF(LOGDEBUG, "Created shared reader for audio track id %u", selTrack->GetId());
 

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -97,7 +97,8 @@ public:
 
   virtual bool Initialize(SESSION::CStream* stream) override;
   virtual void SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
-                            const DRM::DecrypterCapabilites& dcaps) override;
+                            const DRM::DecrypterCapabilites& dcaps,
+                            const std::vector<uint8_t>& defaultKid) override;
 
   AP4_Result Start(bool& bStarted) override;
   AP4_Result ReadSample() override;

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -59,7 +59,11 @@ public:
 
   virtual bool Initialize(SESSION::CStream* stream) { return true; }
   virtual void SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
-                            const DRM::DecrypterCapabilites& dcaps){};
+                            const DRM::DecrypterCapabilites& dcaps,
+                            const std::vector<uint8_t>& defaultKid)
+  {
+  }
+
   /*!
    * \brief Defines if the end of the stream is reached
    */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
the issue #1973 revealed a clear implementation problem that we have been carrying with us since the early days of this add-on
ISA uses an incorrect method to select KID/PSSH to initialize DRM

**current**: look MPD protection data -> init DRM by using MPD data -> but MP4 reader use MP4 init segment protection info (reasons for mismatch and broken playback of your case)

**needed**: look MPD protection data -> look at MP4 init seg protection info -> try init DRM by using MP4 init seg protection info (init segment should have priority, since usually its more reliable, in theory) -> then if fails (e.g. missing KID) -> try init DRM by using MPD data

This is what i was able to understand also with the help of AI
since the drm info provided by segments should have always the priority over the MPD metadata, because segment data should be more updated than the MPD

an example is the CBCS sample stream from ISASamples addon where the MPD provide PSSH/defaultKID for SD content, instead the init segment provide the PSSH/defaultKID for HD content
so using the MPD protection data means broken playback

the issue #1973 instead is a bit different
MPD provide a correct PSSH/defKID, and init segment could be also correct but in this case the license for x reason dont provide the defaut KID specified by init segment, so fails, and should be used the MPD one (we need to fallback to MPD)

Full fixing this is not trivial and require much changes, also on android side that atm i don't have a complete picture due to missing pieces in our android wrapper code

Therefore even though it's a pain shit this workaround is the only thing that i can provide in a fast way

use example
```py
listitem.setProperty('inputstream.adaptive.manifest_config', '{"ignore_fmp4_defaultkid":true}')
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
a workaround for issue #1973
a complete fix require too much changes that touch different components
and too much time is required to do it

anyway it will be my next task to do since IMO is of fundamental importance

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
