### PR TITLE
Live stream jump

### DIFF
--- a/inputstream.adaptive/addon.xml.in
+++ b/inputstream.adaptive/addon.xml.in
@@ -10,7 +10,7 @@
     name="adaptive"
     extension=""
     tags="true"
-    listitemprops="drm_legacy|license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|internal_cookies|config|manifest_config"
+    listitemprops="drm_legacy|license_type|license_key|license_url|license_url_append|license_data|license_flags|manifest_type|server_certificate|manifest_update_parameter|manifest_upd_params|manifest_params|manifest_headers|stream_params|stream_headers|original_audio_language|play_timeshift_buffer|pre_init_data|stream_selection_type|chooser_bandwidth_max|chooser_resolution_max|chooser_resolution_secure_max|live_delay|live_offset|internal_cookies|config|manifest_config"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -52,6 +52,7 @@ constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_he
 constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay";
+constexpr std::string_view PROP_LIVE_OFFSET = "inputstream.adaptive.live_offset";
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data";
 
 constexpr std::string_view PROP_CONFIG = "inputstream.adaptive.config";
@@ -199,6 +200,10 @@ ADP::KODI_PROPS::CCompKodiProps::CCompKodiProps(const std::map<std::string, std:
     else if (prop.first == PROP_LIVE_DELAY)
     {
       m_liveDelay = STRING::ToUint64(prop.second); //! @todo: move to PROP_MANIFEST_CONFIG
+    }
+    else if (prop.first == PROP_LIVE_OFFSET)
+    {
+      m_liveOffset = STRING::ToUint64(prop.second); //! @todo: move to PROP_MANIFEST_CONFIG
     }
     else if (prop.first == PROP_PRE_INIT_DATA)
     {

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -118,6 +118,8 @@ public:
   bool IsPlayTimeshift() const { return m_playTimeshiftBuffer; }
   // \brief Get a custom delay from LIVE edge in seconds
   uint64_t GetLiveDelay() const { return m_liveDelay; }
+  // \brief Get a custom offset from LIVE start in seconds
+  uint64_t GetLiveOffset() const { return m_liveOffset; }
 
   /*
    * \brief Get data to "pre-initialize" the DRM, if set is represented as a string
@@ -162,6 +164,7 @@ private:
   std::string m_audioLanguageOrig;
   bool m_playTimeshiftBuffer{false};
   uint64_t m_liveDelay{0};
+  uint64_t m_liveOffset{0};
   std::string m_drmPreInitData;
   ChooserProps m_chooserProps;
   Config m_config;

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1479,6 +1479,10 @@ int64_t CSession::GetChapterPos(int ch) const
       m_adaptiveTree->IsLive())
     return static_cast<int64_t>(m_adaptiveTree->m_totalTime / 1000);
 
+  // Chapter 1 of a live stream: return configured start offset
+  if (ch == 0 && m_adaptiveTree && m_adaptiveTree->IsLive())
+    return static_cast<int64_t>(CSrvBroker::GetKodiProps().GetLiveOffset());
+
   for (; ch; --ch)
   {
     sum += (m_adaptiveTree->m_periods[ch - 1]->GetDuration() * STREAM_TIME_BASE) /

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1441,15 +1441,15 @@ int CSession::GetChapter() const
       }
     }
   }
-  return -1;
+  return 0;
 }
 
 int CSession::GetChapterCount() const
 {
-  if (m_adaptiveTree && m_adaptiveTree->m_periods.size() > 1)
-      return static_cast<int>(m_adaptiveTree->m_periods.size());
+  if (!m_adaptiveTree)
+    return 0;
 
-  return 0;
+  return static_cast<int>(m_adaptiveTree->m_periods.size());
 }
 
 std::string CSession::GetChapterName(int ch) const

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -26,6 +26,7 @@
 #include "utils/log.h"
 
 #include <array>
+#include <limits>
 
 #include <kodi/addon-instance/Inputstream.h>
 
@@ -1449,7 +1450,10 @@ int CSession::GetChapterCount() const
   if (!m_adaptiveTree)
     return 0;
 
-  return static_cast<int>(m_adaptiveTree->m_periods.size());
+  int count = static_cast<int>(m_adaptiveTree->m_periods.size());
+  if (count > 0 && m_adaptiveTree->IsLive())
+    count += 1;
+  return count;
 }
 
 std::string CSession::GetChapterName(int ch) const
@@ -1459,6 +1463,8 @@ std::string CSession::GetChapterName(int ch) const
     --ch;
     if (ch >= 0 && ch < static_cast<int>(m_adaptiveTree->m_periods.size()))
       return m_adaptiveTree->m_periods[ch]->GetId().data();
+    if (ch == static_cast<int>(m_adaptiveTree->m_periods.size()) && m_adaptiveTree->IsLive())
+      return "Live";
   }
 
   return "[Unknown]";
@@ -1468,6 +1474,10 @@ int64_t CSession::GetChapterPos(int ch) const
 {
   int64_t sum{0};
   --ch;
+
+  if (m_adaptiveTree && ch == static_cast<int>(m_adaptiveTree->m_periods.size()) &&
+      m_adaptiveTree->IsLive())
+    return static_cast<int64_t>(m_adaptiveTree->m_totalTime / 1000);
 
   for (; ch; --ch)
   {
@@ -1516,22 +1526,39 @@ bool CSession::SeekChapter(int ch)
     return true;
 
   --ch;
-  if (ch >= 0 && ch < static_cast<int>(m_adaptiveTree->m_periods.size()) &&
-      m_adaptiveTree->m_periods[ch].get() != m_adaptiveTree->m_currentPeriod)
-  {
-    CPeriod* nextPeriod = m_adaptiveTree->m_periods[ch].get();
-    m_adaptiveTree->m_nextPeriod = nextPeriod;
-    LOG::LogF(LOGDEBUG, "Switching to new Period (id=%s, start=%llu, seq=%u)",
-              nextPeriod->GetId().data(), nextPeriod->GetStart(), nextPeriod->GetSequence());
 
-    for (auto& stream : m_streams)
+  if (ch == static_cast<int>(m_adaptiveTree->m_periods.size()) && m_adaptiveTree->IsLive())
+  {
+    LOG::LogF(LOGDEBUG, "Seeking to live edge (virtual chapter)");
+    SeekTime(std::numeric_limits<double>::max(), 0, false);
+    return true;
+  }
+
+  if (ch >= 0 && ch < static_cast<int>(m_adaptiveTree->m_periods.size()))
+  {
+    CPeriod* targetPeriod = m_adaptiveTree->m_periods[ch].get();
+    if (targetPeriod != m_adaptiveTree->m_currentPeriod)
     {
-      ISampleReader* sr{stream->GetReader()};
-      if (sr)
+      m_adaptiveTree->m_nextPeriod = targetPeriod;
+      LOG::LogF(LOGDEBUG, "Switching to new Period (id=%s, start=%llu, seq=%u)",
+                targetPeriod->GetId().data(), targetPeriod->GetStart(),
+                targetPeriod->GetSequence());
+
+      for (auto& stream : m_streams)
       {
-        sr->WaitReadSampleAsyncComplete();
-        sr->Reset(true);
+        ISampleReader* sr{stream->GetReader()};
+        if (sr)
+        {
+          sr->WaitReadSampleAsyncComplete();
+          sr->Reset(true);
+        }
       }
+    }
+    else
+    {
+      double startTime = GetChapterPos(ch + 1);
+      LOG::LogF(LOGDEBUG, "Seeking to start of current Period (startTime=%.3f)", startTime);
+      SeekTime(startTime, 0, false);
     }
     return true;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,12 +495,21 @@ bool CInputStreamAdaptive::IsRealTimeStream()
 #if INPUTSTREAM_VERSION_LEVEL > 1
 int CInputStreamAdaptive::GetChapter()
 {
+  // Provide the current chapter number
+  // chapter numbering starts from 1, specify 0 for no chapter
   return m_session ? m_session->GetChapter() : 0;
 }
 
 int CInputStreamAdaptive::GetChapterCount()
 {
-  return m_session ? m_session->GetChapterCount() : 0;
+  if (m_session)
+  {
+    const int count = m_session->GetChapterCount();
+    if (count > 1)
+      return count;
+  }
+  // Return 0 to prevent Kodi core from handling chapters
+  return 0;
 }
 
 const char* CInputStreamAdaptive::GetChapterName(int ch)


### PR DESCRIPTION
## Description
To be able to jump forward (to the edge, e.g. the live moment) and jump backward (e.g. the start of the stream) on a live stream (when properly exposed/handled by the content provider/API, we need to cherry-pick commit b2da233e (Cleanups to chapter methods) from Piers which fixes the fact that we do not properly report the chapter count. Then add a commit to add a 'virtual' second chapter matching 'the end' which then gives us 2 chapters; ch1 'the start' and ch2 'now'. A third commit is to help with the start offset, like live_delay, we can add a bit of time to the start, where content providers love to add a conservative padding, to ensure they didn't miss the start of the program, or to make sure we get anything that was shown before the program (like an ad).

## Motivation and context
Being able to 'jump to start' (using |< for example) or 'jump to live/now' using >| which relies on proper chapters to trigger.

## How has this been tested?
Using retrospect and NLZIET we have livestreams from dutch television programs, moving this functionality to the |< and >| buttons allowed us to jump back/forward to the start/edge of a live stream reliably, with offset (where progress bar was showing a 'dot' of the offsetted jump point.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
