### PR TITLE
[SampleReader] TS sample readers force single segment on init

### DIFF
--- a/src/AdaptiveByteStream.cpp
+++ b/src/AdaptiveByteStream.cpp
@@ -71,3 +71,8 @@ void CAdaptiveByteStream::SetSegmentFileOffset(uint64_t offset)
 {
   m_adStream->SetSegmentFileOffset(offset);
 }
+
+void CAdaptiveByteStream::AllowBufferQueue(bool isAllowed)
+{
+  m_adStream->AllowBufferQueue(isAllowed);
+}

--- a/src/AdaptiveByteStream.h
+++ b/src/AdaptiveByteStream.h
@@ -51,6 +51,7 @@ public:
   bool waitingForSegment() const;
   void FixateInitialization(bool on);
   void SetSegmentFileOffset(uint64_t offset);
+  void AllowBufferQueue(bool isAllowed);
 
 protected:
   adaptive::AdaptiveStream* m_adStream;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -945,6 +945,12 @@ bool adaptive::AdaptiveStream::ensureSegment()
         //           clsId, queueSegment->m_number, queueSegment->startPTS_);
         m_segBuffers.Push(std::move(segBuffer));
 
+        // Some sample reader dont use initialization segment so when they are in initialization phase
+        // in order to get info need to parse a media segment, but we want avoid downloading more segments,
+        // this is a workaround, for more info see todo "InputStream resume playback design problem" in the main.cpp
+        if (!m_isAllowedBufferQueue)
+          break;
+
         // Check if there is a following segment (add it to the queue at next iteration)
         if (!m_segBuffers.IsBufferFull())
           queueSegment = newRep->Timeline().GetNext(*queueSegment);

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -127,6 +127,7 @@ enum class EVENT_TYPE
     uint64_t GetAbsolutePTSOffset() const { return absolutePTSOffset_; }
     bool waitingForSegment() const;
     void FixateInitialization(bool on);
+    void AllowBufferQueue(bool isAllowed) { m_isAllowedBufferQueue = isAllowed; }
     void SetSegmentFileOffset(uint64_t offset) { m_segmentFileOffset = offset; };
     bool StreamChanged() { return m_startEvent == EVENT_TYPE::REP_CHANGE; }
 
@@ -279,6 +280,7 @@ enum class EVENT_TYPE
     uint64_t absolutePTSOffset_{0};
 
     bool m_fixateInitialization{false};
+    bool m_isAllowedBufferQueue{true};
     uint64_t m_segmentFileOffset{0};
 
     // Defines the event to start the stream, the status will be resetted by start stream method.

--- a/src/demuxers/ADTSReader.cpp
+++ b/src/demuxers/ADTSReader.cpp
@@ -350,39 +350,44 @@ void ADTSReader::Reset()
   m_frameParser.reset();
 }
 
-bool ADTSReader::GetInformation(kodi::addon::InputstreamInfo& info)
+void ADTSReader::FetchStreamInfo()
 {
   m_id3TagParser.SkipID3Data(m_stream);
-  ADTSFrame::ADTSFrameInfo frameInfo = m_frameParser.GetFrameInfo(m_stream);
-
+  m_frameInfo = m_frameParser.GetFrameInfo(m_stream);
   m_stream->Seek(0); // Seek back because data has been consumed
+}
 
-  if (frameInfo.m_codecType == AdtsType::NONE)
+bool ADTSReader::GetInformation(kodi::addon::InputstreamInfo& info)
+{
+  if (!m_frameInfo.has_value())
+    FetchStreamInfo();
+
+  if (m_frameInfo->m_codecType == AdtsType::NONE)
     return false;
 
   std::string codecName;
   STREAMCODEC_PROFILE codecProfile{CodecProfileUnknown};
 
-  if (frameInfo.m_codecType == AdtsType::AAC)
+  if (m_frameInfo->m_codecType == AdtsType::AAC)
   {
     codecName = CODEC::NAME_AAC;
-    if (frameInfo.m_codecProfile == AP4_AAC_PROFILE_MAIN)
+    if (m_frameInfo->m_codecProfile == AP4_AAC_PROFILE_MAIN)
       codecProfile = AACCodecProfileMAIN;
-    else if (frameInfo.m_codecProfile == AP4_AAC_PROFILE_LC)
+    else if (m_frameInfo->m_codecProfile == AP4_AAC_PROFILE_LC)
       codecProfile = AACCodecProfileLOW;
-    else if (frameInfo.m_codecProfile == AP4_AAC_PROFILE_SSR)
+    else if (m_frameInfo->m_codecProfile == AP4_AAC_PROFILE_SSR)
       codecProfile = AACCodecProfileSSR;
-    else if (frameInfo.m_codecProfile == AP4_AAC_PROFILE_LTP)
+    else if (m_frameInfo->m_codecProfile == AP4_AAC_PROFILE_LTP)
       codecProfile = AACCodecProfileLTP;
   }
-  else if (frameInfo.m_codecType == AdtsType::AC3)
+  else if (m_frameInfo->m_codecType == AdtsType::AC3)
   {
     codecName = CODEC::NAME_AC3;
   }
-  else if (frameInfo.m_codecType == AdtsType::EAC3)
+  else if (m_frameInfo->m_codecType == AdtsType::EAC3)
   {
     codecName = CODEC::NAME_EAC3;
-    if ((frameInfo.m_codecFlags & ADTSFrame::CODEC_FLAG_ATMOS) == ADTSFrame::CODEC_FLAG_ATMOS)
+    if ((m_frameInfo->m_codecFlags & ADTSFrame::CODEC_FLAG_ATMOS) == ADTSFrame::CODEC_FLAG_ATMOS)
       codecProfile = DDPlusCodecProfileAtmos;
   }
 
@@ -398,16 +403,18 @@ bool ADTSReader::GetInformation(kodi::addon::InputstreamInfo& info)
     info.SetCodecProfile(codecProfile);
     isChanged = true;
   }
