### PR TITLE
Rework wait for segment code

### DIFF
--- a/src/AdaptiveByteStream.cpp
+++ b/src/AdaptiveByteStream.cpp
@@ -59,7 +59,7 @@ AP4_Result CAdaptiveByteStream::GetSize(AP4_LargeSize& size)
 
 bool CAdaptiveByteStream::waitingForSegment() const
 {
-  return m_adStream->waitingForSegment();
+  return m_adStream->IsWaitingForSegment();
 }
 
 void CAdaptiveByteStream::FixateInitialization(bool on)

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -828,6 +828,8 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
 
   if (waiting)
   {
+    // Prevents CPU usage spikes due to continuous Kodi VP requests
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     return true;
   }
   else if (res)

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -812,7 +812,7 @@ bool SESSION::CSession::GetNextSample(ISampleReader*& sampleReader)
         {
           if (!res || streamReader->DTSorPTSManifest() < res->GetReader()->DTSorPTSManifest())
           {
-            if (stream->m_adStream.waitingForSegment())
+            if (stream->m_adStream.OnSampleRequested())
             {
               waiting = stream.get();
             }

--- a/src/common/AdaptiveStream.cpp
+++ b/src/common/AdaptiveStream.cpp
@@ -71,6 +71,7 @@ void adaptive::AdaptiveStream::Reset()
   segment_read_pos_ = 0;
   currentPTSOffset_ = 0;
   absolutePTSOffset_ = 0;
+  m_isWaitingForSegment = false;
 }
 
 bool adaptive::AdaptiveStream::Download(const DownloadInfo& downloadInfo,
@@ -969,15 +970,15 @@ bool adaptive::AdaptiveStream::ensureSegment()
     }
     else if (!m_tree->IsLastSegment(current_period_, current_rep_, current_rep_->current_segment_))
     {
-      if (m_segBuffers.IsEmpty() && !current_rep_->IsWaitForSegment())
+      if (m_segBuffers.IsEmpty() && !m_isWaitingForSegment)
       {
-        current_rep_->SetIsWaitForSegment(true);
-        LOG::LogF(LOGDEBUG, "[AS-%u] Begin WaitForSegment stream rep. id \"%s\" period id \"%s\"",
+        m_isWaitingForSegment = true;
+        LOG::LogF(LOGDEBUG, "[AS-%u] Begin WaitForSegment (buffer is empty) stream rep. id \"%s\" period id \"%s\"",
                   clsId, current_rep_->GetId().c_str(), current_period_->GetId().c_str());
       }
       return false;
     }
-    else if (current_rep_->IsWaitForSegment() &&
+    else if (m_isWaitingForSegment &&
              (m_tree->HasManifestUpdates() || m_tree->HasManifestUpdatesSegs()))
     {
       return false;
@@ -1115,7 +1116,7 @@ bool adaptive::AdaptiveStream::seek(uint64_t const pos, bool& isEos)
     if (ensureSegment())
       return true;
 
-    if (!current_rep_->IsWaitForSegment())
+    if (!m_isWaitingForSegment)
       isEos = true;
 
     return false;
@@ -1254,21 +1255,49 @@ bool adaptive::AdaptiveStream::seek_time(double seek_seconds)
   return true;
 }
 
-bool adaptive::AdaptiveStream::waitingForSegment() const
+bool adaptive::AdaptiveStream::OnSampleRequested()
 {
-  if (m_tree->IsLive() && thread_data_->State() == THREADDATA::ThState::RUNNING)
+  if (!m_tree->IsLive() || !thread_data_)
+    return false;
+
+  //! @todo: its missing an appropriate buffering management, example:
+  //!        if the bandwidth is too low stuttering may occur due to constant buffering
+  //!        it should wait that buffer if full before to resume the playback,
+  //!        it should also help to manage adaptive streaming (CRepresentationChooserDefault)
+  //!        the mechanism to auto-increase/decrease stream quality based on the actual network conditions
+
+  const auto now = std::chrono::steady_clock::now();
+  const long long elapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - m_tsOnSampleRequest).count();
+
+  // Sample are requested in a very fast way, limit the requests to a minimum interval of 500 ms
+  if (elapsedMs >= 500)
   {
+    m_tsOnSampleRequest = now;
     std::lock_guard<adaptive::AdaptiveTree::TreeUpdateThread> lckUpdTree(m_tree->GetTreeUpdMutex());
 
     // Some manifests require segments to be generated and managed by the client
     // so they are not provided by the server through periodic manifest updates
     m_tree->InsertLiveSegment(current_period_, current_adp_, current_rep_);
 
-    // Although IsWaitForSegment may be true, do not anticipate the wait for segments
-    // if there are still segments in the buffer that can be read and/or downloaded
-    return current_rep_ && current_rep_->IsWaitForSegment() && m_segBuffers.IsEmpty();
+    if (m_isWaitingForSegment)
+    {
+      if (thread_data_->State() != THREADDATA::ThState::RUNNING)
+        return false;
+
+      // Unlocks buffering wait, if a segment exists and the buffer level is full
+      m_isWaitingForSegment = !current_rep_->GetNextSegment() ||
+                              m_segBuffers.GetSizeDownloaded() < m_segBuffers.GetSize();
+
+      if (!m_isWaitingForSegment)
+      {
+        LOG::LogF(LOGDEBUG, "[AS-%u] End WaitForSegment stream rep. id \"%s\" period id \"%s\"",
+                  clsId, current_rep_->GetId().c_str(), current_period_->GetId().c_str());
+      }
+    }
   }
-  return false;
+
+  return m_isWaitingForSegment;
 }
 
 void adaptive::AdaptiveStream::FixateInitialization(bool on)
@@ -1355,6 +1384,8 @@ void adaptive::AdaptiveStream::Stop()
   // otherwise if read some segments may invalidate this change
   if (current_rep_)
     current_rep_->SetIsEnabled(false);
+
+  m_isWaitingForSegment = false;
 }
 
 void adaptive::AdaptiveStream::clear()

--- a/src/common/AdaptiveStream.h
+++ b/src/common/AdaptiveStream.h
@@ -125,7 +125,9 @@ enum class EVENT_TYPE
 
     uint64_t GetCurrentPTSOffset() const { return currentPTSOffset_; }
     uint64_t GetAbsolutePTSOffset() const { return absolutePTSOffset_; }
-    bool waitingForSegment() const;
+
+    bool OnSampleRequested();
+
     void FixateInitialization(bool on);
     void AllowBufferQueue(bool isAllowed) { m_isAllowedBufferQueue = isAllowed; }
     void SetSegmentFileOffset(uint64_t offset) { m_segmentFileOffset = offset; };
@@ -139,6 +141,8 @@ enum class EVENT_TYPE
     * \return True if its required to create Movie (MOOV) atom, otherwise false
     */
     bool IsRequiredCreateMovieAtom();
+
+    bool IsWaitingForSegment() const { return m_isWaitingForSegment; }
 
   protected:
     virtual bool parseIndexRange(PLAYLIST::CRepresentation* rep,
@@ -161,6 +165,9 @@ enum class EVENT_TYPE
 
     std::string m_streamParams;
     std::map<std::string, std::string> m_streamHeaders;
+
+    bool m_isWaitingForSegment{false};
+    mutable std::chrono::time_point<std::chrono::steady_clock> m_tsOnSampleRequest{};
 
    /*!
     * \brief Download a file, the representation chooser will be updated with current download speed.

--- a/src/common/Representation.h
+++ b/src/common/Representation.h
@@ -145,9 +145,6 @@ public:
   bool IsEnabled() const { return m_isEnabled; }
   void SetIsEnabled(bool isEnabled) { m_isEnabled = isEnabled; }
 
-  bool IsWaitForSegment() const { return m_isWaitForSegment; }
-  void SetIsWaitForSegment(bool isWaitForSegment) { m_isWaitForSegment = isWaitForSegment; }
-
   // Define if it is a dummy representation for audio stream, that is embedded on the video stream
   bool IsIncludedStream() const { return m_isIncludedStream; }
   void SetIsIncludedStream(bool isIncludedStream) { m_isIncludedStream = isIncludedStream; }
@@ -229,7 +226,6 @@ protected:
   bool m_isSubtitleFileStream{false};
 
   bool m_isEnabled{false};
-  bool m_isWaitForSegment{false};
 
   bool m_isIncludedStream{false};
   std::vector<DRM::DRMInfo> m_drmInfo;

--- a/src/common/SegmentBuffer.cpp
+++ b/src/common/SegmentBuffer.cpp
@@ -144,6 +144,21 @@ const size_t ADP::CSegmentBuffers::GetSize() const
   return m_buffers.size();
 }
 
+const size_t ADP::CSegmentBuffers::GetSizeDownloaded() const
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  size_t size{0};
+  for (const auto& segBuffer : m_buffers)
+  {
+    if (segBuffer.State() == BufferState::DOWNLOADED ||
+        segBuffer.State() == BufferState::DOWNLOADING)
+      size++;
+    else
+      break;
+  }
+  return size;
+}
+
 const bool ADP::CSegmentBuffers::IsEmpty() const
 {
   std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/common/SegmentBuffer.h
+++ b/src/common/SegmentBuffer.h
@@ -139,6 +139,11 @@ public:
   */
   const size_t GetSize() const;
 
+  /*!
+  * \brief Get the current number of elements contained in the segment buffers container that are in download or downloaded.
+  */
+  const size_t GetSizeDownloaded() const;
+
  /*!
   * \brief Determines whether the segment buffers container is empty.
   * \return True if empty, otherwise false.

--- a/src/parser/DASHTree.cpp
+++ b/src/parser/DASHTree.cpp
@@ -1738,12 +1738,6 @@ void adaptive::CDashTree::OnUpdateSegments()
               LOG::LogF(LOGDEBUG, "MPD update - Done (repr. id \"%s\", period id \"%s\")",
                         updRepr->GetId().c_str(), period->GetId().c_str());
             }
-
-            if (repr->IsWaitForSegment() && repr->GetNextSegment())
-            {
-              repr->SetIsWaitForSegment(false);
-              LOG::LogF(LOGDEBUG, "End WaitForSegment repr. id %s", repr->GetId().c_str());
-            }
           }
         }
       }
@@ -1875,14 +1869,6 @@ void adaptive::CDashTree::InsertLiveSegment(PLAYLIST::CPeriod* currPeriod,
                                             PLAYLIST::CAdaptationSet* currAdpSet,
                                             PLAYLIST::CRepresentation* currRepr)
 {
-  // InsertLiveSegment is called very frequently, since this implementation update all manifest data
-  // you do not need to have all these callbacks in such a short time
-  auto now = std::chrono::steady_clock::now();
-  if (now - m_insertLiveSegUpdate < std::chrono::milliseconds(500))
-    return;
-
-  m_insertLiveSegUpdate = now;
-
   // This code will keep updated the timeline on all representations
   // (across all periods) with current now time (TSB included),
   // exclusive case of representations having SegmentTemplate without defined timeline
@@ -1951,12 +1937,6 @@ void adaptive::CDashTree::InsertLiveSegment(PLAYLIST::CPeriod* currPeriod,
                 rep->Timeline().GetDuration() * period->GetTimescale() / rep->GetTimescale();
             period->SetTlDuration(tlDuration);
           }
-        }
-
-        if (rep->IsWaitForSegment())
-        {
-          rep->SetIsWaitForSegment(false);
-          LOG::LogF(LOGDEBUG, "End WaitForSegment repr. id %s", rep->GetId().c_str());
         }
       }
     }

--- a/src/parser/DASHTree.h
+++ b/src/parser/DASHTree.h
@@ -126,9 +126,6 @@ protected:
   uint64_t m_minimumUpdatePeriod{PLAYLIST::NO_VALUE}; // in seconds, NO_VALUE if not set
   std::optional<int64_t> m_clockOffset; // Clock offset in ms, based on UTCTiming element
 
-  // The time point when the last live "insert segment update" has been called
-  mutable std::chrono::time_point<std::chrono::steady_clock> m_insertLiveSegUpdate{};
-
   std::string m_locationUrl; // Redirect manifest updates
 };
 } // namespace adaptive

--- a/src/parser/HLSTree.cpp
+++ b/src/parser/HLSTree.cpp
@@ -933,15 +933,6 @@ void adaptive::CHLSTree::PrepareSegments(PLAYLIST::CPeriod* period,
       rep->current_segment_.reset();
     }
   }
-
-  //! @todo: m_currentPeriod != m_periods.back().get() condition should be removed from here
-  //! this is done on AdaptiveStream::ensureSegment on IsLastSegment check
-  if (rep->IsWaitForSegment() &&
-      (rep->GetNextSegment() || m_currentPeriod != m_periods.back().get()))
-  {
-    LOG::LogF(LOGDEBUG, "End WaitForSegment stream id \"%s\"", rep->GetId().c_str());
-    rep->SetIsWaitForSegment(false);
-  }
 }
 
 void adaptive::CHLSTree::OnDataArrived(uint64_t segNum,

--- a/src/parser/SmoothTree.cpp
+++ b/src/parser/SmoothTree.cpp
@@ -631,12 +631,6 @@ void adaptive::CSmoothTree::OnUpdateSegments()
 
         LOG::LogF(LOGDEBUG, "SS update - Done (repr. id \"%s\")", updRepr->GetId().c_str());
       }
-
-      if (repr->IsWaitForSegment() && repr->GetNextSegment())
-      {
-        repr->SetIsWaitForSegment(false);
-        LOG::LogF(LOGDEBUG, "End WaitForSegment repr. id %s", repr->GetId().c_str());
-      }
     }
   }
 

--- a/src/samplereader/ADTSSampleReader.cpp
+++ b/src/samplereader/ADTSSampleReader.cpp
@@ -47,6 +47,13 @@ AP4_Result CADTSSampleReader::ReadSample()
     UpdatePts();
     return AP4_SUCCESS;
   }
+
+  if (m_adByteStream->waitingForSegment())
+  {
+    // if waiting for segment, we will return success to avoid EOS and let the caller to call ReadSample again
+    return AP4_SUCCESS;
+  }
+
   if (!m_adByteStream || !m_adByteStream->waitingForSegment())
   {
     m_eos = true;

--- a/src/samplereader/FragmentedSampleReader.cpp
+++ b/src/samplereader/FragmentedSampleReader.cpp
@@ -266,7 +266,12 @@ AP4_Result CFragmentedSampleReader::ReadSample()
         }
         else
         {
-          if (!adByteStream->waitingForSegment())
+          if (adByteStream->waitingForSegment())
+          {
+            // if waiting for segment, we will return success to avoid EOS and let the caller to call ReadSample again
+            result = AP4_SUCCESS;
+          }
+          else
             m_eos = true;
         }
       }

--- a/src/samplereader/SubtitleSampleReader.cpp
+++ b/src/samplereader/SubtitleSampleReader.cpp
@@ -136,7 +136,7 @@ bool CSubtitleSampleReader::IsReady()
   // 2) segmented subtitles, and its not waiting for segments,
   //    it need to wait for the next manifest live update to get new segments (like HLS)
   return !m_adByteStream ||
-         (m_adByteStream && m_adStream && !m_adStream->getRepresentation()->IsWaitForSegment());
+         (m_adByteStream && m_adStream && !m_adStream->IsWaitingForSegment());
 }
 
 AP4_Result CSubtitleSampleReader::ReadSample()
@@ -197,7 +197,7 @@ AP4_Result CSubtitleSampleReader::ReadSample()
       else
         LOG::LogF(LOGERROR, "Failed to get Representation of subtitle stream");
     }
-    else if (m_adStream->getRepresentation()->IsWaitForSegment())
+    else if (m_adStream->IsWaitingForSegment())
     {
       // Wait for manifest live update to get next segment
       return AP4_SUCCESS;

--- a/src/samplereader/TSSampleReader.cpp
+++ b/src/samplereader/TSSampleReader.cpp
@@ -105,6 +105,13 @@ AP4_Result CTSSampleReader::ReadSample()
     UpdatePts();
     return AP4_SUCCESS;
   }
+
+  if (m_adByteStream->waitingForSegment())
+  {
+    // if waiting for segment, we will return success to avoid EOS and let the caller to call ReadSample again
+    return AP4_SUCCESS;
+  }
+
   if (!m_adByteStream || !m_adByteStream->waitingForSegment())
     m_eos = true;
   return AP4_ERROR_EOS;

--- a/src/samplereader/WebmSampleReader.cpp
+++ b/src/samplereader/WebmSampleReader.cpp
@@ -54,6 +54,13 @@ AP4_Result CWebmSampleReader::ReadSample()
     }
     return AP4_SUCCESS;
   }
+
+  if (m_adByteStream->waitingForSegment())
+  {
+    // if waiting for segment, we will return success to avoid EOS and let the caller to call ReadSample again
+    return AP4_SUCCESS;
+  }
+
   if (!m_adByteStream || !m_adByteStream->waitingForSegment())
     m_eos = true;
   return AP4_ERROR_EOS;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This will rework the WaitingForSegment code, moving it from `CRepresentation` class to the `AdaptiveStream` class
the  `AdaptiveStream` class will be the main place where manage buffering cases, without having to manage buffering per representation (stream) basis,
IMO i don't see negative effects doing this change since one `AdaptiveStream` can manage only one stream at time




## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2075 

1° problem:
from PR #1867 has been added `InsertLiveSegment` call inside `AdaptiveStream::waitingForSegment`
this is good when called from `CSession::GetNextSample`

but this cause wrong things when called from demuxers
what happens, the demuxer try to read data from a segment, and if there is no segment `AdaptiveStream::ensureSegment` set IsWaitForSegment on the representation to "true", after this the demuxer call `AdaptiveStream::waitingForSegment` to check if has to trigger EOS, but calling `AdaptiveStream::waitingForSegment` cause to call `InsertLiveSegment` that invalidate the IsWaitForSegment status previously set, triggering EOS playback will freeze/stall

so the demuxers must not cause a call to `InsertLiveSegment`

2° problem:
when there are no new segments  `CSession::GetNextSample` call `AdaptiveStream::waitingForSegment` to call  `InsertLiveSegment`, but if  `InsertLiveSegment` at the moment dont insert new segments, cause a "cat and mice" behaviour like the following:
```
2026-06-24 18:21:26.417 T:20052   debug <inputstream.adaptive>: adaptive::AdaptiveStream::ensureSegment: [AS-1] Begin WaitForSegment stream rep. id "pa3" period id "1"
2026-06-24 18:21:26.684 T:29408   debug <inputstream.adaptive>: adaptive::CDashTree::InsertLiveSegment: End WaitForSegment repr. id pa3
2026-06-24 18:21:26.685 T:20052   debug <inputstream.adaptive>: adaptive::AdaptiveStream::ensureSegment: [AS-1] Begin WaitForSegment stream rep. id "pa3" period id "1"
2026-06-24 18:21:27.184 T:29408   debug <inputstream.adaptive>: adaptive::CDashTree::InsertLiveSegment: End WaitForSegment repr. id pa3
2026-06-24 18:21:27.185 T:20052   debug <inputstream.adaptive>: adaptive::AdaptiveStream::ensureSegment: [AS-1] Begin WaitForSegment stream rep. id "pa3" period id "1"
2026-06-24 18:21:27.684 T:29408   debug <inputstream.adaptive>: adaptive::CDashTree::InsertLiveSegment: End WaitForSegment repr. id pa3
2026-06-24 18:21:27.685 T:20052   debug <inputstream.adaptive>: adaptive::AdaptiveStream::ensureSegment: [AS-1] Begin WaitForSegment stream rep. id "pa3" period id "1"
2026-06-24 18:21:28.184 T:29408   debug <inputstream.adaptive>: adaptive::CDashTree::InsertLiveSegment: End WaitForSegment repr. id pa3
```
between ensureSegment and InsertLiveSegment, so InsertLiveSegment should set IsWaitForSegment to false only when a new segment exists

3° problem:
When the stream is on buffering (e.g. loading wheel on GUI) the CPU starts to get very busy,
by debugging with in my PC (16 core, not so slow) i can observe CPU spike from 8% to 13% on Kodi when buffering (and fan speed go high), when playback back to normal CPU go down to about 1-7%,
i discovered that kodi VP do callbacks `DemuxRead` in a uncontrolled loop
https://github.com/xbmc/inputstream.adaptive/blob/c04fbd93d3360e0c71692c2a0638951ac2f24b43/src/main.cpp#L330
so when we are in buffering we return empty packets too fast, this cause the CPU spikes.
Add a thread sleep mitigate the problem, but seem that there is something else on VP to be fixed that cause slightly higher CPU usage

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
