### PR TITLE
Live stream jump piers

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -402,6 +402,10 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseManifestConfig(const std::string& dat
     {
       m_manifestConfig.liveDelay = jValue.get<uint64_t>();
     }
+    else if (configName == "live_offset" && jValue.is_number_unsigned())
+    {
+      m_manifestConfig.liveOffset = jValue.get<uint64_t>();
+    }
     else if (configName == "dash_utctiming" && jValue.is_object())
     {
       for (auto& [schemeId, jValue] : jValue.items()) // Iterate JSON dict

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -70,6 +70,8 @@ struct ManifestConfig
   bool hlsFixDiscontSequence{false};
   // Custom delay from LIVE edge in seconds
   uint64_t liveDelay{0};
+  // Apply an offset in seconds from the live start (e.g. to skip pre-program buffered content)
+  uint64_t liveOffset{0};
   // Allows to set a custom UTC Timing for DASH live streams (schemeIdUri, value)
   std::optional<std::pair<std::string, std::string>> dashUTCTiming;
   // If true will ignore default KID provided from FMP4 init segment

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1225,20 +1225,28 @@ int SESSION::CSession::GetChapterCount() const
   if (!m_adaptiveTree)
     return 0;
 
-  return static_cast<int>(m_adaptiveTree->m_periods.size());
+  int count = static_cast<int>(m_adaptiveTree->m_periods.size());
+  if (count > 0 && m_adaptiveTree->IsLive())
+    count += 1;
+  return count;
 }
 
 const char* SESSION::CSession::GetChapterName(int number) const
 {
+  if (!m_adaptiveTree)
+    return nullptr;
+
+  --number; // To convert chapter number to index
+  if (m_adaptiveTree->IsLive() && number == static_cast<int>(m_adaptiveTree->m_periods.size()))
+    return "Live";
+
   // Chapter name is shown on GUI info window
   // Manifests usually dont provide this info
   // so show the period ID for debugging purpose at request
-  if (CSrvBroker::GetSettings().IsDebugVerbose() && m_adaptiveTree)
+  if (CSrvBroker::GetSettings().IsDebugVerbose())
   {
-    --number; // To convert chapter number to index
     if (number >= 0 && number < static_cast<int>(m_adaptiveTree->m_periods.size()))
       return m_adaptiveTree->m_periods[number]->GetId().c_str();
-
     return CHAPTER_NAME_UNKNOWN;
   }
   return nullptr;
@@ -1251,6 +1259,9 @@ int64_t SESSION::CSession::GetChapterPos(int number) const
 
   --number; // To convert chapter number to index
 
+  if (m_adaptiveTree->IsLive() && number == static_cast<int>(m_adaptiveTree->m_periods.size()))
+    return static_cast<int64_t>(GetLiveEdgeMs() / 1000);
+
   //! @todo: Fragile check, accessing to m_periods can potentially cause problems because
   //! manifest updates can make changes (add/remove) to periods asynchronously.
   //! An appropriate solution must be found, taking into account that these methods
@@ -1258,6 +1269,10 @@ int64_t SESSION::CSession::GetChapterPos(int number) const
   //! all other CSession methods on which Kodi core makes callbacks.
   if (number < 0 || number >= static_cast<int>(m_adaptiveTree->m_periods.size()))
     return 0;
+
+  if (number == 0 && m_adaptiveTree->IsLive() && m_adaptiveTree->m_periods.size() == 1 &&
+      m_adaptiveTree->m_liveOffset > 0)
+    return static_cast<int64_t>(m_adaptiveTree->m_liveOffset);
 
   int64_t sum{0};
 
@@ -1268,6 +1283,21 @@ int64_t SESSION::CSession::GetChapterPos(int number) const
   }
 
   return sum / STREAM_TIME_BASE;
+}
+
+uint64_t SESSION::CSession::GetLiveEdgeMs() const
+{
+  uint64_t maxTime{0};
+  for (const auto& stream : m_streams)
+  {
+    if (stream->IsEnabled())
+    {
+      uint64_t curTime = stream->m_adStream.getMaxTimeMs();
+      if (curTime > maxTime)
+        maxTime = curTime;
+    }
+  }
+  return maxTime > 0 ? maxTime : m_adaptiveTree->m_totalTime;
 }
 
 uint64_t SESSION::CSession::GetChapterStartTime() const
@@ -1300,6 +1330,14 @@ bool SESSION::CSession::SeekChapter(int number)
     return true;
 
   --number; // To convert chapter number to index
+
+  if (m_adaptiveTree->IsLive() && number == static_cast<int>(m_adaptiveTree->m_periods.size()))
+  {
+    LOG::LogF(LOGDEBUG, "Seeking to live edge (virtual chapter)");
+    SeekTime(static_cast<double>(GetLiveEdgeMs()) / 1000, 0, false);
+    return true;
+  }
+
   if (number >= 0 && number < static_cast<int>(m_adaptiveTree->m_periods.size()) &&
       m_adaptiveTree->m_periods[number].get() != m_adaptiveTree->m_currentPeriod)
   {
@@ -1317,6 +1355,13 @@ bool SESSION::CSession::SeekChapter(int number)
         sr->Reset(true);
       }
     }
+    return true;
+  }
+  else if (m_adaptiveTree->IsLive() && number >= 0 && number < static_cast<int>(m_adaptiveTree->m_periods.size()))
+  {
+    double startTime = static_cast<double>(GetChapterPos(number + 1));
+    LOG::LogF(LOGDEBUG, "Seeking to start of current Period (startTime=%.3f)", startTime);
+    SeekTime(startTime, 0, false);
     return true;
   }
   return false;

