### PR TITLE
New parameters to "config" property to override streams media flags

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -52,7 +52,7 @@ constexpr std::string_view PROP_MANIFEST_CONFIG = "inputstream.adaptive.manifest
 constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_params";
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 
-constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language";
+constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language"; //! @todo: deprecated, to be removed on Kodi 23
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: deprecated to be removed on Kodi 23
@@ -183,10 +183,14 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
       LogProp(prop.first, prop.second);
       ParseHeaderString(m_streamHeaders, prop.second);
     }
-    else if (prop.first == PROP_AUDIO_LANG_ORIG)
+    else if (prop.first == PROP_AUDIO_LANG_ORIG) //! @todo: deprecated, to be removed on Kodi 23
     {
+      LOG::Log(LOGWARNING, "Warning \"inputstream.adaptive.original_audio_language\" property is "
+                           "deprecated and will be removed on next Kodi version.\n"
+                           "Please read Wiki \"Integration\" page to learn more about the new "
+                           "parameters of \"inputstream.adaptive.config\".");
       LogProp(prop.first, prop.second);
-      m_audioLanguageOrig = prop.second;
+      m_config.mediaAudioLangCodeOrig = prop.second;
     }
     else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
     {
@@ -356,6 +360,36 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseConfig(const std::string& data)
                     value.data(), configName.c_str(), PROP_MANIFEST_CONFIG.data());
         }
       }
+    }
+    else if (configName == "media_audio_langcode_default" && jValue.is_string())
+    {
+      m_config.mediaAudioLangCodeDef = jValue.get<std::string>();
+    }
+    else if (configName == "media_audio_langcode_original" && jValue.is_string())
+    {
+      m_config.mediaAudioLangCodeOrig = jValue.get<std::string>();
+    }
+    else if (configName == "media_subtitle_langcode_default" && jValue.is_string())
+    {
+      m_config.mediaSubtitleLangCodeDef = jValue.get<std::string>();
+    }
+    else if (configName == "media_audio_type_pref" && jValue.is_string())
+    {
+      // Accepted values mimic Kodi VP language settings: "original", "impaired", "default"
+      if (jValue == "" || jValue == "default")
+        m_config.mediaAudioTypePref = MediaFlagType::DEFAULT;
+      else if (jValue == "original")
+        m_config.mediaAudioTypePref = MediaFlagType::ORIGINAL;
+      else if (jValue == "impaired")
+        m_config.mediaAudioTypePref = MediaFlagType::IMPAIRED;
+      else
+        LOG::LogF(LOGERROR, "Value \"%s\" isnt supported on \"%s\" parameter of \"%s\" property",
+                  jValue.get<std::string>().c_str(), configName.c_str(),
+                  PROP_MANIFEST_CONFIG.data());
+    }
+    else if (configName == "media_audio_stereo_pref" && jValue.is_boolean())
+    {
+      m_config.mediaAudioStereoPref = jValue.get<bool>();
     }
     else
     {

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -41,6 +41,13 @@ enum class HdcpCheckType
   LICENSE, // To check HDCP values from DRM license response
 };
 
+enum class MediaFlagType
+{
+  DEFAULT,
+  ORIGINAL,
+  IMPAIRED,
+};
+
 // Generic add-on configuration
 struct Config
 {
@@ -53,6 +60,19 @@ struct Config
   HdcpCheckType hdcpCheck{HdcpCheckType::DEFAULT};
   // Force limit resolutions of manifest streams to the specified value included (value in px, height x width)
   int resolutionLimit{0};
+
+  // To override "default" media flag on audio streams that have the specified language code (IETF BCP-47)
+  std::string mediaAudioLangCodeDef;
+  // To override "original" media flag on audio streams that have the specified language code (IETF BCP-47)
+  std::string mediaAudioLangCodeOrig;
+  // To override "default" media flag on subtitles streams that have the specified language code (IETF BCP-47)
+  std::string mediaSubtitleLangCodeDef;
+  // Defines what type of audio tracks should be preferred for the "default"/"impaired" flag
+  // (applicable when using media flag override)
+  MediaFlagType mediaAudioTypePref{MediaFlagType::DEFAULT};
+  // Defines if stereo audio tracks are preferred over multichannels one
+  // (applicable when using media flag override)
+  bool mediaAudioStereoPref{false};
 };
 
 struct ManifestConfig
