### PR TITLE
[HLSTree] Add m4f extension support / aes info to init segment

### DIFF
--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -554,6 +554,7 @@ bool adaptive::CHLSTree::ProcessChildManifest(PLAYLIST::CPeriod* period,
         segInit.SetIsInitialization(true);
         segInit.url = attribs["URI"];
         segInit.startPTS_ = NO_PTS_VALUE;
+        segInit.AESKeyInfo() = aesKey;
         rep->SetInitSegment(segInit);
         rep->SetContainerType(ContainerType::MP4);
       }

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -98,7 +98,8 @@ ContainerType DetectContainerTypeFromExt(std::string_view extension)
     return ContainerType::TS;
   else if (STRING::CompareNoCase(extension, "aac"))
     return ContainerType::ADTS;
-  else if (STRING::CompareNoCase(extension, "mp4") || STRING::CompareNoCase(extension, "m4s"))
+  else if (STRING::CompareNoCase(extension, "mp4") || STRING::CompareNoCase(extension, "m4s") ||
+           STRING::CompareNoCase(extension, "m4f"))
     return ContainerType::MP4;
   else if (STRING::CompareNoCase(extension, "vtt") || STRING::CompareNoCase(extension, "webvtt"))
     return ContainerType::TEXT;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- add missing m4f extension to hls parser
- add aes info to init segment, it can be encrypted:

```
#EXTM3U
#EXT-X-VERSION:7
#EXT-X-KEY:METHOD=AES-128,URI="https://...",IV=0x6514e7fc887af2ef84a0aea61310612f
#EXT-X-MAP:URI="https://..."
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-TARGETDURATION:10
#EXTINF:10.000,
https://....
#EXTINF:10.000,
...
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2061

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
