### PR TITLE
Fix HEVC TS extra data construction for 3-byte start codes

### DIFF
--- a/lib/mpegts/mpegts/ES_hevc.cpp
+++ b/lib/mpegts/mpegts/ES_hevc.cpp
@@ -10,7 +10,7 @@
 #include "bitstream.h"
 #include "debug.h"
 
-#include <cstring>      // for memset memcpy
+#include <cstring>      // for memset memcpy memcmp
 
 using namespace TSDemux;
 
@@ -43,7 +43,9 @@ void ES_hevc::Parse(STREAM_PKT* pkt)
   uint32_t startcode = m_StartCode;
   bool frameComplete = false;
 
-  if (m_NeedSPS)
+  // Reset extra data only on a fresh capture, so a VPS from a previous PES
+  // payload isn't discarded while waiting for its SPS/PPS.
+  if (m_NeedVPS && m_NeedSPS && m_NeedPPS)
     stream_info.extra_data_size = 0;
 
   while (p < es_len)
@@ -167,20 +169,9 @@ void ES_hevc::Parse_HEVC(int buf_ptr, unsigned int NumBytesInNalUnit, bool &comp
     switch (hdr.nal_unit_type)
     {
     case NAL_VPS_NUT:
-      if (m_NeedVPS)
-      {
-        if (stream_info.extra_data_size + NumBytesInNalUnit <= sizeof(stream_info.extra_data))
-        {
-          memcpy(stream_info.extra_data + stream_info.extra_data_size, es_buf + (buf_ptr - 4), NumBytesInNalUnit);
-          stream_info.extra_data_size += NumBytesInNalUnit;
-          m_NeedVPS = false;
-        }
-        else
-        {
-          DBG(DEMUX_DBG_INFO, "HEVC fixme: stream_info.extra_data too small! %i\n", stream_info.extra_data_size + NumBytesInNalUnit);
-        }
-      }
-       break;
+      if (m_NeedVPS && AppendExtraData(buf_ptr, NumBytesInNalUnit))
+        m_NeedVPS = false;
+      break;
 
     case NAL_SPS_NUT:
     {
@@ -191,19 +182,8 @@ void ES_hevc::Parse_HEVC(int buf_ptr, unsigned int NumBytesInNalUnit, bool &comp
         return;
       }
       Parse_SPS(buf, NumBytesInNalUnit, hdr);
-      if (m_NeedSPS)
-      {
-        if (stream_info.extra_data_size + NumBytesInNalUnit <= sizeof(stream_info.extra_data))
-        {
-          memcpy(stream_info.extra_data + stream_info.extra_data_size, es_buf + (buf_ptr - 4), NumBytesInNalUnit);
-          stream_info.extra_data_size += NumBytesInNalUnit;
-          m_NeedSPS = false;
-        }
-        else
-        {
-          DBG(DEMUX_DBG_INFO, "HEVC fixme: stream_info.extra_data too small! %i\n", stream_info.extra_data_size + NumBytesInNalUnit);
-        }
-      }
+      if (m_NeedSPS && AppendExtraData(buf_ptr, NumBytesInNalUnit))
+        m_NeedSPS = false;
       break;
     }
 
@@ -216,19 +196,8 @@ void ES_hevc::Parse_HEVC(int buf_ptr, unsigned int NumBytesInNalUnit, bool &comp
         return;
       }
       Parse_PPS(buf, NumBytesInNalUnit);
-      if (m_NeedPPS)
-      {
-        if (stream_info.extra_data_size + NumBytesInNalUnit <= sizeof(stream_info.extra_data))
-        {
-          memcpy(stream_info.extra_data + stream_info.extra_data_size, es_buf + (buf_ptr - 4), NumBytesInNalUnit);
-          stream_info.extra_data_size += NumBytesInNalUnit;
-          m_NeedPPS = false;
-        }
-        else
-        {
-          DBG(DEMUX_DBG_INFO, "HEVC fixme: stream_info.extra_data too small! %i\n", stream_info.extra_data_size + NumBytesInNalUnit);
-        }
-      }
+      if (m_NeedPPS && AppendExtraData(buf_ptr, NumBytesInNalUnit))
+        m_NeedPPS = false;
       break;
     }
 
@@ -267,6 +236,41 @@ void ES_hevc::Parse_HEVC(int buf_ptr, unsigned int NumBytesInNalUnit, bool &comp
       break;
     }
   }
