### PR TITLE
[SampleReader] Fix double packet read on seek

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -955,19 +955,23 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
       seekTime = delayPtsSecs;
   }
 
-  // Helper lambda to check if reader is started,
-  // since after seeking across chapters/periods the reader is not started yet
-  auto CheckReaderRunning = [this](CStream& stream) -> bool
+  // Helper lambda to perform the seek on stream reader
+  auto SeekReader = [this](CStream& stream, uint64_t seekTimePts) -> bool
   {
     auto reader = stream.GetReader();
+    // Seeking across chapters/periods the reader is not started yet
     if (!reader->IsStarted())
     {
-      bool isStarted = false;
-      if (AP4_FAILED(reader->Start(isStarted)))
+      if (AP4_FAILED(reader->Start(seekTimePts)))
         return false;
 
-      if (isStarted && reader->GetInformation(stream.m_info))
+      if (reader->GetInformation(stream.m_info))
         m_changed = true;
+    }
+    else
+    {
+      if (!reader->TimeSeek(seekTimePts))
+        return false;
     }
     return true;
   };
@@ -987,43 +991,6 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
 
   // correct for starting segment pts value of chapter and chapter offset within program
   uint64_t seekTimeCorrected{static_cast<uint64_t>(seekTime * STREAM_TIME_BASE)};
-  int64_t ptsDiff{0};
-
-  // If we have a timing stream, ensure it is started first and compute ptsDiff /
-  // corrected seek base that will be used by all other streams.
-  if (m_timingStream)
-  {
-    ISampleReader* timingReader{m_timingStream->GetReader()};
-    if (!timingReader)
-    {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader of timing stream");
-      return false;
-    }
-
-    timingReader->WaitReadSampleAsyncComplete();
-
-    seekTimeCorrected += m_timingStream->m_adStream.GetAbsolutePTSOffset();
-
-    const double seekSecs = static_cast<double>(seekTimeCorrected) / STREAM_TIME_BASE;
-
-    if (!SeekAdStream(*m_timingStream, seekSecs))
-    {
-      isError = true;
-      return false;
-    }
-
-    // Note: The following "running" check will download/read the package right now
-    // allowing you to read the PTS diff from stream reader
-    if (!CheckReaderRunning(*m_timingStream))
-      return false;
-
-    ptsDiff = timingReader->GetPTSDiff();
-
-    if (ptsDiff < 0 && seekTimeCorrected + ptsDiff > seekTimeCorrected)
-      seekTimeCorrected = 0;
-    else
-      seekTimeCorrected += ptsDiff;
-  }
 
   // Note: At the end of the seek operations, you may notice on Kodi debug log "dropping packets" prints
   // this happens because we cannot always guarantee a precise seek, for example
@@ -1032,6 +999,8 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
   // but the sync sample (packet) at least for the video track is usually not available for all PTS
   // so we try choose the sample/package closest to the requested "seek" PTS, causing "dropping packets"
 
+  // NOTE: It is assumed that the streams are ordered by video type (on m_streams), so we will seek first the video stream
+  // to get the closest sample PTS to the requested seek time, then we will use to seek/align the other streams
   for (auto& stream : m_streams)
   {
     ISampleReader* streamReader{stream->GetReader()};
@@ -1042,15 +1011,17 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
     if (!stream->IsEnabled())
       continue;
 
+    const uint64_t seekTimePts = seekTimeCorrected + stream->m_adStream.GetAbsolutePTSOffset();
+
     // With FMP4 audio stream included to video stream you must not seek with AdaptiveStream
     // segments are managed by AdaptiveStream of the video stream
     // so CFragmentedSampleReader read data from the reader of the video stream
     const bool hasAdStream = !(streamReader->GetType() == ISampleReader::Type::FMP4 &&
                                stream->m_adStream.getRepresentation()->IsIncludedStream());
 
-    if (hasAdStream && m_timingStream != stream) // Do not "seek time" on "timing stream" already done above
+    if (hasAdStream)
     {
-      const double seekSecs{static_cast<double>(seekTimeCorrected - ptsDiff) / STREAM_TIME_BASE};
+      const double seekSecs{static_cast<double>(seekTimePts) / STREAM_TIME_BASE};
 
       if (!SeekAdStream(*stream, seekSecs))
       {
@@ -1062,10 +1033,7 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
       }
     }
 
-    if (!CheckReaderRunning(*stream))
-      return false;
-
-    if (!streamReader->TimeSeek(seekTimeCorrected))
+    if (!SeekReader(*stream, seekTimePts))
     {
       streamReader->Reset(true);
 
@@ -1077,13 +1045,14 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
     }
     else
     {
-      double destTime{static_cast<double>(PTSToElapsed(streamReader->PTS())) / STREAM_TIME_BASE};
+      const uint64_t destTimePts = PTSToElapsed(streamReader->PTS());
+      const double destTimeSecs{static_cast<double>(destTimePts) / STREAM_TIME_BASE};
 
       // Note: TS sample reader with included streams have a dynamic streamId,
       // so could be that will be printed on log stream id referred to audio or video,
       // maybe this could be improved on sample reader to always start the seek from a video packet
       LOG::Log(LOGINFO, "Seek time %0.1lf for stream: %i continues at %0.1lf (PTS: %llu)", seekTime,
-               streamReader->GetStreamId(), destTime, streamReader->PTS());
+               streamReader->GetStreamId(), destTimeSecs, streamReader->PTS());
 
       // We replace the seek time PTS initially requested with the PTS of the video sample found
       // in order to search the audio/subtitle sample packet more accurately.
@@ -1093,8 +1062,14 @@ bool SESSION::CSession::SeekTime(double seekTime, bool& isError)
       // Then get the nearest PTS found for the video, then align the audio/subtitles with it.
       if (stream->m_info.GetStreamType() == INPUTSTREAM_TYPE_VIDEO)
       {
-        seekTime = destTime;
-        seekTimeCorrected = streamReader->PTS();
+        seekTime = destTimeSecs;
+
+        if (seekTimeCorrected != destTimePts)
+        {
+          LOG::Log(LOGINFO, "Corrected seek time PTS from %llu to %llu", seekTimeCorrected,
+                   destTimePts);
+          seekTimeCorrected = destTimePts;
+        }
       }
     }
   }

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -15,14 +15,19 @@ CADTSSampleReader::CADTSSampleReader(AP4_ByteStream* input)
 {
 }
 
