### PR TITLE
[DRMEngine] Some fixups

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -228,7 +228,7 @@ bool SESSION::CSession::CheckPlayableStreams(PLAYLIST::CPeriod* period)
             continue;
           }
 
-          const DRM::DRMSession* drmSession = m_drmEngine.InitializeSession(
+          const std::shared_ptr<DRM::DRMSession> drmSession = m_drmEngine.InitializeSession(
               repr->DrmInfos(), {}, drmMediaType, period->IsSecureDecodeNeeded(), isInfo, false);
 
           if (drmSession)
@@ -730,7 +730,7 @@ bool SESSION::CSession::PrepareStream(CStream& stream)
       return false;
     }
 
-    const DRM::DRMSession* drmSession = m_drmEngine.InitializeSession(
+    const std::shared_ptr<DRM::DRMSession> drmSession = m_drmEngine.InitializeSession(
         manifestDrmInfo, mediaDrmInfo, drmMediaType, period->IsSecureDecodeNeeded(), stream.m_info,
         m_adaptiveTree->IsChangingPeriod());
 
@@ -739,7 +739,7 @@ bool SESSION::CSession::PrepareStream(CStream& stream)
 
     isDrmSecure = drmSession->capabilities.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH;
 
-    reader->SetDecrypter(drmSession->decrypter, drmSession->capabilities);
+    reader->SetDecrypter(drmSession);
   }
 
   if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::VIDEO_AUDIO)

--- a/src/decrypters/DrmEngine.cpp
+++ b/src/decrypters/DrmEngine.cpp
@@ -308,7 +308,7 @@ bool DRM::CDRMEngine::PreInitializeDRM(DRMSession& session)
 #ifndef ANDROID
   // On android is not possible add the default KID key used to open DRM
   // then dont add this DRM session, since must be reinitialized
-  m_sessions.emplace_back(session);
+  m_sessions.emplace_back(std::make_shared<DRMSession>(session));
 #endif
 
   m_isPreinitialized = true;
@@ -316,12 +316,13 @@ bool DRM::CDRMEngine::PreInitializeDRM(DRMSession& session)
   return true;
 }
 
-const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> manifestDrmInfos,
-                                                     std::vector<DRM::DRMInfo> mediaDrmInfos,
-                                                     DRM::DRMMediaType mediaType,
-                                                     std::optional<bool> isForceSecureDecoder,
-                                                     kodi::addon::InputstreamInfo& streamInfo,
-                                                     bool canCleanupSessions)
+const std::shared_ptr<DRMSession> DRM::CDRMEngine::InitializeSession(
+    std::vector<DRM::DRMInfo> manifestDrmInfos,
+    std::vector<DRM::DRMInfo> mediaDrmInfos,
+    DRM::DRMMediaType mediaType,
+    std::optional<bool> isForceSecureDecoder,
+    kodi::addon::InputstreamInfo& streamInfo,
+    bool canCleanupSessions)
 {
   const auto& kodiProps = CSrvBroker::GetKodiProps();
   
@@ -375,7 +376,7 @@ const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> m
   }
 
   const auto drmPropCfg = kodiProps.GetDrmConfig(m_keySystem);
-  DRMSession* session{nullptr};
+  std::shared_ptr<DRMSession> session{nullptr};
 
   for (size_t drmInfoIdx = 0; drmInfoIdx < selDrmInfos.size(); ++drmInfoIdx)
   {
@@ -438,20 +439,20 @@ const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> m
       // the session has been created with a custom PSSH/KID and it should
       // be assumed that there is a single session for all streams.
       // In order to reuse this session is needed to add the current KID.
-      if (!m_sessions[0].drm->HasLicenseKey(m_sessions[0].decrypter, drmInfoKidBytes))
+      if (!m_sessions[0]->drm->HasLicenseKey(m_sessions[0]->decrypter, drmInfoKidBytes))
       {
-        m_sessions[0].decrypter->AddKeyId(drmInfoKidBytes);
-        m_sessions[0].decrypter->SetDefaultKeyId(drmInfoKidBytes);
+        m_sessions[0]->decrypter->AddKeyId(drmInfoKidBytes);
+        m_sessions[0]->decrypter->SetDefaultKeyId(drmInfoKidBytes);
       }
     }
 
     // Check whether it is possible to reuse an existing DRM session
     // its recommended to use separate sessions when a/v media types have different KIDs
     // to avoid possible decryption problems that usually affect android devices (corrupted/pixellated video)
