### PR TITLE
[AdaptiveStream] Fix wrong end pts on SIDX segments

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -442,6 +442,7 @@ bool adaptive::AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
 
     CSegment seg;
     seg.startPTS_ = 0;
+    seg.m_time = 0;
 
     // Iterate each atom in the stream
     AP4_DefaultAtomFactory atomFactory;
@@ -484,10 +485,10 @@ bool adaptive::AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
         {
           seg.range_begin_ = seg.range_end_ + 1;
           seg.range_end_ = seg.range_begin_ + refs[i].m_ReferencedSize - 1;
+          seg.m_endPts = seg.startPTS_ + refs[i].m_SubsegmentDuration;
           rep->Timeline().Add(seg);
 
           seg.startPTS_ += refs[i].m_SubsegmentDuration;
-          seg.m_endPts = seg.startPTS_ + refs[i].m_SubsegmentDuration;
           seg.m_time += refs[i].m_SubsegmentDuration;
         }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix wrong end pts on SIDX segments

all problem about all downloaded segments was caused because end pts was not set in the first segment
small oversights big damages

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1982 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
