### PR TITLE
Removed deprecated features / properties

### DIFF
--- a/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.adaptive/resources/language/resource.language.en_gb/strings.po
@@ -142,9 +142,7 @@ msgctxt "#30166"
 msgid "DRM Widevine"
 msgstr ""
 
-msgctxt "#30167"
-msgid "WARNING: This is a TEST feature, may not work appropriately and may change on future versions."
-msgstr ""
+#empty strings from id 30167
 
 msgctxt "#30168"
 msgid "Auto determines initial bandwidth"
@@ -209,16 +207,7 @@ msgid "Test"
 msgstr ""
 
 #empty strings reserved for "stream selection types" from id 30181 to 30190
-
-#. Assured buffer length duration (seconds)
-msgctxt "#30200"
-msgid "Assured buffer duration (sec)"
-msgstr ""
-
-#. Max buffer length duration (seconds)
-msgctxt "#30201"
-msgid "Maximum buffer duration (sec)"
-msgstr ""
+#empty strings from id 30200 to 30201
 
 #. Ignore screen resolution change e.g. window resize
 msgctxt "#30202"

--- a/inputstream.adaptive/resources/settings.xml.in
+++ b/inputstream.adaptive/resources/settings.xml.in
@@ -208,18 +208,6 @@
     </category>
     <category id="expert" label="30120">
       <group id="misc">
-        <setting id="ASSUREDBUFFERDURATION" type="integer" label="30200" help="30167">
-          <level>1</level>
-          <default>60</default>
-          <visible>false</visible> <!-- Working code disabled, rework needed -->
-          <control type="edit" format="integer" />
-        </setting>
-        <setting id="MAXBUFFERDURATION" type="integer" label="30201" help="30167">
-          <level>1</level>
-          <default>120</default>
-          <visible>false</visible> <!-- Working code disabled, rework needed -->
-          <control type="edit" format="integer" />
-        </setting>
         <setting id="MEDIATYPE" type="integer" label="30112">
           <level>1</level>
           <default>0</default>

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -53,7 +53,6 @@ constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_par
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
-constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: deprecated to be removed on Kodi 23
 
 constexpr std::string_view PROP_CONFIG = "inputstream.adaptive.config";
