### PR TITLE
Seek fixes and improvements

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -911,10 +911,8 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
   return false;
 }
 
-bool SESSION::CSession::SeekTime(double seekTime)
+bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
 {
-  bool ret{false};
-
   if (m_streams.empty())
     return false;
 
@@ -949,26 +947,14 @@ bool SESSION::CSession::SeekTime(double seekTime)
 
   seekTime -= chapterTime;
 
-  // don't try to seek past the end of the stream, leave a sensible amount so we can buffer properly
   if (m_adaptiveTree->IsLive())
   {
-    double maxSeek{0};
-    uint64_t curTime;
-    uint64_t maxTime{0};
-    for (auto& stream : m_streams)
-    {
-      if (stream->IsEnabled() && (curTime = stream->m_adStream.getMaxTimeMs()) && curTime > maxTime)
-      {
-        maxTime = curTime;
-      }
-    }
+    double delayPtsSecs =
+        (static_cast<double>(GetMediaDurationMs()) / 1000) - m_adaptiveTree->m_liveDelay;
 
-    maxSeek = (static_cast<double>(maxTime) / 1000) - m_adaptiveTree->m_liveDelay;
-    if (maxSeek < 0)
-      maxSeek = 0;
-
-    if (seekTime > maxSeek)
-      seekTime = maxSeek;
+    // Check to avoid seek into live delay duration portion, to allow an appropriate live buffering
+    if (seekTime > delayPtsSecs)
+      seekTime = delayPtsSecs;
   }
 
   // Helper lambda to check if reader is started,
@@ -1023,12 +1009,18 @@ bool SESSION::CSession::SeekTime(double seekTime)
     const double seekSecs = static_cast<double>(seekTimeCorrected) / STREAM_TIME_BASE;
 
     if (!SeekAdStream(*m_timingStream, seekSecs))
+    {
+      isError = true;
       return false;
+    }
 
+    // Note: The following "running" check will download/read the package right now
+    // allowing you to read the PTS diff from stream reader
     if (!CheckReaderRunning(*m_timingStream))
       return false;
 
     ptsDiff = timingReader->GetPTSDiff();
+
     if (ptsDiff < 0 && seekTimeCorrected + ptsDiff > seekTimeCorrected)
       seekTimeCorrected = 0;
     else
@@ -1063,17 +1055,29 @@ bool SESSION::CSession::SeekTime(double seekTime)
       const double seekSecs{static_cast<double>(seekTimeCorrected - ptsDiff) / STREAM_TIME_BASE};
 
       if (!SeekAdStream(*stream, seekSecs))
-        continue;
+      {
+        if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_SUBTITLE)
+          continue; // Subtitles failure should not block the seek operations
+
+        isError = true;
+        return false;
+      }
     }
 
     if (!CheckReaderRunning(*stream))
-      continue;
+      return false;
 
     streamReader->SetPTSDiff(ptsDiff);
 
     if (!streamReader->TimeSeek(seekTimeCorrected))
     {
       streamReader->Reset(true);
+
+      if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_SUBTITLE)
+        continue; // Subtitles failure should not block the seek operations
+
+      isError = true;
+      return false;
     }
     else
     {
@@ -1085,16 +1089,20 @@ bool SESSION::CSession::SeekTime(double seekTime)
       LOG::Log(LOGINFO, "Seek time %0.1lf for stream: %i continues at %0.1lf (PTS: %llu)", seekTime,
                streamReader->GetStreamId(), destTime, streamReader->PTS());
 
+      // We replace the seek time PTS initially requested with the PTS of the video sample found
+      // in order to search the audio/subtitle sample packet more accurately.
+      // f.e. in the case of MP4 the video packet has very few sample sync points
+      // while the audio stream usually has many sample sync points, this cause a misalignment
+      // because for the video you will never find an exact sample for the requested PTS.
+      // Then get the nearest PTS found for the video, then align the audio/subtitles with it.
       if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
       {
         seekTime = destTime;
         seekTimeCorrected = streamReader->PTS();
       }
-      ret = true;
     }
   }
-
-  return ret;
+  return true;
 }
 
 void SESSION::CSession::OnDemuxRead()
