### PR TITLE
Fixes for VOD MPD SegmentBase with multi-periods

### DIFF
--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -588,8 +588,7 @@ bool adaptive::AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
     }
 
     // Update period timeline duration
-    if (!rep->HasSegmentBase() && (current_adp_->GetStreamType() == StreamType::VIDEO ||
-                                   current_adp_->GetStreamType() == StreamType::AUDIO))
+    if (current_adp_->GetStreamType() == StreamType::VIDEO || current_adp_->GetStreamType() == StreamType::AUDIO)
     {
       if (rep->GetTimescale() == 0)
       {

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -518,12 +518,43 @@ bool adaptive::AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
 
         seg.range_end_ = streamPos + boxSize + sidx->GetFirstOffset() - 1;
 
+        // Compute current period boundaries in milliseconds to filter SIDX refs
+        uint64_t periodStartMs = current_period_->GetStart();
+        if (periodStartMs == NO_VALUE)
+          periodStartMs = 0;
+
+        uint64_t periodEndMs = NO_PTS_VALUE;
+        if (current_period_->GetTlDuration() != 0)
+        {
+          const uint64_t periodDurMs = current_period_->GetTlDuration() * 1000 / current_period_->GetTimescale();
+          periodEndMs = periodStartMs + periodDurMs;
+        }
+
+        // Iterate each SIDX reference to create the segments, and filter them based on the current period boundaries
         for (AP4_Cardinal i{0}; i < refs.ItemCount(); i++)
         {
           seg.range_begin_ = seg.range_end_ + 1;
           seg.range_end_ = seg.range_begin_ + refs[i].m_ReferencedSize - 1;
           seg.m_endPts = seg.startPTS_ + refs[i].m_SubsegmentDuration;
-          rep->Timeline().Add(seg);
+
+          // Convert segment PTS to milliseconds using representation timescale
+          uint64_t segStartMs{0};
+          uint64_t segEndMs{0};
+          if (rep->GetTimescale() != 0)
+          {
+            segStartMs = seg.startPTS_ * 1000 / rep->GetTimescale();
+            segEndMs = seg.m_endPts * 1000 / rep->GetTimescale();
+          }
+
+          // Determine if this segment belongs to the current period
+          bool inCurrentPeriod = true;
+          if (segStartMs < periodStartMs)
+            inCurrentPeriod = false;
+          if (periodEndMs != NO_PTS_VALUE && segStartMs >= periodEndMs)
+            inCurrentPeriod = false;
+
+          if (inCurrentPeriod)
+            rep->Timeline().Add(seg);
 
           seg.startPTS_ += refs[i].m_SubsegmentDuration;
           seg.m_time += refs[i].m_SubsegmentDuration;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -588,8 +588,8 @@ bool adaptive::AdaptiveStream::parseIndexRange(PLAYLIST::CRepresentation* rep,
     }
 
     // Update period timeline duration
-    if (!rep->HasSegmentBase() && current_adp_->GetStreamType() == StreamType::VIDEO ||
-        current_adp_->GetStreamType() == StreamType::AUDIO)
+    if (!rep->HasSegmentBase() && (current_adp_->GetStreamType() == StreamType::VIDEO ||
+                                   current_adp_->GetStreamType() == StreamType::AUDIO))
     {
       if (rep->GetTimescale() == 0)
       {

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1061,8 +1061,8 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   repr->SetScaling();
 
   // Update period timeline duration
-  if (!repr->HasSegmentBase() && adpSet->GetStreamType() == StreamType::VIDEO ||
-      adpSet->GetStreamType() == StreamType::AUDIO)
+  if (!repr->HasSegmentBase() && (adpSet->GetStreamType() == StreamType::VIDEO ||
+      adpSet->GetStreamType() == StreamType::AUDIO))
   {
     if (repr->GetTimescale() == 0)
     {
@@ -1931,8 +1931,8 @@ void adaptive::CDashTree::InsertLiveSegment(PLAYLIST::CPeriod* currPeriod,
         }
 
         // Update period timeline duration
-        if (!rep->HasSegmentBase() && adpSet->GetStreamType() == StreamType::VIDEO ||
-            adpSet->GetStreamType() == StreamType::AUDIO)
+        if (!rep->HasSegmentBase() && (adpSet->GetStreamType() == StreamType::VIDEO ||
+            adpSet->GetStreamType() == StreamType::AUDIO))
         {
           if (rep->GetTimescale() == 0)
           {

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1061,6 +1061,11 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   repr->SetScaling();
 
   // Update period timeline duration
+  if (repr->HasSegmentBase())
+  {
+    // Use this as an estimate (also for multi-periods) it will then be updated using SIDX parsing
+    period->SetTlDuration(period->GetDuration());
+  }
   if (!repr->HasSegmentBase() && (adpSet->GetStreamType() == StreamType::VIDEO ||
       adpSet->GetStreamType() == StreamType::AUDIO))
   {

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -173,7 +173,16 @@ AP4_Result CSubtitleSampleReader::ReadSample()
           AP4_UI32 duration =
               static_cast<AP4_UI32>((segDur * STREAM_TIME_BASE) / rep->GetTimescale());
 
-          const AP4_UI64 pts = (currentSegment->startPTS_ * STREAM_TIME_BASE) / rep->GetTimescale();
+          AP4_UI64 pts = (currentSegment->startPTS_ * STREAM_TIME_BASE) / rep->GetTimescale();
+
+          //! @todo: MPD PTO see also todo in the MPD parser
+          if (rep->HasSegmentTemplate() && rep->GetSegmentTemplate()->HasPresTimeOffset())
+          {
+            uint64_t pto = (rep->GetSegmentTemplate()->GetPresTimeOffset() * STREAM_TIME_BASE) /
+                           rep->GetSegmentTemplate()->GetTimescale();
+            if (pts >= pto)
+              pts -= pto;
+          }
 
           m_codecHandler->Transform(pts, duration, segData, 1000);
           if (m_codecHandler->ReadNextSample(m_sample, m_sampleData))

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -226,7 +226,7 @@ bool CSubtitleSampleReader::TimeSeek(uint64_t pts)
 {
   if (dynamic_cast<WebVTTCodecHandler*>(m_codecHandler.get()))
   {
-    return true;
+    return AP4_SUCCEEDED(ReadSample());
   }
   else
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There are some fixes for VOD MPD SegmentBase with multi-periods

Problem 1:
on multiperiods at least on tested stream the SIDX seems to contains segments references for all periods,
that wasn't expected/supported so was causing to add segments of all periods in the first period
which meant that the first period covered the entire duration of the movie and the other periods had a duration of 0,
fixed by add a period filter in SIDX parsing

Problem 2;
periods with duration 0 on MPD SegmentBase with multi-periods
The duration (timeline) of the period is calculated based on the actual segments
Multi-periods manifests that make use of SegmentBase dont have segments in the timeline so duration is 0
but we can use as an estimate the declared period "duration" attribute

Problem 3:
With tested stream there is the use of presentationTimeOffset on SegmentBase
this is currently not supported yet
and cause that the PTS in the subtitle segments is out of sync
as temporary fix i substracted the PTO in the CSubtitleSampleReader
in the hope of causing no side effects with other manifests

Problem 4:
in the CSubtitleSampleReader::TimeSeek
was missing the ReadSample forgot to add it from last seeks code PR improvements
It's not a big problem, but it causes the demux to read an empty info for the first time

sample manifest: [MPD_manifest_sample.txt](https://github.com/user-attachments/files/28596160/MPD_manifest_sample.txt)


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2043

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