@@ -154,9 +174,6 @@ public:
   // \brief HTTP headers used to download streams
   std::map<std::string, std::string> GetStreamHeaders() const { return m_streamHeaders; }
 
-  // \brief Get language code to identify the audio track in original language
-  std::string GetAudioLangOrig() const { return m_audioLanguageOrig; }
-
   // \brief Specify to start playing a LIVE stream from the beginning of the buffer instead of its end
   bool IsPlayTimeshift() const { return m_playTimeshiftBuffer; }
 
@@ -192,7 +209,6 @@ private:
   std::map<std::string, std::string> m_manifestHeaders;
   std::string m_streamParams;
   std::map<std::string, std::string> m_streamHeaders;
-  std::string m_audioLanguageOrig;
   bool m_playTimeshiftBuffer{false};
   ChooserProps m_chooserProps;
   Config m_config;

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -314,12 +314,6 @@ void SESSION::CSession::InitializePeriod()
     return;
 
   CHOOSER::StreamSelection streamSelectionMode = m_reprChooser->GetStreamSelectionMode();
-  //! @todo: GetAudioLangOrig property should be reworked to allow override or set
-  //! manifest a/v and subtitles streams attributes such as default/original etc..
-  //! since Kodi stream flags dont have always the same meaning of manifest attributes
-  //! and some video services dont follow exactly the specs so can lead to wrong Kodi flags sets.
-  //! An idea is add/move these override of attributes on post manifest parsing.
-  std::string audioLanguageOrig = CSrvBroker::GetKodiProps().GetAudioLangOrig();
 
   // For multi-codec manifests, determine which codec to use by default,
   // then choose the appropriate AdaptationSet. It may also depend on the Chooser behavior.
@@ -369,7 +363,7 @@ void SESSION::CSession::InitializePeriod()
       const uint32_t uniqueId = MakeUniqueId(periodIndex, streamIndex);
       const bool isDefaultVideoRepr{isDefaultAdpSet && repr == defaultRepr};
 
-      AddStream(adp.get(), repr, isDefaultVideoRepr, uniqueId, audioLanguageOrig);
+      AddStream(adp.get(), repr, isDefaultVideoRepr, uniqueId);
       ++streamIndex;
       return true;
     };
@@ -417,8 +411,7 @@ void SESSION::CSession::InitializePeriod()
 void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
                                   PLAYLIST::CRepresentation* initialRepr,
                                   bool isDefaultVideoRepr,
