### PR TITLE
Make effective `check_hdcp` setting, changes about audio secure decoder hack

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -211,28 +211,6 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
                                                           initDrmInfo.defaultKid);
               if (session)
               {
-                //! @todo: HACK REQUIRED BECAUSE ---> Secure path on audio stream is not implemented for CDM Widevine ONLY (non-android) <---
-                //! since audio streams that require Secure path decoder cannot be played
-                //! we have no way to distinguish which ones they are other than to do a KID test with the DRM for each stream,
-                //! this is an expensive method that could open many DRM sessions which will not be unused for playback.
-                //! When in a future this will be implemented, all this code should be cleanup and removed
-                //! and then leave it to CInputStreamAdaptive::OpenStream -> PrepareStream
-                //! the task to initialize DRM session only to the requested streams.
-                //! It can be tested e.g. with some Am@zon videos
-                auto& caps = session->capabilities;
-
-                if (!session->drm->IsSecureDecoderAudioSupported() &&
-                    adp->GetStreamType() == StreamType::AUDIO &&
-                    caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH)
-                {
-                  LOG::Log(LOGWARNING,
-                           "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", "
-                           "Secure path decoder on audio stream is not supported",
-                           repr->GetId().c_str(), adp->GetId().c_str());
-                  repr->isPlayable = false;
-                  continue;
-                }
-
                 // Note to HDCP check:
                 // HDCP check should be done by the DRM where in case of problems should block key's
                 // for example with Widevine you will get "output-restricted" to key status
@@ -249,14 +227,21 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
                     repr->isPlayable = false;
                     continue;
                   }
