### PR TITLE
[mpegts] Accept any PID number not only PAT with PID 0

### DIFF
--- a/lib/mpegts/mpegts/tsDemuxer.cpp
+++ b/lib/mpegts/mpegts/tsDemuxer.cpp
@@ -471,20 +471,26 @@ int AVContext::ProcessTSPacket()
   }
 
   it = this->packets.find(this->pid);
-  if (it == this->packets.end())
+  if (it == this->packets.end()) // Not registered PID.
   {
-    // Not registred PID
-    // We are waiting for unit start of PID 0 else next packet is required
-    if (this->pid == 0 && this->payload_unit_start)
+    // Only auto-register if this payload_unit_start actually contains a PSI table
+    if (this->payload_unit_start && this->payload && this->payload_len > 1)
     {
-      // Registering PID 0
-      Packet pid0;
-      pid0.pid = this->pid;
-      pid0.packet_type = PACKET_TYPE_PSI;
-      pid0.continuity = continuity_counter;
-      it = this->packets.insert(it, std::make_pair(this->pid, pid0));
+      const uint8_t pointerField = av_rb8(this->payload); // pointer_field is at payload[0];
+      if (static_cast<size_t>(pointerField) + 1 < this->payload_len)
+      {
+        const uint8_t tableId = av_rb8(this->payload + 1 + pointerField); // table_id is at payload + 1 + pointer_field
+        if (tableId == 0x00 || tableId == 0x02) // table_id 0x00 = PAT, 0x02 = PMT
+        {
+          Packet p;
+          p.pid = this->pid;
+          p.packet_type = PACKET_TYPE_PSI;
+          p.continuity = continuity_counter;
+          it = this->packets.insert(it, std::make_pair(this->pid, p));
+        }
+      }
     }
-    else
+    if (it == this->packets.end())
       return AVCONTEXT_CONTINUE;
   }
   else


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
From what i understand on TS streams PAT should always be present and have PID 0
while PMT can have different PID numbers

a stream such as provided from the issue #2010 dont contains the PAT, but only PMT with PID 4097
as VLC shown:
```
ts debug: pid[4097] unknown
ts debug: pid[256] unknown
ts debug: pid[257] unknown
```

this is not a standard stream, but VLC is able to play it with some kind of fallback
so the reason why this video cant be played its not a bug, but its needed make the parser less strict

I found this solution with the help of AI, seem to works correctly without cause problems with regular TS streams

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2010

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually tested with provided files from issue

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
