### PR TITLE
[inputstream.adaptive] Fix audio deadlock on quality STREAMCHANGE

### DIFF
--- a/src/common/ChooserDefault.cpp
+++ b/src/common/ChooserDefault.cpp
@@ -91,6 +91,9 @@ void CRepresentationChooserDefault::SetSecureSession(const bool isSecureSession)
 
 void CRepresentationChooserDefault::PostInit()
 {
+  m_screenLastWidth = m_screenCurrentWidth;
+  m_screenLastHeight = m_screenCurrentHeight;
+
   RefreshResolution();
 
   if (!m_bandwidthInitAuto)
@@ -116,7 +119,7 @@ void CRepresentationChooserDefault::PostInit()
 
 void CRepresentationChooserDefault::CheckResolution()
 {
-  if (m_screenWidth != m_screenCurrentWidth || m_screenHeight != m_screenCurrentHeight)
+  if (m_screenLastWidth != m_screenCurrentWidth || m_screenLastHeight != m_screenCurrentHeight)
   {
     // Update the screen resolution values only after n seconds
     // to prevent too fast update when Kodi window will be resized
@@ -128,6 +131,8 @@ void CRepresentationChooserDefault::CheckResolution()
       return;
     }
     RefreshResolution();
+    m_screenLastWidth = m_screenCurrentWidth;
+    m_screenLastHeight = m_screenCurrentHeight;
     m_screenResLastUpdate = std::chrono::steady_clock::now();
     LOG::Log(LOGDEBUG, "[Repr. chooser] Screen resolution has changed: %ix%i", m_screenCurrentWidth,
              m_screenCurrentHeight);

--- a/src/common/ChooserDefault.h
+++ b/src/common/ChooserDefault.h
@@ -49,6 +49,8 @@ protected:
 
   int m_screenWidth{0};
   int m_screenHeight{0};
+  int m_screenLastWidth{0};
+  int m_screenLastHeight{0};
   std::optional<std::chrono::steady_clock::time_point> m_screenResLastUpdate;
 
   std::pair<int, int> m_screenResMax; // Max resolution for non-protected video content

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,10 +184,12 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
   if (!stream)
     return false;
 
+  const bool isStreamChanged{stream->m_adStream.StreamChanged()};
+
   if (stream->IsEnabled())
   {
     // Stream quality changed (by "adaptive" streaming, not OSD)
-    if (stream->m_adStream.StreamChanged())
+    if (isStreamChanged)
     {
       stream->Reset();
       stream->m_adStream.Reset();
@@ -221,7 +223,7 @@ bool CInputStreamAdaptive::OpenStream(int streamid)
     }
   }
 
-  if (m_checkCoreReopen)
+  if (m_checkCoreReopen && !isStreamChanged)
   {
     LOG::Log(LOGDEBUG, "OpenStream(%d): The stream has already been opened", streamid);
     return false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR resolves two intertwined bugs that result in severe playback stalling and complete audio pipeline failure during DASH/adaptive playback, specifically surfacing when users configure maximum video resolution limits (e.g., 1080p) on higher resolution physical displays (e.g., 4K TVs).

Each fix is in its own commit:

1. **`[chooser]` Screen Resolution False Positives (`src/common/ChooserDefault.cpp`, `ChooserDefault.h`)**:
   `CRepresentationChooserDefault::CheckResolution()` compared the user-configured resolution limit (`m_screenWidth`) against the actual physical hardware resolution (`m_screenCurrentWidth`), resulting in perpetual false positives every 10 seconds. Dedicated tracking variables (`m_screenLastWidth`, `m_screenLastHeight`) now correctly isolate physical window resize detection from the addon's maximum configured quality limits.

2. **`[demux]` Audio Deadlock during STREAMCHANGE (`src/main.cpp`)**:
   When a bandwidth fluctuation triggered a representation change, Kodi Core reopened all active streams sequentially. If the first stream (Video) evaluated to no quality change, the `m_checkCoreReopen` optimization flag short-circuited all further `OpenStream` callbacks. If a subsequent stream (Audio) *did* change quality, its `Reset()` and reconstruction was skipped entirely, leaving it stuck at `EVENT_TYPE::REP_CHANGE` and permanently blocking segment downloads. This commit hoists a `!isStreamChanged` conditional to guard the entire `m_checkCoreReopen` block, guaranteeing that a formally changed stream bypasses the fast-path optimization and executes its native `Reset()` cycle.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When playing adaptive streams on displays with a higher physical resolution than the user's Kodi resolution cap (e.g., a 1080p cap on a 4K display), the demuxer would continuously spin false `STREAMCHANGE` events every 10 seconds due to a flawed `m_screenWidth != m_screenCurrentWidth` comparison, severely stuttering playback.

Even without these false positives, a genuine adaptive bandwidth fluctuation would trigger a legitimate `DEMUX_SPECIALID_STREAMCHANGE`. During the subsequent sequential `OpenStream` workload triggered by Kodi Core, the audio stream's `Reset()` operation was swallowed due to a shared `m_checkCoreReopen` fast-path bypass. Because the audio reader's state was abandoned mid-update (stuck at `EVENT_TYPE::REP_CHANGE`), it permanently blocked segment queuing.

These changes are necessary to allow `inputstream.adaptive` to survive legitimate adaptive bandwidth changes without permanently killing the audio output pipeline.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Built and tested on LibreELEC on Raspberry Pi 4 with the `plugin.video.youtube` add-on.
- Tested on standard Kodi playback of YouTube DASH streams (webm video / mp4a audio).
- Verified via trace logs that `DEMUX_SPECIALID_STREAMCHANGE` gracefully reconstructs the audio FFmpeg decoders.

### Log Comparisons

**Bug 1: Screen Resolution False Positives (`ChooserDefault.cpp`)**
*Before Fix:* Kodi routinely and spuriously detects screen resolution changes because `m_screenWidth` (config limit) naturally mismatches `m_screenCurrentWidth` (hardware rendering).
```text
2026-02-24 02:57:35.243 T:72583   debug <inputstream.adaptive>: [Repr. chooser] Screen resolution has changed: 3840x2160
... (10 seconds later)
2026-02-24 02:57:46.157 T:72583   debug <inputstream.adaptive>: [Repr. chooser] Screen resolution has changed: 3840x2160
... (10 seconds later)
2026-02-24 02:57:57.402 T:72648   debug <inputstream.adaptive>: [Repr. chooser] Screen resolution has changed: 3840x2160
```

*After Fix:* The `STREAMCHANGE` storm vanishes. No `Screen resolution has changed` log entries are observed during prolonged, stable 4K playback sessions.

**Bug 2: Audio Deadlock (`main.cpp`)**
*Before Fix:* Following a `STREAMCHANGE`, `OpenStream(1014)` (Audio) hits the early-return optimization set by the preceding video stream, skipping stream construction.
```text
2026-02-24 12:10:19.325 T:9695     info <general>: Opening stream: 1014 source: 256
2026-02-24 12:10:19.325 T:9695    debug <inputstream.adaptive>: OpenStream(1014)
2026-02-24 12:10:19.326 T:9695    debug <inputstream.adaptive>: OpenStream(1014): The stream has already been opened
2026-02-24 12:10:22.509 T:9695    debug <general>: CVideoPlayer::HandlePlaySpeed - audio stream stalled, triggering re-sync
```

*After Fix:* The hoisted `!isStreamChanged` conditional allows genuinely changed streams to fall through, successfully rebuilding their FFmpeg instance.
```text
2026-02-25 11:24:56.931 T:15307   debug <inputstream.adaptive>: DEMUX_SPECIALID_STREAMCHANGE (stream quality changed)
2026-02-25 11:24:56.933 T:15307    info <general>: Opening stream: 1014 source: 256
2026-02-25 11:24:56.933 T:15307   debug <inputstream.adaptive>: OpenStream(1014)
2026-02-25 11:24:56.933 T:15307   debug <inputstream.adaptive>: UpdateSampleDescription: Codec fourcc: mp4a (1836069985)
2026-02-25 11:24:56.934 T:15307    info <general>: CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder aac
2026-02-25 11:24:56.983 T:14828   debug <general>: [plugin.video.youtube] http_server:587(do_GET) ('audio', 'mp4') Range:  'bytes=8728872-8890772'
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