-    for (DRMSession& s : m_sessions)
+    for (const auto& s : m_sessions)
     {
       bool isReuseSession{false};
-      const std::optional<bool> hasKey = s.drm->HasLicenseKey(s.decrypter, drmInfoKidBytes);
+      const std::optional<bool> hasKey = s->drm->HasLicenseKey(s->decrypter, drmInfoKidBytes);
 
       // forced single session, allow to share same session (also with different media types)
       if (drmPropCfg.isForceSingleSession && (!hasKey.has_value() || *hasKey))
@@ -459,14 +460,14 @@ const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> m
         isReuseSession = true;
       }
       // share same session when: KID is the same, otherwise check if there is license key by media type
-      else if ((!s.kid.empty() && s.kid == drmInfo.defaultKid) ||
-               (hasKey.has_value() && *hasKey && s.mediaType == mediaType))
+      else if ((!s->kid.empty() && s->kid == drmInfo.defaultKid) ||
+               (hasKey.has_value() && *hasKey && s->mediaType == mediaType))
       {
         isReuseSession = true;
       }
       if (isReuseSession)
       {
-        session = &s;
+        session = s;
         break;
       }
     }
@@ -576,8 +577,8 @@ const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> m
         return nullptr;
       }
 
-      m_sessions.emplace_back(newSes);
-      session = &m_sessions.back();
+      m_sessions.emplace_back(std::make_shared<DRMSession>(newSes));
+      session = m_sessions.back();
       LOG::Log(LOGDEBUG, "Initialized new DRM session (ID: %s, KID: %s)", session->id.c_str(),
                drmInfo.defaultKid.c_str());
     }
@@ -609,8 +610,8 @@ const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> m
         }
       }
 
-      m_sessions.emplace_back(newSes);
-      session = &m_sessions.back();
+      m_sessions.emplace_back(std::make_shared<DRMSession>(newSes));
+      session = m_sessions.back();
       LOG::Log(LOGDEBUG, "Reused existing DRM session (ID: %s, KID: %s)", session->id.c_str(),
                drmInfo.defaultKid.c_str());
     }
@@ -672,28 +673,28 @@ const DRMSession* DRM::CDRMEngine::InitializeSession(std::vector<DRM::DRMInfo> m
   return session;
 }
 
-const DRMSession* DRM::CDRMEngine::GetSession(const std::string& id) const
+const std::shared_ptr<DRMSession> DRM::CDRMEngine::GetSession(const std::string& id) const
 {
   if (id.empty())
     return nullptr;
 
   for (const auto& session : m_sessions)
   {
-    if (session.id == id)
-      return &session;
+    if (session->id == id)
+      return session;
   }
   return nullptr;
 }
 
-const DRMSession* DRM::CDRMEngine::GetSession(const std::string& id, const std::string& kid) const
+const std::shared_ptr<DRMSession> DRM::CDRMEngine::GetSession(const std::string& id, const std::string& kid) const
 {
   if (id.empty())
     return nullptr;
 
   for (const auto& session : m_sessions)
   {
-    if (session.id == id && session.kid == kid)
-      return &session;
+    if (session->id == id && session->kid == kid)
+      return session;
   }
   return nullptr;
 }
