### PR TITLE
[Widevine] Set a dummy video format to get buffer

### DIFF
--- a/src/decrypters/widevine/WVCdmAdapter.cpp
+++ b/src/decrypters/widevine/WVCdmAdapter.cpp
@@ -223,6 +223,9 @@ cdm::Buffer* CWVCdmAdapter::AllocateBuffer(size_t sz)
 {
   VIDEOCODEC_PICTURE pic;
   pic.decodedDataSize = sz;
+  // Video format is used by GetBuffer to get a free buffer from video buffer pool cache
+  // but we cant set the real format here because we dont know it yet
+  pic.videoFormat = VIDEOCODEC_FORMAT_YV12;
   if (m_host->GetBuffer(m_codecInstance, pic))
   {
     CdmFixedBuffer* buf = new CdmFixedBuffer;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
GetBuffer make use of a pool based on video format
but Widevine CDM allow to know the video format only after obtained the buffer data
this reintroduce the dummy video format to get the buffer

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR: https://github.com/xbmc/xbmc/pull/28090/
has removed the hardcoded format `AV_PIX_FMT_YUV420P` from `CAddonVideoCodec::GetFrameBuffer` by using `ConvertToPixelFormat` method
given that we was not setting the format now the log is filled by wrong video format warnings

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
playing video that require secure decoder

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