-  if (info.GetChannels() != frameInfo.m_channels)
+  if (info.GetChannels() != m_frameInfo->m_channels)
   {
-    info.SetChannels(frameInfo.m_channels);
+    info.SetChannels(m_frameInfo->m_channels);
     isChanged = true;
   }
-  if (info.GetSampleRate() != frameInfo.m_sampleRate)
+  if (info.GetSampleRate() != m_frameInfo->m_sampleRate)
   {
-    info.SetSampleRate(frameInfo.m_sampleRate);
+    info.SetSampleRate(m_frameInfo->m_sampleRate);
     isChanged = true;
   }
+
+  m_frameInfo.reset();
 
   return isChanged;
 }

--- a/src/demuxers/ADTSReader.h
+++ b/src/demuxers/ADTSReader.h
@@ -13,6 +13,8 @@
 #include <bento4/Ap4DataBuffer.h>
 #include <kodi/addon-instance/Inputstream.h>
 
+#include <optional>
+
 // Forwards
 class AP4_ByteStream;
 
@@ -104,6 +106,7 @@ public:
   void Reset();
   bool SeekTime(uint64_t timeInTs);
 
+  void FetchStreamInfo();
   bool GetInformation(kodi::addon::InputstreamInfo& info);
   bool ReadPacket();
 
@@ -118,6 +121,7 @@ private:
   AP4_ByteStream *m_stream;
   ID3TAG m_id3TagParser;
   ADTSFrame m_frameParser;
+  std::optional<ADTSFrame::ADTSFrameInfo> m_frameInfo;
   uint64_t m_basePts{0};
   uint64_t m_pts{0};
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,6 +157,33 @@ void CInputStreamAdaptive::EnableStream(int streamid, bool enable)
   }
 }
 
+//! @todo: InputStream "resume" playback design problem for multi-period/chapter streams case:
+//! Currently, Kodi VideoPlayer operates in this order:
+//!  1. "Open" callback (open the add-on)
+//!  2. ... "GetStreamIds" callback, etc ...
+//!  3. "OpenStream" callbacks (open the streams, and mandatory to provide the extradata when required)
+//!  4. "PosTime" callback (in case of resuming video / seek stream operations)
+//!  5. ... "DemuxRead" callbacks (start to feed data to Kodi core)
+//!
+//! As you can see from the flow when kodi request to open a stream "OpenStream" callbacks you have no way
+//! to know if the playback is starting from the beginning or is resuming from a specific time position,
+//! because "PosTime" callback is called only after "OpenStream" callbacks
+//!
+//! This lead that the add-on start to open all the streams from the beginning of the first chapter/period,
+//! but if the playback is resuming from a chapter/period different from the first one, this is a big problem because we are
+//! performing tons of useless work such as initialize unused streams, download and parse unused segment data, initialize decrypters...
+//!
+//! As workaround when we receive the "PosTime" callback with the position where to start the playback
+//! we send the "DEMUX_SPECIALID_STREAMCHANGE" to VP to force VP to reopen all the streams from the right chapter/period,
+//! but this is a bad design. We should open a stream from the appropriate chapter/period and position since the beginning
+//! but we need a way to know if the playback is starting from the beginning or is resuming from a specific time position.
+//! Related to this problem there is also another workaround applied on some sample readers that use
+//! the AdaptiveStream::m_isAllowedBufferQueue to prevent to start downloading too much uneeded data.
+//! Another side effect of "OpenStream" with TS/ADTS sample readers
+//! since these streams dont have init segment, readers will parse a media segment to extract the stream info/extradata
+//! but since we dont know the resume time, this segment is downloaded from the beginning of the first chapter/period
+//! ofc this is not so good because cause network congestion (repeated downloads) and so worse execution time
+
 // OpenStream method notes:
 // - This method is called:
 //    - At playback start

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -15,6 +15,16 @@ CADTSSampleReader::CADTSSampleReader(AP4_ByteStream* input)
 {
 }
 