-AP4_Result CADTSSampleReader::Start(bool& bStarted)
+AP4_Result CADTSSampleReader::Start(std::optional<uint64_t> pts)
 {
-  bStarted = false;
   if (m_started)
     return AP4_SUCCESS;
-  bStarted = true;
-  m_started = true;
-  return ReadSample();
+
+  AP4_Result ret;
+  if (pts.has_value())
+    TimeSeek(*pts) ? ret = AP4_SUCCESS : ret = AP4_ERROR_EOS;
+  else
+    ret = ReadSample();
+
+  m_started = AP4_SUCCEEDED(ret);
+  return ret;
 }
 
 AP4_Result CADTSSampleReader::ReadSample()
@@ -57,6 +62,9 @@ void CADTSSampleReader::Reset(bool bEOS)
 
 bool CADTSSampleReader::TimeSeek(uint64_t pts)
 {
+  // compensate the pts diff with the manifest timing
+  pts += m_ptsDiff;
+
   AP4_UI64 seekPos{(pts * 9) / 100};
   if (ADTSReader::SeekTime(seekPos))
   {

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -23,7 +23,7 @@ public:
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_pts; }
   uint64_t PTS() const override { return m_pts; }
-  AP4_Result Start(bool& bStarted) override;
+  AP4_Result Start(std::optional<uint64_t> pts) override;
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -143,15 +143,19 @@ void CFragmentedSampleReader::SetDecrypter(std::shared_ptr<Adaptive_CencSingleSa
   }
 }
 
-AP4_Result CFragmentedSampleReader::Start(bool& bStarted)
+AP4_Result CFragmentedSampleReader::Start(std::optional<uint64_t> pts)
 {
-  bStarted = false;
   if (m_started)
     return AP4_SUCCESS;
 
-  m_started = true;
-  bStarted = true;
-  return ReadSample();
+  AP4_Result ret;
+  if (pts.has_value())
+    TimeSeek(*pts) ? ret = AP4_SUCCESS : ret = AP4_ERROR_EOS;
+  else
+    ret = ReadSample();
+
+  m_started = AP4_SUCCEEDED(ret);
+  return ret;
 }
 
 AP4_Result CFragmentedSampleReader::ReadSample()