@@ -186,16 +185,6 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
     {
       LogProp(prop.first, prop.second);
       m_playTimeshiftBuffer = STRING::CompareNoCase(prop.second, "true");
-    }
-    else if (prop.first == PROP_LIVE_DELAY) //! @todo: deprecated to be removed on Kodi 23
-    {
-      LogProp(prop.first, prop.second);
-      LOG::Log(LOGWARNING,
-               "Warning \"inputstream.adaptive.live_delay\" property is deprecated and"
-               " will be removed next Kodi version, use \"inputstream.adaptive.manifest_config\""
-               " instead.\nSee Wiki integration page for more details.");
-
-      m_manifestConfig.liveDelay = STRING::ToUint64(prop.second);
     }
     else if (prop.first == PROP_STREAM_SELECTION_TYPE)
     {

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -29,15 +29,6 @@ namespace
 // clang-format off
 constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"; //! @todo: deprecated to be removed on Kodi 23
-// PROP_LICENSE_URL and PROP_LICENSE_URL_APPEND has been added as workaround for Kodi PVR API bug
-// where limit property values to max 1024 chars, if exceeds the string is truncated.
-// Since some services provide license urls that exceeds 1024 chars,
-// PROP_LICENSE_KEY dont have enough space also because include other parameters
-// so we provide two properties allow set an url split into two 1024-character parts
-// see: https://github.com/xbmc/xbmc/issues/23903#issuecomment-1755264854
-// -> this problem has been fixed on Kodi 22
-constexpr std::string_view PROP_LICENSE_URL = "inputstream.adaptive.license_url"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_LICENSE_URL_APPEND = "inputstream.adaptive.license_url_append"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate"; //! @todo: deprecated to be removed on Kodi 23
@@ -125,28 +116,7 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
   {
     const bool isRedacted = !CSrvBroker::GetSettings().IsDebugVerbose();
 
-    if (prop.first == PROP_LICENSE_URL) //! @todo: deprecated to be removed on Kodi 23
-    {
-      LogProp(prop.first, prop.second, isRedacted);
-      LOG::Log(
-          LOGWARNING,
-          "Warning \"inputstream.adaptive.license_url\" property for PVR API bug is deprecated and "
-          "will be removed on next Kodi version. This because the PVR API bug has been fixed on "
-          "Kodi v22. Please use the appropriate properties to set the DRM configuration.");
-      // If PROP_LICENSE_URL_APPEND is parsed before this one, we need to append it
-      licenseUrl = prop.second + licenseUrl;
-    }
-    else if (prop.first == PROP_LICENSE_URL_APPEND) //! @todo: deprecated to be removed on Kodi 23
-    {
-      LogProp(prop.first, prop.second, isRedacted);
-      LOG::Log(
-          LOGWARNING,
-          "Warning \"inputstream.adaptive.license_url_append\" property for PVR API bug is deprecated and "
-          "will be removed on next Kodi version. This because the PVR API bug has been fixed on "
-          "Kodi v22. Please use the appropriate properties to set the DRM configuration.");
-      licenseUrl += prop.second;
-    }
-    else if (prop.first == PROP_COMMON_HEADERS)
+    if (prop.first == PROP_COMMON_HEADERS)
     {
       LogProp(prop.first, prop.second);
       ParseHeaderString(m_commonHeaders, prop.second);

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -27,11 +27,8 @@ using namespace ADP::KODI_PROPS;
 namespace
 {
 // clang-format off
-constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_LICENSE_DATA = "inputstream.adaptive.license_data"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_LICENSE_FLAGS = "inputstream.adaptive.license_flags"; //! @todo: deprecated to be removed on Kodi 23
-constexpr std::string_view PROP_SERVER_CERT = "inputstream.adaptive.server_certificate"; //! @todo: deprecated to be removed on Kodi 23
+constexpr std::string_view PROP_LICENSE_TYPE = "inputstream.adaptive.license_type"; //! @todo: to be removed on Kodi 24
+constexpr std::string_view PROP_LICENSE_KEY = "inputstream.adaptive.license_key"; //! @todo: to be removed on Kodi 24
 
 constexpr std::string_view PROP_COMMON_HEADERS = "inputstream.adaptive.common_headers";
 
@@ -44,7 +41,6 @@ constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_par
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
-constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: deprecated to be removed on Kodi 23
 
 constexpr std::string_view PROP_CONFIG = "inputstream.adaptive.config";
 constexpr std::string_view PROP_DRM = "inputstream.adaptive.drm";
@@ -88,28 +84,24 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
 {
   std::string licenseUrl;
 
-  if (((STRING::KeyExists(props, PROP_LICENSE_TYPE) || STRING::KeyExists(props, PROP_LICENSE_KEY)) &&
-       (STRING::KeyExists(props, PROP_DRM_LEGACY) || STRING::KeyExists(props, PROP_DRM))) ||
-      (STRING::KeyExists(props, PROP_DRM_LEGACY) && STRING::KeyExists(props, PROP_DRM)))
+  if (STRING::KeyExists(props, PROP_LICENSE_TYPE) || STRING::KeyExists(props, PROP_LICENSE_KEY)) //! @todo: to be removed on Kodi 24
   {
     LOG::Log(LOGERROR,
              "<<<<<<<<< WRONG DRM CONFIGURATION >>>>>>>>>\n"
-             "A mixed use of DRM properties are not supported.\n"
-             "Please fix your configuration by using only one of these:\n"
-             " - Simple method: \"inputstream.adaptive.drm_legacy\"\n"
-             " - Advanced method (deprecated): \"inputstream.adaptive.license_type\" with optional "
-             "\"inputstream.adaptive.license_key\"\n"
-             " - NEW Advanced method: \"inputstream.adaptive.drm\"\n"
+             "DRM WAS CONFIGURED USING DEPRECATED PROPERTIES THAT ARE NO LONGER SUPPORTED.\n"
+             "THE FOLLOWING PROPERTIES ARE NO LONGER SUPPORTED:\n"
+             "- inputstream.adaptive.license_type\n"
+             "- inputstream.adaptive.license_key\n"
+             "- inputstream.adaptive.license_data\n"
+             "- inputstream.adaptive.license_flags\n"
+             "- inputstream.adaptive.server_certificate\n"
+             "- inputstream.adaptive.pre_init_data\n"
+             "YOU MUST MIGRATE TO THE NEW PROPERTIES:\n"
+             "- inputstream.adaptive.drm_legacy\n"
+             "- inputstream.adaptive.drm\n"
              "FOR MORE INFO, PLEASE READ THE WIKI PAGE: "
              "https://github.com/xbmc/inputstream.adaptive/wiki/Integration-DRM");
     return;
-  }
-
-  // If a new DRM property is used, ignore old properties
-  if (!STRING::KeyExists(props, PROP_DRM) && !STRING::KeyExists(props, PROP_DRM_LEGACY))
-  {
-    //! @todo: deprecated DRM properties, all them should be removed
-    ParseDrmOldProps(props);
   }
 
   for (const auto& prop : props)
@@ -124,12 +116,7 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
     else if (prop.first == PROP_MANIFEST_UPD_PARAMS)
     {
       LogProp(prop.first, prop.second);
-      // Should not happen that an add-on try to force the old "full" parameter value
-      // of PROP_MANIFEST_UPD_PARAM here but better verify it, in the future this can be removed
-      if (prop.second == "full")
-        LOG::Log(LOGERROR, "The parameter \"full\" is not supported.");
-      else
-        m_manifestUpdParams = prop.second;
+      m_manifestUpdParams = prop.second;
     }
     else if (prop.first == PROP_MANIFEST_PARAMS)
     {
@@ -210,32 +197,8 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
     }
     else
     {
-      // Ignore legacy DRM props, because has been parsed separately
-      if (prop.first == PROP_LICENSE_TYPE || prop.first == PROP_LICENSE_FLAGS ||
-          prop.first == PROP_LICENSE_DATA || prop.first == PROP_PRE_INIT_DATA ||
-          prop.first == PROP_SERVER_CERT || prop.first == PROP_LICENSE_KEY)
-      {
-        continue;
-      }
       LOG::Log(LOGWARNING, "Property found \"%s\" is not supported", prop.first.c_str());
       continue;
-    }
-  }
-
-  if (!licenseUrl.empty() && !m_drmConfigs.empty()) //! @todo: deprecated to be removed on Kodi 23
-  {
-    // PROP_LICENSE_URL replace the license url on the DRM license config
-    if (m_drmConfigs.size() > 1)
-    {
-      LOG::Log(LOGERROR, "The \"inputstream.adaptive.license_url\" and "
-                         "\"inputstream.adaptive.license_url_append\" properties\n"
-                         "cannot be used with multiple DRM configurations,\n"
-                         "Please set a single DRM configuration.");
-    }
-    else
-    {
-      auto first = m_drmConfigs.begin();
-      first->second.license.serverUri = licenseUrl;
     }
   }
 }
@@ -409,202 +372,6 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseManifestConfig(const std::string& dat
     {
       LOG::LogF(LOGERROR, "Unsupported \"%s\" config or wrong data type on \"%s\" property",
                 configName.c_str(), PROP_MANIFEST_CONFIG.data());
-    }
-  }
-}
-
-void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
-    const std::map<std::string, std::string>& props)
-{
-  // Translate data from old ISA properties to the new DRM config
-
-  if (!STRING::KeyExists(props, PROP_LICENSE_TYPE))
-    return;
-
-  LOG::Log(LOGWARNING, "<<<<<<<<< DEPRECATION NOTICE >>>>>>>>>\n"
-                       "DEPRECATED PROPERTIES HAS BEEN USED TO SET THE DRM CONFIGURATION.\n"
-                       "THE FOLLOWING PROPERTIES WILL BE REMOVED FROM FUTURE KODI VERSIONS:\n"
-                       "- inputstream.adaptive.license_type\n"
-                       "- inputstream.adaptive.license_key\n"
-                       "- inputstream.adaptive.license_data\n"
-                       "- inputstream.adaptive.license_flags\n"
-                       "- inputstream.adaptive.server_certificate\n"
-                       "- inputstream.adaptive.pre_init_data\n"
-                       "YOU SHOULD CONSIDER MIGRATING TO THE NEW PROPERTIES:\n"
-                       "- inputstream.adaptive.drm_legacy\n"
-                       "- inputstream.adaptive.drm\n"
-                       "FOR MORE INFO, PLEASE READ THE WIKI PAGE: "
-                       "https://github.com/xbmc/inputstream.adaptive/wiki/Integration-DRM");
-
-  std::string drmKeySystem{DRM::KS_NONE};
-  if (STRING::KeyExists(props, PROP_LICENSE_TYPE))
-    drmKeySystem = props.at(PROP_LICENSE_TYPE.data());
-
-  LogProp(PROP_LICENSE_TYPE, drmKeySystem);
-
-  if (!DRM::IsValidKeySystem(drmKeySystem))
-  {
-    LOG::LogF(LOGERROR,
-              "Cannot parse DRM configuration, unknown key system \"%s\" on license_type property",
-              drmKeySystem.c_str());
-    return;
-  }
-
-  if (drmKeySystem == DRM::KS_CLEARKEY && STRING::KeyExists(props, PROP_LICENSE_KEY))
-  {
-    LOG::Log(LOGERROR, "The \"inputstream.adaptive.license_key\" property cannot be used to "
-                       "configure ClearKey DRM,\n"
-                       "use \"inputstream.adaptive.drm_legacy\" or \"inputstream.adaptive.drm\" "
-                       "instead.\nSee Wiki integration page for more details.");
-    return;
-  }
-
-  // Create a DRM configuration for the specified key system
-  DrmCfg& drmCfg = m_drmConfigs[drmKeySystem];
-  drmCfg.isNewConfig = false;
-
-  // As legacy behaviour its expected to force the unique drm configuration available
-  drmCfg.priority = 1;
-  // As legacy behaviour force single session (as in the old ISA versions <= v21)
-  drmCfg.isForceSingleSession = true;
-
-  // Parse DRM properties
-  const bool isRedacted = !CSrvBroker::GetSettings().IsDebugVerbose();
-  std::string propValue;
-
-  if (STRING::GetMapValue(props, PROP_LICENSE_FLAGS, propValue))
-  {
-    LogProp(PROP_LICENSE_FLAGS, propValue);
-
-    if (propValue.find("persistent_storage") != std::string::npos)
-      drmCfg.isPersistentStorage = true;
-    if (propValue.find("force_secure_decoder") != std::string::npos)
-      drmCfg.isSecureDecoderEnabled = true;
-  }
-
-  if (STRING::GetMapValue(props, PROP_LICENSE_DATA, propValue))
-  {
-    LogProp(PROP_LICENSE_DATA, propValue, isRedacted);
-    drmCfg.initData = propValue;
-  }
-
-  if (STRING::GetMapValue(props, PROP_PRE_INIT_DATA, propValue))
-  {
-    LogProp(PROP_PRE_INIT_DATA, propValue, isRedacted);
-    drmCfg.preInitData = propValue;
-  }
-
-  // Parse DRM license properties
-
-  if (STRING::GetMapValue(props, PROP_SERVER_CERT, propValue))
-  {
-    LogProp(PROP_SERVER_CERT, propValue, isRedacted);
-    drmCfg.license.serverCert = propValue;
-  }
-
-  if (STRING::GetMapValue(props, PROP_LICENSE_KEY, propValue))
-  {
-    LogProp(PROP_LICENSE_KEY, propValue, isRedacted);
-
-    std::vector<std::string> fields = STRING::SplitToVec(propValue, '|');
-    size_t fieldCount = fields.size();
-
-    if (drmKeySystem == DRM::KS_NONE)
-    {
-      // We assume its HLS AES-128 encrypted case
-      // where "inputstream.adaptive.license_key" have different fields
-
-      // Field 1: HTTP request params to append to key URL
-      if (fieldCount >= 1)
-        drmCfg.license.reqParams = fields[0];
-
-      // Field 2: HTTP request headers
-      if (fieldCount >= 2)
-        ParseHeaderString(drmCfg.license.reqHeaders, fields[1]);
-    }
-    else
-    {
-      // Field 1: License server url
-      if (fieldCount >= 1)
-        drmCfg.license.serverUri = fields[0];
-
-      // Field 2: HTTP request headers
-      if (fieldCount >= 2)
-        ParseHeaderString(drmCfg.license.reqHeaders, fields[1]);
-
-      // Field 3: HTTP request data (POST request)
-      if (fieldCount >= 3)
-        drmCfg.license.reqData = fields[2];
-
-      // Field 4: HTTP response data (license wrappers)
-      if (fieldCount >= 4)
-      {
-        bool isJsonWrapper{false};
-        std::string jsonWrapperCfg;
-        std::string_view wrapperPrefix = fields[3];
-
-        if (wrapperPrefix.empty() || wrapperPrefix == "R")
-        {
-          // Raw, no wrapper, no-op
-        }
-        else if (wrapperPrefix == "B")
-        {
-          drmCfg.license.unwrapper = "base64";
-        }
-        else if (STRING::StartsWith(wrapperPrefix, "BJ"))
-        {
-          isJsonWrapper = true;
-          drmCfg.license.unwrapper = "base64,json";
-          jsonWrapperCfg = wrapperPrefix.substr(2);
-        }
-        else if (STRING::StartsWith(wrapperPrefix, "JB"))
-        {
-          isJsonWrapper = true;
-          drmCfg.license.unwrapper = "json,base64";
-          jsonWrapperCfg = wrapperPrefix.substr(2);
-        }
-        else if (STRING::StartsWith(wrapperPrefix, "J"))
-        {
-          isJsonWrapper = true;
-          drmCfg.license.unwrapper = "json";
-          jsonWrapperCfg = wrapperPrefix.substr(1);
-        }
-        else
-        {
-          LOG::Log(
-              LOGERROR,
-              "Unknown \"%s\" parameter in the \"response data\" field of license_key property",
-              wrapperPrefix.data());
-        }
-
-        // Parse JSON configuration
-        if (isJsonWrapper)
-        {
-          if (jsonWrapperCfg.empty())
-          {
-            LOG::Log(LOGERROR, "Missing JSON dict key names in the \"response data\" field of "
-                               "license_key property");
-          }
-          else
-          {
-            // Expected format as "KeyNameForData;KeyNameForHDCP" with exact order
-            std::vector<std::string> jPaths = STRING::SplitToVec(jsonWrapperCfg, ';');
-            // Position 1: The dict Key name to get license data
-            if (jPaths.size() >= 1)
-            {
-              drmCfg.license.unwrapperParams["path_data_traverse"] = "true";
-              drmCfg.license.unwrapperParams["path_data"] = jPaths[0];
-            }
-
-            // Position 2: The dict Key name to get HDCP value (optional)
-            if (jPaths.size() >= 2)
-            {
-              drmCfg.license.unwrapperParams["path_hdcp_res_traverse"] = "true";
-              drmCfg.license.unwrapperParams["path_hdcp_res"] = jPaths[1];
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -52,7 +52,6 @@ constexpr std::string_view PROP_MANIFEST_CONFIG = "inputstream.adaptive.manifest
 constexpr std::string_view PROP_STREAM_PARAMS = "inputstream.adaptive.stream_params";
 constexpr std::string_view PROP_STREAM_HEADERS = "inputstream.adaptive.stream_headers";
 
-constexpr std::string_view PROP_AUDIO_LANG_ORIG = "inputstream.adaptive.original_audio_language"; //! @todo: deprecated, to be removed on Kodi 23
 constexpr std::string_view PROP_PLAY_TIMESHIFT_BUFFER = "inputstream.adaptive.play_timeshift_buffer";
 constexpr std::string_view PROP_LIVE_DELAY = "inputstream.adaptive.live_delay"; //! @todo: deprecated to be removed on Kodi 23
 constexpr std::string_view PROP_PRE_INIT_DATA = "inputstream.adaptive.pre_init_data"; //! @todo: deprecated to be removed on Kodi 23
@@ -182,15 +181,6 @@ void ADP::KODI_PROPS::CCompKodiProps::InitStage1(const std::map<std::string, std
     {
       LogProp(prop.first, prop.second);
       ParseHeaderString(m_streamHeaders, prop.second);
-    }
-    else if (prop.first == PROP_AUDIO_LANG_ORIG) //! @todo: deprecated, to be removed on Kodi 23
-    {
-      LOG::Log(LOGWARNING, "Warning \"inputstream.adaptive.original_audio_language\" property is "
-                           "deprecated and will be removed on next Kodi version.\n"
-                           "Please read Wiki \"Integration\" page to learn more about the new "
-                           "parameters of \"inputstream.adaptive.config\".");
-      LogProp(prop.first, prop.second);
-      m_config.mediaAudioLangCodeOrig = prop.second;
     }
     else if (prop.first == PROP_PLAY_TIMESHIFT_BUFFER)
     {

--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -620,15 +620,6 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseDrmOldProps(
           drmCfg.license.unwrapper = "json";
           jsonWrapperCfg = wrapperPrefix.substr(1);
         }
-        else if (STRING::StartsWith(wrapperPrefix, "HB"))
-        {
-          // HB has been removed, we have no info about this use case
-          // if someone will open an issue we can try get more info for the reimplementation
-          //! @todo: if no feedbacks in future this can be removed, see also todo on decrypters/Helpers.cpp
-          LOG::Log(LOGERROR, "The support for \"HB\" parameter in the \"Response data\" field of "
-                             "license_key property has been removed. If this is a requirement for "
-                             "your video service, let us know by opening an issue on GitHub.");
-        }
         else
         {
           LOG::Log(

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -146,9 +146,6 @@ struct DrmCfg
 
   // The license configuration
   License license;
-  // Specifies if has been parsed the new DRM config ("drm" or "drm_legacy" kodi property)
-  //! @todo: to remove when deprecated DRM properties will be removed
-  bool isNewConfig{true};
 };
 
 class ATTR_DLL_LOCAL CCompKodiProps
@@ -199,7 +196,6 @@ private:
   void ParseConfig(const std::string& data);
   void ParseManifestConfig(const std::string& data);
 
-  void ParseDrmOldProps(const std::map<std::string, std::string>& props);
   bool ParseDrmConfig(const std::string& data);
   bool ParseDrmLegacyConfig(const std::string& data);
 

--- a/src/Iaes_decrypter.h
+++ b/src/Iaes_decrypter.h
@@ -28,6 +28,4 @@ public:
                        bool lastChunk) = 0;
   virtual std::vector<uint8_t> convertIV(const std::string& input) = 0;
   virtual void ivFromSequence(uint8_t* buffer, uint64_t sid) = 0;
-  // virtual const std::string& getLicenseKey() const = 0;
-  // virtual bool RenewLicense(const std::string& pluginUrl) = 0;
 };

--- a/src/aes_decrypter.h
+++ b/src/aes_decrypter.h
@@ -25,7 +25,6 @@ class ATTR_DLL_LOCAL AESDecrypter : public IAESDecrypter
 {
 public:
   AESDecrypter() = default;
-  // AESDecrypter(std::string_view licenseKey) : m_licenseKey(licenseKey) {}
   virtual ~AESDecrypter() = default;
 
   void decrypt(const AP4_UI08* aes_key,
@@ -37,9 +36,4 @@ public:
                bool lastChunk);
   std::vector<uint8_t> convertIV(const std::string& input);
   void ivFromSequence(uint8_t* buffer, uint64_t sid);
-  // const std::string& getLicenseKey() const { return m_licenseKey; };
-  // bool RenewLicense(const std::string& pluginUrl);
-
-  // private:
-  //   std::string m_licenseKey;
 };

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -1318,15 +1318,6 @@ bool adaptive::AdaptiveStream::GenerateSidxSegments(PLAYLIST::CRepresentation* r
               "due to missing data range positions",
               clsId, rep->GetId().data());
     return false;
-    /*
-     *! @todo: This part is not clear for which manifest use it should be
-     *         if there are no new issues about it, this code can be deleted in the future
-     *
-    // We dont know the range positions for the index segment
-    static const uint64_t indexRangeEnd = 1024 * 200;
-    seg.range_begin_ = 0;
-    seg.range_end_ = indexRangeEnd;
-    */
   }
 
   std::vector<uint8_t> sidxBuffer;

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -613,39 +613,10 @@ bool adaptive::AdaptiveStream::start_stream()
   if (!current_rep_ || current_rep_->IsSubtitleFileStream())
     return false;
 
-  //! @todo: the assured_buffer_duration_ and max_buffer_duration_
-  //! isnt implemeted correctly and need to be reworked,
-  //! these properties are intended to determine the amount of buffer
-  //! customizable in seconds, but segments do not ensure that they always have
-  //! a fixed duration of 1 sec moreover these properties currently works for
-  //! the DASH manifest with "SegmentTemplate" tags defined only,
-  //! in all other type of manifest cases always fallback on hardcoded values
-  /*
-   * Adaptive/custom buffering code disabled
-   * currently cause a bad memory management especially for 4k content
-   * too much buffer length leads to filling the RAM and cause kodi to crash
-   * required to implement a way to determine the max length of the buffer
-   * by taking in account also the device RAM
-   *
-  assured_buffer_length_ = current_rep_->assured_buffer_duration_;
-  max_buffer_length_ = current_rep_->max_buffer_duration_;
-
-  if (current_rep_->HasSegmentTemplate())
-  {
-    const auto& segTemplate = current_rep_->GetSegmentTemplate();
-    assured_buffer_length_ = std::ceil((assured_buffer_length_ * segTemplate->GetTimescale()) /
-                                       static_cast<float>(segTemplate->GetDuration()));
-    max_buffer_length_ = std::ceil((max_buffer_length_ * segTemplate->GetTimescale()) /
-                                   static_cast<float>(segTemplate->GetDuration()));
-  }
-
-  assured_buffer_length_  = assured_buffer_length_ <4 ? 4:assured_buffer_length_;//for incorrect settings input
-  if(max_buffer_length_<=assured_buffer_length_)//for incorrect settings input
-    max_buffer_length_=assured_buffer_length_+4u;
-
-  m_segBuffers.SetMaxSize(max_buffer_length_);
-  */
-
+  //! @todo: its hardcoded the buffer size to 4 segments
+  //! originally introduced to ensure smooth 4K playback
+  //! this is a temporary solution until we implement a better adaptive buffer management
+  //! its important to note that set the buffer too high can cause RAM to become saturated resulting in a crash
   m_segBuffers.SetMaxSize(4);
 
   if (!thread_data_)

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -269,11 +269,6 @@ enum class EVENT_TYPE
     // We need to store here because linked to representation
     uint8_t m_decrypterIv[16]{0};
 
-    // Minimum segment buffer size (segment_buffers_)
-    uint32_t assured_buffer_length_{0};
-    // The segment buffer size (segment_buffers_), so the max number of segments that can be downloaded and stored in memory
-    uint32_t max_buffer_length_{0};
-
     std::size_t segment_read_pos_{0};
     uint64_t absolute_position_{0}; // The absolute position is the segment range begin (if available), and will be increased with each reading
     uint64_t currentPTSOffset_{0};

--- a/src/common/AdaptiveTree.cpp
+++ b/src/common/AdaptiveTree.cpp
@@ -32,7 +32,6 @@ namespace adaptive
     m_reprChooser = left.m_reprChooser;
     m_manifestParams = left.m_manifestParams;
     m_manifestHeaders = left.m_manifestHeaders;
-    m_settings = left.m_settings;
     m_pathSaveManifest = left.m_pathSaveManifest;
     stream_start_ = left.stream_start_;
 
@@ -58,15 +57,6 @@ namespace adaptive
     m_manifestHeaders = srvBroker->GetKodiProps().GetManifestHeaders();
     m_manifestUpdParams = manifestUpdParams;
     stream_start_ = GetTimestamp();
-
-    // Convenience way to share common addon settings we avoid
-    // calling the API many times to improve parsing performance
-    /*
-    m_settings.m_bufferAssuredDuration =
-        static_cast<uint32_t>(kodi::addon::GetSettingInt("ASSUREDBUFFERDURATION"));
-    m_settings.m_bufferMaxDuration =
-        static_cast<uint32_t>(kodi::addon::GetSettingInt("MAXBUFFERDURATION"));
-    */
   }
 
   uint64_t AdaptiveTree::GetTimestamp()

--- a/src/common/AdaptiveTree.h
+++ b/src/common/AdaptiveTree.h
@@ -51,12 +51,6 @@ enum class TreeType
 class ATTR_DLL_LOCAL AdaptiveTree
 {
 public:
-  struct Settings
-  {
-    uint32_t m_bufferAssuredDuration{60};
-    uint32_t m_bufferMaxDuration{120};
-  };
-
   std::vector<std::unique_ptr<PLAYLIST::CPeriod>> m_periods;
   PLAYLIST::CPeriod* m_currentPeriod{nullptr};
   PLAYLIST::CPeriod* m_nextPeriod{nullptr};
@@ -268,8 +262,6 @@ public:
   }
 
   virtual AdaptiveTree* Clone() const = 0;
-
-  Settings m_settings;
 
   class TreeUpdateThread
   {

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -199,10 +199,6 @@ public:
 
   std::chrono::time_point<std::chrono::system_clock> repLastUpdated_;
 
-  //! @todo: to be reworked or deleted
-  uint32_t assured_buffer_duration_{0};
-  uint32_t max_buffer_duration_{0};
-
   bool isPlayable{true}; //! @todo: decouple "adaptivetree" with a kind of new streams interface could remove it
 
 protected:

--- a/src/decrypters/DrmEngineDefines.h
+++ b/src/decrypters/DrmEngineDefines.h
@@ -93,9 +93,6 @@ struct Config
 
   // The license configuration
   License license;
-  // Specifies if has been parsed the new DRM config ("drm" or "drm_legacy" kodi property)
-  //! @todo: to remove when deprecated DRM properties will be removed
-  bool isNewConfig{true};
 };
 
 constexpr std::string_view ROBUSTNESS_HW_SECDEC = "HW_SECURE_DECODE";

--- a/src/decrypters/DrmFactory.cpp
+++ b/src/decrypters/DrmFactory.cpp
@@ -71,7 +71,6 @@ DRM::Config DRM::CreateDRMConfig(std::string_view keySystem, const ADP::KODI_PRO
   cfg.keySystem = keySystem;
   cfg.isPersistentStorage = propCfg.isPersistentStorage;
   cfg.optKeyReqParams = propCfg.optKeyReqParams;
-  cfg.isNewConfig = propCfg.isNewConfig;
 
   auto& propLicCfg = propCfg.license;
   auto& licCfg = cfg.license;
@@ -80,8 +79,7 @@ DRM::Config DRM::CreateDRMConfig(std::string_view keySystem, const ADP::KODI_PRO
   licCfg.serverUri = propLicCfg.serverUri;
   licCfg.isHttpGetRequest = propLicCfg.isHttpGetRequest;
 
-  if (!propLicCfg.reqData.empty() && !BASE64::IsValidBase64(propLicCfg.reqData) &&
-      propCfg.isNewConfig)
+  if (!propLicCfg.reqData.empty() && !BASE64::IsValidBase64(propLicCfg.reqData))
   {
     LOG::LogF(LOGERROR, "The license \"req_data\" parameter must have data encoded as base 64.");
   }

--- a/src/decrypters/HelperWv.cpp
+++ b/src/decrypters/HelperWv.cpp
@@ -677,13 +677,6 @@ bool DRM::WvUnwrapLicense(std::string_view wrapper,
     return false;
   }
 
-  //! @todo: the support to binary license data (with HB) that start with "\r\n\r\n" has not been reintroduced with the
-  //! rework of this code, this is a old unclear addition, seem there are no info about this on web,
-  //! and seem no addons use it, so for now is removed, if in the future someone complain about this lack
-  //! will be possible reintroduce it and include more clear info about this use case.
-  // if (data.compare(0, 4, "\r\n\r\n") == 0)
-  //   data.erase(0, 4);
-
   dataOut = data;
 
   return true;

--- a/src/decrypters/HelperWv.cpp
+++ b/src/decrypters/HelperWv.cpp
@@ -172,68 +172,6 @@ std::vector<Wrapper> TranslateWrapper(std::string_view wrapper)
   }
   return result;
 }
-
-//! @todo: to be removed in future when the old DRM properties will be removed
-void ConvertDeprecatedPlaceholders(std::string& data)
-{
-  if (data.empty())
-    return;
-
-  if (STRING::Contains(data, "R{SSM}", false)) // Raw data
-  {
-    STRING::ReplaceFirst(data, "R{SSM}", "{CHA-RAW}");
-  }
-  else if (STRING::Contains(data, "b{SSM}", false)) // Base64 encoded
-  {
-    STRING::ReplaceFirst(data, "b{SSM}", "{CHA-B64}");
-  }
-  else if (STRING::Contains(data, "B{SSM}", false)) // Base64 and URL encoded
-  {
-    STRING::ReplaceFirst(data, "B{SSM}", "{CHA-B64U}");
-  }
-  else if (STRING::Contains(data, "D{SSM}", false)) // Decimal converted
-  {
-    STRING::ReplaceFirst(data, "D{SSM}", "{CHA-DEC}");
-  }
-
-  // SESSION ID - Placeholder {SID-?}
-
-  if (STRING::Contains(data, "R{SID}", false)) // Raw
-  {
-    STRING::ReplaceFirst(data, "R{SID}", "{SID-RAW}");
-  }
-  else if (STRING::Contains(data, "b{SID}", false)) // Base64 encoded
-  {
-    STRING::ReplaceFirst(data, "b{SID}", "{SID-B64}");
-  }
-  else if (STRING::Contains(data, "B{SID}", false)) // Base64 and URL encoded
-  {
-    STRING::ReplaceFirst(data, "B{SID}", "{SID-B64U}");
-  }
-
-  // KEY ID - Placeholder {KID-?}
-
-  if (STRING::Contains(data, "R{KID}", false)) // KID converted to UUID format
-  {
-    STRING::ReplaceFirst(data, "R{KID}", "{KID-UUID}");
-  }
-  else if (STRING::Contains(data, "H{KID}", false)) // Hexadecimal converted
-  {
-    STRING::ReplaceFirst(data, "H{KID}", "{KID-HEX}");
-  }
-
-  // PSSH - Placeholder {PSSH-?}
-
-  if (STRING::Contains(data, "b{PSSH}", false)) // Base64 encoded
-  {
-    STRING::ReplaceFirst(data, "b{PSSH}", "{PSSH-B64}");
-  }
-  else if (STRING::Contains(data, "B{PSSH}", false)) // Base64 and URL encoded
-  {
-    STRING::ReplaceFirst(data, "B{PSSH}", "{PSSH-B64U}");
-  }
-}
-
 } // unnamed namespace
 
 std::vector<uint8_t> DRM::MakeWidevinePsshData(const std::vector<std::vector<uint8_t>>& keyIds,
@@ -325,13 +263,8 @@ bool DRM::WvWrapLicense(std::string& data,
                         std::string_view sessionId,
                         const std::vector<uint8_t>& kid,
                         const std::vector<uint8_t>& pssh,
-                        std::string_view wrapper,
-                        const bool isNewConfig)
+                        std::string_view wrapper)
 {
-  //! @todo: to be removed in future when the old DRM properties will be removed
-  if (!isNewConfig)
-    ConvertDeprecatedPlaceholders(data);
-
   // By default raw key request (challenge) data
   if (data.empty())
     data = "{CHA-RAW}";
@@ -682,20 +615,8 @@ bool DRM::WvUnwrapLicense(std::string_view wrapper,
   return true;
 }
 
-void DRM::TranslateLicenseUrlPh(std::string& url,
-                                const std::vector<uint8_t>& challenge,
-                                const bool isNewConfig)
+void DRM::TranslateLicenseUrlPh(std::string& url, const std::vector<uint8_t>& challenge)
 {
-  if (!isNewConfig)
-  {
-    // Replace deprecated placeholders
-    //! @todo: to be removed in future when the old DRM properties will be removed
-    if (STRING::Contains(url, "B{SSM}", false)) // Base64 and URL encoded
-      STRING::ReplaceFirst(url, "B{SSM}", "{CHA-B64U}");
-    if (STRING::Contains(url, "{HASH}", false)) // MD5 hash
-      STRING::ReplaceFirst(url, "{HASH}", "{CHA-MD5}");
-  }
-
   if (STRING::Contains(url, "{CHA-B64U}", false))  // Base64 and URL encoded
   {
     const std::string krEnc = STRING::URLEncode(BASE64::Encode(challenge));

--- a/src/decrypters/HelperWv.h
+++ b/src/decrypters/HelperWv.h
@@ -144,8 +144,7 @@ bool WvWrapLicense(std::string& data,
                    std::string_view sessionId,
                    const std::vector<uint8_t>& kid,
                    const std::vector<uint8_t>& pssh,
-                   std::string_view wrapper,
-                   const bool isNewConfig);
+                   std::string_view wrapper);
 
 bool WvUnwrapLicense(std::string_view wrapper,
                      const std::map<std::string, std::string>& params,
@@ -155,9 +154,7 @@ bool WvUnwrapLicense(std::string_view wrapper,
                      int& hdcpResLimit,
                      uint16_t& hdcpVerLimit);
 
-void TranslateLicenseUrlPh(std::string& url,
-                           const std::vector<uint8_t>& challenge,
-                           const bool isNewConfig);
+void TranslateLicenseUrlPh(std::string& url, const std::vector<uint8_t>& challenge);
 
 /*!
  * \brief Parse the value of "X-Limit-Video" HTTP header.

--- a/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevine/WVCencSingleSampleDecrypter.cpp
@@ -297,15 +297,18 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
     {
       if (BASE64::IsValidBase64(licConfig.reqData))
         reqData = BASE64::DecodeToStr(licConfig.reqData);
-      else //! @todo: this fallback as plain text must be removed when the deprecated DRM properties are removed, and so replace it to return error
-        reqData = licConfig.reqData;
+      else
+      {
+        LOG::Log(LOGERROR, "The license request data is not in a valid base64 format");
+        return false;
+      }
 
       // Some services have a customized license server that require data to be wrapped with their formats (e.g. JSON).
       // Here we provide a built-in way to customize the license data to be sent, this avoid force add-ons to integrate
       // an HTTP server proxy to manage the license data request/response, and so use Kodi properties to set wrappers.
       if (m_cdmAdapter->GetKeySystem() == DRM::KS_WIDEVINE &&
           !DRM::WvWrapLicense(reqData, challenge, m_strSession, m_defaultKeyId, m_pssh,
-                              licConfig.wrapper, drmCfg.isNewConfig))
+                              licConfig.wrapper))
       {
         return false;
       }
@@ -320,7 +323,7 @@ bool CWVCencSingleSampleDecrypter::SendSessionMessage()
   }
 
   std::string url = licConfig.serverUri;
-  DRM::TranslateLicenseUrlPh(url, challenge, drmCfg.isNewConfig);
+  DRM::TranslateLicenseUrlPh(url, challenge);
 
   CURL::CUrl cUrl{url, reqData};
   cUrl.AddHeaders(licConfig.reqHeaders);

--- a/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
+++ b/src/decrypters/widevineandroid/WVCencSingleSampleDecrypter.cpp
@@ -402,15 +402,18 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<uint8_t
     {
       if (BASE64::IsValidBase64(licConfig.reqData))
         reqData = BASE64::DecodeToStr(licConfig.reqData);
-      else //! @todo: this fallback as plain text must be removed when the deprecated DRM properties are removed, and so replace it to return error
-        reqData = licConfig.reqData;
+      else
+      {
+        LOG::Log(LOGERROR, "The license request data is not in a valid base64 format");
+        return false;
+      }
 
       // Some services have a customized license server that require data to be wrapped with their formats (e.g. JSON).
       // Here we provide a built-in way to customize the license data to be sent, this avoid force add-ons to integrate
       // an HTTP server proxy to manage the license data request/response, and so use Kodi properties to set wrappers.
       if (m_cdmAdapter->GetKeySystem() == DRM::KS_WIDEVINE &&
           !DRM::WvWrapLicense(reqData, challenge, m_sessionId, m_defaultKeyId, m_pssh,
-                              licConfig.wrapper, drmCfg.isNewConfig))
+                              licConfig.wrapper))
       {
         return false;
       }
@@ -426,7 +429,7 @@ bool CWVCencSingleSampleDecrypterA::SendSessionMessage(const std::vector<uint8_t
   }
 
   std::string url = licConfig.serverUri;
-  DRM::TranslateLicenseUrlPh(url, challenge, drmCfg.isNewConfig);
+  DRM::TranslateLicenseUrlPh(url, challenge);
 
   CURL::CUrl cUrl{url, reqData};
   cUrl.AddHeaders(licConfig.reqHeaders);

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -436,19 +436,7 @@ void adaptive::CDashTree::ParseTagAdaptationSet(pugi::xml_node nodeAdp, PLAYLIST
 
     if (schemeIdUri == "urn:mpeg:dash:role:2011")
     {
-      //! @todo: If no complains, remove commented lines on Kodi 23
-      // if ((value == "subtitle" || value == "caption") && contentType.empty())
-      //   contentType = "text";
-
-      //! @todo: Remove custom "forced" value support on Kodi 23
-      if (value == "forced") // ISA custom attribute
-      {
-        LOG::LogF(LOGWARNING, "The support for the custom \"forced\" value on \"Role\" tag is now "
-                              "deprecated, it will be removed on Kodi v23.\n"
-                              "Please use the \"forced-subtitle\" standard value.");
-        adpSet->SetIsForced(true);
-      }
-      else if (value == "forced-subtitle")
+      if (value == "forced-subtitle")
         adpSet->SetIsForced(true);
       else if (value == "main")
         adpSet->SetIsDefault(true);

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -659,8 +659,6 @@ void adaptive::CDashTree::ParseTagRepresentation(pugi::xml_node nodeRepr,
   std::unique_ptr<CRepresentation> repr = CRepresentation::MakeUniquePtr(adpSet);
 
   repr->SetStartNumber(adpSet->GetStartNumber());
-  repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-  repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
 
   repr->SetId(XML::GetAttrib(nodeRepr, "id"));
 

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -962,7 +962,6 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
 
       if (aesKey->key.empty())
       {
-        // RETRY:
         auto drmCfgProp = CSrvBroker::GetKodiProps().GetDrmConfig(DRM::KS_NONE);
 
         CURL::HTTPResponse resp;
@@ -972,33 +971,9 @@ void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,
           aesKey->key.assign(resp.data.begin(), resp.data.end());
           m_aesUrlKeyCache[aesKey->keyUrl] = aesKey->key;
         }
-
-        /*
-         *! @todo: unclear if could be used by some old addon,
-         *!        for now all related code has been commented for a future removal
-         *
-        else if (pssh.defaultKID_ != "0")
-        {
-          //! @todo: RenewLicense (addon) callback is not wiki documented, there are addons that could use this?
-          //!        currently code fall here when the above download fail, there is no a better behaviour to avoid to do a broken download?
-          //!        the defaultKID_ is set with a single "0" instead of provide 16 chars, reason?
-          pssh.defaultKID_ = "0";
-          if (keyParts.size() >= 5 && !keyParts[4].empty() &&
-              m_decrypter->RenewLicense(keyParts[4]))
-            goto RETRY;
-        }
-        */
       }
     }
 
-    /*
-    if (pssh.defaultKID_ == "0")
-    {
-      segBuffer.resize(segBufferSize + srcDataSize, 0);
-      return;
-    }
-    else if (!segBufferSize)
-    */
     if (!segBufferSize)
     {
       if (aesKey->iv.empty())

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -1142,9 +1142,6 @@ bool adaptive::CHLSTree::ParseManifest(const std::string& data)
     repr->SetSourceUrl(manifest_url_);
     repr->AddCodecs(CODEC::FOURCC_H264);
 
-    repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-    repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
-
     repr->SetScaling();
 
     newAdpSet->AddCodecs(repr->GetCodecs());
@@ -1363,9 +1360,6 @@ bool adaptive::CHLSTree::ParseRenditon(const Rendition& r,
     if ((r.m_features & REND_FEATURE_EC3_JOC) == REND_FEATURE_EC3_JOC)
       repr->AddCodecs(CODEC::NAME_EAC3_JOC);
   }
-
-  repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-  repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
 
   repr->SetScaling();
 
@@ -1706,8 +1700,6 @@ bool adaptive::CHLSTree::ParseMultivariantPlaylist(const std::string& data)
         repr->SetFrameRateScale(1000);
       }
 
-      repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-      repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
       repr->SetScaling();
 
       std::string uri = var.m_uri;
@@ -1757,9 +1749,6 @@ void adaptive::CHLSTree::AddIncludedAudioStream(std::unique_ptr<PLAYLIST::CPerio
   repr->AddCodecs(codec);
   repr->SetAudioChannels(2);
   repr->SetIsIncludedStream(true);
-
-  repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-  repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
 
   repr->SetScaling();
 

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -427,9 +427,6 @@ void adaptive::CSmoothTree::ParseTagQualityLevel(pugi::xml_node nodeQI,
 
   repr->SetSegmentTemplate(segTpl);
 
-  repr->assured_buffer_duration_ = m_settings.m_bufferAssuredDuration;
-  repr->max_buffer_duration_ = m_settings.m_bufferMaxDuration;
-
   repr->SetScaling();
 
   adpSet->AddRepresentation(repr);

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -471,52 +471,6 @@ void adaptive::CSmoothTree::CreateSegmentTimeline()
   }
 }
 
-/*! @todo: commented for future removal
-bool adaptive::CSmoothTree::InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
-                                               PLAYLIST::CRepresentation* repr,
-                                               uint64_t fTimestamp,
-                                               uint64_t fDuration,
-                                               uint32_t fTimescale)
-{
-  if (!m_isLive)
-    return false;
-
-  const CSegment* lastSeg = repr->Timeline().GetBack();
-  if (!lastSeg)
-    return false;
-
-  LOG::Log(LOGDEBUG,
-           "Fragment info - timestamp: %llu, duration: %llu, timescale: %u (PTS base: %llu)",
-           fTimestamp, fDuration, fTimescale, m_ptsBase);
-
-  const uint64_t fStartPts =
-      static_cast<uint64_t>(static_cast<double>(fTimestamp) / fTimescale * repr->GetTimescale()) -
-      m_ptsBase;
-
-  if (fStartPts <= lastSeg->startPTS_)
-    return false;
-
-  CSegment segCopy = *lastSeg;
-  const uint64_t duration =
-      static_cast<uint64_t>(static_cast<double>(fDuration) / fTimescale * repr->GetTimescale());
-
-  segCopy.startPTS_ = fStartPts;
-  segCopy.m_endPts = segCopy.startPTS_ + duration;
-  segCopy.m_time = fTimestamp;
-  segCopy.m_number++;
-
-  LOG::Log(LOGDEBUG, "Insert fragment to adaptation set \"%s\" (PTS: %llu, number: %llu)",
-           adpSet->GetId().c_str(), segCopy.startPTS_, segCopy.m_number);
-
-  for (auto& repr : adpSet->GetRepresentations())
-  {
-    repr->Timeline().Append(segCopy);
-  }
-
-  return true;
-}
-*/
-
 void adaptive::CSmoothTree::OnUpdateSegments()
 {
   lastUpdated_ = std::chrono::system_clock::now();

--- a/src/parser/SmoothTree.h
+++ b/src/parser/SmoothTree.h
@@ -40,13 +40,6 @@ public:
 
   virtual CSmoothTree* Clone() const override { return new CSmoothTree{*this}; }
 
-  //! @todo: commented for future removal
-  // virtual bool InsertLiveFragment(PLAYLIST::CAdaptationSet* adpSet,
-  //                                 PLAYLIST::CRepresentation* repr,
-  //                                 uint64_t fTimestamp,
-  //                                 uint64_t fDuration,
-  //                                 uint32_t fTimescale) override;
-
   virtual void OnUpdateSegments() override;
 
 protected:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
### List of deprecated properties that has been removed, and explanation for the alternatives

---

DRM properties:
```
inputstream.adaptive.license_type
inputstream.adaptive.license_key
inputstream.adaptive.license_data
inputstream.adaptive.server_certificate
inputstream.adaptive.license_flags
inputstream.adaptive.pre_init_data
```
addons that still use deprecated properties must migrate to the new:
`inputstream.adaptive.drm_legacy` or `inputstream.adaptive.drm`
wiki: https://github.com/xbmc/inputstream.adaptive/wiki/Integration-DRM

---

```
inputstream.adaptive.live_delay
```
This property has been moved on `inputstream.adaptive.manifest_config`
wiki: https://github.com/xbmc/inputstream.adaptive/wiki/Integration

---

```
inputstream.adaptive.license_url
inputstream.adaptive.license_url_append
```
These properties used for PVR, are no longer needed, because the Kodi bug has been already solved on Kodi 22

---

```
inputstream.adaptive.original_audio_language
```
This property has been moved on `inputstream.adaptive.config`
wiki: https://github.com/xbmc/inputstream.adaptive/wiki/Integration

---

### Other cleanups-removal

- Removed Widevine HB wrapper commented code https://github.com/xbmc/inputstream.adaptive/blob/6b8cb3707b985f74446ad9e2781053a30f7870c6/src/decrypters/HelperWv.cpp#L622-L627
- Removed HLS "renew license url" add-on callbacks commented code
- [Dash] Removed support for custom `forced` attribute for `<Role>` with scheme `urn:mpeg:dash:role:2011`
- [AdaptiveStream] Removed code with fixed size sidx, the specific use case is unknown; it's probably just leftover code from the past that wasn't managed properly
- [SmoothTree] Removed unused InsertLiveFragment implementation, we currently manage updates by periodically downloading the updated manifest
- [AdaptiveStream] Removed adaptive buffering code, there is no plan to reimplement this soon

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All of these features were already planned to be removed for Kodi v23, no further support will be provided

All add-ons that still use some of these deprecated properties, must migrate to use the new one

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
