### PR TITLE
[Session] Removed SeekTime preceeding

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -911,7 +911,7 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
   return false;
 }
 
-bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
+bool SESSION::CSession::SeekTime(double seekTime)
 {
   bool ret{false};
 
@@ -989,16 +989,15 @@ bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
   };
 
   // Helper lambda to perform seek on adaptive stream segment buffer
-  auto SeekAdStream = [](CStream& stream, double seekSecs, bool preceeding) -> bool
+  auto SeekAdStream = [](CStream& stream, double seekSecs) -> bool
   {
     if (!stream.m_adStream.seek_time(seekSecs))
     {
       stream.GetReader()->Reset(true);
       return false;
     }
-    if (!preceeding)
-      stream.GetReader()->Reset(false);
 
+    stream.GetReader()->Reset(false);
     return true;
   };
 
@@ -1023,7 +1022,7 @@ bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
 
     const double seekSecs = static_cast<double>(seekTimeCorrected) / STREAM_TIME_BASE;
 
-    if (!SeekAdStream(*m_timingStream, seekSecs, preceeding))
+    if (!SeekAdStream(*m_timingStream, seekSecs))
       return false;
 
     if (!CheckReaderRunning(*m_timingStream))
@@ -1063,7 +1062,7 @@ bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
     {
       const double seekSecs{static_cast<double>(seekTimeCorrected - ptsDiff) / STREAM_TIME_BASE};
 
-      if (!SeekAdStream(*stream, seekSecs, preceeding))
+      if (!SeekAdStream(*stream, seekSecs))
         continue;
     }
 
@@ -1072,7 +1071,7 @@ bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
 
     streamReader->SetPTSDiff(ptsDiff);
 
-    if (!streamReader->TimeSeek(seekTimeCorrected, preceeding))
+    if (!streamReader->TimeSeek(seekTimeCorrected))
     {
       streamReader->Reset(true);
     }
@@ -1090,7 +1089,6 @@ bool SESSION::CSession::SeekTime(double seekTime, bool preceeding)
       {
         seekTime = destTime;
         seekTimeCorrected = streamReader->PTS();
-        preceeding = false;
       }
       ret = true;
     }

--- a/src/Session.h
+++ b/src/Session.h
@@ -149,12 +149,10 @@ public:
 
   /*! \brief Seek streams and readers to a specified time
    *  \param seekTime The seek time in seconds
-   *  \param preceeding True to seek to keyframe preceeding seektime,
-   *         false to clamp to the start of the next segment
    *  \return True if seeking to another chapter or 1+ streams successfully
    *          seeked, false on error or no streams seeked
    */