@@ -307,10 +311,13 @@ bool CFragmentedSampleReader::GetInformation(kodi::addon::InputstreamInfo& info)
 
 bool CFragmentedSampleReader::TimeSeek(uint64_t pts)
 {
+  // compensate the pts diff with the manifest timing
+  pts += m_ptsDiff;
+
   AP4_Ordinal sampleIndex;
   AP4_UI64 seekPos(static_cast<AP4_UI64>((pts * m_timeBaseInt) / m_timeBaseExt));
 
-  AP4_Result result = m_lReader->SeekSample(m_track->GetId(), seekPos, sampleIndex);
+  AP4_Result result = m_lReader->SeekSample(this, m_track->GetId(), seekPos, sampleIndex);
   if (AP4_FAILED(result))
   {
     if (result != AP4_ERROR_EOS)
@@ -817,7 +824,10 @@ AP4_Movie& CLinearReader::GetMovie()
   return AP4_LinearReader::m_Movie;
 }
 
-AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id, AP4_UI64 ts, AP4_Ordinal& sample_index)
+AP4_Result CLinearReader::SeekSample(CLinearReaderCB* lReaderCB,
+                                     AP4_UI32 track_id,
+                                     AP4_UI64 ts,
+                                     AP4_Ordinal& sample_index)
 {
   // we only support fragmented sources for now
   if (!m_HasFragments)
@@ -827,6 +837,12 @@ AP4_Result CLinearReader::SeekSample(AP4_UI32 track_id, AP4_UI64 ts, AP4_Ordinal
   {
     return AP4_ERROR_NO_SUCH_ITEM;
   }
+
+  // Protect call to SeekSample until method exit,
+  // to ensure appropriate callback to ProcessMoof from Advance
+  // with the specified reader (CLinearReaderCB) instance
+  std::lock_guard<std::mutex> lock(m_readerMtx);
+  SetCallback(lReaderCB);
 
   // look for a sample from a specific track
   Tracker* tracker = FindTracker(track_id);

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -70,7 +70,10 @@ public:
   // \brief Get AP4_LinearReader::m_Movie
   AP4_Movie& GetMovie();
 
-  AP4_Result SeekSample(AP4_UI32 track_id, AP4_UI64 ts, AP4_Ordinal& sample_index);
+  AP4_Result SeekSample(CLinearReaderCB* lReaderCB,
+                        AP4_UI32 track_id,
+                        AP4_UI64 ts,
+                        AP4_Ordinal& sample_index);
 
 protected:
   // AP4_LinearReader implementations
@@ -97,7 +100,7 @@ public:
                             const DRM::DecrypterCapabilites& dcaps,
                             const std::vector<uint8_t>& defaultKid) override;
 
-  AP4_Result Start(bool& bStarted) override;
+  AP4_Result Start(std::optional<uint64_t> pts) override;
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;
   bool EOS() const override { return m_eos; }

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -20,6 +20,8 @@
 #include <kodi/addon-instance/Inputstream.h>
 #endif
 
+#include <cstdint>
+#include <optional>
 #include <future>
 
 class Adaptive_CencSingleSampleDecrypter;
@@ -77,7 +79,12 @@ public:
   virtual uint64_t DTS() const = 0;
   virtual uint64_t PTS() const = 0;
   virtual uint64_t DTSorPTS() const { return DTS() < PTS() ? DTS() : PTS(); };
-  virtual AP4_Result Start(bool& bStarted) = 0;
+  /*!
+   * \brief Start the reader by reading the first packet.
+   * \param pts[OPT] The PTS where to start reading.
+   * \return AP4_SUCCESS if reader is started or was already started, otherwise an error result.
+   */
+  virtual AP4_Result Start(std::optional<uint64_t> pts = std::nullopt) = 0;
   virtual AP4_Result ReadSample() = 0;
   virtual void Reset(bool bEOS) = 0;
   virtual bool GetInformation(kodi::addon::InputstreamInfo& info) = 0;

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -108,7 +108,7 @@ bool CSubtitleSampleReader::InitializeFile(std::string url)
   return true;
 }
 
-AP4_Result CSubtitleSampleReader::Start(bool& bStarted)
+AP4_Result CSubtitleSampleReader::Start(std::optional<uint64_t> pts)
 {
   if (!m_codecHandler)
   {
@@ -119,8 +119,14 @@ AP4_Result CSubtitleSampleReader::Start(bool& bStarted)
   if (m_started)
     return AP4_SUCCESS;
 
-  m_started = true;
-  return ReadSample();
+  AP4_Result ret;
+  if (pts.has_value())
+    TimeSeek(*pts) ? ret = AP4_SUCCESS : ret = AP4_ERROR_EOS;
+  else
+    ret = ReadSample();
+
+  m_started = AP4_SUCCEEDED(ret);
+  return ret;
 }
 
 bool CSubtitleSampleReader::IsReady()

--- a/src/samplereader/SubtitleSampleReader.h
+++ b/src/samplereader/SubtitleSampleReader.h
@@ -37,7 +37,7 @@ public:
   bool IsReady() override;
   uint64_t DTS() const override { return m_pts; }
   uint64_t PTS() const override { return m_pts; }
-  AP4_Result Start(bool& bStarted) override;
+  AP4_Result Start(std::optional<uint64_t> pts) override;
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override;

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -48,9 +48,8 @@ bool CTSSampleReader::RemoveStreamType(INPUTSTREAM_TYPE type)
   return m_typeMask == 0;
 }
 