@@ -820,8 +821,8 @@ void DRM::CDRMEngine::DeleteSessionsByType(const DRMMediaType mediaType)
   // Despite this will delete sessions, the shared IDecrypter/Adaptive_CencSingleSampleDecrypter
   // might still be in use, for example on CVideoCodecAdaptive, so shared uses can be deleted at later time
   m_sessions.erase(std::remove_if(m_sessions.begin(), m_sessions.end(),
-                                  [mediaType](const DRMSession& session)
-                                  { return session.mediaType == mediaType; }),
+                                  [mediaType](const std::shared_ptr<DRMSession>& session)
+                                  { return session->mediaType == mediaType; }),
                    m_sessions.end());
 }
 

--- a/src/decrypters/DrmEngine.h
+++ b/src/decrypters/DrmEngine.h
@@ -48,26 +48,26 @@ public:
    * \param canCleanupSessions Delete existing sessions before to create a new one
    * \return The DRM session if has success, otherwise nullptr
    */
-  const DRMSession* InitializeSession(std::vector<DRM::DRMInfo> manifestDrmInfos,
-                                      std::vector<DRM::DRMInfo> mediaDrmInfos,
-                                      DRM::DRMMediaType mediaType,
-                                      std::optional<bool> isForceSecureDecoder,
-                                      kodi::addon::InputstreamInfo& streamInfo,
-                                      bool canCleanupSessions);
+  const std::shared_ptr<DRMSession> InitializeSession(std::vector<DRM::DRMInfo> manifestDrmInfos,
+                                                      std::vector<DRM::DRMInfo> mediaDrmInfos,
+                                                      DRM::DRMMediaType mediaType,
+                                                      std::optional<bool> isForceSecureDecoder,
+                                                      kodi::addon::InputstreamInfo& streamInfo,
+                                                      bool canCleanupSessions);
 
   /*!
    * \brief Get the session by ID (dont take in account KID).
    * \param id The session ID
    * \return The session, otherwise nullptr if not found
    */
-  const DRMSession* GetSession(const std::string& id) const;
+  const std::shared_ptr<DRMSession> GetSession(const std::string& id) const;
 
   /*!
    * \brief Get the session by ID that match the specified KID.
    * \param id The session ID
    * \return The session, otherwise nullptr if not found
    */