@@ -1105,7 +1113,10 @@ void SESSION::CSession::OnDemuxRead()
 
     if (GetChapterSeekTime() > 0)
     {
-      SeekTime(GetChapterSeekTime());
+      bool isError{false};
+      if (!SeekTime(GetChapterSeekTime(), isError))
+        DeleteStreams();
+
       ResetChapterSeekTime();
     }
   }
@@ -1348,4 +1359,12 @@ PLAYLIST::CAdaptationSet* SESSION::CSession::DetermineDefaultAdpSet(PLAYLIST::CP
   }
 
   return defaultAdp;
+}
+
+uint64_t SESSION::CSession::GetMediaDurationMs()
+{
+  if (!m_timingStream || !m_timingStream->IsEnabled())
+    return 0;
+
+  return m_timingStream->m_adStream.getMaxTimeMs();
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -147,12 +147,14 @@ public:
    */
   void OnScreenResChange();
 
-  /*! \brief Seek streams and readers to a specified time
-   *  \param seekTime The seek time in seconds
-   *  \return True if seeking to another chapter or 1+ streams successfully
-   *          seeked, false on error or no streams seeked
+  /*!
+   * \brief Seek streams and readers to a specified time.
+   * \param seekTime The seek time in seconds.
+   * \param isError Cannot seek due to unrecoverable error,
+   *                in this case the method always return false.
+   * \return True if the operation is successful (or seek through chapter/s), otherwise false
    */
-  bool SeekTime(double seekTime);
+  bool SeekTime(double seekTime, bool& isError);
 
   /*! \brief Report if the current content is dynamic/live
    *  \return True if live, false if VOD
@@ -261,6 +263,11 @@ protected:
    * \return The AdaptationSet, or nullptr if unhandled
    */
   PLAYLIST::CAdaptationSet* DetermineDefaultAdpSet(PLAYLIST::CPeriod* period);
+
+  /*!
+   * \brief Get the media duration in ms, based on segments.
+   */
+  uint64_t GetMediaDurationMs();
 
 private:
   DRM::CDRMEngine m_drmEngine;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1135,25 +1135,21 @@ bool adaptive::AdaptiveStream::seek(uint64_t const pos, bool& isEos)
 
 uint64_t adaptive::AdaptiveStream::getMaxTimeMs()
 {
-  if (current_rep_->Timeline().IsEmpty())
+  const CSegment* lastSeg = current_rep_->Timeline().GetBack();
+  if (!lastSeg)
     return 0;
 
-  uint64_t duration{0};
-  if (current_rep_->Timeline().GetSize() > 1)
+  const uint64_t maxPts =
+      (lastSeg->m_endPts * current_rep_->timescale_ext_) / current_rep_->timescale_int_;
+
+  if (absolutePTSOffset_ > maxPts)
   {
-    duration =
-        current_rep_->Timeline().Get(current_rep_->Timeline().GetSize() - 1)->startPTS_ -
-        current_rep_->Timeline().Get(current_rep_->Timeline().GetSize() - 2)->startPTS_;
+    LOG::LogF(LOGERROR, "Absolute PTS offset (%llu) exceeds max PTS (%llu)", absolutePTSOffset_,
+              maxPts);
+    return 0;
   }
 
-  uint64_t timeExt = ((current_rep_->Timeline()
-                           .Get(current_rep_->Timeline().GetSize() - 1)
-                           ->startPTS_ +
-                       duration) *
-                      current_rep_->timescale_ext_) /
-                     current_rep_->timescale_int_;
-
-  return (timeExt - absolutePTSOffset_) / 1000;
+  return (maxPts - absolutePTSOffset_) / 1000;
 }
 
 void adaptive::AdaptiveStream::Disable()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -301,13 +301,6 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
   // since it can cause to reopen all streams, reset the check just before
   m_checkCoreReopen = false;
 
-  if (~m_failedSeekTime)
-  {
-    LOG::Log(LOGDEBUG, "Seeking to last failed seek position (%d)", m_failedSeekTime);
-    m_session->SeekTime(static_cast<double>(m_failedSeekTime) * 0.001f);
-    m_failedSeekTime = ~0;
-  }
-
   ISampleReader* sr{nullptr};
 
   if (m_session->GetNextSample(sr))
@@ -425,15 +418,36 @@ void CInputStreamAdaptive::SetVideoResolution(unsigned int width,
 
 bool CInputStreamAdaptive::PosTime(int ms)
 {
+  // Note: VP may require a seek (ms) even beyond the total duration of the media.
+  // Note: When you return false VP will continue to request packets with DemuxRead callbacks
+  // VP should expect to continue playback from the last PTS fed (as if the seek had not occurred)
+  // or you can stop playback by forcibly stop the packet feed from DemuxRead callbacks.
   if (!m_session)
     return false;
 
   LOG::Log(LOGINFO, "PosTime (%d)", ms);
 
-  bool ret = m_session->SeekTime(static_cast<double>(ms) * 0.001f);
-  m_failedSeekTime = ret ? ~0 : ms;
+  const uint64_t currentTimeMs = m_session->GetElapsedTimeMs();
+  bool isError{false};
 
-  return ret;
+  if (m_session->SeekTime(static_cast<double>(ms) * 0.001f, isError))
+    return true;
+
+  if (!isError)
+  {
+    // If for some reason the seek operation fails without errors
+    // try to restore the streams/readers to previous (current) position
+    LOG::Log(LOGWARNING, "PosTime - Seek failed. Attempt to restore previous %llu ms position",
+             currentTimeMs);
+
+    if (m_session->SeekTime(static_cast<double>(currentTimeMs) * 0.001f, isError))
+      return false; // returns false because the initially requested seek was unsuccessful
+  }
+
+  // A problem has occurred or EOS, force stop playback
+  LOG::Log(LOGDEBUG, "PosTime - Cannot seek at %d ms position.", ms);
+  m_session->DeleteStreams();
+  return false;
 }
 
 int CInputStreamAdaptive::GetTotalTime()

--- a/src/main.h
+++ b/src/main.h
@@ -57,7 +57,6 @@ public:
 
 private:
   std::shared_ptr<SESSION::CSession> m_session;
-  int m_failedSeekTime = ~0;
 
   // The last PTS of the segment package fed to kodi.
   // NO_PTS_VALUE only when playback starts or a new period starts

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1825,8 +1825,17 @@ void adaptive::CDashTree::GenerateTemplatedSegments(PLAYLIST::CSegmentTemplate& 
 
   const uint64_t timeEnd = wndEnd * segTimescale / 1000;
 
-  // Create segments within time window
-  while (time + segDuration <= timeEnd && segNumber <= segNumberEnd)
+  // Create segments within time window,
+  // a segment that begins within the period and partially
+  // extends beyond the period boundaries must still be generated
+  //! @todo: currently when a segment extends beyond the period boundaries
+  //! it will exist also on next period, this will cause duplicate playback of the content (you can see also twice downloads)
+  //! in theory this should be fixed in the sample reader, where the sample packets of a segment
+  //! (at the beginning or end) must be filtered based on the duration of the period.
+  //! In other words, finish playing a segment early by skipping the samples that fall outside the period,
+  //! while in the next period, start playing the segment from a sample with a specific PTS,
+  //! thus skipping part of the initial samples.
+  while (time < timeEnd && segNumber <= segNumberEnd)
   {
     CSegment seg;
     seg.startPTS_ = time;

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -63,5 +63,5 @@ bool CADTSSampleReader::TimeSeek(uint64_t pts)
     m_started = true;
     return AP4_SUCCEEDED(ReadSample());
   }
-  return AP4_ERROR_EOS;
+  return false; // EOS
 }

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -313,7 +313,9 @@ bool CFragmentedSampleReader::TimeSeek(uint64_t pts)
   AP4_Result result = m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex);
   if (AP4_FAILED(result))
   {
-    LOG::LogF(LOGERROR, "Cannot seek track id %u, error %i", m_track->GetId(), result);
+    if (result != AP4_ERROR_EOS)
+      LOG::LogF(LOGERROR, "Cannot seek track id %u, error %i", m_track->GetId(), result);
+
     return false;
   }
 

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -113,5 +113,5 @@ bool CTSSampleReader::TimeSeek(uint64_t pts)
     m_started = true;
     return AP4_SUCCEEDED(ReadSample());
   }