-  bool SeekTime(double seekTime, bool preceeding = true);
+  bool SeekTime(double seekTime);
 
   /*! \brief Report if the current content is dynamic/live
    *  \return True if live, false if VOD

--- a/src/demuxers/ADTSReader.cpp
+++ b/src/demuxers/ADTSReader.cpp
@@ -413,7 +413,7 @@ bool ADTSReader::GetInformation(kodi::addon::InputstreamInfo& info)
 }
 
 // We assume that m_startpos is the current I-Frame position
-bool ADTSReader::SeekTime(uint64_t timeInTs, bool preceeding)
+bool ADTSReader::SeekTime(uint64_t timeInTs)
 {
   while (m_pts < timeInTs)
     if (!ReadPacket())

--- a/src/demuxers/ADTSReader.h
+++ b/src/demuxers/ADTSReader.h
@@ -102,7 +102,7 @@ public:
   virtual ~ADTSReader();
 
   void Reset();
-  bool SeekTime(uint64_t timeInTs, bool preceeding);
+  bool SeekTime(uint64_t timeInTs);
 
   bool GetInformation(kodi::addon::InputstreamInfo& info);
   bool ReadPacket();

--- a/src/demuxers/TSReader.cpp
+++ b/src/demuxers/TSReader.cpp
@@ -206,7 +206,7 @@ bool TSReader::GetInformation(kodi::addon::InputstreamInfo& info)
 }
 
 // We assume that m_startpos is the current I-Frame position
-bool TSReader::SeekTime(uint64_t timeInTs, bool preceeding)
+bool TSReader::SeekTime(uint64_t timeInTs)
 {
   bool hasVideo(false);
   //look if we have video
@@ -218,7 +218,7 @@ bool TSReader::SeekTime(uint64_t timeInTs, bool preceeding)
     }
 
   uint64_t lastRecovery(static_cast<uint64_t>(m_startPos));
-  while (m_pkt.pts == PTS_UNSET || !preceeding || static_cast<uint64_t>(m_pkt.pts) < timeInTs)
+  while (m_pkt.pts == PTS_UNSET || static_cast<uint64_t>(m_pkt.pts) < timeInTs)
   {
     uint64_t thisFrameStart(m_AVContext->GetRecoveryPos());
     if (!ReadPacket())
@@ -226,7 +226,7 @@ bool TSReader::SeekTime(uint64_t timeInTs, bool preceeding)
     if (!hasVideo || m_pkt.recoveryPoint || thisFrameStart >= m_startPos)
     {
       lastRecovery = thisFrameStart;
-      if (!preceeding && static_cast<uint64_t>(m_pkt.pts) >= timeInTs)
+      if (static_cast<uint64_t>(m_pkt.pts) >= timeInTs)
         break;
     }
   }

--- a/src/demuxers/TSReader.h
+++ b/src/demuxers/TSReader.h
@@ -30,7 +30,7 @@ public:
 
   void Reset(bool resetPackets = true);
   bool StartStreaming(AP4_UI32 typeMask);
-  bool SeekTime(uint64_t timeInTs, bool preceeding);
+  bool SeekTime(uint64_t timeInTs);
 
   bool GetInformation(kodi::addon::InputstreamInfo& info);
   bool ReadPacket(bool streamInfo = false);

--- a/src/demuxers/WebmReader.cpp
+++ b/src/demuxers/WebmReader.cpp
@@ -174,7 +174,7 @@ bool WebmReader::GetInformation(kodi::addon::InputstreamInfo& info)
 }
 
 // We assume that m_startpos is the current I-Frame position
-bool WebmReader::SeekTime(uint64_t timeInTs, bool preceeding)
+bool WebmReader::SeekTime(uint64_t timeInTs)
 {
   Reset();
   return true;

--- a/src/demuxers/WebmReader.h
+++ b/src/demuxers/WebmReader.h
@@ -41,7 +41,7 @@ public:
   bool Initialize();
 
   void Reset();
-  bool SeekTime(uint64_t timeInTs, bool preceeding);
+  bool SeekTime(uint64_t timeInTs);
 
   bool GetInformation(kodi::addon::InputstreamInfo& info);
   bool ReadPacket();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -304,7 +304,7 @@ DEMUX_PACKET* CInputStreamAdaptive::DemuxRead(void)
   if (~m_failedSeekTime)
   {
     LOG::Log(LOGDEBUG, "Seeking to last failed seek position (%d)", m_failedSeekTime);
-    m_session->SeekTime(static_cast<double>(m_failedSeekTime) * 0.001f, false);
+    m_session->SeekTime(static_cast<double>(m_failedSeekTime) * 0.001f);
     m_failedSeekTime = ~0;
   }
 
@@ -430,7 +430,7 @@ bool CInputStreamAdaptive::PosTime(int ms)
 
   LOG::Log(LOGINFO, "PosTime (%d)", ms);
 
-  bool ret = m_session->SeekTime(static_cast<double>(ms) * 0.001f, false);
+  bool ret = m_session->SeekTime(static_cast<double>(ms) * 0.001f);
   m_failedSeekTime = ret ? ~0 : ms;
 
   return ret;

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -55,10 +55,10 @@ void CADTSSampleReader::Reset(bool bEOS)
   m_eos = bEOS;
 }
 
-bool CADTSSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+bool CADTSSampleReader::TimeSeek(uint64_t pts)
 {
   AP4_UI64 seekPos{(pts * 9) / 100};
-  if (ADTSReader::SeekTime(seekPos, preceeding))
+  if (ADTSReader::SeekTime(seekPos))
   {
     m_started = true;
     return AP4_SUCCEEDED(ReadSample());

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -30,7 +30,7 @@ public:
   {
     return ADTSReader::GetInformation(info);
   }
-  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  bool TimeSeek(uint64_t pts) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 90000; }

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -305,7 +305,7 @@ bool CFragmentedSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
   return isChanged;
 }
 
-bool CFragmentedSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+bool CFragmentedSampleReader::TimeSeek(uint64_t pts)
 {
   AP4_Ordinal sampleIndex;
   AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -109,7 +109,7 @@ public:
   uint64_t GetDuration() const override;
   bool IsEncrypted() const override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
-  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  bool TimeSeek(uint64_t pts) override;
   void SetPTSOffset(uint64_t offset) override;
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   bool GetFragmentInfo(uint64_t& duration) override;

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -85,10 +85,9 @@ public:
   /*!
    * \brief Advance the reader to requested PTS.
    * \param pts The PTS to seek for
-   * \param preceeding Allow a backward seek for sample sync
    * \return True if has success, otherwise false.
    */
