### PR TITLE
[FragmentedSampleReader] Rework method to find the sample index

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1036,6 +1036,13 @@ bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
       seekTimeCorrected += ptsDiff;
   }
 
+  // Note: At the end of the seek operations, you may notice on Kodi debug log "dropping packets" prints
+  // this happens because we cannot always guarantee a precise seek, for example
+  // with FragmentedSampleReader (MP4 samples/packets)
+  // we need to start feeding the Kodi demuxer with a synchronization sample/packet
+  // but the sync sample (packet) at least for the video track is usually not available for all PTS
+  // so we try choose the sample/package closest to the requested "seek" PTS, causing "dropping packets"
+
   for (auto& stream : m_streams)
   {
     ISampleReader* streamReader{stream->GetReader()};

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -28,6 +28,8 @@
 
 #include <bento4/Ap4SencAtom.h>
 
+#include <limits>
+
 using namespace UTILS;
 
 namespace
@@ -308,7 +310,7 @@ bool CFragmentedSampleReader::TimeSeek(uint64_t pts, bool preceeding)
   AP4_Ordinal sampleIndex;
   AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));
 
-  AP4_Result result = m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex, preceeding);
+  AP4_Result result = m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex);
   if (AP4_FAILED(result))
   {
     LOG::LogF(LOGERROR, "Cannot seek track id %u, error %i", m_track->GetId(), result);
@@ -813,10 +815,7 @@ AP4_Movie& CLinearReader::GetMovie()
   return AP4_LinearReader::m_Movie;
 }
 
-AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id,
-                                     AP4_UI64 ts,
-                                     AP4_Ordinal& sample_index,
-                                     bool preceedingSync)
+AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id, AP4_UI64 ts, AP4_Ordinal& sample_index)
 {
   // we only support fragmented sources for now
   if (!m_HasFragments)
@@ -838,24 +837,23 @@ AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id,
 
   AP4_Result result;
 
-  if (!tracker->m_SampleTable && AP4_FAILED(result = Advance()))
-    return result;
-
-  while (AP4_FAILED(result = tracker->m_SampleTable->GetSampleIndexForTimeStamp(ts, sample_index)))
+  if (!tracker->m_SampleTable)
   {
-    if (result == AP4_ERROR_NOT_ENOUGH_DATA)
+    if (AP4_FAILED(result = Advance()))
+      return result;
+    // Ensure that Advance has populated the sample table
+    if (!tracker->m_SampleTable)
     {
-      tracker->m_NextSampleIndex = tracker->m_SampleTable->GetSampleCount();
-      if (AP4_FAILED(result = Advance()))
-        return result;
-      continue;
+      LOG::LogF(LOGERROR, "No sample table");
+      return AP4_ERROR_INVALID_STATE;
     }
-    return result;
   }
 
-  sample_index = tracker->m_SampleTable->GetNearestSyncSampleIndex(sample_index, preceedingSync);
-  //we have reached the end -> go for the first sample of the next segment
-  if (sample_index == tracker->m_SampleTable->GetSampleCount())
+  //! @todo: remove our custom GetNearestSyncSampleIndex from Bento4
+  AP4_Cardinal samplesCount = tracker->m_SampleTable->GetSampleCount();
+
+  // No samples, attempt advance to (download/read) next segment
+  if (samplesCount == 0)
   {
     tracker->m_NextSampleIndex = tracker->m_SampleTable->GetSampleCount();
 
@@ -869,13 +867,70 @@ AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id,
       tracker->m_SampleTableIsOwned = isOwned;
       return result;
     }
+    // Ensure that Advance has populated the sample table
+    if (!tracker->m_SampleTable)
+    {
+      LOG::LogF(LOGERROR, "No sample table");
+      return AP4_ERROR_INVALID_STATE;
+    }
 
     tracker->m_SampleTableIsOwned = isOwned;
-    sample_index = 0;
+    samplesCount = tracker->m_SampleTable->GetSampleCount();
+
+    if (samplesCount == 0)
+    {
+      LOG::LogF(LOGERROR, "No samples found in the segment packet");
+      return AP4_ERROR_INVALID_STATE;
+    }
+  }
+
+  constexpr AP4_Cardinal indexNoValue{std::numeric_limits<AP4_Cardinal>::max()};
+  AP4_Cardinal syncIndex{indexNoValue};
+  AP4_UI64 syncCts{0};
+  AP4_Cardinal sampleIndex{indexNoValue};
+
+  // Try find a sample "sync", when possible, with equal or higher ts than the target ts
+  // or, fallback to the sample (without sync) with nearest ts
+  // NOTE: search exclusively within this segment,
+  // avoiding requesting (download/read) other segments to speedup the seek operation
+  for (AP4_Cardinal index{0}; index < samplesCount; ++index)
+  {
+    AP4_Sample sample;
+    if (AP4_FAILED(tracker->m_SampleTable->GetSample(index, sample)))
+      continue;
+
+    const AP4_UI64 cts = sample.GetCts();
+    if (sample.IsSync())
+    {
+      if (syncIndex == indexNoValue || syncCts < ts && cts > syncCts)
+      {
+        syncCts = cts;
+        syncIndex = index;
+      }
+    }
+    // Find any sample (no sync) closer to the target ts
+    if (cts <= ts)
+      sampleIndex = index;
+  }
+
+  if (syncIndex != indexNoValue)
+    sample_index = syncIndex;
+  else if (sampleIndex != indexNoValue)
+  {
+    LOG::LogF(LOGDEBUG, "No sample sync found, fallback to sample with nearest timestamp");
+    sample_index = sampleIndex;
+  }
+  else
+  {
+    LOG::LogF(LOGERROR, "Cannot determine the sample index");
+    return AP4_ERROR_INVALID_STATE;
   }
 
   if (!tracker->m_SampleTable) // Required for SetSampleIndex
