### PR TITLE
[mpegts] Enlarge H.264 SPS/PPS raw_data buffers to 256 bytes

### DIFF
--- a/lib/mpegts/mpegts/ES_h264.cpp
+++ b/lib/mpegts/mpegts/ES_h264.cpp
@@ -158,18 +158,30 @@ void ES_h264::Parse(STREAM_PKT* pkt)
       {
         if (m_streamData.sps[0].raw_data_size)
         {
-          uint8_t *ed(stream_info.extra_data);
-          stream_info.extra_data_size = 4 + m_streamData.sps[0].raw_data_size;
-          ed[0] = ed[1] = ed[2] = 0, ed[3] = 1, ed += 4;
-          memcpy(ed, m_streamData.sps[0].raw_data, m_streamData.sps[0].raw_data_size), ed += m_streamData.sps[0].raw_data_size;
+          uint8_t* ed = stream_info.extra_data;
+          const uint8_t* edEnd = stream_info.extra_data + sizeof(stream_info.extra_data);
+          stream_info.extra_data_size = 0;
+
+          // Append a parameter set NAL (SPS/PPS) as Annex B, bounded by the
+          // destination buffer to avoid overflowing stream_info.extra_data
+          auto appendNal = [&](const uint8_t* src, size_t n) -> bool {
+            if (ed + 4 + n > edEnd)
+            {
+              DBG(DEMUX_DBG_INFO, "H.264: stream_info.extra_data too small! %u\n",
+                  static_cast<unsigned int>(stream_info.extra_data_size + 4 + n));
+              return false;
+            }
+            ed[0] = ed[1] = ed[2] = 0, ed[3] = 1, ed += 4;
+            memcpy(ed, src, n), ed += n;
+            stream_info.extra_data_size += 4 + n;
+            return true;
+          };
+
+          appendNal(m_streamData.sps[0].raw_data, m_streamData.sps[0].raw_data_size);
           for (int i = 0; i < 256; ++i)
           {
             if (m_streamData.pps[i].raw_data_size)
-            {
-              ed[0] = ed[1] = ed[2] = 0, ed[3] = 1, ed += 4;
-              memcpy(ed, m_streamData.pps[i].raw_data, m_streamData.pps[i].raw_data_size), ed += m_streamData.pps[i].raw_data_size;
-              stream_info.extra_data_size += 4 + m_streamData.pps[i].raw_data_size;
-            }
+              appendNal(m_streamData.pps[i].raw_data, m_streamData.pps[i].raw_data_size);
           }
         }
         else

--- a/lib/mpegts/mpegts/ES_h264.h
+++ b/lib/mpegts/mpegts/ES_h264.h
@@ -28,7 +28,7 @@ namespace TSDemux
         int log2_max_pic_order_cnt_lsb;
         int delta_pic_order_always_zero_flag;
         int raw_data_size;
-        uint8_t raw_data[64];
+        uint8_t raw_data[256];
       } sps[256];
 
       struct PPS
@@ -36,7 +36,7 @@ namespace TSDemux
         uint8_t sps;
         uint8_t pic_order_present_flag;
         uint16_t raw_data_size;
-        uint8_t raw_data[64];
+        uint8_t raw_data[256];
       } pps[256];
 
       struct VCL_NAL

--- a/lib/mpegts/mpegts/elementaryStream.h
+++ b/lib/mpegts/mpegts/elementaryStream.h
@@ -61,7 +61,7 @@ namespace TSDemux
     int                   bit_rate;
     int                   bits_per_sample;
     bool                  interlaced;
-    uint8_t               extra_data[512];
+    uint8_t               extra_data[1024];
     int                   extra_data_size;
   };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The per-NAL raw_data buffers used to build the codec extra data were only 64 bytes. Some SPS with full VUI/HRD parameters can exceed that (e.g. Wowza-originated HLS), so the SPS was silently dropped (raw_data_size reset to 0) and the H.264 extra data ended up empty.

Kodi then rejects the video stream with "Codec id 27 require extradata" and disables it, leaving an audio-only stream that immediately hits EOF.

Increase the SPS/PPS raw_data buffers to 256 bytes so that for some large SPS extra data is built correctly.

Also extra_data was increase from 512 to 1024 to accommodate rare situations.
NAL buffers are now 256 bytes each, so a single legitimate SPS+PPS can be up to 4+255+4+255 = 518 bytes. With only 512, the guard I added would correctly refuse to overflow — but it would then drop a valid PPS, silently reintroducing a decode failure. 1024 ensures the destination can hold whatever the 256-byte NAL buffers can legitimately produce. The guard prevents the crash; the 1024 prevents truncation.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix some streams that are not playing due to small buffer size.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Kodi 21 with a custom IA build. The falling stream was now able to be played. No regression on other streams

## Screenshots (if appropriate):
Stream: https://streamtv.novotempo.com/CDN-TV-PT/smil:tvnovotempo.smil/playlist.m3u8
  12:07:59.315  CDVDDemuxClient::RequestStream(): added/updated stream 1001 with codec_id 27
  12:07:59.315  CDVDDemuxClient::RequestStream(): added/updated stream 1002 with codec_id 86018
  12:07:59.316  Opening stream: 1001 source: 256
  12:07:59.932  [WHITELIST] Searching the whitelist for: width: 1280, height: 720, fps: 29.970, 3D: false
  12:07:59.979  error: OpenStream: Codec id 27 require extradata.
  12:07:59.979  warning: OpenStream - Unsupported stream 1001. Stream disabled.
  12:07:59.979  Opening stream: 1002 source: 256
  12:08:00.004  CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder aac
  12:08:00.034  Process - eof reading from demuxer

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
