### PR TITLE
[mpegts] Only auto-register PAT PIDs and validate the PSI section header - PlutoTv fails on ads for 21.5.21.1

### DIFF
--- a/lib/mpegts/mpegts/tsDemuxer.cpp
+++ b/lib/mpegts/mpegts/tsDemuxer.cpp
@@ -473,14 +473,26 @@ int AVContext::ProcessTSPacket()
   it = this->packets.find(this->pid);
   if (it == this->packets.end()) // Not registered PID.
   {
-    // Only auto-register if this payload_unit_start actually contains a PSI table
-    if (this->payload_unit_start && this->payload && this->payload_len > 1)
+    // Auto-register a first-seen PID only when it carries the start of a *PAT*
+    // section. PMT PIDs are discovered from the PAT (see parse_ts_psi, table_id
+    // 0x00) and are registered before any PMT packet arrives, so they never reach
+    // this branch. Registering an arbitrary PID as PSI just because its payload
+    // bytes match a PMT table_id (0x02) false-positives on discontinuous/corrupt
+    // TS, corrupts the demux state and crashes on the next TSResync(). Validate
+    // the section header before trusting it.
+    if (this->payload_unit_start && this->payload)
     {
-      const uint8_t pointerField = av_rb8(this->payload); // pointer_field is at payload[0];
-      if (static_cast<size_t>(pointerField) + 1 < this->payload_len)
+      const uint8_t pointerField = av_rb8(this->payload); // pointer_field is at payload[0]
+      // need pointer_field + table_id (1 byte) + section length field (2 bytes)
+      if (static_cast<size_t>(pointerField) + 4 <= this->payload_len)
       {
-        const uint8_t tableId = av_rb8(this->payload + 1 + pointerField); // table_id is at payload + 1 + pointer_field
-        if (tableId == 0x00 || tableId == 0x02) // table_id 0x00 = PAT, 0x02 = PMT
+        const unsigned char* section = this->payload + 1 + pointerField;
+        const uint8_t tableId = av_rb8(section);              // table_id
+        const uint16_t sectionHeader = av_rb16(section + 1);  // syntax + reserved + section_length
+        // table_id 0x00 = PAT; reserved bits must be set ('11'); sane section_length
+        if (tableId == 0x00 &&
+            (sectionHeader & 0x3000) == 0x3000 &&
+            (sectionHeader & 0x0fff) <= 1021)
         {
           Packet p;
           p.pid = this->pid;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Commit 59fd1b3e84 ("Accept any PID number not only PAT with PID 0") made ProcessTSPacket auto-register any first-seen PID as a PSI packet when its payload bytes matched table_id 0x00 (PAT) or 0x02 (PMT).


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The PMT case is both redundant and unsafe: PMT PIDs are always registered by the PAT parser (parse_ts_psi, table_id 0x00) before any PMT packet arrives, so a valid PMT PID never reaches this branch. The only PID that does is a non-PSI PID whose payload happens to begin with table_id 0x02 -- common on discontinuous /corrupt live HLS-TS. Such a PID is then misparsed as a PMT, triggers a spurious program change, corrupts the demux state, and crashes on the next TSResync() in AP4_ByteStream::Read (SIGSEGV).


Fix: auto-register only when the PID carries the start of a *PAT* section, and validate the section header (reserved bits set, sane section_length) before trusting it. This preserves the original intent (accept a PAT not on PID 0) while removing the crash. No regression observed on DASH or well-formed TS.
  ###############  LOG FILE ################
  14:00:42.107 T:418559  inputstream.adaptive: [AS-16] Download finished: .../hls/stream-13259.ts (2223852 byte)
  14:00:42.108 T:418559  CurlFile::Open - <https://redebrasil.nuvemplay.live/hls/stream-13260.ts>
  14:00:42.255 T:1258    inputstream.adaptive: Download finished: .../hls/stream.m3u8 (438 byte)
  14:00:42.256 T:1258    inputstream.adaptive: Manifest saved to: .../manifest_1782493242_child-video.txt
  14:00:42.376 T:1170    warning: ActiveAE - large audio sync error: -1007.649115
  14:00:42.426 T:1170    warning: ActiveAE - large audio sync error: -1006.661655
          ... (≈20 consecutive ~-1007 ms audio-sync warnings) ...
  14:00:42.626 T:418559  inputstream.adaptive: [AS-16] Download finished: .../hls/stream-13260.ts (2137936 byte)
  14:00:42.628 T:418559  CurlFile::Open - <https://redebrasil.nuvemplay.live/hls/stream-13261.ts>
          ...
  14:00:43.126 T:1170    ActiveAE::SyncStream - average error -989.564397 above threshold of 200.000000
  14:00:43.379 T:1170    ActiveAE::SyncStream - average error -0.017912 below threshold of 30.000000
  14:00:43.536 T:418994  inputstream.adaptive: IsLastSegment: Check for last segment (period end PTS: 6000, segment end PTS: 6000)
  ############### END LOG FILE ################


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A custom version with those changes was built and installed on Kodi.

The same stream that was failing after a few minutes, every time, now run for more than 24h without crashing. Same thing was happening with PlutoTv when ads were playing, it crashed every time, but now works fine.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