-                                  uint32_t uniqueId,
-                                  std::string_view audioLanguageOrig)
+                                  uint32_t uniqueId)
 {
   m_streams.push_back(std::make_shared<CStream>(m_adaptiveTree, adp, initialRepr));
 
@@ -443,11 +436,8 @@ void SESSION::CSession::AddStream(PLAYLIST::CAdaptationSet* adp,
         flags |= INPUTSTREAM_FLAG_VISUAL_IMPAIRED;
       if (adp->IsDefault())
         flags |= INPUTSTREAM_FLAG_DEFAULT;
-      if (adp->IsOriginal() || (!audioLanguageOrig.empty() &&
-                                adp->GetLanguage() == audioLanguageOrig))
-      {
+      if (adp->IsOriginal())
         flags |= INPUTSTREAM_FLAG_ORIGINAL;
-      }
       break;
     }
     case StreamType::SUBTITLE:

--- a/src/Session.h
+++ b/src/Session.h
@@ -64,8 +64,7 @@ public:
   void AddStream(PLAYLIST::CAdaptationSet* adp,
                  PLAYLIST::CRepresentation* repr,
                  bool isDefaultVideoRepr,
-                 uint32_t uniqueId,
-                 std::string_view audioLanguageOrig);
+                 uint32_t uniqueId);
 
   /*! \brief Update stream's InputstreamInfo
    *  \param stream The stream to update

--- a/src/common/AdaptationSet.cpp
+++ b/src/common/AdaptationSet.cpp
@@ -247,3 +247,63 @@ PLAYLIST::CAdaptationSet* PLAYLIST::CAdaptationSet::FindByFirstAVStream(
 
   return adp;
 }
+
+std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator PLAYLIST::CAdaptationSet::
+    FindAudioAdpSet(const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                    const std::string langCode,
+                    bool isPreferStereo)
+{
+  for (auto itAdpSet = adpSets.cbegin(); itAdpSet != adpSets.cend(); ++itAdpSet)
+  {
+    auto adpSet = itAdpSet->get();
+    if (adpSet->GetStreamType() == StreamType::AUDIO &&
+        STRING::CompareNoCase(adpSet->GetLanguage(), langCode) &&
+        !adpSet->GetRepresentations().empty() &&
+        (isPreferStereo ? adpSet->GetRepresentations()[0]->GetAudioChannels() <= 2
+                        : adpSet->GetRepresentations()[0]->GetAudioChannels() > 2))
+    {
+      return itAdpSet;
+    }
+  }
+  return adpSets.end();
+}
+
+std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator PLAYLIST::CAdaptationSet::
+    FindAudioAdpSet(const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                    const std::string langCode,
+                    bool isPreferStereo,
+                    bool filterImpaired)
+{
+  for (auto itAdpSet = adpSets.cbegin(); itAdpSet != adpSets.cend(); ++itAdpSet)
+  {
+    auto adpSet = itAdpSet->get();
+    if (adpSet->GetStreamType() == StreamType::AUDIO &&
+        STRING::CompareNoCase(adpSet->GetLanguage(), langCode) &&
+        !adpSet->GetRepresentations().empty() &&
+        (isPreferStereo ? adpSet->GetRepresentations()[0]->GetAudioChannels() <= 2
+                        : adpSet->GetRepresentations()[0]->GetAudioChannels() > 2) &&
+        adpSet->IsImpaired() == filterImpaired)
+    {
+      return itAdpSet;
+    }
+  }
+  return adpSets.end();
+}
+
+std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator PLAYLIST::CAdaptationSet::
+    FindSubtitleAdpSet(const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+                       const std::string langCode,
+                       bool filterImpaired)
+{
+  for (auto itAdpSet = adpSets.cbegin(); itAdpSet != adpSets.cend(); ++itAdpSet)
+  {
+    auto adpSet = itAdpSet->get();
+    if (adpSet->GetStreamType() == StreamType::SUBTITLE &&
+        STRING::CompareNoCase(adpSet->GetLanguage(), langCode) &&
+        !adpSet->GetRepresentations().empty() && adpSet->IsImpaired() == filterImpaired)
+    {
+      return itAdpSet;
+    }
+  }
+  return adpSets.end();
+}

--- a/src/common/AdaptationSet.h
+++ b/src/common/AdaptationSet.h
@@ -170,6 +170,22 @@ public:
    */
   static CAdaptationSet* FindByFirstAVStream(std::vector<std::unique_ptr<CAdaptationSet>>& adpSets);
 