-  return AP4_ERROR_EOS;
+  return false; // EOS
 }

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -67,5 +67,5 @@ bool CWebmSampleReader::TimeSeek(uint64_t pts)
     m_started = true;
     return AP4_SUCCEEDED(ReadSample());
   }
-  return AP4_ERROR_EOS;
+  return false; // EOS
 }

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -285,7 +285,7 @@ TEST_F(DASHTreeTest, CalculateCorrectSegmentNumbersFromSegmentTemplateWithOldPub
 
   auto& segments = tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
-  EXPECT_EQ(segments.GetSize(), 30);
+  EXPECT_EQ(segments.GetSize(), 31);
   EXPECT_EQ(segments.Get(0)->m_number, 603271);
 }
 
@@ -712,7 +712,7 @@ TEST_F(DASHTreeTest, SegmentTemplateStartNumber)
 
   // Verify segments
   auto& rep1Timeline = adpSets[0]->GetRepresentations()[0]->Timeline();
-  EXPECT_EQ(rep1Timeline.GetSize(), 143);
+  EXPECT_EQ(rep1Timeline.GetSize(), 144);
 
   EXPECT_EQ(rep1Timeline.Get(0)->startPTS_, 0);
   EXPECT_EQ(rep1Timeline.Get(0)->m_number, 0);