+bool CADTSSampleReader::Initialize(SESSION::CStream* stream)
+{
+  // This is a workaround to avoid start buffering many segments
+  // when the sample reader is initialized just to retrieve the stream info
+  m_adByteStream->AllowBufferQueue(false);
+  ADTSReader::FetchStreamInfo();
+  m_adByteStream->AllowBufferQueue(true);
+  return true;
+}
+
 AP4_Result CADTSSampleReader::Start(std::optional<uint64_t> pts)
 {
   if (m_started)

--- a/src/samplereader/ADTSSampleReader.h
+++ b/src/samplereader/ADTSSampleReader.h
@@ -17,6 +17,8 @@ class ATTR_DLL_LOCAL CADTSSampleReader : public ISampleReader, public ADTSReader
 public:
   CADTSSampleReader(AP4_ByteStream* input);
 
+  bool Initialize(SESSION::CStream* stream) override;
+
   Type GetType() const override { return Type::ADTS; }
 
   bool IsStarted() const override { return m_started; }

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -24,7 +24,12 @@ void CTSSampleReader::SetStreamId(INPUTSTREAM_TYPE type, int streamId)
 
 bool CTSSampleReader::Initialize(SESSION::CStream* stream)
 {
-  return TSReader::Initialize();
+  // This is a workaround to avoid start buffering many segments
+  // when the sample reader is initialized just to retrieve the stream info
+  m_adByteStream->AllowBufferQueue(false);
+  bool ret = TSReader::Initialize();
+  m_adByteStream->AllowBufferQueue(true);
+  return ret;
 }
 
 void CTSSampleReader::AddStreamType(INPUTSTREAM_TYPE type, int streamId)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
**_to test this use case you need a HLS TS stream with multiple periods/chapters, and the video "resume" must fall into a chapter different from the first one_**

This introduce a new workaround for TS (and ADTS) streams
TS streams have no initialization segment such as mp4 or webm
so to read stream info (extradata) we need to read from a stream segment

when a sample reader try to read data cause `AdaptiveStream` to put in download queue all other subsequent segments
and if you are resuming a video from last playback position, this data will be deleted so all these download operations are useless and worsen network traffic

so to avoid `AdaptiveStream` to put in download queue all other subsequent segments, i add a variable to block subsequent downloads

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is one of the many issues that have been left unaddressed since the early stages of this add-on development
i add a large "todo" code comment about this because its more complex problem that can involve more components

```c++
//! @todo: InputStream "resume" playback design problem for multi-period/chapter streams case:
//! Currently, Kodi VideoPlayer operates in this order:
//!  1. "Open" callback (open the add-on)
//!  2. ... "GetStreamIds" callback, etc ...
//!  3. "OpenStream" callbacks (open the streams, and mandatory to provide the extradata when required)
//!  4. "PosTime" callback (in case of resuming video / seek stream operations)
//!  5. ... "DemuxRead" callbacks (start to feed data to Kodi core)
//!
//! As you can see from the flow when kodi request to open a stream "OpenStream" callbacks you have no way
//! to know if the playback is starting from the beginning or is resuming from a specific time position,
//! because "PosTime" callback is called only after "OpenStream" callbacks
//!
//! This lead that the add-on start to open all the streams from the beginning of the first chapter/period,
//! but if the playback is resuming from a chapter/period different from the first one, this is a big problem because we are
//! performing tons of useless work such as initialize unused streams, download and parse unused segment data, initialize decrypters...
//!
//! As workaround when we receive the "PosTime" callback with the position where to start the playback
//! we send the "DEMUX_SPECIALID_STREAMCHANGE" to VP to force VP to reopen all the streams from the right chapter/period,
//! but this is a bad design. We should open a stream from the appropriate chapter/period and position since the beginning
//! but we need a way to know if the playback is starting from the beginning or is resuming from a specific time position.
//! Related to this problem there is also another workaround applied on some sample readers that use
//! the AdaptiveStream::m_isAllowedBufferQueue to prevent to start downloading too much uneeded data.
//! Another side effect of "OpenStream" with TS/ADTS sample readers
//! since these streams dont have init segment, readers will parse a media segment to extract the stream info/extradata
//! but since we dont know the resume time, this segment is downloaded from the beginning of the first chapter/period
//! ofc this is not so good because cause network congestion (repeated downloads) and so worse execution time
```

i add also a commented log that provide some kind of guidance of the root of problem
[Log.txt](https://github.com/user-attachments/files/27805456/Log.txt)
I don't know if this will help you understand without writing a poem

in my opinion, this needs some tweaking, which will most likely have to involve VP as well

PS. to test the "todo" behavior you can use any stream that have multi-periods/chapters,
instead to verify the sample reader case you need TS/ADTS streams (HLS multi-period)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally with a local HLS multi-period TS stream

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