-  const DRMSession* GetSession(const std::string& id, const std::string& kid) const;
+  const std::shared_ptr<DRMSession> GetSession(const std::string& id, const std::string& kid) const;
 
 
   /*!
@@ -110,7 +110,7 @@ private:
 
   std::string m_keySystem; // Choosen key system
   std::vector<DRMInstance> m_drms;
-  std::vector<DRMSession> m_sessions;
+  std::vector<std::shared_ptr<DRMSession>> m_sessions;
 
   EngineStatus m_status{EngineStatus::NONE};
   bool m_isPreinitialized{false};

--- a/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/clearkey/ClearKeyCencSingleSampleDecrypter.cpp
@@ -146,16 +146,14 @@ AP4_Result CClearKeyCencSingleSampleDecrypter::SetFragmentInfo(AP4_UI32 poolId,
   PINFO& pInfo = m_pool[poolId];
   FINFO& fInfo = pInfo.fInfo;
 
-  const std::vector<uint8_t>& currentKid = keyId.empty() ? m_defaultKeyId : keyId;
-
   // Compare the encryption info from the previous fragment to see if it has been changed,
   // if so, the decrypter will have to be recreated
-  pInfo.isChanged = fInfo.kid != currentKid || fInfo.cryptoInfo.m_mode != cryptoInfo.m_mode ||
+  pInfo.isChanged = fInfo.kid != keyId || fInfo.cryptoInfo.m_mode != cryptoInfo.m_mode ||
                     fInfo.cryptoInfo.m_cryptBlocks != cryptoInfo.m_cryptBlocks ||
                     fInfo.cryptoInfo.m_skipBlocks != cryptoInfo.m_skipBlocks;
 
   // Update with the current fragment info
-  fInfo.kid = currentKid;
+  fInfo.kid = keyId;
   fInfo.cryptoInfo = cryptoInfo;
 
   return AP4_SUCCESS;

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -202,6 +202,11 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
     {
       encryptedBytes[0] = 12;
       clearBytes[0] = 0;
+
+      // Ignore callbacks to OnKeyStatusChangeNotify when testing capabilities,
+      // when the decryption fails CDM trigger a key status change with keys as unusable but this is expected
+      m_isTestingCapabilities = true;
+
       if (DecryptSampleData(poolId, in, out, iv, 1, clearBytes, encryptedBytes, mediaType) !=
           AP4_SUCCESS)
       {
@@ -216,6 +221,8 @@ void CWVCencSingleSampleDecrypter::GetCapabilities(const std::vector<uint8_t>& k
         caps.hdcpVersion = DRM::HDCP_V_MAX;
         caps.hdcpLimit = m_resolutionLimit;
       }
+
+      m_isTestingCapabilities = false;
     }
     catch (const std::exception& e)
     {
@@ -408,6 +415,9 @@ void CWVCencSingleSampleDecrypter::OnNotify(const CdmMessage& message)
 
 void CWVCencSingleSampleDecrypter::OnKeyStatusChangeNotify(const std::string& sessionId, const std::vector<DRM::KeyInfo>& keysInfo)
 {
+  if (m_isTestingCapabilities)
+    return;
+
   if (!m_strSession.empty() && m_strSession != sessionId)
     return;
 
@@ -433,8 +443,12 @@ bool CWVCencSingleSampleDecrypter::HasKeyId(const std::vector<uint8_t>& keyid)
   {
     for (const DRM::KeyInfo& key : m_keys)
     {
-      if (key.kid == keyid)
+      if (key.kid == keyid &&
+          (key.status == DRM::KeyStatus::USABLE || key.status == DRM::KeyStatus::USABLE_IN_FUTURE ||
+           key.status == DRM::KeyStatus::PENDING))
+      {
         return true;
+      }
     }
   }
   return false;

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -450,11 +450,7 @@ AP4_Result CWVCencSingleSampleDecrypter::SetFragmentInfo(AP4_UI32 poolId,
   if (poolId >= m_fragmentPool.size())
     return AP4_ERROR_OUT_OF_RANGE;
 
-  if (keyId.empty())
-    m_fragmentPool[poolId].m_key = m_defaultKeyId;
-  else
-    m_fragmentPool[poolId].m_key = keyId;
-
+  m_fragmentPool[poolId].m_key = keyId;
   m_fragmentPool[poolId].m_nalLengthSize = nalLengthSize;
   m_fragmentPool[poolId].m_annexbSpsPps = annexbSpsPps;
   m_fragmentPool[poolId].m_decrypterFlags = flags;

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.h
@@ -156,4 +156,5 @@ private:
   CryptoMode m_EncryptionMode;
 
   std::optional<cdm::VideoDecoderConfig_3> m_currentVideoDecConfig;
+  bool m_isTestingCapabilities{false};
 };

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -528,11 +528,7 @@ AP4_Result CWVCencSingleSampleDecrypterA::SetFragmentInfo(AP4_UI32 poolId,
   if (poolId >= m_fragmentPool.size())
     return AP4_ERROR_OUT_OF_RANGE;
 
-  if (keyId.empty())
-    m_fragmentPool[poolId].m_key = m_defaultKeyId;
-  else
-    m_fragmentPool[poolId].m_key = keyId;
-
+  m_fragmentPool[poolId].m_key = keyId;
   m_fragmentPool[poolId].m_nalLengthSize = nalLengthSize;
   m_fragmentPool[poolId].m_annexbSpsPps = annexbSpsPps;
   m_fragmentPool[poolId].m_decrypterFlags = flags;

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -190,8 +190,12 @@ bool CWVCencSingleSampleDecrypterA::HasKeyId(const std::vector<uint8_t>& keyid)
   {
     for (const DRM::KeyInfo& key : m_keys)
     {
-      if (key.kid == keyid)
+      if (key.kid == keyid &&
+          (key.status == DRM::KeyStatus::USABLE || key.status == DRM::KeyStatus::USABLE_IN_FUTURE ||
+           key.status == DRM::KeyStatus::PENDING))
+      {
         return true;
+      }
     }
   }
   return false;

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -59,8 +59,8 @@ CFragmentedSampleReader::CFragmentedSampleReader(std::shared_ptr<CLinearReader> 
 CFragmentedSampleReader::~CFragmentedSampleReader()
 {
   // Remove the decryptor pool only with the last CLinearReader instance
-  if (m_lReader.use_count() == 1 && m_singleSampleDecryptor)
-    m_singleSampleDecryptor->RemovePool(m_poolId);
+  if (m_lReader.use_count() == 1 && m_drmSession)
+    m_drmSession->decrypter->RemovePool(m_poolId);
 
   delete m_codecHandler;
 }
@@ -215,16 +215,14 @@ std::vector<DRM::DRMInfo> CFragmentedSampleReader::GetInitDRMInfo()
   return drmInfos;
 }
 
-void CFragmentedSampleReader::SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
-                                           const DRM::DecrypterCapabilites& dcaps)
+void CFragmentedSampleReader::SetDecrypter(std::shared_ptr<DRM::DRMSession> drmSession)
 {
-  if (ssd)
+  if (drmSession)
   {
-    m_poolId = ssd->AddPool();
-    m_singleSampleDecryptor = ssd;
+    m_poolId = drmSession->decrypter->AddPool();
+    m_decrypterCaps = drmSession->capabilities;
+    m_drmSession = drmSession;
   }
-  
-  m_decrypterCaps = dcaps;
 }
 
 AP4_Result CFragmentedSampleReader::Start(std::optional<uint64_t> pts)
@@ -281,8 +279,7 @@ AP4_Result CFragmentedSampleReader::ReadSample()
 
     //Protection could have changed in ProcessMoof
     bool useDecryptingDecoder =
-        m_singleSampleDecryptor &&
-        (m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0;
+        m_drmSession && (m_decrypterCaps.flags & DRM::DecrypterCapabilites::SSD_SECURE_PATH) != 0;
 
     if (m_decrypter)
     {
@@ -315,7 +312,7 @@ AP4_Result CFragmentedSampleReader::ReadSample()
       //!        and may not be suitable for other decryptors
       m_sampleData.Reserve(sampleData.GetDataSize());
       if (AP4_FAILED(
-              result = m_singleSampleDecryptor->DecryptSampleData(
+              result = m_drmSession->decrypter->DecryptSampleData(
                   m_poolId, sampleData, m_sampleData, nullptr, 0, nullptr, nullptr, streamType)))
       {
         Reset(true);
@@ -457,7 +454,7 @@ std::unique_ptr<ISampleReader> CFragmentedSampleReader::CreateReaderByTrack()
   }
 
   auto newFragReader = std::make_unique<CFragmentedSampleReader>(m_lReader, selTrack);
-  newFragReader->SetDecrypter(m_singleSampleDecryptor, m_decrypterCaps);
+  newFragReader->SetDecrypter(m_drmSession);
 
   LOG::LogF(LOGDEBUG, "Created shared reader for audio track id %u", selTrack->GetId());
 
@@ -595,10 +592,10 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
         // we assume unencrypted fragment here
         goto SUCCESS;
 
-      if (!m_singleSampleDecryptor)
+      if (!m_drmSession)
         return AP4_ERROR_INVALID_PARAMETERS;
 
-      m_decrypter = std::make_unique<CAdaptiveCencSampleDecrypter>(m_singleSampleDecryptor, sample_table);
+      m_decrypter = std::make_unique<CAdaptiveCencSampleDecrypter>(m_drmSession->decrypter, sample_table);
 
       // Inform decrypter of pattern decryption (CBCS)
       AP4_UI32 schemeType = m_protectedDesc->GetSchemeType();
@@ -629,11 +626,13 @@ AP4_Result CFragmentedSampleReader::ProcessMoof(AP4_ContainerAtom* moof,
     }
   }
 SUCCESS:
-  if (m_singleSampleDecryptor && m_codecHandler)
+  if (m_drmSession && m_codecHandler)
   {
-    //! @todo: handle the default KID from the media segment/package
-    if (AP4_FAILED(m_singleSampleDecryptor->SetFragmentInfo(
-            m_poolId, {}, m_codecHandler->m_naluLengthSize, m_codecHandler->m_extraData,
+    //! @todo: if the media segment/package provide a different KID, the decrypter should be informed (key rotation)
+    std::vector<uint8_t> kid = DRM::ConvertKidStrToBytes(m_drmSession->kid);
+
+    if (AP4_FAILED(m_drmSession->decrypter->SetFragmentInfo(
+            m_poolId, kid, m_codecHandler->m_naluLengthSize, m_codecHandler->m_extraData,
             m_decrypterCaps.flags, m_readerCryptoInfo)))
     {
       return AP4_ERROR_INVALID_FORMAT;

--- a/src/samplereader/FragmentedSampleReader.h
+++ b/src/samplereader/FragmentedSampleReader.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "SampleReader.h"
-#include "decrypters/IDecrypter.h"
 
 #include <bento4/Ap4.h>
 #include <bento4/Ap4LinearReader.h>
@@ -99,8 +98,7 @@ public:
 
   virtual std::vector<DRM::DRMInfo> GetInitDRMInfo() override;
 
-  virtual void SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
-                            const DRM::DecrypterCapabilites& dcaps) override;
+  virtual void SetDecrypter(std::shared_ptr<DRM::DRMSession> drmSession) override;
 
   AP4_Result Start(std::optional<uint64_t> pts) override;
   AP4_Result ReadSample() override;
@@ -158,7 +156,7 @@ private:
   AP4_DataBuffer m_sampleData;
   CodecHandler* m_codecHandler{nullptr};
   AP4_ProtectedSampleDescription* m_protectedDesc{nullptr};
-  std::shared_ptr<Adaptive_CencSingleSampleDecrypter> m_singleSampleDecryptor{nullptr};
+  std::shared_ptr<DRM::DRMSession> m_drmSession;
   std::unique_ptr<CAdaptiveCencSampleDecrypter> m_decrypter;
   CryptoInfo m_readerCryptoInfo{};
 

--- a/src/samplereader/SampleReader.h
+++ b/src/samplereader/SampleReader.h
@@ -61,8 +61,7 @@ public:
 
   virtual std::vector<DRM::DRMInfo> GetInitDRMInfo() { return {}; }
 
-  virtual void SetDecrypter(std::shared_ptr<Adaptive_CencSingleSampleDecrypter> ssd,
-                            const DRM::DecrypterCapabilites& dcaps)
+  virtual void SetDecrypter(std::shared_ptr<DRM::DRMSession> drmSession)
   {
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Two fixups:

1) Previous PR #2038 has introduced wrong code on decrypters, where the stored default KID (m_defaultKeyId) was used from SetFragmentInfo, this cant works when a DRMSession and decrypter is shared from DRMEngine. This because the default KID is stored the first time that the decrypter is created, when the decrypter is shared the default KID stored in the decrypter is always the same but the decrypter can be used by another stream with a different valid KID. The previous behavior has been restored.

2) Previous PR #2038 has introduced KID fallback, but from comment https://github.com/xbmc/inputstream.adaptive/issues/1973#issuecomment-4621305664 the fallback was not working correctly because the KID status was not taken in account, if a KID has a not USABLE status it should be skipped

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2041 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