--- a/src/Session.h
+++ b/src/Session.h
@@ -270,6 +270,8 @@ protected:
   uint64_t GetMediaDurationMs();
 
 private:
+  uint64_t GetLiveEdgeMs() const;
+
   DRM::CDRMEngine m_drmEngine;
 
   adaptive::AdaptiveTree* m_adaptiveTree{nullptr};

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1133,7 +1133,7 @@ bool adaptive::AdaptiveStream::seek(uint64_t const pos, bool& isEos)
   return true;
 }
 
-uint64_t adaptive::AdaptiveStream::getMaxTimeMs()
+uint64_t adaptive::AdaptiveStream::getMaxTimeMs() const
 {
   const CSegment* lastSeg = current_rep_->Timeline().GetBack();
   if (!lastSeg)

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -71,7 +71,7 @@ enum class EVENT_TYPE
      *        and that the relative sample reader is already stopped, to avoid data access violations.
      */
     void Dispose();
-    uint64_t getMaxTimeMs();
+    uint64_t getMaxTimeMs() const;
 
     void Disable();
 

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -94,6 +94,8 @@ namespace adaptive
     else if (m_liveDelay < 16)
       m_liveDelay = 16;
 
+    m_liveOffset = CSrvBroker::GetKodiProps().GetManifestConfig().liveOffset;
+
     StartUpdateThread();
 
     LOG::Log(LOGINFO,

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -70,6 +70,7 @@ public:
   uint64_t stream_start_{0}; // in ms
   uint64_t available_time_{0}; // in ms
   uint64_t m_liveDelay{0}; // Apply a delay in seconds from the live edge
+  uint64_t m_liveOffset{0}; // Apply an offset in seconds from the live start
 
   AdaptiveTree() = default;
   AdaptiveTree(const AdaptiveTree& left);

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -700,11 +700,25 @@ TEST_F(DASHTreeTest, SuggestedPresentationDelay)
   EXPECT_EQ(tree->m_liveDelay, 32);
 }
 
+TEST_F(DASHTreeTest, LiveDelayFromManifestConfig)
+{
+  m_kodiProps["inputstream.adaptive.manifest_config"] = R"({"live_delay": 60})";
+  OpenTestFile("mpd/segtpl_spd.mpd", "https://foo.bar/segtpl_spd.mpd");
+  EXPECT_EQ(tree->m_liveDelay, 60u);
+}
+
 TEST_F(DASHTreeTest, LiveOffsetFromManifestConfig)
 {
   m_kodiProps["inputstream.adaptive.manifest_config"] = R"({"live_offset": 30})";
   OpenTestFile("mpd/segtimeline_live_pd.mpd");
   EXPECT_EQ(tree->m_liveOffset, 30u);
+}
+
+TEST_F(DASHTreeTest, LiveStreamTotalTimeIsSet)
+{
+  // m_totalTime drives GetChapterPos for the virtual live chapter (jump-to-live)
+  OpenTestFile("mpd/segtimeline_live_pd.mpd");
+  EXPECT_EQ(tree->m_totalTime, 9000000u); // mediaPresentationDuration="PT9000S" -> 9000000ms
 }
 
 TEST_F(DASHTreeTest, SegmentTemplateStartNumber)

--- a/src/test/TestDASHTree.cpp
+++ b/src/test/TestDASHTree.cpp
@@ -700,6 +700,13 @@ TEST_F(DASHTreeTest, SuggestedPresentationDelay)
   EXPECT_EQ(tree->m_liveDelay, 32);
 }
 
+TEST_F(DASHTreeTest, LiveOffsetFromManifestConfig)
+{
+  m_kodiProps["inputstream.adaptive.manifest_config"] = R"({"live_offset": 30})";
+  OpenTestFile("mpd/segtimeline_live_pd.mpd");
+  EXPECT_EQ(tree->m_liveOffset, 30u);
+}
+
 TEST_F(DASHTreeTest, SegmentTemplateStartNumber)
 {
   OpenTestFile("mpd/segmenttemplate_startnumber.mpd", "https://vod.service.net/SGP1/highlightpost/1234567890/1/web/dash/segtpl_sn.mpd");


### PR DESCRIPTION
## Description
To be able to jump forward (to the edge, e.g. the live moment) and jump backward (e.g. the start of the stream) on a live stream (when properly exposed/handled by the content provider/API, we need to cherry-pick commit b2da233e (Cleanups to chapter methods) from Piers which fixes the fact that we do not properly report the chapter count. Then add a commit to add a 'virtual' second chapter matching 'the end' which then gives us 2 chapters; ch1 'the start' and ch2 'now'. A third commit is to help with the start offset, like live_delay, we can add a bit of time to the start, where content providers love to add a conservative padding, to ensure they didn't miss the start of the program, or to make sure we get anything that was shown before the program (like an ad).

## Motivation and context
Being able to 'jump to start' (using |< for example) or 'jump to live/now' using >| which relies on proper chapters to trigger.

## How has this been tested?
Using retrospect and NLZIET we have livestreams from dutch television programs, moving this functionality to the |< and >| buttons allowed us to jump back/forward to the start/edge of a live stream reliably, with offset (where progress bar was showing a 'dot' of the offsetted jump point. Further more I used a test file as mentioned in #1517 and backported the changes to omega https://github.com/xbmc/inputstream.adaptive/pull/2005 but with fixes in place as per review comments.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