+  static std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator FindAudioAdpSet(
+      const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+      const std::string langCode,
+      bool isPreferStereo);
+
+  static std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator FindAudioAdpSet(
+      const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+      const std::string langCode,
+      bool isPreferStereo,
+      bool filterImpaired);
+
+  static std::vector<std::unique_ptr<CAdaptationSet>>::const_iterator FindSubtitleAdpSet(
+      const std::vector<std::unique_ptr<CAdaptationSet>>& adpSets,
+      const std::string langCode,
+      bool filterImpaired);
+
 protected:
   std::vector<std::unique_ptr<CRepresentation>> m_representations;
 

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -84,6 +84,7 @@ namespace adaptive
   void AdaptiveTree::PostOpen()
   {
     SortTree();
+    OverrideStreamsMediaFlags(m_periods);
 
     // A manifest can provide live delay value, if not so we use our default
     // value of 16 secs, this is needed to ensure an appropriate playback,
@@ -112,6 +113,192 @@ namespace adaptive
                                    bool isLastChunk)
   {
     segBuffer.insert(segBuffer.end(), srcData, srcData + srcDataSize);
+  }
+
+  void AdaptiveTree::OverrideStreamsMediaFlags(
+      std::vector<std::unique_ptr<PLAYLIST::CPeriod>>& periods)
+  {
+    const auto& config = CSrvBroker::GetKodiProps().GetConfig();
+
+    const std::string& audioLangCodeDef = config.mediaAudioLangCodeDef;
+    const std::string& audioLangCodeOrig = config.mediaAudioLangCodeOrig;
+    const std::string& subtitleLangCodeDef = config.mediaSubtitleLangCodeDef;
+    const bool isAudioStereoPref = config.mediaAudioStereoPref;
+    const auto audioTypePref = config.mediaAudioTypePref;
+
+    // Media flags note:
+    // Manifests of video services dont always set appropriately the default stream media flags
+    // moreover the manifest "default" stream flag dont have always the same meaning of Kodi track "default" flag
+    // so this can lead to wrong audio track selected when playback start.
+    //
+    // NOTE: to simplify the code it dont take in account of multi-codecs streams with same language code and channels,
+    //  this is not a common use case and we ignore it.
+    // NOTE 2: To allow Kodi VP to do a better track auto-selection we need:
+    //  - Set default/impaired/original flag to a single track only
+    //  - Set default/impaired/original flag to stereo or multichannels track, not both
+    // NOTE 3: At moment Kodi dont support any kind of track auto-selection fallback for language code
+    //  that have variants e.g. "pt-BR" for Brazilian Portuguese vs "pt" for Portuguese,
+    //  so here at moment its the same, if you set as default "pt-BR" but exists only a "pt" stream
+    //  no stream will be set as default. This could be improved in future but for now we keep it simple.
+    //
+    //! @todo: For the way it works, we have to rely on each add-on to provide the necessary parameters.
+    //! This is because the C++ interface does not provide access to language settings,
+    //! whereas the Python interface has access to everything. This could be improved in the future.
+
+    // Override subtitles "default" flag to streams
+    if (!audioLangCodeDef.empty())
+    {
+      for (auto& period : periods)
+      {
+        for (auto& adpSet : period->GetAdaptationSets())
+        {
+          if (adpSet->GetStreamType() == StreamType::SUBTITLE)
+          {
+            adpSet->SetIsDefault(STRING::CompareNoCase(adpSet->GetLanguage(), audioLangCodeDef));
+          }
+        }
+      }
+    }
+
+    // Override audio "original" flag to streams
+    if (!audioLangCodeOrig.empty())
+    {
+      for (auto& period : periods)
+      {
+        auto& adpSets = period->GetAdaptationSets();
+        auto itAudioStream = adpSets.cend();
+
+        if (isAudioStereoPref)
+        {
+          itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, true);
+          if (itAudioStream == adpSets.cend()) // No stereo stream, find multichannels
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, false);
+        }
+        else
+        {
+          itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, false);
+          if (itAudioStream == adpSets.cend()) // No multichannels stream, find stereo
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, true);
+        }
+
+        // Update "original" flags
+        if (itAudioStream != adpSets.cend())
+        {
+          for (auto& adpSet : adpSets)
+          {
+            adpSet->SetIsOriginal(adpSet.get() == itAudioStream->get());
+          }
+        }
+      }
+    }
+
+    // Override audio "default" flag to streams, we give priority to "impaired" streams if specified
+    if (!audioLangCodeDef.empty() || !audioLangCodeOrig.empty())
+    {
+      for (auto& period : periods)
+      {
+        auto& adpSets = period->GetAdaptationSets();
+        auto itAudioStream = adpSets.cend();
+
+        // Try give priority to "impaired" streams
+        if (audioTypePref == ADP::KODI_PROPS::MediaFlagType::IMPAIRED)
+        {
+          if (isAudioStereoPref)
+          {
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, true, true);
+            if (itAudioStream == adpSets.cend()) // No stereo stream, find multichannels
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, false, true);
+          }
+          else
+          {
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, false, true);
+            if (itAudioStream == adpSets.cend()) // No multichannels stream, find stereo
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, true, true);
+          }
+
+          // No stream found, try find a "impaired" stream with the "original" language code
+          if (itAudioStream == adpSets.cend() && !audioLangCodeOrig.empty())
+          {
+            if (isAudioStereoPref)
+            {
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, true, true);
+              if (itAudioStream == adpSets.cend()) // No stereo stream, find multichannels
+                itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, false, true);
+            }
+            else
+            {
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, false, true);
+              if (itAudioStream == adpSets.cend()) // No multichannels stream, find stereo
+                itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, true, true);
+            }
+          }
+        }
+
+        // Try find a stream with specified lang code
+        if (audioTypePref != ADP::KODI_PROPS::MediaFlagType::ORIGINAL &&
+            itAudioStream == adpSets.cend() && !audioLangCodeDef.empty())
+        {
+          if (isAudioStereoPref)
+          {
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, true);
+            if (itAudioStream == adpSets.cend()) // No stereo stream, find multichannels
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, false);
+          }
+          else
+          {
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, false);
+            if (itAudioStream == adpSets.cend()) // No multichannels stream, find stereo
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeDef, true);
+          }
+        }
+
+        // No stream found, try find a stream with the "original" language code
+        if (itAudioStream == adpSets.cend() && !audioLangCodeOrig.empty())
+        {
+          if (isAudioStereoPref)
+          {
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, true);
+            if (itAudioStream == adpSets.cend()) // No stereo stream, find multichannels
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, false);
+          }
+          else
+          {
+            itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, false);
+            if (itAudioStream == adpSets.cend()) // No multichannels stream, find stereo
+              itAudioStream = CAdaptationSet::FindAudioAdpSet(adpSets, audioLangCodeOrig, true);
+          }
+        }
+
+        // Update "default" flags
+        if (itAudioStream != adpSets.cend())
+        {
+          for (auto& adpSet : adpSets)
+          {
+            adpSet->SetIsDefault(adpSet.get() == itAudioStream->get());
+          }
+        }
+      }
+    }
+
+    // Override subtitles "default" flag to streams
+    if (!subtitleLangCodeDef.empty())
+    {
+      for (auto& period : periods)
+      {
+        auto& adpSets = period->GetAdaptationSets();
+
+        auto itSubtitleStream = CAdaptationSet::FindSubtitleAdpSet(adpSets, subtitleLangCodeDef, false);
+
+        // Update "default" flags
+        if (itSubtitleStream != adpSets.cend())
+        {
+          for (auto& adpSet : adpSets)
+          {
+            adpSet->SetIsDefault(adpSet.get() == itSubtitleStream->get());
+          }
+        }
+      }
+    }
   }
 
   void AdaptiveTree::SortTree()

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -362,6 +362,12 @@ protected:
                             const std::string& data,
                             std::string_view info);
 
