### PR TITLE
[ISampleReader] Removed SetPTSDiff method

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1067,8 +1067,6 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
     if (!CheckReaderRunning(*stream))
       return false;
 
-    streamReader->SetPTSDiff(ptsDiff);
-
     if (!streamReader->TimeSeek(seekTimeCorrected))
     {
       streamReader->Reset(true);

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -91,7 +91,6 @@ public:
 
   virtual void SetPTSOffset(uint64_t offset) = 0;
   virtual int64_t GetPTSDiff() const = 0;
-  virtual void SetPTSDiff(uint64_t pts) {}
 
   /*!
    * \brief Get the DTS or PTS of current packet, in manifest timing format


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
after old PR #1907 SetPTSDiff method is no longer used since it is noop
since the mentioned PR at today no reports of subtitles malfunctions due to that code change
so lets remove this code

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleanup 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