+}
+
+// Append a parameter set NAL (VPS/SPS/PPS) to the extra data as Annex B.
+// numBytes spans to the end of the next start code (3 or 4 bytes), stripped here if present.
+bool ES_hevc::AppendExtraData(int buf_ptr, unsigned int numBytes)
+{
+  if (numBytes < 3)
+    return false;
+
+  unsigned int nalSize = numBytes;
+  const unsigned char* tail = es_buf + buf_ptr + numBytes;
+  if (numBytes >= 4 && std::memcmp(tail - 4, "\0\0\0\x01", 4) == 0)
+    nalSize = numBytes - 4;
+  else if (std::memcmp(tail - 3, "\0\0\x01", 3) == 0)
+    nalSize = numBytes - 3;
+
+  if (nalSize == 0)
+    return false;
+
+  if (static_cast<size_t>(stream_info.extra_data_size) + 4 + nalSize >
+      sizeof(stream_info.extra_data))
+  {
+    DBG(DEMUX_DBG_INFO, "HEVC fixme: stream_info.extra_data too small! %u\n",
+        static_cast<unsigned int>(stream_info.extra_data_size) + 4 + nalSize);
+    return false;
+  }
+
+  uint8_t* ed = stream_info.extra_data + stream_info.extra_data_size;
+  ed[0] = 0;
+  ed[1] = 0;
+  ed[2] = 0;
+  ed[3] = 1;
+  std::memcpy(ed + 4, es_buf + buf_ptr, nalSize);
+  stream_info.extra_data_size += 4 + nalSize;
+  return true;
 }
 
 void ES_hevc::Parse_PPS(uint8_t *buf, int len)

--- a/lib/mpegts/mpegts/ES_hevc.h
+++ b/lib/mpegts/mpegts/ES_hevc.h
@@ -90,6 +90,7 @@ namespace TSDemux
     bool            m_Interlaced;
 
     void Parse_HEVC(int buf_ptr, unsigned int NumBytesInNalUnit, bool &complete);
+    bool AppendExtraData(int buf_ptr, unsigned int numBytes);
     void Parse_PPS(uint8_t *buf, int len);
     void Parse_SLH(uint8_t *buf, int len, HDR_NAL hdr, hevc_private::VCL_NAL &vcl);
     void Parse_SPS(uint8_t *buf, int len, HDR_NAL hdr);


### PR DESCRIPTION
## Description
The VPS/SPS/PPS copy assumed 4-byte start codes on both ends, so with 3-byte start codes it prepended a stray byte (extra data misdetected as hvcC) and truncated the NAL's last byte (corrupt PPS). Emit a clean Annex-B start code and copy only the NAL, mirroring the H.264 path.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Playback of 4k HEVC streams is failing with inputstream.adaptive while working with inputstream.ffmpegdirect.

This is a demuxer bug, independent of and complementary to xbmc/xbmc#28103. #28103 fixes Kodi's VAAPI path allocating 8-bit (NV12) surfaces for 10-bit HEVC; this fixes the invalid HEVC extra data emitted by the MPEG-TS demuxer. Software decoding plays on both platforms - it's the hardware paths that fail, for different reasons:

- Android (MediaCodec): the invalid extra data is fatal - `CBitstreamConverter` mis-detects it as hvcC and can't convert.
- Linux (VAAPI): this fix clears the extra-data parse error, but #28103 is still needed for the 10-bit surface (error 18).

```
[Android / MediaCodec — invalid extra data is fatal here]
2026-06-15 13:08:12.407 T:12836 error <general>: CBitstreamConverter::Convert: error converting.
2026-06-15 13:08:12.407 T:12836 debug <general>: CDVDVideoCodecAndroidMediaCodec::AddData: waiting for keyframe (bitstream)
2026-06-15 13:08:12.418 T:12836 debug <general>: CDVDVideoCodecAndroidMediaCodec::AddData current state (2)

[Linux / ffmpeg — the invalid extra data this PR fixes]
2026-06-15 13:27:42.562 T:1837798 error <general>: ffmpeg[0x55c873bf0880]: [hevc] log2_parallel_merge_level_minus2 out of range: -1

[Linux / VAAPI — separate 10-bit surface fault, fixed by xbmc/xbmc#28103]
2026-06-15 13:18:24.888 T:1836092 error <general>: ffmpeg[0x55c8734a6be0]: [hevc] Failed to end picture decode issue: 18 (invalid parameter).
2026-06-15 13:18:24.888 T:1836092 error <general>: ffmpeg[0x55c8734a6be0]: [hevc] hardware accelerator failed to decode picture
2026-06-15 13:18:24.888 T:1836092 error <general>: GetPicture - avcodec_receive_frame returned failure
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
A test [build](https://github.com/kontell/inputstream.adaptive/actions/runs/27549433348) for Android V22 was created and playback is now successful.

On Linux, without PR28103, the parallel_merge error is removed but playback still fails.
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
