### PR TITLE
[CurlUtils] Replace empty acceptencoding with all

### DIFF
--- a/src/CompKodiProps.cpp
+++ b/src/CompKodiProps.cpp
@@ -325,6 +325,10 @@ void ADP::KODI_PROPS::CCompKodiProps::ParseConfig(const std::string& data)
     {
       m_config.curlSSLVerifyPeer = jValue.get<bool>();
     }
+    else if (configName == "disable_accept_encoding" && jValue.is_boolean())
+    {
+      m_config.curlDisableAcceptEncoding = jValue.get<bool>();
+    }
     else if (configName == "internal_cookies" && jValue.is_boolean())
     {
       m_config.internalCookies = jValue.get<bool>();

--- a/src/CompKodiProps.h
+++ b/src/CompKodiProps.h
@@ -54,6 +54,9 @@ struct Config
   // Determines whether curl verifies the authenticity of the peer's certificate,
   // if set to false CA certificates are not loaded and verification will be skipped.
   bool curlSSLVerifyPeer{true};
+  // Determines whether curl disables the Accept-Encoding header
+  // if set to true, the header will not be sent
+  bool curlDisableAcceptEncoding{false};
   // Determines if cookies are internally handled by InputStream Adaptive add-on
   bool internalCookies{false};
   // Determines how HDCP should be checked

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -196,7 +196,10 @@ UTILS::CURL::CUrl::CUrl(const std::string& url, const RequestType reqType /* = R
 
     // Default curl options
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
-    m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "all"); // Accept all encodings, e.g. gzip, deflate, br
+
+    if (!kodiProps.GetConfig().curlDisableAcceptEncoding)
+      m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "all"); // Accept all encodings, e.g. gzip, deflate, br
+
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
     if (!kodiProps.GetConfig().curlSSLVerifyPeer)
       m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "verifypeer", "false");

--- a/src/utils/CurlUtils.cpp
+++ b/src/utils/CurlUtils.cpp
@@ -196,7 +196,7 @@ UTILS::CURL::CUrl::CUrl(const std::string& url, const RequestType reqType /* = R
 
     // Default curl options
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "seekable", "0");
-    m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", ""); // Empty to accept all encodings, e.g. gzip, deflate, br
+    m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "acceptencoding", "all"); // Accept all encodings, e.g. gzip, deflate, br
     m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
     if (!kodiProps.GetConfig().curlSSLVerifyPeer)
       m_file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "verifypeer", "false");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
"all" value is undocumented on kodi inputstream interface
and it stand for empty value for CURLOPT_ACCEPT_ENCODING


https://github.com/xbmc/xbmc/blob/d7a2d07d06fee69d282a64e74a3b5de16db4fdf5/xbmc/filesystem/CurlFile.cpp#L625-L626

so set empty value silently ignore CURLOPT_ACCEPT_ENCODING configuration

the strange thing is that I can't reproduce the same problems that other users mention,
except for am@zon which was testing with "mpd" alteration setting disabled so previously i couldn't reproduce the problem, by enabling the alteration i can reproduce it

---

this invalidate the x-gzip support goal of PR #2058
the only way i found to make it working is disable "accept-encoding" header
so that the server is forced to avoid encoding
in fact because of this misunderstanding, tested website was "working" because was disabled

add `disable_accept_encoding` to `inputstream.adaptive.config` that allow to disable accepted encoding

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2067 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