-
                 }
               }
             }
           }
           else
           {
-            if (m_drmEngine.GetStatus() == DRM::EngineStatus::DRM_ERROR ||
+            if (m_drmEngine.GetStatus() == DRM::EngineStatus::NOT_SUPPORTED)
+            {
+              LOG::Log(LOGWARNING,
+                       "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", due to unsupported DRM feature",
+                       repr->GetId().c_str(), adp->GetId().c_str());
+              repr->isPlayable = false;
+              continue;
+            }
+            else if (m_drmEngine.GetStatus() == DRM::EngineStatus::DRM_ERROR ||
                 m_drmEngine.GetStatus() == DRM::EngineStatus::DECRYPTER_ERROR)
             {
               return false; // return here, a bad status dont allow you to play streams
@@ -1124,6 +1109,20 @@ void SESSION::CSession::OnStreamChange(adaptive::AdaptiveStream* adStream)
 
 bool SESSION::CSession::OnGetStream(int streamid, kodi::addon::InputstreamInfo& info)
 {
+  if (m_drmEngine.GetStatus() == DRM::EngineStatus::NOT_SUPPORTED)
+  {
+    auto stream = GetStream(GetStreamIndexFromId(streamid));
+    if (!stream)
+      return false;
+
+    CAdaptationSet* adp{stream->m_adStream.getAdaptationSet()};
+    CRepresentation* repr{stream->m_adStream.getRepresentation()};
+    LOG::Log(
+        LOGERROR,
+        "Stream repr ID \"%s\", AdpSet ID \"%s\", cant be played due to unsupported DRM feature",
+        repr->GetId().c_str(), adp->GetId().c_str());
+    return false;
+  }
   if (m_drmEngine.GetStatus() == DRM::EngineStatus::DRM_ERROR ||
       m_drmEngine.GetStatus() == DRM::EngineStatus::DECRYPTER_ERROR)
   {

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -157,14 +157,11 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
 {
   auto& kodiPropCfg = CSrvBroker::GetKodiProps().GetConfig();
 
-  /*! @todo: Code commented, see todo below about: "Secure path on audio stream is not implemented"
-   *
   if (kodiPropCfg.resolutionLimit == 0 &&
       kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::DEFAULT)
   {
-    return;
+    return true;
   }
-  */
 
   for (auto& adp : period->GetAdaptationSets())
   {
@@ -173,10 +170,8 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
 
     for (auto& repr : adp->GetRepresentations())
     {
-      //! @todo: Code changed, see todo below about: "Secure path on audio stream is not implemented"
-      // if (kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::LICENSE &&
-      //     !m_adaptiveTree->IsReqPrepareStream())
-      if (!m_adaptiveTree->IsReqPrepareStream())
+      if (kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::LICENSE &&
+          !m_adaptiveTree->IsReqPrepareStream())
       {
         // The LICENSE method assume that a service provide in the license response the HDCP parameters
         // currently a comparison is made between the license HDCP values and the one provided by the manifest.
@@ -215,18 +210,17 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
                 // HDCP check should be done by the DRM where in case of problems should block key's
                 // for example with Widevine you will get "output-restricted" to key status
                 // the following it's an additional check for custom manifest's
-                if (kodiPropCfg.hdcpCheck == ADP::KODI_PROPS::HdcpCheckType::LICENSE)
+                auto& caps = session->capabilities;
+
+                if (repr->GetHdcpVersion() > caps.hdcpVersion ||
+                    (caps.hdcpLimit > 0 && repr->GetWidth() * repr->GetHeight() > caps.hdcpLimit))
                 {
-                  if (repr->GetHdcpVersion() > caps.hdcpVersion ||
-                      (caps.hdcpLimit > 0 && repr->GetWidth() * repr->GetHeight() > caps.hdcpLimit))
-                  {
-                    LOG::Log(
-                        LOGWARNING,
-                        "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", as not HDCP compliant",
-                        repr->GetId().c_str(), adp->GetId().c_str());
-                    repr->isPlayable = false;
-                    continue;
-                  }
+                  LOG::Log(
+                      LOGWARNING,
+                      "Disabled stream repr ID \"%s\", AdpSet ID \"%s\", as not HDCP compliant",
+                      repr->GetId().c_str(), adp->GetId().c_str());
+                  repr->isPlayable = false;
+                  continue;
                 }
               }
             }

--- a/src/decrypters/DrmEngine.cpp
+++ b/src/decrypters/DrmEngine.cpp
@@ -282,6 +282,9 @@ bool DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
   if (!Initialize())
     return false;
 
+  // Reset status before to start a new initialization
+  m_status = EngineStatus::NONE;
+
   LOG::Log(LOGDEBUG, "Initialize crypto session");
 
   ConfigureClearKey(drmInfos);
@@ -502,6 +505,17 @@ bool DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> drmInfos,
   }
 
   auto& caps = session->capabilities;
+
+  //! @todo: Secure decoder on audio stream is not implemented on CDM Widevine (non-android)
+  //! since audio streams that require Secure path decoder cannot be played
+  //! we have no way to distinguish which ones they are other than to do a KID test with the DRM
+  if (!session->drm->IsSecureDecoderAudioSupported() && session->mediaType == DRMMediaType::AUDIO &&
+      caps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH)
+  {
+    LOG::Log(LOGWARNING, "Secure decoder on audio stream is not supported");
+    m_status = EngineStatus::NOT_SUPPORTED;
+    return false;
+  }
 
   // Create crypto session
   kodi::addon::StreamCryptoSession cryptoSession;

--- a/src/decrypters/DrmEngineDefines.h
+++ b/src/decrypters/DrmEngineDefines.h
@@ -103,6 +103,7 @@ enum class EngineStatus
   NONE,
   DRM_ERROR, // Unsupported DRM, or a problem in the initialization of DRM
   DECRYPTER_ERROR, // A DRM decrypter error
+  NOT_SUPPORTED, // The content is not supported by the DRM (e.g. unsupported crypto mode)
 };
 
 enum class DRMMediaType


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Make effective `check_hdcp` setting implemented time ago
changes about audio secure decoder "hack" due to unimplemented feature

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
propedeutic changes to try implement future improvements

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
