### PR TITLE
Some cleanups/fixes mainly to sample readers

### DIFF
--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -734,15 +734,6 @@ bool SESSION::CSession::PrepareStream(CStream& stream)
   if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::VIDEO_AUDIO)
     m_reprChooser->SetSecureSession(isDrmSecure);
 
-  if (reprContainerType == ContainerType::TS || reprContainerType == ContainerType::ADTS)
-  {
-    // With TS streams the elapsed time would be calculated incorrectly as during the tree refresh,
-    // nextSegment would be deleted by the FreeSegments/newsegments swap. Do this now before the tree refresh.
-    // Also, when reopening a stream (switching reps) the elapsed time would be incorrectly set until the
-    // second segment plays, now force a correct calculation at the start of the stream.
-    OnSegmentChanged(&stream.m_adStream);
-  }
-
   return true;
 }
 

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -792,22 +792,6 @@ uint64_t SESSION::CSession::GetTotalTimeMs() const
     return m_adaptiveTree->m_totalTime;
 }
 
-uint64_t SESSION::CSession::GetTimeshiftBufferStart()
-{
-  if (m_timingStream)
-  {
-    ISampleReader* timingReader{m_timingStream->GetReader()};
-    if (!timingReader)
-    {
-      LOG::LogF(LOGERROR, "Cannot get the stream sample reader");
-      return 0ULL;
-    }
-    return m_timingStream->m_adStream.GetAbsolutePTSOffset() + timingReader->GetPTSDiff();
-  }
-  else
-    return 0ULL;
-}
-
 void SESSION::CSession::OnScreenResChange()
 {
   m_reprChooser->OnUpdateScreenRes();

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -695,13 +695,12 @@ bool SESSION::CSession::PrepareStream(CStream& stream)
 
   ContainerType reprContainerType = repr->GetContainerType();
   uint32_t mask = (1U << stream.m_info.GetStreamType()) | GetIncludedStreamMask();
-  auto reader = ADP::CreateStreamReader(reprContainerType, &stream, mask);
 
-  if (!reader)
+  if (!ADP::CreateStreamReader(reprContainerType, &stream, mask))
     return false;
 
   std::vector<DRM::DRMInfo> manifestDrmInfo = repr->DrmInfos();
-  std::vector<DRM::DRMInfo> mediaDrmInfo = reader->GetInitDRMInfo();
+  std::vector<DRM::DRMInfo> mediaDrmInfo = stream.GetReader()->GetInitDRMInfo();
   bool isDrmSecure{false};
 
   if (!manifestDrmInfo.empty() || !mediaDrmInfo.empty())
@@ -729,13 +728,11 @@ bool SESSION::CSession::PrepareStream(CStream& stream)
 
     isDrmSecure = drmSession->capabilities.HasFlag(DRM::Capabilities::SECURE_PATH);
 
-    reader->SetDecrypter(drmSession);
+    stream.GetReader()->SetDecrypter(drmSession);
   }
 
   if (adp->GetStreamType() == StreamType::VIDEO || adp->GetStreamType() == StreamType::VIDEO_AUDIO)
     m_reprChooser->SetSecureSession(isDrmSecure);