+  /*!
+   * \brief Override streams media flags.
+   * \param periods The periods to override the media flags.
+   */
+  void OverrideStreamsMediaFlags(std::vector<std::unique_ptr<PLAYLIST::CPeriod>>& periods);
+
   void SortTree();
 
   // Live segment update section

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1590,6 +1590,8 @@ void adaptive::CDashTree::OnUpdateSegments()
     return;
   }
 
+  OverrideStreamsMediaFlags(updateTree->m_periods);
+
   const uint64_t liveEdgeMs = GetTimestamp() - m_timeShiftBufferDepth + *m_clockOffset;
 
   // Update local members for the next manifest update

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -445,3 +445,31 @@ std::string UTILS::STRING::Format(const char* fmt, ...)
   return str;
 }
 
+
+std::map<std::string_view, std::string_view> UTILS::STRING::ToMap(std::string_view str,
+                                                                  const char delimiter,
+                                                                  const char separator)
+{
+  std::map<std::string_view, std::string_view> mapped;
+
+  size_t keyPos = 0;
+  size_t keyEnd;
+  size_t valPos;
+  size_t valEnd;
+
+  while ((keyEnd = str.find(delimiter, keyPos)) != std::string::npos)
+  {
+    valPos = str.find_first_not_of(delimiter, keyEnd);
+    if (valPos == std::string::npos)
+      break;
+
+    valEnd = str.find(separator, valPos);
+    mapped.emplace(str.substr(keyPos, keyEnd - keyPos), str.substr(valPos, valEnd - valPos));
+
+    keyPos = valEnd;
+    if (keyPos != std::string::npos)
+      ++keyPos;
+  }
+
+  return mapped;
+}

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -351,5 +351,16 @@ std::string ReplacePlaceholders(const std::string& text,
  */
 std::string Format(const char* fmt, ...);
 
+/*!
+ * \brief Convert a string to a map.
+ * \param str The string to convert
+ * \param delimiter The character separating the key from the value
+ * \param separator The character separating more key/value pairs
+ * \return The mapped string.
+ */
+std::map<std::string_view, std::string_view> ToMap(std::string_view str,
+                                                   const char delimiter,
+                                                   const char separator);
+
 } // namespace STRING
 } // namespace UTILS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