-  virtual bool TimeSeek(uint64_t pts, bool preceeding) = 0;
+  virtual bool TimeSeek(uint64_t pts) = 0;
 
   virtual void SetPTSOffset(uint64_t offset) = 0;
   virtual int64_t GetPTSDiff() const = 0;

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -216,7 +216,7 @@ bool CSubtitleSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
   return false;
 }
 
-bool CSubtitleSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+bool CSubtitleSampleReader::TimeSeek(uint64_t pts)
 {
   if (dynamic_cast<WebVTTCodecHandler*>(m_codecHandler.get()))
   {

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -41,7 +41,7 @@ public:
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;
-  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  bool TimeSeek(uint64_t pts) override;
   void SetPTSOffset(uint64_t offset) override { }
   int64_t GetPTSDiff() const override { return 0; }
   uint32_t GetTimeScale() const override { return 1000; }

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -102,13 +102,13 @@ void CTSSampleReader::Reset(bool bEOS)
   m_eos = bEOS;
 }
 
-bool CTSSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+bool CTSSampleReader::TimeSeek(uint64_t pts)
 {
   if (!StartStreaming(m_typeMask))
     return false;
 
   AP4_UI64 seekPos((pts * 9) / 100);
-  if (TSReader::SeekTime(seekPos, preceeding))
+  if (TSReader::SeekTime(seekPos))
   {
     m_started = true;
     return AP4_SUCCEEDED(ReadSample());

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -36,7 +36,7 @@ public:
   {
     return TSReader::GetInformation(info);
   }
-  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  bool TimeSeek(uint64_t pts) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 90000; }

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -59,10 +59,10 @@ void CWebmSampleReader::Reset(bool bEOS)
   m_eos = bEOS;
 }
 
-bool CWebmSampleReader::TimeSeek(uint64_t pts, bool preceeding)
+bool CWebmSampleReader::TimeSeek(uint64_t pts)
 {
   AP4_UI64 seekPos((pts * 9) / 100);
-  if (WebmReader::SeekTime(seekPos, preceeding))
+  if (WebmReader::SeekTime(seekPos))
   {
     m_started = true;
     return AP4_SUCCEEDED(ReadSample());

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -31,7 +31,7 @@ public:
   {
     return WebmReader::GetInformation(info);
   }
-  bool TimeSeek(uint64_t pts, bool preceeding) override;
+  bool TimeSeek(uint64_t pts) override;
   void SetPTSOffset(uint64_t offset) override { m_ptsOffs = offset; }
   int64_t GetPTSDiff() const override { return m_ptsDiff; }
   uint32_t GetTimeScale() const override { return 1000; }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After recent code change on MP4 sample reader 
the "preceeding" behavior is now used only by TSReader

the "preceeding" was by default, on normal seek, set always to "false"

the only part where was used with preceeding set to "true" is when you seek across chapters/periods
from here
https://github.com/xbmc/inputstream.adaptive/blob/afe341493622fccc2a7a253f4947c96e19041570/src/Session.cpp#L1110

by debugging TSReader while doing video seeking across chapters
i have not found different behavior on removing it

now idk if there are some particolar stream that require it but i don't think so
anyway in case its not so complex to revert

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
another step to make the "seek" code more simpler

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
HLS TS stream with multiple chapters
then seek more times on all chapters

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