@@ -720,8 +720,8 @@ TEST_F(DASHTreeTest, SegmentTemplateStartNumber)
   EXPECT_EQ(rep1Timeline.Get(1)->startPTS_, 48000);
   EXPECT_EQ(rep1Timeline.Get(1)->m_number, 1);
 
-  EXPECT_EQ(rep1Timeline.Get(142)->startPTS_, 6816000);
-  EXPECT_EQ(rep1Timeline.Get(142)->m_number, 142);
+  EXPECT_EQ(rep1Timeline.Get(143)->startPTS_, 6864000);
+  EXPECT_EQ(rep1Timeline.Get(143)->m_number, 143);
 }
 
 TEST_F(DASHTreeTest, TSBMiddlePeriods)
@@ -743,9 +743,9 @@ TEST_F(DASHTreeTest, TSBMiddlePeriods)
   auto& tlPeriod2 =
       tree->m_periods[1]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
-  EXPECT_EQ(tlPeriod2.GetSize(), 2);
+  EXPECT_EQ(tlPeriod2.GetSize(), 3);
   EXPECT_EQ(tlPeriod2.GetFront()->m_number, 856065420);
-  EXPECT_EQ(tlPeriod2.GetBack()->m_number, 856065421);
+  EXPECT_EQ(tlPeriod2.GetBack()->m_number, 856065422);
 }
 
 TEST_F(DASHTreeTest, TSBMiddlePeriodsPastNowTime)
@@ -778,9 +778,9 @@ TEST_F(DASHTreeTest, TSBAvailabilityStartTime)
   auto& tl =
       tree->m_periods[0]->GetAdaptationSets()[0]->GetRepresentations()[0]->Timeline();
 
-  EXPECT_EQ(tl.GetSize(), 1200);
+  EXPECT_EQ(tl.GetSize(), 1201);
   EXPECT_EQ(tl.GetFront()->m_number, 129069);
-  EXPECT_EQ(tl.GetBack()->m_number, 130268);
+  EXPECT_EQ(tl.GetBack()->m_number, 130269);
 }
 
 TEST_F(DASHTreeTest, TSBUTCTimingDirect1)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Seeking to end can makes video stall and audio continue from previous position, or both a/v return to previous position as if the seek had not occurred,
this can be caused from:
- `PosTime` called by VP with a time that exceeds the total media time. For some reason that i dont have understood yet when you seek to the end (e.g. with keyboard) the VP call `PosTime` by requesting a ms time that can go beyond the total time of duration of media. This can cause some mess such as video segment that cannot be found with `FindByPTSOrNext` where instead the audio is found due to possible segment misalignment, so video stall and audio continue to play
- In case of some sort of failing of `Session::SeekTime` can trigger `m_failedSeekTime` behavior
- The stream readers `TimeSeek` methods was returning wrongly "true" when fails for EOS causing bad behaviors

i reworked a bit things also by removing `m_failedSeekTime` so now a possible fallback is handled always from the `PosTime` method and not from DemuxRead callback

---

The last commit: `[DashTree] Allow generate segment beyond period boudaries`
concern segment generated from DASH manifest SegmentTemplate,
where in case the last segment have a partial duration it was previously not created
this was causing video seek stall/freeze when you do a video seek that falls into the last missing segment

an complete example to reproduce the video seek freeze problem is on Issue: https://github.com/xbmc/xbmc/issues/27816

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #1989 


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