New parameters to `inputstream.adaptive.config`:
- `media_audio_langcode_default`: Set the "default" flag to the audio streams with specified language code
- `media_audio_langcode_original`: Set the "original" flag to the audio streams with specified language code
- `media_audio_stereo_pref`: Can be set to `true` when you want prefer stereo track as default instead of multi-channels (it will be applied to `media_audio_langcode_default` and `media_audio_langcode_original`)
- `media_audio_type_pref`: Can be set to `original` to prefer set as default the stream with original language, or `impaired` to prefer set as default the stream for impaired, otherwise left empty value for default behaviour.
- `media_subtitle_langcode_default`: Set the "default" flag to the subtitle streams with specified language code

about the language code format used should be the IETF RFC 5646 (BCP-47), but i suggest you to check also your manifest data

The property `inputstream.adaptive.original_audio_language` is now deprecated and will be removed from next kodi (major) version

NOTE FOR LANG CODE VARIANTS: At moment Kodi dont support any kind of track auto-selection fallback for language code that have variants e.g. "pt-BR" for Brazilian Portuguese vs "pt" for Portuguese, so here at moment its the same, if you set as default "pt-BR" but exists only a "pt" stream no stream will be set as default. This could be improved in future but for now we keep it simple.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Completed fix for #422 in more generic way

this will allow to override streams media flags in a generic way without being strictly limited to a single manifest type

the reason behind this is that Kodi stream media flags have not always have the same meaning of manifests attributes
and/or there are video services that dont follow exactly the specs and lead to wrong flags set to the audio/subtitle tracks

this will make the life easier for devs without the needs to implement a proxy on each addon to modify on the fly the manifest media flags

### HLS manifest side effect
The HLS manifests dont always provide the appropriate language codes and also dont always provide the right number of audio channels in the manifest, therefore the use of these new overrides may fails, you will need to check what your provider offers and act accordingly

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