-
-  stream.SetReader(std::move(reader));
 
   if (reprContainerType == ContainerType::TS || reprContainerType == ContainerType::ADTS)
   {

--- a/src/Session.h
+++ b/src/Session.h
@@ -118,12 +118,6 @@ public:
    */
   uint64_t GetElapsedTimeMs() const { return m_elapsedTime / 1000; };
 
-  /*! \brief Get the start pts of the first segment in the timing stream
-   *       with the difference in manifest time and reader time added
-   *  \return The reader's timeshift buffer starting pts
-   */
-  uint64_t GetTimeshiftBufferStart();
-
   /*! \brief Check if the stream has changed, reset changed status
    *  \param bSet True to keep m_changed value true
    *  \return True if stream has changed

--- a/src/samplereader/SampleReaderFactory.cpp
+++ b/src/samplereader/SampleReaderFactory.cpp
@@ -22,9 +22,9 @@
 
 using namespace PLAYLIST;
 
-std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& containerType,
-                                                       SESSION::CStream* stream,
-                                                       uint32_t includedStreamMask)
+bool ADP::CreateStreamReader(PLAYLIST::ContainerType& containerType,
+                             SESSION::CStream* stream,
+                             uint32_t includedStreamMask)
 {
   std::unique_ptr<ISampleReader> reader;
 
@@ -61,7 +61,7 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
     if (!movie)
     {
       LOG::LogF(LOGERROR, "No MOOV atom in stream");
-      return nullptr;
+      return false;
     }
 
     AP4_Track* track =
@@ -73,14 +73,14 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
       if (!track)
       {
         LOG::LogF(LOGERROR, "No suitable Track atom found in stream");
-        return nullptr;
+        return false;
       }
     }
 
     if (!track->GetSampleDescription(0))
     {
       LOG::LogF(LOGERROR, "No STSD atom in stream");
-      return nullptr;
+      return false;
     }
 
     reader = std::make_unique<CFragmentedSampleReader>(stream->GetAdByteStream(), movie, track);
@@ -89,10 +89,14 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
   {
     LOG::Log(LOGWARNING,
              "Cannot create sample reader due to unhandled representation container type");
-    return nullptr;
+    return false;
   }
 
-  if (!reader->Initialize(stream))
+  // We have to set the reader before initialize it, the reader initialization require to read data from AdaptiveStream
+  // and the AdaptiveStream need to callback (OnSegmentChanged) to the reader to update the PTS of the sample read
+  stream->SetReader(std::move(reader));
+
+  if (!stream->GetReader()->Initialize(stream))
   {
     if (containerType == ContainerType::TS &&
         stream->m_adStream.GetStreamType() == StreamType::AUDIO)
@@ -107,13 +111,13 @@ std::unique_ptr<ISampleReader> ADP::CreateStreamReader(PLAYLIST::ContainerType& 
       stream->m_adStream.getRepresentation()->SetContainerType(containerType);
 
       stream->GetAdByteStream()->Seek(0); // Seek because bytes are consumed from previous reader
-      reader = std::make_unique<CADTSSampleReader>(stream->GetAdByteStream());
-      if (!reader->Initialize(stream))
-        reader.reset();
+      stream->SetReader(std::make_unique<CADTSSampleReader>(stream->GetAdByteStream()));
+      if (!stream->GetReader()->Initialize(stream))
+        return false;
     }
     else
-      reader.reset();
+      return false;
   }
 
-  return reader;
+  return true;
 }

--- a/src/samplereader/SampleReaderFactory.cpp
+++ b/src/samplereader/SampleReaderFactory.cpp
@@ -111,7 +111,13 @@ bool ADP::CreateStreamReader(PLAYLIST::ContainerType& containerType,
       stream->m_adStream.getRepresentation()->SetContainerType(containerType);
 
       stream->GetAdByteStream()->Seek(0); // Seek because bytes are consumed from previous reader
+
       stream->SetReader(std::make_unique<CADTSSampleReader>(stream->GetAdByteStream()));
+
+      // Set the PTS offset manually because the AdaptiveStream has been already started by the previous reader,
+      // and the OnSegmentChanged callback has been already invoked, the new reader needs to be aligned with the PTS reference
+      stream->GetReader()->SetPTSOffset(stream->m_adStream.GetCurrentPTSOffset());
+
       if (!stream->GetReader()->Initialize(stream))
         return false;
     }

--- a/src/samplereader/SampleReaderFactory.h
+++ b/src/samplereader/SampleReaderFactory.h
@@ -27,12 +27,12 @@ namespace ADP
 /*!
  * \brief Create and initialize a sample stream reader for the specified container
  * \param containerType The type of stream container, the value could be changed if the type is wrong
- * \param stream The stream object that will use the reader
+ * \param stream The stream object where create the reader
  * \param includedStreamMask The flags for included streams
- * \return The sample reader if has success, otherwise nullptr
+ * \return True if the sample reader is created successfully, otherwise false
  */
-std::unique_ptr<ISampleReader> CreateStreamReader(PLAYLIST::ContainerType& containerType,
-                                                  SESSION::CStream* stream,
-                                                  uint32_t includedStreamMask);
+bool CreateStreamReader(PLAYLIST::ContainerType& containerType,
+                        SESSION::CStream* stream,
+                        uint32_t includedStreamMask);
 
 } // namespace ADP


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
One change allow to get rid of these warnings
`2026-06-11 08:45:28.906 T:9952  warning <inputstream.adaptive>: SESSION::CSession::OnSegmentChanged: Cannot get the stream sample reader`
this was happening because the OnSegmentChanged callback was happening before we had set the sample reader in the Stream
(AdaptiveStream makes a callback to the sample reader when the sample reader is initialized) and so the CB was lost

The other relevant change is about removal of the forced callback to OnSegmentChanged for TS/ADTS, by debugging the callback for TS its already done on initialization, and only for the ADTS fallabck instead we have to manually set it, this because the AdaptiveStream has already been started with the TS reader and so there is no callback, however, as explained by todo, the fallback is already a sort of workaround so for now it's fine like this

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