+  {
+    LOG::LogF(LOGERROR, "Missing sample table, cannot set the sample index");
     return AP4_ERROR_INVALID_STATE;
+  }
 
   return SetSampleIndex(tracker->m_Track->GetId(), sample_index);
 }

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -70,10 +70,7 @@ public:
   // \brief Get AP4_LinearReader::m_Movie
   AP4_Movie& GetMovie();
 
-  AP4_Result SeekSample(AP4_UI32 track_id,
-                        AP4_UI64 ts,
-                        AP4_Ordinal& sample_index,
-                        bool preceedingSync);
+  AP4_Result SeekSample(AP4_UI32 track_id, AP4_UI64 ts, AP4_Ordinal& sample_index);
 
 protected:
   // AP4_LinearReader implementations


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The old method was using two methods sequentially to find the sample index
GetSampleIndexForTimeStamp
GetNearestSyncSampleIndex

this was a method that could sometimes cause problems
the situation example:

target timestamp (TS): 155
list of samples:
- sample 150
- sample 151
- sample 152
- sample 153 (sync point)
- sample 154
- sample 155
- sample 156

`GetSampleIndexForTimeStamp` will return index 5
(if fails execute `Advance` to get next segment)
since the above have set index to 5
`GetNearestSyncSampleIndex` will try to find a sample sync from index 5 and subsequent, and nothing will return
causing to fails and execute `Advance` to get next segment

It is understandable that there are several points where Advance could be executed and force a download of more segments,
and so causing a slowdown in the seek, as the data from these downloads needs to be read immediately

this PR will rework this, by try finding a sample sync closer to the target ts (any available) in the current segment
and in case fallback to a sample with closer ts (without sync)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found while investigating
i always suspected that Advance method used was one of cause to do some delay on seek but i never looked deeply
so this will improve the video seek speed on mp4 streams

fix #1992

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
test a stream using MP4 container, then while seeking, check downloaded segments
but it is still better to debug the underlying code and check when Advance method is called

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