-AP4_Result CTSSampleReader::Start(bool& bStarted)
+AP4_Result CTSSampleReader::Start(std::optional<uint64_t> pts)
 {
-  bStarted = false;
   if (m_started)
     return AP4_SUCCESS;
 
@@ -60,9 +59,14 @@ AP4_Result CTSSampleReader::Start(bool& bStarted)
     return AP4_ERROR_CANNOT_OPEN_FILE;
   }
 
-  m_started = true;
-  bStarted = true;
-  return ReadSample();
+  AP4_Result ret;
+  if (pts.has_value())
+    TimeSeek(*pts) ? ret = AP4_SUCCESS : ret = AP4_ERROR_EOS;
+  else
+    ret = ReadSample();
+
+  m_started = AP4_SUCCEEDED(ret);
+  return ret;
 }
 
 AP4_Result CTSSampleReader::ReadSample()
@@ -106,6 +110,8 @@ bool CTSSampleReader::TimeSeek(uint64_t pts)
 {
   if (!StartStreaming(m_typeMask))
     return false;
+  // compensate the pts diff with the manifest timing
+  pts += m_ptsDiff;
 
   AP4_UI64 seekPos((pts * 9) / 100);
   if (TSReader::SeekTime(seekPos))

--- a/src/samplereader/TSSampleReader.h
+++ b/src/samplereader/TSSampleReader.h
@@ -29,7 +29,7 @@ public:
   bool EOS() const override { return m_eos; }
   uint64_t DTS() const override { return m_dts; }
   uint64_t PTS() const override { return m_pts; }
-  AP4_Result Start(bool& bStarted) override;
+  AP4_Result Start(std::optional<uint64_t> pts) override;
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -25,13 +25,19 @@ bool CWebmSampleReader::Initialize(SESSION::CStream* stream)
   return ret;
 }
 
-AP4_Result CWebmSampleReader::Start(bool& bStarted)
+AP4_Result CWebmSampleReader::Start(std::optional<uint64_t> pts)
 {
-  bStarted = false;
   if (m_started)
     return AP4_SUCCESS;
-  m_started = bStarted = true;
-  return ReadSample();
+
+  AP4_Result ret;
+  if (pts.has_value())
+    TimeSeek(*pts) ? ret = AP4_SUCCESS : ret = AP4_ERROR_EOS;
+  else
+    ret = ReadSample();
+
+  m_started = AP4_SUCCEEDED(ret);
+  return ret;
 }
 
 AP4_Result CWebmSampleReader::ReadSample()
@@ -61,6 +67,9 @@ void CWebmSampleReader::Reset(bool bEOS)
 
 bool CWebmSampleReader::TimeSeek(uint64_t pts)
 {
+  // compensate the pts diff with the manifest timing
+  pts += m_ptsDiff;
+
   AP4_UI64 seekPos((pts * 9) / 100);
   if (WebmReader::SeekTime(seekPos))
   {

--- a/src/samplereader/WebmSampleReader.h
+++ b/src/samplereader/WebmSampleReader.h
@@ -24,7 +24,7 @@ public:
   uint64_t DTS() const override { return m_dts; }
   uint64_t PTS() const override { return m_pts; }
   bool Initialize(SESSION::CStream* stream) override;
-  AP4_Result Start(bool& bStarted) override;
+  AP4_Result Start(std::optional<uint64_t> pts) override;
   AP4_Result ReadSample() override;
   void Reset(bool bEOS) override;
   bool GetInformation(kodi::addon::InputstreamInfo& info) override


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The problem is that when you resume a video
`CSession::SeekTime` check if the sample reader is running or not (with `CheckReaderRunning`)
when you start a stopped sample reader, you will call `Start` method on sample reader performing a `ReadSample` call,
after this, the `CSession::SeekTime` call the sample reader `TimeSeek` method, that will call `ReadSample` a second time
which results that you read two stream packages, discarding the previous one

this cause with WebM a bad side effect with the webm demuxer (that i didn't quite understand the problem) anyway avoid this works correctly again

this problem has been highlighted from the `CSession::SeekTime` PR rework #1986, anyway the problem was already here

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
the video resume with WebM container is broken

example broken Youtube videos playback, to reproduce:
1) On youtube addon settings, On "general" settings ->"stream features"->remove all audios, and keep only Vorbis+Opus
2) Play a video and seek to middle, than stop
3) Play same video by resuming it from previous time
4) Video dont start

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
without youtube its possible to test webm use case from ISASamples
Dash->VOD->Bitmovin "av01" or Bitmovin "av1"

tested also video seeks during playback on:
HLS TS streams with multiperiods
and LA7 live stream
Am@zon VOD
some other sample dash VOD streams

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
